### PR TITLE
Derive release actions from the extension catalog

### DIFF
--- a/crates/homeboy-release/src/release/cascade.rs
+++ b/crates/homeboy-release/src/release/cascade.rs
@@ -277,13 +277,8 @@ fn find_update_dependency_extension(downstream: &Component) -> Result<String> {
     let extensions = super::context::resolve_extensions(downstream)?;
     extensions
         .into_iter()
-        .find(|manifest| {
-            manifest
-                .actions
-                .iter()
-                .any(|action| action.id == UPDATE_DEPENDENCY_ACTION)
-        })
-        .map(|manifest| manifest.id)
+        .find(|extension| extension.provides_action(UPDATE_DEPENDENCY_ACTION))
+        .map(|extension| extension.id)
         .ok_or_else(|| {
             Error::validation_invalid_argument(
                 "cascade.update_dependency",

--- a/crates/homeboy-release/src/release/context.rs
+++ b/crates/homeboy-release/src/release/context.rs
@@ -1,7 +1,13 @@
 use homeboy_core::component::{self, Component};
 use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_core::{self};
-use homeboy_extension_contract::ExtensionManifest;
+use homeboy_extension_contract::api::v1::{
+    ExtensionApiCatalogEntryStatus, ExtensionApiCatalogRequest, ACTION_CAPABILITY_PREFIX,
+    EXTENSION_API_CATALOG_REQUEST_SCHEMA, EXTENSION_API_V1,
+};
+use homeboy_extension_contract::manifest_capability_config::ReleasePreflightConfig;
+use homeboy_extension_contract::HookEvent;
+use std::collections::BTreeSet;
 
 use super::types::{ReleaseOptions, ReleaseReadinessProvenance};
 
@@ -11,19 +17,107 @@ pub(crate) fn load_component(component_id: &str, options: &ReleaseOptions) -> Re
     component::resolve_effective(Some(component_id), options.path_override.as_deref(), None)
 }
 
-/// Resolve the component's declared extensions for release dispatch.
-pub(super) fn resolve_extensions(component: &Component) -> Result<Vec<ExtensionManifest>> {
+/// Release's bounded view of a configured extension.
+///
+/// Action ownership comes only from the versioned Extension API descriptor.
+/// Release-preflight declarations are local release policy, not public API data.
+#[derive(Debug, Clone, Default)]
+pub(super) struct ReleaseExtension {
+    pub(super) id: String,
+    action_ids: BTreeSet<String>,
+    pub(super) release_preflights: Vec<ReleasePreflightConfig>,
+    pub(super) post_release_hooks: Vec<String>,
+}
+
+impl ReleaseExtension {
+    pub(super) fn provides_action(&self, action_id: &str) -> bool {
+        self.action_ids.contains(action_id)
+    }
+
+    #[cfg(test)]
+    pub(super) fn from_manifest(manifest: &homeboy_extension_contract::ExtensionManifest) -> Self {
+        Self {
+            id: manifest.id.clone(),
+            action_ids: manifest
+                .actions
+                .iter()
+                .map(|action| action.id.clone())
+                .collect(),
+            release_preflights: manifest.release_preflights.clone(),
+            post_release_hooks: manifest
+                .hooks
+                .get(&HookEvent::PostRelease)
+                .cloned()
+                .unwrap_or_default(),
+        }
+    }
+}
+
+/// Resolve the component's declared extensions from one Extension API v1 catalog snapshot.
+pub(super) fn resolve_extensions(component: &Component) -> Result<Vec<ReleaseExtension>> {
     let mut extensions = Vec::new();
     if let Some(configured) = component.extensions.as_ref() {
         let mut extension_ids: Vec<String> = configured.keys().cloned().collect();
         extension_ids.sort();
-        let suggestions = homeboy_core::extension::catalog::available_extension_ids();
+        let catalog = homeboy_core::extension::catalog::list_api(&ExtensionApiCatalogRequest {
+            schema: EXTENSION_API_CATALOG_REQUEST_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+        });
+        if let Some(failure) = catalog.failure {
+            return Err(Error::validation_invalid_argument(
+                "extension_api",
+                failure.message,
+                None,
+                None,
+            ));
+        }
+        let suggestions: Vec<String> = catalog
+            .entries
+            .iter()
+            .map(|entry| entry.id.clone())
+            .collect();
         for extension_id in extension_ids {
-            let manifest = homeboy_core::extension::catalog::load_extension(&extension_id)
-                .map_err(|_| {
+            let entry = catalog
+                .entries
+                .iter()
+                .find(|entry| entry.id == extension_id)
+                .ok_or_else(|| {
                     Error::extension_not_found(extension_id.to_string(), suggestions.clone())
                 })?;
-            extensions.push(manifest);
+            if entry.status != ExtensionApiCatalogEntryStatus::Available {
+                return Err(Error::validation_invalid_argument(
+                    "extensions",
+                    format!(
+                        "Configured extension '{}' is not available through Extension API v1",
+                        extension_id
+                    ),
+                    Some(extension_id),
+                    None,
+                ));
+            }
+            let descriptor = entry.descriptor.as_ref().ok_or_else(|| {
+                Error::internal_unexpected(format!(
+                    "Extension API v1 catalog entry '{}' is missing its descriptor",
+                    entry.id
+                ))
+            })?;
+            // Preflight metadata is intentionally kept out of the public catalog.
+            let manifest = homeboy_core::extension::catalog::load_extension(&entry.id)?;
+            extensions.push(ReleaseExtension {
+                id: descriptor.identity.id.clone(),
+                action_ids: descriptor
+                    .capabilities
+                    .iter()
+                    .filter_map(|capability| capability.id.strip_prefix(ACTION_CAPABILITY_PREFIX))
+                    .map(str::to_string)
+                    .collect(),
+                release_preflights: manifest.release_preflights,
+                post_release_hooks: manifest
+                    .hooks
+                    .get(&HookEvent::PostRelease)
+                    .cloned()
+                    .unwrap_or_default(),
+            });
         }
     }
     Ok(extensions)
@@ -53,16 +147,18 @@ pub fn readiness_provenance(component: &Component) -> Result<ReleaseReadinessPro
         }
     }
     for extension in resolve_extensions(component)? {
-        let path = extension.extension_path.as_deref().ok_or_else(|| {
+        // Installation paths remain private to provenance hashing.
+        let manifest = homeboy_core::extension::catalog::load_extension(&extension.id)?;
+        let path = manifest.extension_path.as_deref().ok_or_else(|| {
             Error::internal_unexpected(format!(
                 "resolved extension '{}' has no materialized path",
-                extension.id
+                manifest.id
             ))
         })?;
-        let manifest = std::path::Path::new(path).join(format!("{}.json", extension.id));
-        let revision =
-            homeboy_engine_primitives::content_hash::sha256_file(&manifest).map_err(|error| {
-                Error::internal_io(error.to_string(), Some(manifest.display().to_string()))
+        let manifest_path = std::path::Path::new(path).join(format!("{}.json", manifest.id));
+        let revision = homeboy_engine_primitives::content_hash::sha256_file(&manifest_path)
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(manifest_path.display().to_string()))
             })?;
         provenance
             .extensions
@@ -75,7 +171,8 @@ pub fn readiness_provenance(component: &Component) -> Result<ReleaseReadinessPro
 mod tests {
     use super::{load_component, resolve_extensions};
     use crate::release::types::ReleaseOptions;
-    use homeboy_core::component::Component;
+    use homeboy_core::component::{Component, ScopedExtensionConfig};
+    use homeboy_extension_contract::ExtensionManifest;
 
     #[test]
     fn test_load_component() {
@@ -132,5 +229,44 @@ mod tests {
         let extensions = resolve_extensions(&component).expect("missing extensions are optional");
 
         assert!(extensions.is_empty());
+    }
+
+    #[test]
+    fn resolve_extensions_derives_actions_from_the_api_catalog() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+                "name": "Registry",
+                "version": "1.0.0",
+                "actions": [{
+                    "id": "release.publish",
+                    "label": "Publish release",
+                    "type": "command",
+                    "command": "true"
+                }],
+                "release_preflights": [{
+                    "id": "publish_token",
+                    "label": "Validate publish token",
+                    "action": "release.preflight.publish-token"
+                }]
+            }))
+            .expect("extension manifest");
+            manifest.id = "registry".to_string();
+            homeboy_core::extension::catalog::save_manifest(&manifest)
+                .expect("save extension manifest");
+            let component = Component {
+                extensions: Some(std::collections::HashMap::from([(
+                    "registry".to_string(),
+                    ScopedExtensionConfig::default(),
+                )])),
+                ..Component::default()
+            };
+
+            let extensions = resolve_extensions(&component).expect("resolve extensions");
+
+            assert_eq!(extensions.len(), 1);
+            assert!(extensions[0].provides_action("release.publish"));
+            assert!(!extensions[0].provides_action("release.package"));
+            assert_eq!(extensions[0].release_preflights.len(), 1);
+        });
     }
 }

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -1,17 +1,17 @@
+use super::context::ReleaseExtension;
 use crate::release::executor;
 use crate::release::types::{ReleaseOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus};
 use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
 use homeboy_core::plan::{PlanStep, PlanStepStatus};
-use homeboy_extension_contract::ExtensionManifest;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::process::Command;
 
 pub(super) struct ReleaseExecutionContext<'a> {
     pub(super) component: &'a Component,
-    pub(super) extensions: &'a [ExtensionManifest],
+    pub(super) extensions: &'a [ReleaseExtension],
     pub(super) component_id: &'a str,
     pub(super) options: &'a ReleaseOptions,
     /// Homeboy roots resolved once for the whole plan by
@@ -1046,6 +1046,7 @@ mod tests {
         release_step_is_plan_only, release_step_is_show_stopper,
         release_step_unexpected_dirty_files, tracked_dirty_snapshot, ReleaseExecutionContext,
     };
+    use crate::release::context::ReleaseExtension;
     use crate::release::types::{
         ReleaseOptions, ReleasePipelineOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus,
     };
@@ -1122,7 +1123,7 @@ mod tests {
                 ..Component::default()
             };
             let options = ReleaseOptions::default();
-            let extensions = vec![extension];
+            let extensions = vec![ReleaseExtension::from_manifest(&extension)];
             let mut context = ReleaseExecutionContext {
                 component: &component,
                 extensions: &extensions,
@@ -1176,7 +1177,7 @@ mod tests {
                 ..Component::default()
             };
             let options = ReleaseOptions::default();
-            let extensions = vec![package];
+            let extensions = vec![ReleaseExtension::from_manifest(&package)];
             let mut context = ReleaseExecutionContext {
                 component: &component,
                 extensions: &extensions,
@@ -1243,7 +1244,7 @@ mod tests {
                 skip_build_validation: true,
                 ..ReleaseOptions::default()
             };
-            let extensions = vec![package];
+            let extensions = vec![ReleaseExtension::from_manifest(&package)];
             let mut context = ReleaseExecutionContext {
                 component: &component,
                 extensions: &extensions,
@@ -1303,7 +1304,7 @@ mod tests {
                 ..Component::default()
             };
             let options = ReleaseOptions::default();
-            let extensions = vec![package];
+            let extensions = vec![ReleaseExtension::from_manifest(&package)];
             let mut context = ReleaseExecutionContext {
                 component: &component,
                 extensions: &extensions,
@@ -1369,7 +1370,7 @@ mod tests {
                 ..Component::default()
             };
             let options = ReleaseOptions::default();
-            let extensions = vec![package];
+            let extensions = vec![ReleaseExtension::from_manifest(&package)];
             let mut context = ReleaseExecutionContext {
                 component: &component,
                 extensions: &extensions,
@@ -1404,7 +1405,7 @@ mod tests {
             );
             homeboy_core::extension::catalog::save_manifest(&package)
                 .expect("replace package extension");
-            let recovery_extensions = vec![package];
+            let recovery_extensions = vec![ReleaseExtension::from_manifest(&package)];
             let mut recovery = ReleaseExecutionContext {
                 component: &component,
                 extensions: &recovery_extensions,
@@ -1462,7 +1463,7 @@ mod tests {
                 ..Component::default()
             };
             let options = ReleaseOptions::default();
-            let extensions = vec![package];
+            let extensions = vec![ReleaseExtension::from_manifest(&package)];
             let mut context = ReleaseExecutionContext {
                 component: &component,
                 extensions: &extensions,
@@ -2017,7 +2018,7 @@ mod tests {
                 ..Default::default()
             };
             let options = ReleaseOptions::default();
-            let extensions = vec![extension];
+            let extensions = vec![ReleaseExtension::from_manifest(&extension)];
             let mut context = ReleaseExecutionContext {
                 component: &component,
                 extensions: &extensions,

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -553,6 +553,7 @@ mod tests {
 
     use super::package::store_artifacts_from_output;
     use super::{github_release, package_preflight, run_cleanup, run_package, PackageRequest};
+    use crate::release::context::ReleaseExtension;
     use crate::release::types::ReleaseState;
     use crate::release::types::{ReleaseArtifact, ReleaseStepStatus};
     use homeboy_core::component::{Component, ScopedExtensionConfig};
@@ -950,7 +951,7 @@ mod tests {
             };
             let result = run_package(
                 &test_roots(),
-                &[package],
+                &[ReleaseExtension::from_manifest(&package)],
                 &mut state,
                 &component_config,
                 "fixture",
@@ -1021,7 +1022,7 @@ mod tests {
             };
             run_package(
                 &test_roots(),
-                &[package],
+                &[ReleaseExtension::from_manifest(&package)],
                 &mut state,
                 &component,
                 "plugin",
@@ -1151,7 +1152,7 @@ mod tests {
 
             let error = run_package(
                 &test_roots(),
-                &[package],
+                &[ReleaseExtension::from_manifest(&package)],
                 &mut ReleaseState::default(),
                 &Component::default(),
                 "plugin",
@@ -1322,7 +1323,11 @@ mod tests {
             let mut state = crate::release::types::ReleaseState::default();
             let result = run_package(
                 &test_roots(),
-                &[package_a, non_package_extension("docs"), package_b],
+                &[
+                    ReleaseExtension::from_manifest(&package_a),
+                    ReleaseExtension::from_manifest(&non_package_extension("docs")),
+                    ReleaseExtension::from_manifest(&package_b),
+                ],
                 &mut state,
                 &Component::default(),
                 "fixture",
@@ -1362,7 +1367,7 @@ mod tests {
             let mut state = crate::release::types::ReleaseState::default();
             let result = run_package(
                 &test_roots(),
-                &[package],
+                &[ReleaseExtension::from_manifest(&package)],
                 &mut state,
                 &Component::default(),
                 "intelligence-horse-theme",
@@ -1434,7 +1439,7 @@ mod tests {
             let mut state = ReleaseState::default();
             let result = run_package(
                 &test_roots(),
-                &[package],
+                &[ReleaseExtension::from_manifest(&package)],
                 &mut state,
                 &component,
                 "fixture",
@@ -1551,7 +1556,7 @@ mod tests {
             let mut state = ReleaseState::default();
             let err = run_package(
                 &test_roots(),
-                &[package],
+                &[ReleaseExtension::from_manifest(&package)],
                 &mut state,
                 &Component::default(),
                 "fixture",
@@ -1589,7 +1594,10 @@ mod tests {
             let mut state = crate::release::types::ReleaseState::default();
             let err = run_package(
                 &test_roots(),
-                &[package_a, package_b],
+                &[
+                    ReleaseExtension::from_manifest(&package_a),
+                    ReleaseExtension::from_manifest(&package_b),
+                ],
                 &mut state,
                 &Component::default(),
                 "fixture",
@@ -1632,7 +1640,7 @@ mod tests {
             let mut state = crate::release::types::ReleaseState::default();
             let err = run_package(
                 &test_roots(),
-                &[package],
+                &[ReleaseExtension::from_manifest(&package)],
                 &mut state,
                 &Component::default(),
                 "fixture",
@@ -1689,7 +1697,7 @@ mod tests {
             let mut state = crate::release::types::ReleaseState::default();
             let result = run_package(
                 &test_roots(),
-                &[package],
+                &[ReleaseExtension::from_manifest(&package)],
                 &mut state,
                 &Component::default(),
                 "fixture",

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -4,11 +4,12 @@
 //!
 //! Split out of `executor.rs` to keep packaging/payload logic together.
 
+use crate::release::context::ReleaseExtension;
 use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension;
 use homeboy_core::{self};
-use homeboy_extension_contract::{ExtensionCapability, ExtensionManifest};
+use homeboy_extension_contract::ExtensionCapability;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs;
@@ -49,7 +50,7 @@ pub(crate) struct PackageRequest<'a> {
 /// Those children read their own environment by design and must keep doing so.
 pub(crate) fn run_package(
     roots: &homeboy_core::paths::PathRoots,
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     state: &mut ReleaseState,
     component: &Component,
     component_id: &str,
@@ -63,9 +64,9 @@ pub(crate) fn run_package(
     } = request;
     let cleanup_before = package_cleanup_snapshot(component)?;
     let result = (|| {
-        let package_extensions: Vec<&ExtensionManifest> = extensions
+        let package_extensions: Vec<&ReleaseExtension> = extensions
             .iter()
-            .filter(|m| m.actions.iter().any(|a| a.id == "release.package"))
+            .filter(|extension| extension.provides_action("release.package"))
             .collect();
 
         let component_build =
@@ -691,7 +692,7 @@ fn run_package_action_with_retry(
 /// Invoke an extension-declared release preflight action.
 pub(crate) fn run_extension_release_preflight(
     step: &homeboy_core::plan::PlanStep,
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     state: &ReleaseState,
     component_id: &str,
     component_local_path: &str,
@@ -726,11 +727,7 @@ pub(crate) fn run_extension_release_preflight(
         );
     };
 
-    if !extension
-        .actions
-        .iter()
-        .any(|action| action.id == action_id)
-    {
+    if !extension.provides_action(action_id) {
         return step_failed(
             &step.id,
             &step.kind,

--- a/crates/homeboy-release/src/release/executor/prepare.rs
+++ b/crates/homeboy-release/src/release/executor/prepare.rs
@@ -1,21 +1,21 @@
+use crate::release::context::ReleaseExtension;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension;
 use homeboy_core::{self};
-use homeboy_extension_contract::ExtensionManifest;
 
 use super::{build_release_payload, publish_response_output, step_failed, step_success};
 use crate::release::types::{ReleaseState, ReleaseStepResult};
 
 /// Invoke every `release.prepare` action provided by the component's extensions.
 pub(crate) fn run_prepare(
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     state: &ReleaseState,
     component_id: &str,
     component_local_path: &str,
 ) -> Result<ReleaseStepResult> {
-    let providers: Vec<&ExtensionManifest> = extensions
+    let providers: Vec<&ReleaseExtension> = extensions
         .iter()
-        .filter(|m| m.actions.iter().any(|a| a.id == "release.prepare"))
+        .filter(|extension| extension.provides_action("release.prepare"))
         .collect();
 
     if providers.is_empty() {

--- a/crates/homeboy-release/src/release/executor/publish.rs
+++ b/crates/homeboy-release/src/release/executor/publish.rs
@@ -1,17 +1,17 @@
 use homeboy_core::extension;
 use std::fmt::Write;
 
+use crate::release::context::ReleaseExtension;
 use crate::release::types::{ReleaseState, ReleaseStepResult};
 use homeboy_core::component::GithubConfig;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::{self};
-use homeboy_extension_contract::ExtensionManifest;
 
 use super::{build_release_payload, step_failed, step_skipped, step_success};
 
 /// Invoke the `release.publish` action on the named extension.
 pub(crate) fn run_publish(
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     state: &ReleaseState,
     component_id: &str,
     component_local_path: &str,
@@ -31,7 +31,7 @@ pub(crate) fn run_publish(
     })?;
 
     let action_id = "release.publish";
-    let has_action = extension.actions.iter().any(|a| a.id == action_id);
+    let has_action = extension.provides_action(action_id);
     if !has_action {
         return Err(Error::validation_invalid_argument(
             "release.publish",
@@ -434,6 +434,7 @@ fn publish_failure_message(target: &str, response: &serde_json::Value) -> String
 #[cfg(test)]
 mod tests {
     use super::{publish_step_result, run_publish};
+    use crate::release::context::ReleaseExtension;
     use crate::release::types::ReleaseState;
     use crate::release::types::ReleaseStepStatus;
     use homeboy_core::component::{GithubConfig, GithubHostConfig};
@@ -506,7 +507,7 @@ mod tests {
                 .expect("save publish extension");
 
             let result = run_publish(
-                &[publish],
+                &[ReleaseExtension::from_manifest(&publish)],
                 &ReleaseState::default(),
                 "intelligence-horse-theme",
                 &component.path().to_string_lossy(),
@@ -553,7 +554,7 @@ mod tests {
             };
 
             let result = run_publish(
-                &[publish],
+                &[ReleaseExtension::from_manifest(&publish)],
                 &ReleaseState::default(),
                 "intelligence-horse-theme",
                 &component.path().to_string_lossy(),

--- a/crates/homeboy-release/src/release/pipeline_capabilities.rs
+++ b/crates/homeboy-release/src/release/pipeline_capabilities.rs
@@ -1,34 +1,35 @@
-use homeboy_extension_contract::ExtensionManifest;
+use super::context::ReleaseExtension;
 
 /// Derive publish targets from extensions that have `release.publish` action.
-pub(super) fn get_publish_targets(extensions: &[ExtensionManifest]) -> Vec<String> {
+pub(super) fn get_publish_targets(extensions: &[ReleaseExtension]) -> Vec<String> {
     extensions
         .iter()
-        .filter(|m| m.actions.iter().any(|a| a.id == "release.publish"))
+        .filter(|extension| extension.provides_action("release.publish"))
         .map(|m| m.id.clone())
         .collect()
 }
 
 /// Check if any extension provides the `release.package` action.
-pub(super) fn has_package_capability(extensions: &[ExtensionManifest]) -> bool {
+pub(super) fn has_package_capability(extensions: &[ReleaseExtension]) -> bool {
     extensions
         .iter()
-        .any(|m| m.actions.iter().any(|a| a.id == "release.package"))
+        .any(|extension| extension.provides_action("release.package"))
 }
 
 /// Check if any extension provides the `release.prepare` action.
-pub(super) fn has_prepare_capability(extensions: &[ExtensionManifest]) -> bool {
+pub(super) fn has_prepare_capability(extensions: &[ReleaseExtension]) -> bool {
     extensions
         .iter()
-        .any(|m| m.actions.iter().any(|a| a.id == "release.prepare"))
+        .any(|extension| extension.provides_action("release.prepare"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{get_publish_targets, has_package_capability, has_prepare_capability};
+    use crate::release::context::ReleaseExtension;
     use homeboy_extension_contract::ExtensionManifest;
 
-    fn extension(id: &str, actions: &[&str]) -> ExtensionManifest {
+    fn extension(id: &str, actions: &[&str]) -> ReleaseExtension {
         let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
             "name": id,
             "version": "1.0.0",
@@ -41,7 +42,7 @@ mod tests {
         }))
         .expect("extension manifest");
         manifest.id = id.to_string();
-        manifest
+        ReleaseExtension::from_manifest(&manifest)
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/plan_steps/preflight.rs
+++ b/crates/homeboy-release/src/release/plan_steps/preflight.rs
@@ -1,15 +1,15 @@
 use super::builders::{disabled_step, ready_step, string_config, StepConfig};
+use crate::release::context::ReleaseExtension;
 use crate::release::types::{ReleaseOptions, ReleaseSemverRecommendation};
 use homeboy_core::plan::PlanStep;
 use homeboy_core::quality::{
     build_quality_steps as build_shared_quality_steps, QualityPlanOptions,
 };
-use homeboy_extension_contract::ExtensionManifest;
 
 pub(in crate::release) fn build_preflight_steps(
     options: &ReleaseOptions,
     semver_recommendation: Option<&ReleaseSemverRecommendation>,
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
 ) -> Vec<PlanStep> {
     let default_branch_step = if options.pipeline.head {
         disabled_step(
@@ -216,7 +216,7 @@ fn quality_plan_options(options: &ReleaseOptions) -> QualityPlanOptions {
     quality.with_granular_skips(&options.skip_checks_granular)
 }
 
-fn build_extension_release_preflight_steps(extensions: &[ExtensionManifest]) -> Vec<PlanStep> {
+fn build_extension_release_preflight_steps(extensions: &[ReleaseExtension]) -> Vec<PlanStep> {
     extensions
         .iter()
         .flat_map(|extension| {

--- a/crates/homeboy-release/src/release/plan_steps/release.rs
+++ b/crates/homeboy-release/src/release/plan_steps/release.rs
@@ -1,6 +1,7 @@
 use super::builders::{disabled_step, ready_step, string_array_config, string_config, StepConfig};
 use super::changelog::build_changelog_steps;
 use super::hints::{github_release_applies, push_publish_vs_github_release_hints};
+use crate::release::context::ReleaseExtension;
 use crate::release::pipeline_capabilities::{
     get_publish_targets, has_package_capability, has_prepare_capability,
 };
@@ -9,11 +10,11 @@ use crate::release::types::{ReleaseChangelogPlan, ReleaseOptions};
 use homeboy_core::component::Component;
 use homeboy_core::plan::PlanStep;
 use homeboy_core::Result;
-use homeboy_extension_contract::{ExtensionCapability, ExtensionManifest};
+use homeboy_extension_contract::ExtensionCapability;
 
 pub(in crate::release) fn build_release_steps_with_reconciliation(
     component: &Component,
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     current_version: &str,
     new_version: &str,
     changelog_plan: &ReleaseChangelogPlan,
@@ -235,11 +236,16 @@ pub(in crate::release) fn build_release_steps_with_reconciliation(
         ));
     }
 
-    let post_release_hooks = homeboy_core::engine::hooks::resolve_hooks_with_extensions(
-        component,
-        extensions,
-        homeboy_extension_contract::HookEvent::PostRelease,
-    )?;
+    let mut post_release_hooks = extensions
+        .iter()
+        .flat_map(|extension| extension.post_release_hooks.iter().cloned())
+        .collect::<Vec<_>>();
+    if let Some(component_hooks) = component
+        .hooks
+        .get(&homeboy_extension_contract::HookEvent::PostRelease)
+    {
+        post_release_hooks.extend(component_hooks.clone());
+    }
     if !post_release_hooks.is_empty() {
         let post_release_needs = if package_step_needed && !options.pipeline.deploy {
             vec!["cleanup".to_string()]
@@ -291,7 +297,7 @@ pub(in crate::release) fn build_release_steps_with_reconciliation(
 
 fn build_head_release_steps(
     component: &Component,
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     version: &str,
     options: &ReleaseOptions,
     release_scope: &ReleaseScope,
@@ -403,10 +409,16 @@ fn build_head_release_steps(
         ));
     }
 
-    let post_release_hooks = homeboy_core::engine::hooks::resolve_hooks(
-        component,
-        homeboy_extension_contract::HookEvent::PostRelease,
-    )?;
+    let mut post_release_hooks = extensions
+        .iter()
+        .flat_map(|extension| extension.post_release_hooks.iter().cloned())
+        .collect::<Vec<_>>();
+    if let Some(component_hooks) = component
+        .hooks
+        .get(&homeboy_extension_contract::HookEvent::PostRelease)
+    {
+        post_release_hooks.extend(component_hooks.clone());
+    }
     if !post_release_hooks.is_empty() {
         let post_release_needs = if package_step_needed && !options.pipeline.deploy {
             vec!["cleanup".to_string()]
@@ -463,7 +475,7 @@ fn build_head_release_steps(
 fn add_package_preflight_step(
     steps: &mut Vec<PlanStep>,
     component: &Component,
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     publish_targets: &[String],
     options: &ReleaseOptions,
     github_release_needed: bool,
@@ -496,7 +508,7 @@ fn github_release_needed(component: &Component, options: &ReleaseOptions) -> boo
 
 fn package_step_needed(
     component: &Component,
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     publish_targets: &[String],
     options: &ReleaseOptions,
     github_release_needed: bool,
@@ -510,7 +522,7 @@ fn package_step_needed(
 
 fn head_package_step_needed(
     component: &Component,
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     publish_targets: &[String],
     options: &ReleaseOptions,
 ) -> bool {
@@ -543,7 +555,7 @@ fn add_disabled_publish_steps(steps: &mut Vec<PlanStep>, publish_targets: &[Stri
 
 fn add_release_extension_diagnostics(
     component: &Component,
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     publish_targets: &[String],
     options: &ReleaseOptions,
     warnings: &mut Vec<String>,
@@ -570,11 +582,10 @@ fn add_release_extension_diagnostics(
     let loaded = extensions
         .iter()
         .map(|extension| {
-            let mut action_ids: Vec<&str> = extension
-                .actions
-                .iter()
-                .map(|action| action.id.as_str())
-                .collect();
+            let mut action_ids = ["release.prepare", "release.package", "release.publish"]
+                .into_iter()
+                .filter(|action| extension.provides_action(action))
+                .collect::<Vec<_>>();
             action_ids.sort_unstable();
             format!("{} [{}]", extension.id, action_ids.join(", "))
         })
@@ -594,13 +605,12 @@ fn add_release_extension_diagnostics(
 
 fn configured_extension_has_release_actions(
     configured_ids: &[String],
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
 ) -> bool {
     extensions.iter().any(|extension| {
         configured_ids.iter().any(|id| id == &extension.id)
-            && extension
-                .actions
-                .iter()
-                .any(|action| action.id.starts_with("release."))
+            && ["release.prepare", "release.package", "release.publish"]
+                .into_iter()
+                .any(|action| extension.provides_action(action))
     })
 }

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::hints::{github_release_applies, push_publish_vs_github_release_hints};
 use super::preflight::build_preflight_steps;
 use super::release::build_release_steps_with_reconciliation;
+use crate::release::context::ReleaseExtension;
 use crate::release::scope::ReleaseScope;
 use crate::release::types::{
     ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleasePipelineOptions,
@@ -16,7 +17,7 @@ use homeboy_extension_contract::ExtensionManifest;
 #[allow(clippy::too_many_arguments)]
 fn build_release_steps(
     component: &Component,
-    extensions: &[ExtensionManifest],
+    extensions: &[ReleaseExtension],
     current_version: &str,
     new_version: &str,
     changelog_plan: &ReleaseChangelogPlan,
@@ -165,7 +166,11 @@ fn release_plan_adds_extension_declared_release_preflight() {
     .expect("extension manifest");
     extension.id = "registry".to_string();
 
-    let steps = build_preflight_steps(&options, None, &[extension]);
+    let steps = build_preflight_steps(
+        &options,
+        None,
+        &[ReleaseExtension::from_manifest(&extension)],
+    );
     let token = steps
         .iter()
         .find(|step| step.id == "preflight.extension.registry.publish_token")
@@ -558,7 +563,7 @@ fn release_plan_records_dry_run_lower_bump_preview() {
 #[test]
 fn test_build_release_steps() {
     let component = fixture_component();
-    let extension = serde_json::from_value(serde_json::json!({
+    let extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
         "name": "Fixture",
         "version": "1.0.0",
         "actions": [
@@ -581,7 +586,7 @@ fn test_build_release_steps() {
 
     let steps = build_release_steps(
         &component,
-        &[extension],
+        &[ReleaseExtension::from_manifest(&extension)],
         "1.0.0",
         "1.0.1",
         &fixture_changelog_plan(),
@@ -664,7 +669,7 @@ fn release_plan_runs_package_preflight_before_mutating_release_steps() {
 
         let steps = build_release_steps(
             &component,
-            &[extension],
+            &[ReleaseExtension::from_manifest(&extension)],
             "1.0.0",
             "1.0.1",
             &fixture_changelog_plan(),
@@ -1132,7 +1137,7 @@ fn head_release_plan_skips_mutation_steps_and_uses_existing_artifacts() {
 
     let steps = build_release_steps(
         &component,
-        &[extension],
+        &[ReleaseExtension::from_manifest(&extension)],
         "1.0.1",
         "1.0.1",
         &fixture_changelog_plan(),
@@ -1245,7 +1250,7 @@ fn head_release_skip_publish_still_uploads_existing_artifacts() {
 
     let steps = build_release_steps(
         &component,
-        &[extension],
+        &[ReleaseExtension::from_manifest(&extension)],
         "1.0.1",
         "1.0.1",
         &fixture_changelog_plan(),
@@ -1278,8 +1283,6 @@ fn release_plan_warns_when_configured_extensions_have_no_publish_action() {
             ScopedExtensionConfig::default(),
         )]));
         let extension = release_extension("wordpress", &["release.package"]);
-        homeboy_core::extension::catalog::save_manifest(&extension)
-            .expect("install extension manifest");
         let mut warnings = Vec::new();
         let mut hints = Vec::new();
         let release_scope =
@@ -1440,7 +1443,7 @@ fn fixture_changelog_plan() -> ReleaseChangelogPlan {
     }
 }
 
-fn release_extension(id: &str, actions: &[&str]) -> ExtensionManifest {
+fn release_extension(id: &str, actions: &[&str]) -> ReleaseExtension {
     let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
         "name": id,
         "version": "1.0.0",
@@ -1453,7 +1456,7 @@ fn release_extension(id: &str, actions: &[&str]) -> ExtensionManifest {
     }))
     .expect("extension manifest");
     extension.id = id.to_string();
-    extension
+    ReleaseExtension::from_manifest(&extension)
 }
 
 fn semver_recommendation(


### PR DESCRIPTION
## Summary
- compile one canonical release extension inventory from the API catalog
- derive package, prepare, publish, preflight, and dependency actions from that inventory
- remove duplicated manifest interpretation across release planning and execution

Closes #14191

## Verification
- `cargo test -p homeboy-release resolve_extensions_derives_actions_from_the_api_catalog -j1`
- `cargo check -p homeboy-release --tests -j1`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## AI Assistance
Implemented and reviewed with OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode. AI was used to audit release extension consumers, consolidate catalog resolution, migrate tests, and verify the branch.