### PR TITLE
Type Runner API workspace authority sidecars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,7 @@ dependencies = [
 name = "homeboy-runner-contract"
 version = "0.1.0"
 dependencies = [
+ "homeboy-error",
  "homeboy-redaction",
  "homeboy-source-snapshot-contract",
  "serde",

--- a/crates/contracts/homeboy-runner-contract/Cargo.toml
+++ b/crates/contracts/homeboy-runner-contract/Cargo.toml
@@ -10,5 +10,6 @@ publish = false
 [dependencies]
 homeboy-source-snapshot-contract = { version = "0.1.0", path = "../homeboy-source-snapshot-contract" }
 homeboy-redaction = { version = "0.1.0", path = "../../homeboy-redaction" }
+homeboy-error = { version = "0.1.0", path = "../../homeboy-error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -16,6 +16,7 @@ pub mod secret_env_plan;
 mod session;
 mod submission;
 mod workspace;
+mod workspace_authority;
 
 pub use artifact::{RunnerArtifactRef, RunnerMutationArtifacts};
 pub use capability::{
@@ -54,6 +55,12 @@ pub use submission::{
 };
 pub use workspace::{
     ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceLease, RunnerWorkspaceSyncMode,
+};
+pub use workspace_authority::{
+    WorkspaceClaim, WorkspaceClaimBinding, WorkspaceClaimProtocol, WorkspaceIdentity,
+    WorkspaceOwnerLease, WorkspaceOwnerLeaseProtocol, WORKSPACE_CLAIM_CAPABILITY,
+    WORKSPACE_CLAIM_PROTOCOL_VERSION, WORKSPACE_CLAIM_SCHEMA, WORKSPACE_IDENTITY_SCHEMA,
+    WORKSPACE_OWNER_LEASE_CAPABILITY, WORKSPACE_OWNER_LEASE_SCHEMA,
 };
 
 use serde::{Deserialize, Serialize};

--- a/crates/contracts/homeboy-runner-contract/src/submission.rs
+++ b/crates/contracts/homeboy-runner-contract/src/submission.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
-use crate::{RunnerApiOperationFailure, RunnerApiVersion, RunnerExecutionEnvelope};
+use crate::{
+    RunnerApiOperationFailure, RunnerApiVersion, RunnerExecutionEnvelope, WorkspaceClaimBinding,
+    WorkspaceOwnerLease,
+};
 
 pub const RUNNER_API_SUBMIT_REQUEST_SCHEMA: &str = "homeboy/runner-api-submit-request/v1";
 pub const RUNNER_API_SUBMIT_RESPONSE_SCHEMA: &str = "homeboy/runner-api-submit-response/v1";
@@ -15,9 +17,9 @@ pub struct RunnerApiSubmitRequest {
     pub submission_key: String,
     pub envelope: RunnerExecutionEnvelope,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_claim_binding: Option<Value>,
+    pub workspace_claim_binding: Option<WorkspaceClaimBinding>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_owner_lease: Option<Value>,
+    pub workspace_owner_lease: Option<WorkspaceOwnerLease>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -38,7 +40,11 @@ pub enum RunnerApiSubmitOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{RunnerApiOperationFailureCode, RUNNER_API_V1};
+    use crate::{
+        RunnerApiOperationFailureCode, WorkspaceClaim, WorkspaceClaimProtocol, WorkspaceIdentity,
+        WorkspaceOwnerLeaseProtocol, RUNNER_API_V1, WORKSPACE_CLAIM_SCHEMA,
+        WORKSPACE_OWNER_LEASE_SCHEMA,
+    };
 
     #[test]
     fn submit_request_has_a_strict_versioned_wire_shape() {
@@ -62,6 +68,50 @@ mod tests {
                 "unexpected": true,
             }))
             .is_err()
+        );
+    }
+
+    #[test]
+    fn submit_request_authority_sidecars_have_canonical_wire_shapes() {
+        let workspace = WorkspaceIdentity::new("managed-workspace", "repo@task").unwrap();
+        let request = RunnerApiSubmitRequest {
+            schema: RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            submission_key: "agent-task:v1:lab:run-1".to_string(),
+            envelope: RunnerExecutionEnvelope::planned("run-1", "test"),
+            workspace_claim_binding: Some(WorkspaceClaimBinding {
+                workspace: workspace.clone(),
+                lifecycle_revision: 7,
+                claim: Some(WorkspaceClaim {
+                    schema: WORKSPACE_CLAIM_SCHEMA.to_string(),
+                    protocol: WorkspaceClaimProtocol::current(),
+                    workspace: workspace.clone(),
+                    lifecycle_revision: 7,
+                    token: "claim-token".to_string(),
+                    expires_at_ms: 100,
+                }),
+            }),
+            workspace_owner_lease: Some(crate::WorkspaceOwnerLease {
+                schema: WORKSPACE_OWNER_LEASE_SCHEMA.to_string(),
+                protocol: WorkspaceOwnerLeaseProtocol::current(),
+                workspace,
+                owner_id: "runner:one".to_string(),
+                lifecycle_revision: 8,
+                token: "lease-token".to_string(),
+                expires_at_ms: 101,
+            }),
+        };
+
+        let encoded = serde_json::to_value(&request).unwrap();
+        let decoded: RunnerApiSubmitRequest = serde_json::from_value(encoded.clone()).unwrap();
+        assert_eq!(decoded, request);
+        assert_eq!(
+            encoded["workspace_claim_binding"]["claim"]["protocol"],
+            serde_json::json!({ "capability": "workspace-claim", "version": 2 })
+        );
+        assert_eq!(
+            encoded["workspace_owner_lease"]["protocol"],
+            serde_json::json!({ "capability": "workspace-owner-lease", "version": 2 })
         );
     }
 

--- a/crates/contracts/homeboy-runner-contract/src/workspace_authority.rs
+++ b/crates/contracts/homeboy-runner-contract/src/workspace_authority.rs
@@ -1,0 +1,274 @@
+use homeboy_error::{Error, Result};
+use serde::{Deserialize, Serialize};
+
+pub const WORKSPACE_CLAIM_CAPABILITY: &str = "workspace-claim";
+pub const WORKSPACE_OWNER_LEASE_CAPABILITY: &str = "workspace-owner-lease";
+pub const WORKSPACE_CLAIM_PROTOCOL_VERSION: u32 = 2;
+pub const WORKSPACE_IDENTITY_SCHEMA: &str = "homeboy/workspace-identity/v1";
+pub const WORKSPACE_CLAIM_SCHEMA: &str = "homeboy/workspace-claim/v2";
+pub const WORKSPACE_OWNER_LEASE_SCHEMA: &str = "homeboy/workspace-owner-lease/v2";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceClaimProtocol {
+    pub capability: String,
+    pub version: u32,
+}
+
+impl WorkspaceClaimProtocol {
+    pub fn current() -> Self {
+        Self {
+            capability: WORKSPACE_CLAIM_CAPABILITY.into(),
+            version: WORKSPACE_CLAIM_PROTOCOL_VERSION,
+        }
+    }
+
+    pub fn verify(&self) -> Result<()> {
+        (self.capability == WORKSPACE_CLAIM_CAPABILITY
+            && self.version == WORKSPACE_CLAIM_PROTOCOL_VERSION)
+            .then_some(())
+            .ok_or_else(|| {
+                invalid(
+                    "workspace_claim_protocol",
+                    "workspace authority does not advertise the required claim protocol",
+                )
+            })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceOwnerLeaseProtocol {
+    pub capability: String,
+    pub version: u32,
+}
+
+impl WorkspaceOwnerLeaseProtocol {
+    pub fn current() -> Self {
+        Self {
+            capability: WORKSPACE_OWNER_LEASE_CAPABILITY.into(),
+            version: WORKSPACE_CLAIM_PROTOCOL_VERSION,
+        }
+    }
+
+    pub fn verify(&self) -> Result<()> {
+        (self.capability == WORKSPACE_OWNER_LEASE_CAPABILITY
+            && self.version == WORKSPACE_CLAIM_PROTOCOL_VERSION)
+            .then_some(())
+            .ok_or_else(|| {
+                invalid(
+                    "workspace_owner_lease_protocol",
+                    "workspace authority does not advertise the required owner lease protocol",
+                )
+            })
+    }
+}
+
+/// A portable logical locator. Host paths are deliberately excluded.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WorkspaceIdentity {
+    pub schema: String,
+    pub kind: String,
+    pub locator: String,
+}
+
+impl WorkspaceIdentity {
+    pub fn new(kind: impl Into<String>, locator: impl Into<String>) -> Result<Self> {
+        let identity = Self {
+            schema: WORKSPACE_IDENTITY_SCHEMA.into(),
+            kind: kind.into(),
+            locator: locator.into(),
+        };
+        identity.verify()?;
+        Ok(identity)
+    }
+
+    pub fn verify(&self) -> Result<()> {
+        (self.schema == WORKSPACE_IDENTITY_SCHEMA
+            && !self.kind.trim().is_empty()
+            && !self.locator.trim().is_empty()
+            && !self.kind.contains('\n')
+            && !self.locator.contains('\n'))
+        .then_some(())
+        .ok_or_else(|| {
+            invalid(
+                "workspace_identity",
+                "workspace identity is malformed or unsupported",
+            )
+        })
+    }
+}
+
+/// An exclusive short reconciliation fence. `lifecycle_revision` is an
+/// authority-issued monotonically increasing epoch; callers never supply it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceClaim {
+    pub schema: String,
+    pub protocol: WorkspaceClaimProtocol,
+    pub workspace: WorkspaceIdentity,
+    pub lifecycle_revision: u64,
+    pub token: String,
+    pub expires_at_ms: u64,
+}
+
+/// A renewable active-task authority. Several distinct owner identities may be live.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceOwnerLease {
+    pub schema: String,
+    pub protocol: WorkspaceOwnerLeaseProtocol,
+    pub workspace: WorkspaceIdentity,
+    pub owner_id: String,
+    pub lifecycle_revision: u64,
+    pub token: String,
+    pub expires_at_ms: u64,
+}
+
+/// Optional transport binding for a reconciliation operation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceClaimBinding {
+    pub workspace: WorkspaceIdentity,
+    pub lifecycle_revision: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim: Option<WorkspaceClaim>,
+}
+
+impl WorkspaceClaimBinding {
+    pub fn verify(&self) -> Result<()> {
+        self.workspace.verify()?;
+        if let Some(claim) = &self.claim {
+            claim.verify_shape(0)?;
+            if claim.workspace != self.workspace
+                || claim.lifecycle_revision != self.lifecycle_revision
+            {
+                return Err(invalid(
+                    "workspace_claim_binding",
+                    "workspace identity and authority epoch do not agree",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl WorkspaceClaim {
+    pub fn verify_shape(&self, now_ms: u64) -> Result<()> {
+        self.protocol.verify()?;
+        self.workspace.verify()?;
+        (self.schema == WORKSPACE_CLAIM_SCHEMA
+            && !self.token.trim().is_empty()
+            && self.lifecycle_revision > 0
+            && self.expires_at_ms > now_ms)
+            .then_some(())
+            .ok_or_else(|| {
+                invalid(
+                    "workspace_claim",
+                    "workspace reconciliation claim is malformed or expired",
+                )
+            })
+    }
+}
+
+impl WorkspaceOwnerLease {
+    pub fn verify_shape(&self, now_ms: u64) -> Result<()> {
+        self.protocol.verify()?;
+        self.workspace.verify()?;
+        (self.schema == WORKSPACE_OWNER_LEASE_SCHEMA
+            && !self.owner_id.trim().is_empty()
+            && !self.token.trim().is_empty()
+            && self.lifecycle_revision > 0
+            && self.expires_at_ms > now_ms)
+            .then_some(())
+            .ok_or_else(|| {
+                invalid(
+                    "workspace_owner_lease",
+                    "workspace owner lease is malformed or expired",
+                )
+            })
+    }
+}
+
+fn invalid(field: &str, message: &str) -> Error {
+    Error::validation_invalid_argument(field, message, None, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn authority_values_preserve_exact_wire_shapes() {
+        let workspace = WorkspaceIdentity::new("managed-workspace", "repo@task").unwrap();
+        let claim = WorkspaceClaim {
+            schema: WORKSPACE_CLAIM_SCHEMA.into(),
+            protocol: WorkspaceClaimProtocol::current(),
+            workspace: workspace.clone(),
+            lifecycle_revision: 7,
+            token: "claim-token".into(),
+            expires_at_ms: 100,
+        };
+        let lease = WorkspaceOwnerLease {
+            schema: WORKSPACE_OWNER_LEASE_SCHEMA.into(),
+            protocol: WorkspaceOwnerLeaseProtocol::current(),
+            workspace: workspace.clone(),
+            owner_id: "runner:one".into(),
+            lifecycle_revision: 8,
+            token: "lease-token".into(),
+            expires_at_ms: 101,
+        };
+        let binding = WorkspaceClaimBinding {
+            workspace,
+            lifecycle_revision: 7,
+            claim: Some(claim.clone()),
+        };
+
+        assert_eq!(
+            serde_json::to_value(&claim).unwrap(),
+            json!({
+                "schema": "homeboy/workspace-claim/v2",
+                "protocol": { "capability": "workspace-claim", "version": 2 },
+                "workspace": { "schema": "homeboy/workspace-identity/v1", "kind": "managed-workspace", "locator": "repo@task" },
+                "lifecycle_revision": 7,
+                "token": "claim-token",
+                "expires_at_ms": 100,
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(&lease).unwrap(),
+            json!({
+                "schema": "homeboy/workspace-owner-lease/v2",
+                "protocol": { "capability": "workspace-owner-lease", "version": 2 },
+                "workspace": { "schema": "homeboy/workspace-identity/v1", "kind": "managed-workspace", "locator": "repo@task" },
+                "owner_id": "runner:one",
+                "lifecycle_revision": 8,
+                "token": "lease-token",
+                "expires_at_ms": 101,
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(&binding).unwrap(),
+            json!({
+                "workspace": { "schema": "homeboy/workspace-identity/v1", "kind": "managed-workspace", "locator": "repo@task" },
+                "lifecycle_revision": 7,
+                "claim": claim,
+            })
+        );
+    }
+
+    #[test]
+    fn authority_values_round_trip_and_binding_omits_absent_claim() {
+        let binding: WorkspaceClaimBinding = serde_json::from_value(json!({
+            "workspace": { "schema": WORKSPACE_IDENTITY_SCHEMA, "kind": "managed-workspace", "locator": "repo@task" },
+            "lifecycle_revision": 9,
+        }))
+        .unwrap();
+
+        assert_eq!(binding.claim, None);
+        assert_eq!(
+            serde_json::to_value(&binding).unwrap(),
+            json!({
+                "workspace": { "schema": WORKSPACE_IDENTITY_SCHEMA, "kind": "managed-workspace", "locator": "repo@task" },
+                "lifecycle_revision": 9,
+            })
+        );
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -20,6 +20,7 @@ use crate::agent_task_scheduler::{
 };
 use crate::agent_task_secrets::validate_secret_env;
 use homeboy_core::{defaults, worktree, Error, Result};
+use homeboy_runner_contract::WorkspaceIdentity;
 
 use super::agent_task_dispatch_service::{
     initial_provider_route_from_policy, AgentTaskDispatchRequest, AgentTaskModelSelection,
@@ -668,7 +669,7 @@ pub(crate) struct DispatchWorkspaceTarget {
     component_id: Option<String>,
     branch: Option<String>,
     base_ref: Option<String>,
-    workspace_identity: Option<homeboy_core::workspace_claim::WorkspaceIdentity>,
+    workspace_identity: Option<WorkspaceIdentity>,
     pub(crate) metadata: Value,
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use homeboy_core::run_lifecycle_status::RunLifecycleStatus;
+use homeboy_runner_contract::{WorkspaceClaim, WorkspaceIdentity, WorkspaceOwnerLease};
 
 pub(crate) mod schemas {
     pub(crate) const RUN: &str = "homeboy/agent-task-run/v1";
@@ -138,13 +139,13 @@ pub struct AgentTaskRunRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acceptance: Option<AgentTaskAcceptanceRecord>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_identity: Option<homeboy_core::workspace_claim::WorkspaceIdentity>,
+    pub workspace_identity: Option<WorkspaceIdentity>,
     #[serde(default)]
     pub workspace_lifecycle_revision: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_owner_lease: Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>,
+    pub workspace_owner_lease: Option<WorkspaceOwnerLease>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_claim: Option<homeboy_core::workspace_claim::WorkspaceClaim>,
+    pub workspace_claim: Option<WorkspaceClaim>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
 }
@@ -340,13 +341,13 @@ pub struct AgentTaskLabHandoff {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expired_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_identity: Option<homeboy_core::workspace_claim::WorkspaceIdentity>,
+    pub workspace_identity: Option<WorkspaceIdentity>,
     #[serde(default)]
     pub workspace_lifecycle_revision: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_owner_lease: Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>,
+    pub workspace_owner_lease: Option<WorkspaceOwnerLease>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_claim: Option<homeboy_core::workspace_claim::WorkspaceClaim>,
+    pub workspace_claim: Option<WorkspaceClaim>,
 }
 
 /// An immutable runner repair emitted by Lab admission before provider work.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -16,8 +16,7 @@ use homeboy_core::api_jobs::{
     Job, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup, RunnerJobLogSnapshot,
 };
 use homeboy_core::error::{Error, Result};
-use homeboy_core::workspace_claim::{WorkspaceClaim, WorkspaceIdentity};
-use homeboy_runner_contract::RunnerApiSubmitRequest;
+use homeboy_runner_contract::{RunnerApiSubmitRequest, WorkspaceClaim, WorkspaceIdentity};
 
 /// Result of reconciling a runner job across its known daemon generations.
 ///

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -3,14 +3,14 @@
 use super::runner_continuation::with_runner_continuation;
 use super::*;
 use homeboy_core::engine::local_files::{remove_file_durably, write_json_file_owner_only};
-use homeboy_core::workspace_claim::{
-    WorkspaceClaim, WorkspaceClaimBinding, WorkspaceClaimStore, WorkspaceIdentity,
-    WorkspaceOwnerLease, MAX_WORKSPACE_CLAIM_TTL_MS,
-};
+use homeboy_core::workspace_claim::{WorkspaceClaimStore, MAX_WORKSPACE_CLAIM_TTL_MS};
 use homeboy_core::worktree::{
     authority_set_fingerprint, TaskWorktreeRecord, TerminalWorkspaceAuthorityObservation,
     TerminalWorkspaceAuthorityProof, TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY,
     TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
+};
+use homeboy_runner_contract::{
+    WorkspaceClaim, WorkspaceClaimBinding, WorkspaceIdentity, WorkspaceOwnerLease,
 };
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -1378,7 +1378,7 @@ pub(crate) fn identity_for_plan(plan: &AgentTaskPlan) -> Result<Option<Workspace
 mod tests {
     use super::*;
     use homeboy_core::test_support::with_isolated_home;
-    use homeboy_core::workspace_claim::{WorkspaceClaimProtocol, WORKSPACE_CLAIM_SCHEMA};
+    use homeboy_runner_contract::{WorkspaceClaimProtocol, WORKSPACE_CLAIM_SCHEMA};
     use std::collections::BTreeSet;
     use std::sync::{Arc, Mutex};
 

--- a/crates/homeboy-agents/src/agent_task_schedule.rs
+++ b/crates/homeboy-agents/src/agent_task_schedule.rs
@@ -10,7 +10,7 @@ use crate::agent_task::{AgentTaskComponentContract, AgentTaskOutcome, AgentTaskR
 use homeboy_core::plan::{
     HomeboyPlan, PlanArtifact, PlanKind, PlanStep, PlanStepDependencyKind, PlanStepStatus,
 };
-use homeboy_core::workspace_claim::{WorkspaceIdentity, WorkspaceOwnerLease};
+use homeboy_runner_contract::{WorkspaceIdentity, WorkspaceOwnerLease};
 
 mod plan {
     use super::*;

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -948,25 +948,13 @@ impl JobStore {
             .submission_key()
             .map(str::to_string)
             .unwrap_or_else(|| format!("test:runner-api:{}", Uuid::new_v4()));
-        let workspace_claim_binding = request
-            .workspace_claim_binding
-            .as_ref()
-            .map(serde_json::to_value)
-            .transpose()
-            .map_err(|error| Error::internal_json(error.to_string(), None))?;
-        let workspace_owner_lease = request
-            .workspace_owner_lease
-            .as_ref()
-            .map(serde_json::to_value)
-            .transpose()
-            .map_err(|error| Error::internal_json(error.to_string(), None))?;
         self.submit_runner_api_request(RunnerApiSubmitRequest {
             schema: RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
             api_version: RUNNER_API_V1,
             submission_key,
             envelope: request.execution_envelope(),
-            workspace_claim_binding,
-            workspace_owner_lease,
+            workspace_claim_binding: request.workspace_claim_binding,
+            workspace_owner_lease: request.workspace_owner_lease,
         })
     }
 
@@ -1016,31 +1004,8 @@ impl JobStore {
             ));
         }
         validate_command_assets(Some(&envelope.metadata))?;
-        let workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding> =
-            submission
-                .workspace_claim_binding
-                .map(serde_json::from_value)
-                .transpose()
-                .map_err(|error| {
-                    Error::validation_invalid_argument(
-                        "workspace_claim_binding",
-                        error.to_string(),
-                        None,
-                        None,
-                    )
-                })?;
-        let workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease> = submission
-            .workspace_owner_lease
-            .map(serde_json::from_value)
-            .transpose()
-            .map_err(|error| {
-                Error::validation_invalid_argument(
-                    "workspace_owner_lease",
-                    error.to_string(),
-                    None,
-                    None,
-                )
-            })?;
+        let workspace_claim_binding = submission.workspace_claim_binding;
+        let workspace_owner_lease = submission.workspace_owner_lease;
         if let Some(binding) = workspace_claim_binding.as_ref() {
             binding.verify()?;
         }

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -572,7 +572,7 @@ fn remote_runner_protocol_v1_claim_retains_legacy_request_projection() {
 }
 
 #[test]
-fn runner_api_claim_sidecars_match_across_v2_and_v1_projections() {
+fn runner_api_legacy_json_claim_sidecars_match_across_v2_and_v1_projections() {
     let store = JobStore::default();
     let workspace =
         crate::workspace_claim::WorkspaceIdentity::new("test", "claim-sidecars").expect("identity");
@@ -599,17 +599,19 @@ fn runner_api_claim_sidecars_match_across_v2_and_v1_projections() {
     };
     let submit = |submission_key: &str| {
         let request = remote_runner_request("homeboy-lab", None);
+        let legacy_json = serde_json::to_value(homeboy_runner_contract::RunnerApiSubmitRequest {
+            schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: homeboy_runner_contract::RUNNER_API_V1,
+            submission_key: submission_key.to_string(),
+            envelope: request.execution_envelope(),
+            workspace_claim_binding: Some(binding.clone()),
+            workspace_owner_lease: Some(owner_lease.clone()),
+        })
+        .expect("legacy Runner API JSON");
+        let submission =
+            serde_json::from_value(legacy_json).expect("legacy Runner API JSON remains readable");
         store
-            .submit_runner_api_request(homeboy_runner_contract::RunnerApiSubmitRequest {
-                schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
-                api_version: homeboy_runner_contract::RUNNER_API_V1,
-                submission_key: submission_key.to_string(),
-                envelope: request.execution_envelope(),
-                workspace_claim_binding: Some(serde_json::to_value(&binding).expect("binding")),
-                workspace_owner_lease: Some(
-                    serde_json::to_value(&owner_lease).expect("owner lease"),
-                ),
-            })
+            .submit_runner_api_request(submission)
             .expect("Runner API request queues")
     };
 

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -645,34 +645,8 @@ fn enqueue(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) 
                     )
                 })?;
             auth.authorize(BrokerScope::Submit, Some(runner_id))?;
-            let workspace_claim_binding = submission
-                .workspace_claim_binding
-                .as_ref()
-                .map(|binding| serde_json::from_value(binding.clone()))
-                .transpose()
-                .map_err(|error| {
-                    Error::validation_invalid_argument(
-                        "workspace_claim_binding",
-                        format!("malformed reverse runner workspace claim binding: {error}"),
-                        None,
-                        None,
-                    )
-                })?;
-            let workspace_owner_lease = submission
-                .workspace_owner_lease
-                .as_ref()
-                .map(|lease| serde_json::from_value(lease.clone()))
-                .transpose()
-                .map_err(|error| {
-                    Error::validation_invalid_argument(
-                        "workspace_owner_lease",
-                        format!("malformed reverse runner workspace owner lease: {error}"),
-                        None,
-                        None,
-                    )
-                })?;
-            authorize_workspace_claim_binding(workspace_claim_binding.as_ref())?;
-            authorize_workspace_owner_lease(workspace_owner_lease.as_ref())?;
+            authorize_workspace_claim_binding(submission.workspace_claim_binding.as_ref())?;
+            authorize_workspace_owner_lease(submission.workspace_owner_lease.as_ref())?;
             let response = match job_store.submit_runner_api_request(submission) {
                 Ok(job) => RunnerApiSubmitResponse {
                     schema: RUNNER_API_SUBMIT_RESPONSE_SCHEMA.to_string(),

--- a/crates/homeboy-core/src/workspace_claim.rs
+++ b/crates/homeboy-core/src/workspace_claim.rs
@@ -13,127 +13,17 @@ use sha2::{Digest, Sha256};
 
 use crate::error::{Error, Result};
 
-pub const WORKSPACE_CLAIM_CAPABILITY: &str = "workspace-claim";
-pub const WORKSPACE_OWNER_LEASE_CAPABILITY: &str = "workspace-owner-lease";
-pub const WORKSPACE_CLAIM_PROTOCOL_VERSION: u32 = 2;
-pub const WORKSPACE_IDENTITY_SCHEMA: &str = "homeboy/workspace-identity/v1";
-pub const WORKSPACE_CLAIM_SCHEMA: &str = "homeboy/workspace-claim/v2";
-pub const WORKSPACE_OWNER_LEASE_SCHEMA: &str = "homeboy/workspace-owner-lease/v2";
+pub use homeboy_runner_contract::{
+    WorkspaceClaim, WorkspaceClaimBinding, WorkspaceClaimProtocol, WorkspaceIdentity,
+    WorkspaceOwnerLease, WorkspaceOwnerLeaseProtocol, WORKSPACE_CLAIM_CAPABILITY,
+    WORKSPACE_CLAIM_PROTOCOL_VERSION, WORKSPACE_CLAIM_SCHEMA, WORKSPACE_IDENTITY_SCHEMA,
+    WORKSPACE_OWNER_LEASE_CAPABILITY, WORKSPACE_OWNER_LEASE_SCHEMA,
+};
 pub const WORKSPACE_OWNER_RELEASE_RECOVERY_SCHEMA: &str =
     "homeboy/workspace-owner-release-recovery/v1";
 pub const LOCAL_WORKSPACE_CLAIMS_DIR: &str = "agent-task-workspace-claims";
 const WORKSPACE_AUTHORITY_SCHEMA: &str = "homeboy/workspace-authority/v2";
 pub const MAX_WORKSPACE_CLAIM_TTL_MS: u64 = 300_000;
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceClaimProtocol {
-    pub capability: String,
-    pub version: u32,
-}
-impl WorkspaceClaimProtocol {
-    pub fn current() -> Self {
-        Self {
-            capability: WORKSPACE_CLAIM_CAPABILITY.into(),
-            version: WORKSPACE_CLAIM_PROTOCOL_VERSION,
-        }
-    }
-    pub fn verify(&self) -> Result<()> {
-        (self.capability == WORKSPACE_CLAIM_CAPABILITY
-            && self.version == WORKSPACE_CLAIM_PROTOCOL_VERSION)
-            .then_some(())
-            .ok_or_else(|| {
-                invalid(
-                    "workspace_claim_protocol",
-                    "workspace authority does not advertise the required claim protocol",
-                )
-            })
-    }
-}
-
-/// Versioned negotiation record for direct-daemon owner leases. Reconciliation
-/// claims deliberately use a different capability so the two authorities
-/// cannot be substituted for one another.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceOwnerLeaseProtocol {
-    pub capability: String,
-    pub version: u32,
-}
-impl WorkspaceOwnerLeaseProtocol {
-    pub fn current() -> Self {
-        Self {
-            capability: WORKSPACE_OWNER_LEASE_CAPABILITY.into(),
-            version: WORKSPACE_CLAIM_PROTOCOL_VERSION,
-        }
-    }
-    pub fn verify(&self) -> Result<()> {
-        (self.capability == WORKSPACE_OWNER_LEASE_CAPABILITY
-            && self.version == WORKSPACE_CLAIM_PROTOCOL_VERSION)
-            .then_some(())
-            .ok_or_else(|| {
-                invalid(
-                    "workspace_owner_lease_protocol",
-                    "workspace authority does not advertise the required owner lease protocol",
-                )
-            })
-    }
-}
-
-/// A portable logical locator. Host paths are deliberately excluded.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub struct WorkspaceIdentity {
-    pub schema: String,
-    pub kind: String,
-    pub locator: String,
-}
-impl WorkspaceIdentity {
-    pub fn new(kind: impl Into<String>, locator: impl Into<String>) -> Result<Self> {
-        let identity = Self {
-            schema: WORKSPACE_IDENTITY_SCHEMA.into(),
-            kind: kind.into(),
-            locator: locator.into(),
-        };
-        identity.verify()?;
-        Ok(identity)
-    }
-    pub fn verify(&self) -> Result<()> {
-        (self.schema == WORKSPACE_IDENTITY_SCHEMA
-            && !self.kind.trim().is_empty()
-            && !self.locator.trim().is_empty()
-            && !self.kind.contains('\n')
-            && !self.locator.contains('\n'))
-        .then_some(())
-        .ok_or_else(|| {
-            invalid(
-                "workspace_identity",
-                "workspace identity is malformed or unsupported",
-            )
-        })
-    }
-}
-
-/// An exclusive short reconciliation fence. `lifecycle_revision` is an
-/// authority-issued monotonically increasing epoch; callers never supply it.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceClaim {
-    pub schema: String,
-    pub protocol: WorkspaceClaimProtocol,
-    pub workspace: WorkspaceIdentity,
-    pub lifecycle_revision: u64,
-    pub token: String,
-    pub expires_at_ms: u64,
-}
-
-/// A renewable active-task authority. Several distinct owner identities may be live.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceOwnerLease {
-    pub schema: String,
-    pub protocol: WorkspaceOwnerLeaseProtocol,
-    pub workspace: WorkspaceIdentity,
-    pub owner_id: String,
-    pub lifecycle_revision: u64,
-    pub token: String,
-    pub expires_at_ms: u64,
-}
 
 /// Token-free owner identity returned by authority inventory. The stable digest
 /// lets callers distinguish live owners without disclosing owner identifiers.
@@ -205,67 +95,6 @@ pub struct WorkspaceOwnerReleaseRecovery {
     pub lease: WorkspaceOwnerLease,
     pub error_code: String,
     pub error_message: String,
-}
-
-/// Optional transport binding for a reconciliation operation.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceClaimBinding {
-    pub workspace: WorkspaceIdentity,
-    pub lifecycle_revision: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub claim: Option<WorkspaceClaim>,
-}
-impl WorkspaceClaimBinding {
-    pub fn verify(&self) -> Result<()> {
-        self.workspace.verify()?;
-        if let Some(claim) = &self.claim {
-            claim.verify_shape(0)?;
-            if claim.workspace != self.workspace
-                || claim.lifecycle_revision != self.lifecycle_revision
-            {
-                return Err(invalid(
-                    "workspace_claim_binding",
-                    "workspace identity and authority epoch do not agree",
-                ));
-            }
-        }
-        Ok(())
-    }
-}
-impl WorkspaceClaim {
-    pub fn verify_shape(&self, now_ms: u64) -> Result<()> {
-        self.protocol.verify()?;
-        self.workspace.verify()?;
-        (self.schema == WORKSPACE_CLAIM_SCHEMA
-            && !self.token.trim().is_empty()
-            && self.lifecycle_revision > 0
-            && self.expires_at_ms > now_ms)
-            .then_some(())
-            .ok_or_else(|| {
-                invalid(
-                    "workspace_claim",
-                    "workspace reconciliation claim is malformed or expired",
-                )
-            })
-    }
-}
-impl WorkspaceOwnerLease {
-    pub fn verify_shape(&self, now_ms: u64) -> Result<()> {
-        self.protocol.verify()?;
-        self.workspace.verify()?;
-        (self.schema == WORKSPACE_OWNER_LEASE_SCHEMA
-            && !self.owner_id.trim().is_empty()
-            && !self.token.trim().is_empty()
-            && self.lifecycle_revision > 0
-            && self.expires_at_ms > now_ms)
-            .then_some(())
-            .ok_or_else(|| {
-                invalid(
-                    "workspace_owner_lease",
-                    "workspace owner lease is malformed or expired",
-                )
-            })
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -17,9 +17,9 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use homeboy_core::error::{Error, Result};
-use homeboy_core::workspace_claim::{
-    WorkspaceAuthorityStatus, WorkspaceClaim, WorkspaceClaimProtocol, WorkspaceIdentity,
-    WORKSPACE_CLAIM_CAPABILITY,
+use homeboy_core::workspace_claim::WorkspaceAuthorityStatus;
+use homeboy_runner_contract::{
+    WorkspaceClaim, WorkspaceClaimProtocol, WorkspaceIdentity, WORKSPACE_CLAIM_CAPABILITY,
 };
 
 /// The runner layer's `RunnerContinuationProvider`. Registered with core at startup.

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -9,7 +9,7 @@ use homeboy_core::error::{Error, Result};
 use homeboy_core::lab_contract::LabRunnerWorkload;
 use homeboy_core::source_snapshot::SourceSnapshot;
 use homeboy_runner_contract::{
-    RunnerApiSubmitOutcome, RunnerApiSubmitRequest, RunnerApiSubmitResponse,
+    RunnerApiSubmitOutcome, RunnerApiSubmitRequest, RunnerApiSubmitResponse, WorkspaceOwnerLease,
     RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_V1,
 };
 use reqwest::blocking::Client;
@@ -140,7 +140,7 @@ pub(super) fn exec_via_reverse_broker(
                 "register reverse broker workspace owner",
                 token.as_deref(),
             )?;
-            let lease: homeboy_core::workspace_claim::WorkspaceOwnerLease = serde_json::from_value(
+            let lease: WorkspaceOwnerLease = serde_json::from_value(
                 data.get("workspace_owner_lease")
                     .cloned()
                     .unwrap_or_default(),
@@ -163,16 +163,7 @@ pub(super) fn exec_via_reverse_broker(
         submission_key: submission_key.clone(),
         envelope,
         workspace_claim_binding: None,
-        workspace_owner_lease: workspace_owner_lease
-            .as_ref()
-            .map(serde_json::to_value)
-            .transpose()
-            .map_err(|error| {
-                Error::internal_json(
-                    error.to_string(),
-                    Some("serialize workspace owner lease".to_string()),
-                )
-            })?,
+        workspace_owner_lease: workspace_owner_lease.clone(),
     };
     if detach_after_handoff {
         if let Some(run_id) = run_id.as_deref() {

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -15,7 +15,9 @@ use homeboy_core::lab_contract::{run_location_index_path, JobArtifactMetadata, L
 use homeboy_core::redaction::redact_argv;
 use homeboy_core::source_snapshot::SourceSnapshot;
 use homeboy_runner_contract::{
-    RunnerApiSubmitRequest, RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_V1,
+    RunnerApiSubmitRequest, WorkspaceIdentity, WorkspaceOwnerLease,
+    RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_V1, WORKSPACE_CLAIM_PROTOCOL_VERSION,
+    WORKSPACE_OWNER_LEASE_CAPABILITY,
 };
 
 use super::super::capabilities::{
@@ -560,11 +562,9 @@ fn require_daemon_workspace_owner_lease_v2(client: &Client, local_url: &str) -> 
         .is_some_and(|capabilities| {
             capabilities.iter().any(|capability| {
                 capability.get("capability").and_then(Value::as_str)
-                    == Some(homeboy_core::workspace_claim::WORKSPACE_OWNER_LEASE_CAPABILITY)
+                    == Some(WORKSPACE_OWNER_LEASE_CAPABILITY)
                     && capability.get("version").and_then(Value::as_u64)
-                        == Some(
-                            homeboy_core::workspace_claim::WORKSPACE_CLAIM_PROTOCOL_VERSION as u64,
-                        )
+                        == Some(WORKSPACE_CLAIM_PROTOCOL_VERSION as u64)
             })
         });
     supported.then_some(()).ok_or_else(|| {
@@ -584,7 +584,7 @@ pub(crate) enum DaemonAdmissionPolicy {
     DurableLeaseRequired,
 }
 
-type WorkspaceOwnerRegistration = (homeboy_core::workspace_claim::WorkspaceIdentity, String);
+type WorkspaceOwnerRegistration = (WorkspaceIdentity, String);
 
 const ADMISSION_RECOVERY_WINDOW: Duration = Duration::from_secs(10);
 const ADMISSION_RECOVERY_RETRY_INTERVAL: Duration = Duration::from_millis(250);
@@ -693,7 +693,7 @@ pub(crate) struct DaemonAdmissionReservation {
     local_url: String,
     job_id: String,
     token: Option<String>,
-    workspace_owner_lease: Arc<Mutex<Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>>>,
+    workspace_owner_lease: Arc<Mutex<Option<WorkspaceOwnerLease>>>,
     renewer_stop: Option<Sender<()>>,
     renewer: Option<std::thread::JoinHandle<()>>,
     authority: DaemonAdmissionReservationAuthority,
@@ -1087,7 +1087,7 @@ fn spawn_admission_renewer(
     local_url: String,
     job_id: String,
     token: String,
-    workspace_owner_lease: Arc<Mutex<Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>>>,
+    workspace_owner_lease: Arc<Mutex<Option<WorkspaceOwnerLease>>>,
     health: Arc<Mutex<AdmissionRenewalHealth>>,
 ) -> (Sender<()>, std::thread::JoinHandle<()>) {
     let (stop, shutdown) = mpsc::channel();

--- a/crates/homeboy-lab-runner/src/worker/broker.rs
+++ b/crates/homeboy-lab-runner/src/worker/broker.rs
@@ -10,6 +10,9 @@ use serde_json::json;
 
 use homeboy_core::api_jobs::{Job, JobStatus, RemoteRunnerJobClaim, RemoteRunnerJobResult};
 use homeboy_core::error::{Error, Result};
+use homeboy_runner_contract::{
+    WorkspaceClaimBinding, WorkspaceClaimProtocol, WorkspaceOwnerLease, WorkspaceOwnerLeaseProtocol,
+};
 
 use super::super::broker_http;
 use super::types::ReverseRunnerWorkerOptions;
@@ -28,8 +31,8 @@ pub(super) fn claim_job(
             "lease_ms": options.lease_ms.max(1),
             "concurrency_limit": options.concurrency_limit,
             "execution_protocol": homeboy_core::runner_job_execution_context::RunnerJobExecutionProtocol::current(),
-            "workspace_claim_protocol": homeboy_core::workspace_claim::WorkspaceClaimProtocol::current(),
-            "workspace_owner_lease_protocol": homeboy_core::workspace_claim::WorkspaceOwnerLeaseProtocol::current(),
+            "workspace_claim_protocol": WorkspaceClaimProtocol::current(),
+            "workspace_owner_lease_protocol": WorkspaceOwnerLeaseProtocol::current(),
         }),
         "claim reverse runner job",
         options.broker_token.as_deref(),
@@ -57,8 +60,8 @@ pub(super) fn append_progress_data(
     runner_id: &str,
     job: &Job,
     data: serde_json::Value,
-    workspace_claim_binding: Option<&homeboy_core::workspace_claim::WorkspaceClaimBinding>,
-    workspace_owner_lease: Option<&homeboy_core::workspace_claim::WorkspaceOwnerLease>,
+    workspace_claim_binding: Option<&WorkspaceClaimBinding>,
+    workspace_owner_lease: Option<&WorkspaceOwnerLease>,
 ) -> Result<()> {
     let claim_id = remote_runner_claim_id(job)?;
     broker_http::post_json(
@@ -90,8 +93,8 @@ pub(super) fn finish_job(
     runner_id: &str,
     job: &Job,
     result: RemoteRunnerJobResult,
-    workspace_claim_binding: Option<&homeboy_core::workspace_claim::WorkspaceClaimBinding>,
-    workspace_owner_lease: Option<&homeboy_core::workspace_claim::WorkspaceOwnerLease>,
+    workspace_claim_binding: Option<&WorkspaceClaimBinding>,
+    workspace_owner_lease: Option<&WorkspaceOwnerLease>,
 ) -> Result<Job> {
     let claim_id = remote_runner_claim_id(job)?;
     let data = broker_http::post_json(
@@ -128,8 +131,8 @@ pub(super) fn consume_execution(
     runner_id: &str,
     job: &Job,
     context_id: &str,
-    workspace_claim_binding: Option<&homeboy_core::workspace_claim::WorkspaceClaimBinding>,
-    workspace_owner_lease: Option<&homeboy_core::workspace_claim::WorkspaceOwnerLease>,
+    workspace_claim_binding: Option<&WorkspaceClaimBinding>,
+    workspace_owner_lease: Option<&WorkspaceOwnerLease>,
 ) -> Result<Job> {
     let claim_id = remote_runner_claim_id(job)?;
     let data = broker_http::post_json(
@@ -163,7 +166,7 @@ pub(super) fn validate_workspace_owner(
     token: Option<&str>,
     runner_id: &str,
     job: &Job,
-    workspace_owner_lease: &homeboy_core::workspace_claim::WorkspaceOwnerLease,
+    workspace_owner_lease: &WorkspaceOwnerLease,
 ) -> Result<()> {
     let claim_id = remote_runner_claim_id(job)?;
     let data = broker_http::post_json(
@@ -200,12 +203,9 @@ fn renew_claim(
     runner_id: &str,
     job: &Job,
     lease_ms: u64,
-    workspace_claim_binding: Option<&homeboy_core::workspace_claim::WorkspaceClaimBinding>,
-    workspace_owner_lease: Option<&homeboy_core::workspace_claim::WorkspaceOwnerLease>,
-) -> Result<(
-    Job,
-    Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>,
-)> {
+    workspace_claim_binding: Option<&WorkspaceClaimBinding>,
+    workspace_owner_lease: Option<&WorkspaceOwnerLease>,
+) -> Result<(Job, Option<WorkspaceOwnerLease>)> {
     let claim_id = remote_runner_claim_id(job)?;
     let data = broker_http::post_json(
         client,
@@ -235,8 +235,8 @@ pub(super) fn start_claim_heartbeat(
     client: &Client,
     options: &ReverseRunnerWorkerOptions,
     job: &Job,
-    workspace_claim_binding: Option<homeboy_core::workspace_claim::WorkspaceClaimBinding>,
-    workspace_owner_lease: Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>,
+    workspace_claim_binding: Option<WorkspaceClaimBinding>,
+    workspace_owner_lease: Option<WorkspaceOwnerLease>,
 ) -> Result<ClaimHeartbeat> {
     remote_runner_claim_id(job)?;
     let (stop, stopped) = mpsc::channel();
@@ -293,13 +293,11 @@ pub(super) fn start_claim_heartbeat(
 pub(super) struct ClaimHeartbeat {
     stop: Option<Sender<()>>,
     handle: Option<JoinHandle<()>>,
-    owner_lease: Arc<Mutex<Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>>>,
+    owner_lease: Arc<Mutex<Option<WorkspaceOwnerLease>>>,
 }
 
 impl ClaimHeartbeat {
-    pub(super) fn owner_lease_handle(
-        &self,
-    ) -> Arc<Mutex<Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>>> {
+    pub(super) fn owner_lease_handle(&self) -> Arc<Mutex<Option<WorkspaceOwnerLease>>> {
         self.owner_lease.clone()
     }
 }


### PR DESCRIPTION
## Summary
- move portable workspace identity, claim, binding, owner-lease, and protocol values into `homeboy-runner-contract`
- type Runner API submit authority sidecars and remove core JSON conversion plumbing
- retain workspace authority persistence and mutation behavior in `homeboy-core`, with compatibility re-exports and exact wire coverage

Closes #14205.

## Verification
- `cargo test -p homeboy-runner-contract --locked`
- `cargo test -p homeboy-core api_jobs::tests --lib --locked`
- `cargo test -p homeboy-core daemon::tests --lib --locked`
- `cargo test -p homeboy-lab-runner worker::tests --lib --locked`
- `cargo check -p homeboy-runner-contract -p homeboy-core -p homeboy-agents -p homeboy-lab-runner --all-targets --locked`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo run -q -p homeboy-cli -- audit --changed-since origin/main --profile pr --full`

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode and Homeboy Cook produced the candidate after provider rotation. OpenAI GPT-5.6 Sol via OpenCode reviewed the ownership and compatibility boundaries, ran verification, rebased the commit, and finalized the pull request under Chris Huber's direction.