### PR TITLE
Project bounded live provider progress

### DIFF
--- a/crates/contracts/homeboy-control-plane-contract/src/lib.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/lib.rs
@@ -41,8 +41,8 @@ pub use resolve::{resolve, IdentityKind, ResolveError, ResolvedIdentities};
 pub use resource::{
     ControlPlaneAction, ControlPlaneActionAvailability, ControlPlaneActionConfirmation,
     ControlPlaneActionEligibility, ControlPlaneActionEligibilityReport, ControlPlaneBlocker,
-    ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEvidenceRef, ControlPlaneLocation,
-    ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneResult, ControlPlaneRun,
-    ControlPlaneRunState, ControlPlaneRuntime, ControlPlaneStateSummary,
+    ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEvidenceRef, ControlPlaneLiveness,
+    ControlPlaneLocation, ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneResult,
+    ControlPlaneRun, ControlPlaneRunState, ControlPlaneRuntime, ControlPlaneStateSummary,
     CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA, CONTROL_PLANE_RESULT_SCHEMA, CONTROL_PLANE_RUN_SCHEMA,
 };

--- a/crates/contracts/homeboy-control-plane-contract/src/resource.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/resource.rs
@@ -134,6 +134,8 @@ pub struct ControlPlaneRun {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub heartbeat_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub liveness: Option<ControlPlaneLiveness>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub candidate: Option<ControlPlaneStateSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub gates: Vec<ControlPlaneStateSummary>,
@@ -169,6 +171,7 @@ impl ControlPlaneRun {
             runtime: None,
             provider: None,
             heartbeat_at: None,
+            liveness: None,
             candidate: None,
             gates: Vec::new(),
             publication: None,
@@ -180,6 +183,20 @@ impl ControlPlaneRun {
             artifacts: Vec::new(),
         }
     }
+}
+
+/// Bounded live provider evidence. This intentionally carries timestamps and a
+/// source name only; provider output and filesystem paths remain out of status.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControlPlaneLiveness {
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_observed_progress_at: Option<String>,
+    pub age_seconds: u64,
+    pub window_seconds: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -332,9 +349,9 @@ mod tests {
     use super::{
         ControlPlaneAction, ControlPlaneActionAvailability, ControlPlaneActionConfirmation,
         ControlPlaneActionEligibility, ControlPlaneActionEligibilityReport, ControlPlaneBlocker,
-        ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEvidenceRef, ControlPlaneLocation,
-        ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneResult, ControlPlaneRun,
-        ControlPlaneRunState, ControlPlaneRuntime, ControlPlaneStateSummary,
+        ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEvidenceRef, ControlPlaneLiveness,
+        ControlPlaneLocation, ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneResult,
+        ControlPlaneRun, ControlPlaneRunState, ControlPlaneRuntime, ControlPlaneStateSummary,
         CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA, CONTROL_PLANE_RESULT_SCHEMA,
         CONTROL_PLANE_RUN_SCHEMA,
     };
@@ -374,6 +391,13 @@ mod tests {
             session: Some(ProviderSessionId::new("sess-1").expect("session")),
         });
         resource.heartbeat_at = Some("2026-01-01T00:00:30Z".to_string());
+        resource.liveness = Some(ControlPlaneLiveness {
+            state: "active".to_string(),
+            source: Some("structured_progress".to_string()),
+            last_observed_progress_at: Some("2026-01-01T00:00:45Z".to_string()),
+            age_seconds: 15,
+            window_seconds: 300,
+        });
         resource.candidate = Some(ControlPlaneStateSummary {
             id: Some("review".to_string()),
             state: "applied".to_string(),
@@ -431,6 +455,7 @@ mod tests {
         assert_eq!(value["runtime"]["build_identity"], "homeboy 0.1.0+test");
         assert_eq!(value["provider"]["id"], "claude");
         assert_eq!(value["heartbeat_at"], "2026-01-01T00:00:30Z");
+        assert_eq!(value["liveness"]["state"], "active");
         assert_eq!(value["candidate"]["state"], "applied");
         assert_eq!(value["gates"][0]["id"], "test");
         assert_eq!(value["publication"]["state"], "published");

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -4074,6 +4074,7 @@ pub fn record_provider_execution_runtime_evidence_in_store(
     attempt: u32,
     stdout_uri: Option<String>,
     stderr_uri: Option<String>,
+    structured_progress_uri: Option<String>,
 ) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let key = format!("{task_id}:{attempt}");
@@ -4091,6 +4092,7 @@ pub fn record_provider_execution_runtime_evidence_in_store(
         execution["runtime_evidence"] = json!({
             "stdout": stdout_uri,
             "stderr": stderr_uri,
+            "structured_progress": structured_progress_uri,
             "capture": "bounded_incremental",
         });
         true
@@ -4111,6 +4113,7 @@ pub(crate) fn record_provider_execution_runtime_evidence(
     attempt: u32,
     stdout_uri: Option<String>,
     stderr_uri: Option<String>,
+    structured_progress_uri: Option<String>,
 ) -> Result<AgentTaskRunRecord> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     record_provider_execution_runtime_evidence_in_store(
@@ -4120,7 +4123,45 @@ pub(crate) fn record_provider_execution_runtime_evidence(
         attempt,
         stdout_uri,
         stderr_uri,
+        structured_progress_uri,
     )
+}
+
+/// Persist the timestamp of a workspace change observed by provider supervision.
+/// The status projection uses this finite lifecycle fact and never inspects a workspace.
+pub(crate) fn record_provider_execution_workspace_activity(
+    run_id: &str,
+    task_id: &str,
+    attempt: u32,
+) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    let run_id = sanitize_run_id(run_id);
+    let key = format!("{task_id}:{attempt}");
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
+        let Some(execution) = record.metadata["provider_executions"]
+            .as_array_mut()
+            .and_then(|executions| {
+                executions
+                    .iter_mut()
+                    .find(|execution| execution["key"] == key)
+            })
+        else {
+            return false;
+        };
+        if execution["state"] != json!("running") {
+            return false;
+        }
+        execution["workspace_activity_observed_at"] = json!(now_timestamp());
+        true
+    })?;
+    record.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "provider_execution",
+            "cannot attach workspace activity to an inactive provider execution",
+            Some(key),
+            None,
+        )
+    })
 }
 
 // The ambient `has_active_provider_execution()` shim that used to sit here is gone;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -2780,6 +2780,7 @@ fn cancelled_local_provider_retains_runtime_evidence_in_terminal_logs() {
         1,
         Some(format!("file://{}", stdout.display())),
         None,
+        None,
     )
     .expect("runtime evidence recorded before cancellation");
 

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -1131,6 +1131,13 @@ fn run_materialized_provider_command_once_contained(
             stderr_runtime_capture
                 .as_ref()
                 .map(|capture| capture.uri.clone()),
+            Some(format!(
+                "file://{}",
+                request
+                    .artifacts_path
+                    .join("provider-progress.jsonl")
+                    .display()
+            )),
         );
     }
     let stdout_reader = child.stdout.take().map(|stdout| {
@@ -1180,6 +1187,7 @@ fn run_materialized_provider_command_once_contained(
                 let elapsed = started.elapsed();
                 let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
                 let mut progressed = false;
+                let mut workspace_progressed = false;
                 let current_runtime_progress = runtime_progress_snapshot(&request.artifacts_path);
                 if runtime_progress_advanced(&runtime_progress, &current_runtime_progress) {
                     progressed = true;
@@ -1199,6 +1207,7 @@ fn run_materialized_provider_command_once_contained(
                             &current_workspace_progress,
                         ) {
                             progressed = true;
+                            workspace_progressed = true;
                             workspace_progress_events = workspace_progress_events.saturating_add(1);
                         }
                         workspace_progress = current_workspace_progress;
@@ -1206,6 +1215,15 @@ fn run_materialized_provider_command_once_contained(
                 }
                 if progressed {
                     last_progress_ms.store(elapsed_ms, Ordering::SeqCst);
+                }
+                if workspace_progressed {
+                    if let Some(run_id) = run_id {
+                        let _ = crate::agent_task_lifecycle::record_provider_execution_workspace_activity(
+                            run_id,
+                            &request.request.task_id,
+                            attempt,
+                        );
+                    }
                 }
                 if elapsed >= process_timeout {
                     break (None, false, true);

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -5,21 +5,24 @@
 //! projection. Construct with an explicit lookup — the service does not
 //! resolve ambient stores or providers itself.
 
+use chrono::{DateTime, Utc};
 use homeboy_control_plane_contract::ControlPlaneRetryParameters;
 use homeboy_control_plane_contract::{
     ControlPlaneAction, ControlPlaneActionAcknowledgement, ControlPlaneActionOutcome,
     ControlPlaneActionPayload, ControlPlaneActionRequest, ControlPlaneBlocker,
     ControlPlaneCancelParameters, ControlPlaneCapabilities, ControlPlaneError,
-    ControlPlaneErrorClass, ControlPlaneEvidenceRef, ControlPlaneLocation, ControlPlaneOperation,
-    ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneResource, ControlPlaneRun,
-    ControlPlaneRunState, ControlPlaneRuntime, ControlPlaneStateSummary, ExecutionId,
-    ProviderSessionId, RunId, CONTROL_PLANE_ACTION_ACKNOWLEDGEMENT_SCHEMA,
+    ControlPlaneErrorClass, ControlPlaneEvidenceRef, ControlPlaneLiveness, ControlPlaneLocation,
+    ControlPlaneOperation, ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneResource,
+    ControlPlaneRun, ControlPlaneRunState, ControlPlaneRuntime, ControlPlaneStateSummary,
+    ExecutionId, ProviderSessionId, RunId, CONTROL_PLANE_ACTION_ACKNOWLEDGEMENT_SCHEMA,
     CONTROL_PLANE_ACTION_REQUEST_SCHEMA, CONTROL_PLANE_CANCEL_PARAMETERS_SCHEMA,
     CONTROL_PLANE_EMPTY_ACTION_PAYLOAD_SCHEMA, CONTROL_PLANE_PROMOTE_PARAMETERS_SCHEMA,
     CONTROL_PLANE_PROMOTE_RESULT_SCHEMA, CONTROL_PLANE_RESUME_RESULT_SCHEMA,
     CONTROL_PLANE_RETRY_PARAMETERS_SCHEMA, CONTROL_PLANE_RETRY_RESULT_SCHEMA,
 };
 use homeboy_core::control_plane::{register_control_plane_provider, ControlPlaneProvider};
+use serde_json::Value;
+use std::path::Path;
 
 use crate::agent_task_lifecycle::{
     canonical_control_plane_identities, claim_operation_with_intent_in_store,
@@ -861,12 +864,20 @@ pub fn project_record(
     resource.runtime = runtime(record);
     resource.provider = assigned_provider(record);
     resource.heartbeat_at = heartbeat_at(record);
+    resource.created_at = record.submitted_at.clone();
+    resource.updated_at = record.updated_at.clone();
+    resource.liveness = live_provider_liveness(record, plan, Utc::now());
+    if let Some(observed_at) = resource
+        .liveness
+        .as_ref()
+        .and_then(|liveness| liveness.last_observed_progress_at.as_deref())
+    {
+        resource.updated_at = newest_timestamp(resource.updated_at.as_deref(), Some(observed_at));
+    }
     resource.candidate = candidate(record);
     resource.gates = gates(record);
     resource.publication = publication(record);
     resource.action_eligibility = Some(lifecycle_action_eligibility(record, plan));
-    resource.created_at = record.submitted_at.clone();
-    resource.updated_at = record.updated_at.clone();
     if resource.state.is_terminal() {
         resource.finished_at = record.updated_at.clone();
     }
@@ -963,6 +974,9 @@ fn execution(record: &AgentTaskRunRecord) -> Result<Option<ExecutionId>, Control
 }
 
 fn phase(record: &AgentTaskRunRecord) -> Option<String> {
+    if has_running_provider_execution(record) {
+        return Some("provider_execution".to_string());
+    }
     record
         .metadata
         .pointer("/cook_progress/phase")
@@ -976,6 +990,122 @@ fn phase(record: &AgentTaskRunRecord) -> Option<String> {
                 .map(|adoption| bounded(&adoption.phase, STATE_BOUND))
                 .filter(|value| !value.is_empty())
         })
+}
+
+fn has_running_provider_execution(record: &AgentTaskRunRecord) -> bool {
+    record.state == AgentTaskRunState::Running
+        && record.metadata["provider_executions"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|execution| execution["state"].as_str() == Some("running"))
+}
+
+/// Read metadata for the finite stream references recorded at provider launch.
+/// No provider content is opened and no artifact directory is enumerated.
+fn live_provider_liveness(
+    record: &AgentTaskRunRecord,
+    plan: Option<&AgentTaskPlan>,
+    now: DateTime<Utc>,
+) -> Option<ControlPlaneLiveness> {
+    if record.state != AgentTaskRunState::Running {
+        return None;
+    }
+    let executions = record.metadata["provider_executions"].as_array()?;
+    let execution = executions
+        .iter()
+        .rev()
+        .find(|execution| execution["state"].as_str() == Some("running"))?;
+    let window_seconds = execution
+        .get("task_id")
+        .and_then(Value::as_str)
+        .and_then(|task_id| {
+            plan.and_then(|plan| {
+                plan.tasks
+                    .iter()
+                    .find(|task| task.task_id == task_id)
+                    .and_then(|task| task.limits.liveness_timeout_ms)
+            })
+        })
+        .map(|milliseconds| milliseconds.saturating_add(999) / 1_000)
+        .unwrap_or_else(|| {
+            crate::agent_task_timeout::effective_provider_liveness_timeout_ms(None)
+                .saturating_add(999)
+                / 1_000
+        });
+    let mut observations = Vec::new();
+    for (source, fields) in [
+        ("structured_progress", ["structured_progress"].as_slice()),
+        ("runtime_output", ["stdout", "stderr"].as_slice()),
+    ] {
+        for field in fields {
+            if let Some(observed_at) = execution
+                .pointer(&format!("/runtime_evidence/{field}"))
+                .and_then(Value::as_str)
+                .and_then(observed_file_timestamp)
+            {
+                observations.push((source, observed_at));
+            }
+        }
+    }
+    if let Some(observed_at) = execution
+        .get("workspace_activity_observed_at")
+        .and_then(Value::as_str)
+        .and_then(parse_timestamp)
+    {
+        observations.push(("workspace_activity", observed_at));
+    }
+    let started_at = execution
+        .get("started_at")
+        .and_then(Value::as_str)
+        .and_then(parse_timestamp);
+    let latest = observations
+        .into_iter()
+        .max_by_key(|(_, observed_at)| *observed_at);
+    let (source, observed_at) = match latest {
+        Some((source, observed_at)) => (Some(source.to_string()), Some(observed_at)),
+        None => (None, started_at),
+    };
+    let age_seconds = observed_at
+        .map(|observed_at| now.signed_duration_since(observed_at).num_seconds().max(0) as u64)
+        .unwrap_or(u64::MAX);
+    Some(ControlPlaneLiveness {
+        state: if age_seconds <= window_seconds {
+            "active"
+        } else {
+            "silent"
+        }
+        .to_string(),
+        source,
+        last_observed_progress_at: observed_at.map(|observed_at| observed_at.to_rfc3339()),
+        age_seconds,
+        window_seconds,
+    })
+}
+
+fn observed_file_timestamp(uri: &str) -> Option<DateTime<Utc>> {
+    let path = uri.strip_prefix("file://")?;
+    let metadata = std::fs::metadata(Path::new(path)).ok()?;
+    let modified = metadata.modified().ok()?;
+    Some(DateTime::<Utc>::from(modified))
+}
+
+fn parse_timestamp(timestamp: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(timestamp)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+}
+
+fn newest_timestamp(existing: Option<&str>, observed: Option<&str>) -> Option<String> {
+    match (
+        existing.and_then(parse_timestamp),
+        observed.and_then(parse_timestamp),
+    ) {
+        (Some(existing), Some(observed)) => Some(existing.max(observed).to_rfc3339()),
+        (Some(existing), None) => Some(existing.to_rfc3339()),
+        (None, Some(observed)) => Some(observed.to_rfc3339()),
+        (None, None) => None,
+    }
 }
 
 fn blocker(record: &AgentTaskRunRecord) -> Option<ControlPlaneBlocker> {
@@ -1304,8 +1434,8 @@ pub fn register() {
 #[cfg(test)]
 mod tests {
     use super::{
-        event_page, project_record, LifecycleStoreLookup, OrchestrationService, RunLookup,
-        RunSnapshot,
+        event_page, live_provider_liveness, observed_file_timestamp, phase, project_record,
+        LifecycleStoreLookup, OrchestrationService, RunLookup, RunSnapshot,
     };
     use crate::agent_task_lifecycle::{
         AgentTaskLifecycleStore, AgentTaskRunRecord, AgentTaskRunState,
@@ -1415,6 +1545,118 @@ mod tests {
             artifacts: Vec::new(),
             evidence: Vec::new(),
         }
+    }
+
+    #[test]
+    fn live_provider_liveness_projects_newer_structured_progress_without_reading_content() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_output = temp.path().join("provider-runtime-stdout.log");
+        let structured_progress = temp.path().join("provider-progress.jsonl");
+        std::fs::write(&runtime_output, "runtime output").expect("runtime output");
+        std::fs::write(&structured_progress, "provider-secret-content").expect("progress");
+        let runtime_output_at = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000);
+        let structured_progress_at = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_005);
+        std::fs::File::open(&runtime_output)
+            .expect("open runtime output")
+            .set_times(std::fs::FileTimes::new().set_modified(runtime_output_at))
+            .expect("set runtime output timestamp");
+        std::fs::File::open(&structured_progress)
+            .expect("open structured progress")
+            .set_times(std::fs::FileTimes::new().set_modified(structured_progress_at))
+            .expect("set structured progress timestamp");
+        let observed_at =
+            observed_file_timestamp(&format!("file://{}", structured_progress.display()))
+                .expect("structured progress timestamp");
+        let mut record = record(AGENT_TASK_RUN);
+        record.state = AgentTaskRunState::Running;
+        record.updated_at = Some("1970-01-01T00:00:01Z".to_string());
+        record.metadata["provider_executions"] = json!([{
+            "task_id": "review",
+            "state": "running",
+            "started_at": "2020-01-01T00:00:00Z",
+            "runtime_evidence": {
+                "stdout": format!("file://{}", runtime_output.display()),
+                "structured_progress": format!("file://{}", structured_progress.display()),
+            },
+        }]);
+
+        let liveness =
+            live_provider_liveness(&record, None, observed_at + chrono::Duration::seconds(5))
+                .expect("running provider liveness");
+
+        assert_eq!(liveness.state, "active");
+        assert_eq!(liveness.source.as_deref(), Some("structured_progress"));
+        assert_eq!(
+            liveness.last_observed_progress_at.as_deref(),
+            Some(observed_at.to_rfc3339().as_str())
+        );
+        assert_eq!(liveness.age_seconds, 5);
+        assert_eq!(phase(&record).as_deref(), Some("provider_execution"));
+        assert!(!serde_json::to_string(&liveness)
+            .expect("liveness JSON")
+            .contains("provider-secret-content"));
+
+        let resource = project_record(&record, None).expect("project running record");
+        assert_eq!(
+            resource.updated_at.as_deref(),
+            Some(observed_at.to_rfc3339().as_str())
+        );
+    }
+
+    #[test]
+    fn silent_provider_becomes_silent_after_its_liveness_window() {
+        let mut record = record(AGENT_TASK_RUN);
+        record.state = AgentTaskRunState::Running;
+        record.metadata["provider_executions"] = json!([{
+            "task_id": "review",
+            "state": "running",
+            "started_at": "2020-01-01T00:00:00Z",
+        }]);
+
+        let liveness = live_provider_liveness(
+            &record,
+            None,
+            chrono::DateTime::parse_from_rfc3339("2020-01-02T00:00:00Z")
+                .expect("timestamp")
+                .with_timezone(&chrono::Utc),
+        )
+        .expect("running provider liveness");
+
+        assert_eq!(liveness.state, "silent");
+        assert_eq!(liveness.source, None);
+        assert_eq!(
+            liveness.last_observed_progress_at.as_deref(),
+            Some("2020-01-01T00:00:00+00:00")
+        );
+        assert!(liveness.age_seconds > liveness.window_seconds);
+    }
+
+    #[test]
+    fn live_provider_liveness_uses_durable_workspace_activity() {
+        let mut record = record(AGENT_TASK_RUN);
+        record.state = AgentTaskRunState::Running;
+        record.metadata["provider_executions"] = json!([{
+            "task_id": "review",
+            "state": "running",
+            "started_at": "2020-01-01T00:00:00Z",
+            "workspace_activity_observed_at": "2020-01-01T00:00:05Z",
+        }]);
+
+        let liveness = live_provider_liveness(
+            &record,
+            None,
+            chrono::DateTime::parse_from_rfc3339("2020-01-01T00:00:10Z")
+                .expect("timestamp")
+                .with_timezone(&chrono::Utc),
+        )
+        .expect("running provider liveness");
+
+        assert_eq!(liveness.state, "active");
+        assert_eq!(liveness.source.as_deref(), Some("workspace_activity"));
+        assert_eq!(
+            liveness.last_observed_progress_at.as_deref(),
+            Some("2020-01-01T00:00:05+00:00")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- project current provider liveness from bounded structured progress evidence
- keep provider process and workspace activity attributed to the owning run
- avoid freezing status at provider startup while retaining bounded reads

Closes #13737

## Verification
- `cargo test -p homeboy-agents live_provider_liveness_projects_newer_structured_progress_without_reading_content -j1`
- `cargo check -p homeboy-agents --tests -j1`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## AI Assistance
Implemented and reviewed with OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode. AI was used to trace durable liveness evidence, correct projection semantics, add regression coverage, and verify the branch.