### PR TITLE
Separate structural and live inference readiness

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -96,7 +96,8 @@ pub use dispatchability::{
     AgentTaskProviderConfigurationDiagnosis, AgentTaskProviderCredentialStatus,
     AgentTaskProviderDispatchability, AgentTaskProviderDispatchabilityCheck,
     AgentTaskProviderDispatchabilityChecks, AgentTaskProviderDispatchabilityCredentialCheck,
-    AgentTaskProviderOwner, AgentTaskProviderRuntimeEvidence,
+    AgentTaskProviderLiveInferenceReadiness, AgentTaskProviderOwner, AgentTaskProviderReadiness,
+    AgentTaskProviderReadinessScope, AgentTaskProviderRuntimeEvidence,
 };
 pub(crate) use fixture_gate::fixture_provider_outcome;
 pub use fixture_gate::is_fixture_backend;

--- a/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
@@ -21,8 +21,34 @@ pub struct AgentTaskProviderDispatchability {
     pub ready: bool,
     pub reason: String,
     pub checks: AgentTaskProviderDispatchabilityChecks,
+    /// Structural routing and live inference answer different questions. Keep
+    /// both scopes in the shared verdict so inventory and Cook cannot claim a
+    /// provider-native account check that never ran.
+    pub readiness: AgentTaskProviderReadiness,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub configuration_diagnosis: Option<AgentTaskProviderConfigurationDiagnosis>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentTaskProviderReadiness {
+    pub structural_dispatchability: AgentTaskProviderReadinessScope,
+    pub live_inference: AgentTaskProviderLiveInferenceReadiness,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentTaskProviderReadinessScope {
+    pub state: &'static str,
+    pub ready: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentTaskProviderLiveInferenceReadiness {
+    pub state: &'static str,
+    pub ready: bool,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<AgentTaskProviderRuntimeEvidence>,
 }
 
 /// A static provider contract defect that prevents dispatch. This keeps the
@@ -235,42 +261,47 @@ fn evaluate_provider_dispatchability_with_config_credentials_and_deadline(
             && candidate_providers
                 .iter()
                 .all(|provider| validate_provider_immediate_failure_patterns(provider).is_ok());
+        let checks = AgentTaskProviderDispatchabilityChecks {
+            route: AgentTaskProviderDispatchabilityCheck {
+                ready: false,
+                reason: Some(route_reason),
+            },
+            model: AgentTaskProviderDispatchabilityCheck {
+                ready: false,
+                reason: None,
+            },
+            credentials: AgentTaskProviderDispatchabilityCredentialCheck {
+                status: if credentials_ready {
+                    AgentTaskProviderCredentialStatus::Unverified
+                } else {
+                    AgentTaskProviderCredentialStatus::Missing
+                },
+                ready: credentials_ready,
+                missing: Vec::new(),
+                // A route that never resolved to one provider was never
+                // probed, so nothing here was live-verified.
+                verified: false,
+                reason: Some(
+                    "the provider route did not resolve, so credentials were not live-validated"
+                        .to_string(),
+                ),
+                remediation: Vec::new(),
+            },
+            configuration: AgentTaskProviderDispatchabilityCheck {
+                ready: configuration_ready,
+                reason: None,
+            },
+            runtime: AgentTaskProviderDispatchabilityCheck {
+                ready: false,
+                reason: None,
+            },
+        };
         AgentTaskProviderDispatchability {
             state,
             ready: false,
             reason: reason.to_string(),
-            checks: AgentTaskProviderDispatchabilityChecks {
-                route: AgentTaskProviderDispatchabilityCheck {
-                    ready: false,
-                    reason: Some(route_reason),
-                },
-                model: AgentTaskProviderDispatchabilityCheck {
-                    ready: false,
-                    reason: None,
-                },
-                credentials: AgentTaskProviderDispatchabilityCredentialCheck {
-                    status: if credentials_ready {
-                        AgentTaskProviderCredentialStatus::Unverified
-                    } else {
-                        AgentTaskProviderCredentialStatus::Missing
-                    },
-                    ready: credentials_ready,
-                    missing: Vec::new(),
-                    // A route that never resolved to one provider was never
-                    // probed, so nothing here was live-verified.
-                    verified: false,
-                    reason: Some("the provider route did not resolve, so credentials were not live-validated".to_string()),
-                    remediation: Vec::new(),
-                },
-                configuration: AgentTaskProviderDispatchabilityCheck {
-                    ready: configuration_ready,
-                    reason: None,
-                },
-                runtime: AgentTaskProviderDispatchabilityCheck {
-                    ready: false,
-                    reason: None,
-                },
-            },
+            readiness: readiness_scopes(&checks, false, false, None),
+            checks,
             configuration_diagnosis: None,
         }
     };
@@ -425,9 +456,13 @@ fn evaluate_provider_dispatchability_with_config_credentials_and_deadline(
     let credentials_verified =
         probe_runtime && provider.readiness_invocation.is_some() && runtime.ready;
     let provider_owned_auth = provider_requires_live_auth_validation(provider);
-    let credentials_rejected = runtime_evidence.as_ref().is_some_and(|evidence| {
-        matches!(evidence.classification.as_str(), "auth_failure" | "account")
-    });
+    let credentials_rejected = runtime_evidence
+        .as_ref()
+        .is_some_and(|evidence| evidence.classification == "auth_failure");
+    let account_blocked = !runtime.ready
+        && runtime_evidence
+            .as_ref()
+            .is_some_and(|evidence| evidence.classification == "account");
     let (credential_status, credential_reason) = if !credentials.dispatchable {
         (AgentTaskProviderCredentialStatus::Missing, None)
     } else if credentials_verified {
@@ -514,6 +549,12 @@ fn evaluate_provider_dispatchability_with_config_credentials_and_deadline(
             false,
             "provider-owned authentication has no live validation route",
         )
+    } else if account_blocked {
+        (
+            "account_unavailable",
+            false,
+            "provider account quota or billing is unavailable",
+        )
     } else if provider_owned_auth && !runtime.ready && credentials_rejected {
         (
             "credentials_unusable",
@@ -526,56 +567,136 @@ fn evaluate_provider_dispatchability_with_config_credentials_and_deadline(
             false,
             "provider runtime readiness validation failed",
         )
-    } else if !probe_runtime {
-        ("ready", true, "live runtime readiness was not requested")
+    } else if !probe_runtime || provider.readiness_invocation.is_none() {
+        (
+            "structurally_dispatchable",
+            true,
+            "structural dispatchability checks passed; live inference was not probed",
+        )
     } else if !provider_owned_auth || credentials_verified {
         ("ready", true, "all dispatchability checks passed")
     } else {
         unreachable!("provider-owned auth without verification is rejected above")
     };
+    let reason = if state == "runtime_unavailable" {
+        format!(
+            "runtime_unavailable: {}",
+            runtime.reason.as_deref().unwrap_or(reason)
+        )
+    } else {
+        reason.to_string()
+    };
+    let checks = AgentTaskProviderDispatchabilityChecks {
+        route: AgentTaskProviderDispatchabilityCheck {
+            ready: true,
+            reason: Some(provider.id.clone()),
+        },
+        model: AgentTaskProviderDispatchabilityCheck {
+            ready: model_ready,
+            reason: (!model_ready).then_some("unsupported selected model".to_string()),
+        },
+        credentials: AgentTaskProviderDispatchabilityCredentialCheck {
+            status: credential_status,
+            ready: credentials.dispatchable,
+            missing: credentials.missing,
+            verified: credentials_verified,
+            reason: credential_reason,
+            remediation: if provider_owned_auth
+                && probe_runtime
+                && provider.readiness_invocation.is_none()
+            {
+                configuration_diagnosis
+                    .as_ref()
+                    .map(|diagnosis| vec![diagnosis.remediation.clone()])
+                    .unwrap_or_default()
+            } else {
+                runtime_remediation
+            },
+        },
+        configuration,
+        runtime,
+    };
+    let readiness = readiness_scopes(
+        &checks,
+        probe_runtime,
+        provider.readiness_invocation.is_some(),
+        runtime_evidence.clone(),
+    );
     *runtime_evidence_out = runtime_evidence;
     AgentTaskProviderDispatchability {
         state,
         ready,
-        reason: if state == "runtime_unavailable" {
-            format!(
-                "runtime_unavailable: {}",
-                runtime.reason.as_deref().unwrap_or(reason)
-            )
-        } else {
-            reason.to_string()
-        },
-        checks: AgentTaskProviderDispatchabilityChecks {
-            route: AgentTaskProviderDispatchabilityCheck {
-                ready: true,
-                reason: Some(provider.id.clone()),
-            },
-            model: AgentTaskProviderDispatchabilityCheck {
-                ready: model_ready,
-                reason: (!model_ready).then_some("unsupported selected model".to_string()),
-            },
-            credentials: AgentTaskProviderDispatchabilityCredentialCheck {
-                status: credential_status,
-                ready: credentials.dispatchable,
-                missing: credentials.missing,
-                verified: credentials_verified,
-                reason: credential_reason,
-                remediation: if provider_owned_auth
-                    && probe_runtime
-                    && provider.readiness_invocation.is_none()
-                {
-                    configuration_diagnosis
-                        .as_ref()
-                        .map(|diagnosis| vec![diagnosis.remediation.clone()])
-                        .unwrap_or_default()
-                } else {
-                    runtime_remediation
-                },
-            },
-            configuration,
-            runtime,
-        },
+        reason,
+        readiness,
+        checks,
         configuration_diagnosis,
+    }
+}
+
+fn readiness_scopes(
+    checks: &AgentTaskProviderDispatchabilityChecks,
+    probe_requested: bool,
+    probe_declared: bool,
+    evidence: Option<AgentTaskProviderRuntimeEvidence>,
+) -> AgentTaskProviderReadiness {
+    let structural_ready = checks.route.ready
+        && checks.model.ready
+        && checks.credentials.ready
+        && checks.configuration.ready;
+    let structural_reason = if structural_ready {
+        "route, model, credentials, and configuration are structurally dispatchable".to_string()
+    } else {
+        "one or more structural dispatchability checks failed".to_string()
+    };
+    let live_inference = if !structural_ready {
+        AgentTaskProviderLiveInferenceReadiness {
+            state: "unavailable",
+            ready: false,
+            reason: structural_reason.clone(),
+            evidence: None,
+        }
+    } else if !probe_requested {
+        AgentTaskProviderLiveInferenceReadiness {
+            state: "structurally_dispatchable",
+            ready: false,
+            reason: "live inference probe was not requested".to_string(),
+            evidence: None,
+        }
+    } else if !probe_declared {
+        AgentTaskProviderLiveInferenceReadiness {
+            state: "inference_unverified",
+            ready: false,
+            reason: "the provider declares no bounded live inference probe".to_string(),
+            evidence: None,
+        }
+    } else if checks.runtime.ready {
+        AgentTaskProviderLiveInferenceReadiness {
+            state: "validated",
+            ready: true,
+            reason: "a bounded provider-native probe accepted the selected route".to_string(),
+            evidence,
+        }
+    } else {
+        AgentTaskProviderLiveInferenceReadiness {
+            state: "unavailable",
+            ready: false,
+            reason: checks.runtime.reason.clone().unwrap_or_else(|| {
+                "the bounded live inference probe did not accept work".to_string()
+            }),
+            evidence,
+        }
+    };
+    AgentTaskProviderReadiness {
+        structural_dispatchability: AgentTaskProviderReadinessScope {
+            state: if structural_ready {
+                "ready"
+            } else {
+                "unavailable"
+            },
+            ready: structural_ready,
+            reason: structural_reason,
+        },
+        live_inference,
     }
 }
 
@@ -828,6 +949,19 @@ fn unavailable_request_dispatchability(
             ready: false,
             reason: reason.to_string(),
             configuration_diagnosis: None,
+            readiness: AgentTaskProviderReadiness {
+                structural_dispatchability: AgentTaskProviderReadinessScope {
+                    state: "unavailable",
+                    ready: false,
+                    reason: reason.to_string(),
+                },
+                live_inference: AgentTaskProviderLiveInferenceReadiness {
+                    state: "unavailable",
+                    ready: false,
+                    reason: reason.to_string(),
+                    evidence: None,
+                },
+            },
             checks: AgentTaskProviderDispatchabilityChecks {
                 route: AgentTaskProviderDispatchabilityCheck {
                     ready: false,
@@ -1511,6 +1645,72 @@ mod tests {
         assert_eq!(
             verdict.checks.credentials.remediation,
             vec!["Start the provider runtime."]
+        );
+    }
+
+    #[test]
+    fn account_blocked_probe_is_unavailable_before_a_provider_execution() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let count = root.path().join("probe-count");
+        let script = root.path().join("readiness.js");
+        std::fs::write(
+            &script,
+            "const fs=require('fs');fs.appendFileSync(process.argv[2],'probe\\n');process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:false,classification:'account',retryable:false,remediation:'restore account quota or billing access',reason:'account spending limit is exhausted',cache_key:'blocked-account',identity:{account:'blocked'}}));",
+        )
+        .expect("readiness script");
+        let mut provider = provider(&script, &count);
+        provider.cli.profiles = serde_json::from_value(json!([
+            { "name": "blocked", "model": "selected-model" }
+        ]))
+        .expect("model profile");
+        let catalog = catalog(provider);
+
+        let verdict =
+            evaluate_provider_dispatchability(&catalog, "test", None, Some("selected-model"), true);
+
+        assert_eq!(verdict.state, "account_unavailable");
+        assert!(!verdict.ready);
+        assert!(verdict.readiness.structural_dispatchability.ready);
+        assert_ne!(
+            verdict.checks.credentials.status,
+            AgentTaskProviderCredentialStatus::Unusable,
+            "an account quota or billing block is not a rejected credential"
+        );
+        assert_eq!(verdict.readiness.live_inference.state, "unavailable");
+        assert_eq!(
+            verdict
+                .readiness
+                .live_inference
+                .evidence
+                .as_ref()
+                .map(|evidence| evidence.classification.as_str()),
+            Some("account")
+        );
+        assert!(verdict.reason.contains("quota or billing"));
+        assert_eq!(
+            std::fs::read_to_string(&count).expect("one bounded probe"),
+            "probe\n"
+        );
+
+        std::fs::remove_file(&count).expect("reset probe evidence for Cook admission");
+
+        let error = admit_plan_provider_dispatchability_with_providers(
+            &AgentTaskPlan::new("account-blocked", vec![request("selected-model")]),
+            &catalog,
+            &mut ProviderRuntimeReadinessCache::default(),
+        )
+        .expect_err("Cook admission must reject an account-blocked route");
+        assert_eq!(
+            error.details["route_evidence"][0]["classification"],
+            "account"
+        );
+        assert_eq!(
+            error.details["route_evidence"][0]["state"],
+            "account_unavailable"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&count).expect("one bounded Cook admission probe"),
+            "probe\n"
         );
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -2831,21 +2831,18 @@ fn declared_backend_readiness(
 }
 
 fn live_dispatch_readiness(
-    provider: Option<&AgentTaskExecutorProvider>,
-    validation_requested: bool,
+    dispatchability: Option<
+        &homeboy::agents::agent_tasks::provider::AgentTaskProviderDispatchability,
+    >,
 ) -> &'static str {
-    if !validation_requested {
-        return "not_requested";
-    }
-    provider
-        .filter(|provider| provider.readiness_invocation.is_some())
-        .map(|_| "validated")
-        .unwrap_or("unverified")
+    dispatchability
+        .map(|verdict| verdict.readiness.live_inference.state)
+        .unwrap_or("inference_unverified")
 }
 
 fn readiness_validation_projection(
     identity: Option<&(String, String)>,
-    provider: Option<&AgentTaskExecutorProvider>,
+    _provider: Option<&AgentTaskExecutorProvider>,
     route: Option<&ProviderRoute>,
     dispatchability: Option<
         &homeboy::agents::agent_tasks::provider::AgentTaskProviderDispatchability,
@@ -2878,14 +2875,19 @@ fn readiness_validation_projection(
         ),
     };
     serde_json::json!({
-        "validated": validation_requested && identity.is_some(),
+        // Identity resolution proves which provider was inspected, not that it
+        // accepted inference. Reserve this for a successful bounded probe.
+        "validated": validation_requested && dispatchability.is_some_and(|verdict| verdict.readiness.live_inference.ready),
         "effective_backend": effective_backend,
         "effective_provider_id": effective_provider_id,
         "effective_model": effective_model,
-        // Catalog discovery proves static configuration only. A live dispatch
-        // probe is opt-in because providers own its request.
+        // Structural dispatchability is distinct from a bounded provider-native
+        // inference probe. Never promote a declared-but-unrun probe to live
+        // validation.
         "static_configuration": "declared",
-        "live_dispatch": live_dispatch_readiness(provider, validation_requested),
+        "structural_dispatchability": dispatchability.map(|verdict| &verdict.readiness.structural_dispatchability),
+        "live_inference": dispatchability.map(|verdict| &verdict.readiness.live_inference),
+        "live_dispatch": live_dispatch_readiness(dispatchability),
         "route_state": route.map(ProviderRoute::state),
         "next_command": provider_next_command(route, dispatchability),
         "reason": match route { Some(ProviderRoute::Blocked { reason, .. }) => Some(reason), _ => None },
@@ -3900,6 +3902,47 @@ mod tests {
         });
     }
 
+    #[test]
+    fn providers_reports_account_block_as_structural_not_live_readiness() {
+        crate::test_support::with_isolated_home(|_| {
+            let mut provider = provider("blocked.provider", "blocked");
+            provider.cli.profiles = serde_json::from_value(serde_json::json!([
+                { "name": "blocked", "model": "blocked-model" }
+            ]))
+            .expect("provider profile");
+            provider.readiness_invocation = Some(
+                serde_json::from_value(serde_json::json!({
+                    "argv": ["sh", "-c", "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":false,\"classification\":\"account\",\"retryable\":false,\"remediation\":\"restore account quota or billing access\",\"reason\":\"account spending limit is exhausted\",\"cache_key\":\"blocked-account\",\"identity\":{\"account\":\"blocked\"}}'"]
+                }))
+                .expect("account-blocked readiness invocation"),
+            );
+            let mut args = providers_args();
+            args.backend = Some("blocked".to_string());
+            args.selector = Some("blocked.provider".to_string());
+            args.model = Some("blocked-model".to_string());
+            args.validate_readiness = true;
+
+            let (output, status) = providers_with_catalog(args, provider_catalog(vec![provider]))
+                .expect("account-blocked provider report");
+
+            assert_eq!(status, 0);
+            assert_eq!(output["dispatchability"]["state"], "account_unavailable");
+            assert_eq!(
+                output["readiness_validation"]["structural_dispatchability"]["ready"],
+                true
+            );
+            assert_eq!(
+                output["readiness_validation"]["live_dispatch"],
+                "unavailable"
+            );
+            assert_eq!(output["readiness_validation"]["validated"], false);
+            assert_eq!(
+                output["readiness_validation"]["live_inference"]["evidence"]["classification"],
+                "account"
+            );
+        });
+    }
+
     /// `--validate-readiness` with no `--backend` and no configured default is
     /// exactly the discovery question Cook's missing-default error sends the
     /// operator here to answer, so it must sweep instead of inheriting Cook's
@@ -4600,28 +4643,6 @@ mod tests {
     }
 
     #[test]
-    fn live_dispatch_readiness_uses_the_resolved_provider_only() {
-        let mut probed: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
-            "id": "probed", "backend": "test", "readiness_invocation": { "argv": ["true"] }
-        }))
-        .expect("probed provider");
-        let unprobed: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
-            "id": "unprobed", "backend": "test"
-        }))
-        .expect("unprobed provider");
-
-        assert_eq!(live_dispatch_readiness(Some(&probed), true), "validated");
-        assert_eq!(live_dispatch_readiness(Some(&unprobed), true), "unverified");
-        assert_eq!(live_dispatch_readiness(None, true), "unverified");
-        assert_eq!(
-            live_dispatch_readiness(Some(&probed), false),
-            "not_requested"
-        );
-        probed.readiness_invocation = None;
-        assert_eq!(live_dispatch_readiness(Some(&probed), true), "unverified");
-    }
-
-    #[test]
     fn readiness_validation_reports_effective_identity_not_raw_arguments() {
         let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
             "id": "resolved.provider", "backend": "resolved-backend",
@@ -4644,7 +4665,7 @@ mod tests {
 
         assert_eq!(projection["effective_backend"], "resolved-backend");
         assert_eq!(projection["effective_provider_id"], "resolved.provider");
-        assert_eq!(projection["live_dispatch"], "validated");
+        assert_eq!(projection["live_dispatch"], "inference_unverified");
         // A single-backend query is not a sweep: it reports no per-backend
         // readiness rather than an empty one (#12569).
         assert!(projection["backends"].is_null());
@@ -4689,8 +4710,14 @@ mod tests {
             .expect("provider envelope")
             .0;
 
-        assert_eq!(output["dispatchability"]["state"], "ready");
-        assert_eq!(output["operator_summary"]["state"], "ready");
+        assert_eq!(
+            output["dispatchability"]["state"],
+            "structurally_dispatchable"
+        );
+        assert_eq!(
+            output["readiness_validation"]["live_dispatch"],
+            "structurally_dispatchable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- expose structural dispatchability and bounded live-inference readiness as separate scopes
- classify account quota and billing blocks as unavailable before provider execution
- make provider inventory and Cook admission consume the same typed verdict

Closes #14199

## Verification
- `cargo test -p homeboy-agents account_blocked_probe_is_unavailable_before_a_provider_execution -j1`
- `cargo check -p homeboy-agents -p homeboy-cli --tests -j1`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## AI Assistance
Implemented and reviewed with OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode. AI was used to design readiness scopes, implement shared verdict projection, correct probe-count coverage, and verify the branch.