### PR TITLE
fix(agent-task): reload materialized aggregate bytes

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -6471,17 +6471,9 @@ pub fn aggregate_source_in_store(
             None,
         )
     })?;
-    // `record.run_id` is already resolved, so these are the store's own exact
-    // reads rather than the alias-resolving `lifecycle_ops` wrappers.
-    let aggregate = lifecycle_store.read_aggregate(&record.run_id)?;
-    let raw = serde_json::to_string_pretty(&aggregate).map_err(|error| {
-        Error::internal_json(
-            error.to_string(),
-            Some(format!("serialize agent-task aggregate {}", record.run_id)),
-        )
-    })?;
-    let path = lifecycle_store.aggregate_path(&record.run_id);
-    Ok((raw, path))
+    // `record.run_id` is already resolved, so this exact read reloads the
+    // controller-owned aggregate file rather than the observation mirror.
+    lifecycle_store.aggregate_source_exact(&record.run_id)
 }
 
 pub fn record_cook_attempt_in_store(

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -404,14 +404,15 @@ impl AgentTaskLifecycleStore {
                 None,
             )
         })?;
-        let aggregate = self.read_aggregate(&record.run_id)?;
-        let raw = serde_json::to_string_pretty(&aggregate).map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some(format!("serialize agent-task aggregate {}", record.run_id)),
-            )
+        let path = self.aggregate_path(&record.run_id);
+        let raw = read_aggregate_bytes_bounded_in_store(self, &record.run_id)?;
+        serde_json::from_slice::<AgentTaskAggregate>(&raw).map_err(|error| {
+            Error::internal_json(error.to_string(), Some(path.display().to_string()))
         })?;
-        Ok((raw, self.aggregate_path(&record.run_id)))
+        let raw = String::from_utf8(raw).map_err(|error| {
+            Error::internal_json(error.to_string(), Some(path.display().to_string()))
+        })?;
+        Ok((raw, path))
     }
 
     pub fn operation_claim(
@@ -1270,6 +1271,16 @@ pub(super) fn read_aggregate_bounded_in_store(
     run_id: &str,
 ) -> Result<AgentTaskAggregate> {
     let path = store.aggregate_path(run_id);
+    let raw = read_aggregate_bytes_bounded_in_store(store, run_id)?;
+    serde_json::from_slice(&raw)
+        .map_err(|error| Error::internal_json(error.to_string(), Some(path.display().to_string())))
+}
+
+fn read_aggregate_bytes_bounded_in_store(
+    store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Vec<u8>> {
+    let path = store.aggregate_path(run_id);
     let metadata = fs::metadata(&path)
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
     if metadata.len() > DURABLE_AGGREGATE_MAX_BYTES {
@@ -1302,8 +1313,7 @@ pub(super) fn read_aggregate_bounded_in_store(
         error.details = json!({ "reason_code": "durable_read.oversized" });
         return Err(error);
     }
-    serde_json::from_slice(&raw)
-        .map_err(|error| Error::internal_json(error.to_string(), Some(path.display().to_string())))
+    Ok(raw)
 }
 
 pub(super) fn aggregate_path(run_id: &str) -> Result<PathBuf> {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -549,7 +549,7 @@ fn cook_readers_keep_the_substantive_candidate_after_a_no_change_retry() {
 
 #[cfg(unix)]
 #[test]
-fn direct_cook_promotion_uses_selected_retained_large_patch() {
+fn direct_cook_promotion_resolves_recovered_patch_from_run_id_and_aggregate_path() {
     with_temp_home(|| {
         let temp = tempfile::tempdir().expect("tempdir");
         let source = temp.path().join("source");
@@ -778,36 +778,57 @@ fn direct_cook_promotion_uses_selected_retained_large_patch() {
         permissions.set_mode(0o755);
         std::fs::set_permissions(&provider, permissions).expect("make provider executable");
 
-        let cli = crate::cli_surface::Cli::try_parse_from([
-            "homeboy",
-            "agent-task",
-            "promote",
-            cook_id,
-            "--artifact-id",
-            artifact_id,
-            "--to-worktree",
-            "fixture@selected-large-patch",
-            "--provider-argv",
-            "sh",
-            "--provider-argv",
-            provider.to_str().expect("provider path"),
-            "--dry-run",
-            "--gates-from-cook-recipe",
-        ])
-        .expect("parse public direct promotion command");
-        let crate::cli_surface::Commands::AgentTask(agent_task) = cli.command else {
-            panic!("agent-task command");
-        };
-        let super::super::AgentTaskCommand::Promote(args) = agent_task.command else {
-            panic!("promote command");
-        };
-        let (report, exit_code) = review::promote_artifact(*args)
-            .expect("selected Cook candidate remains directly promotable");
+        agent_task_lifecycle::materialize_recovered_patch_artifact(
+            candidate_run_id,
+            Some(task_id),
+            Some(artifact_id),
+        )
+        .expect("recover retained patch into the canonical aggregate");
+        let (run_source, aggregate_path) =
+            review::read_promotion_source(candidate_run_id).expect("read run source");
+        let aggregate_path = aggregate_path.expect("canonical aggregate path");
+        let (path_source, _) = review::read_promotion_source(&aggregate_path.display().to_string())
+            .expect("read exact aggregate source");
+        assert_eq!(run_source, path_source);
 
-        assert_eq!(exit_code, 0);
-        assert_eq!(report["status"], "dry_run");
-        assert_eq!(report["source"]["run_id"], candidate_run_id);
-        assert_eq!(report["patch_artifact"]["id"], artifact_id);
+        let mut reports = Vec::new();
+        for source_spec in [
+            candidate_run_id.to_string(),
+            aggregate_path.display().to_string(),
+        ] {
+            let cli = crate::cli_surface::Cli::try_parse_from([
+                "homeboy",
+                "agent-task",
+                "promote",
+                &source_spec,
+                "--artifact-id",
+                artifact_id,
+                "--to-worktree",
+                "fixture@selected-large-patch",
+                "--provider-argv",
+                "sh",
+                "--provider-argv",
+                provider.to_str().expect("provider path"),
+                "--dry-run",
+                "--gates-from-cook-recipe",
+            ])
+            .expect("parse public direct promotion command");
+            let crate::cli_surface::Commands::AgentTask(agent_task) = cli.command else {
+                panic!("agent-task command");
+            };
+            let super::super::AgentTaskCommand::Promote(args) = agent_task.command else {
+                panic!("promote command");
+            };
+            let (report, exit_code) = review::promote_artifact(*args)
+                .expect("recovered candidate remains directly promotable");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(report["status"], "dry_run");
+            assert_eq!(report["source"]["run_id"], candidate_run_id);
+            assert_eq!(report["patch_artifact"]["id"], artifact_id);
+            reports.push(report);
+        }
+        assert_eq!(reports[0]["patch_artifact"], reports[1]["patch_artifact"]);
     });
 }
 


### PR DESCRIPTION
## Summary
Reload controller-materialized canonical aggregate bytes for run-ID promotion.

## What changed
- Use the exact bounded aggregate-file accessor after lifecycle reconciliation.
- Prove run-ID and aggregate-path promotion resolve the same recovered retained patch.

## How to test
1. Run `cargo test -p homeboy-cli direct_cook_promotion_resolves_recovered_patch_from_run_id_and_aggregate_path -- --quiet`; expect passes as recorded by Homeboy's deterministic gate.
2. Run `cargo fmt --all --check`; expect passes as recorded by Homeboy's deterministic gate.
3. Run `cargo check --workspace --all-targets -j2`; expect passes as recorded by Homeboy's deterministic gate.

## Compatibility
No public schema change; run-ID promotion now matches exact aggregate-path behavior while retaining existing safety bounds.

## Evidence
- Base unchanged since verification: main remains at aa500b9fb72200fa9300bd6f7e3480de008058dd.
- CI expected: Homeboy CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/14219
- Verified finalization base: main at aa500b9fb72200fa9300bd6f7e3480de008058dd
- manual-verify-1: passed (cargo test -p homeboy-cli direct\_cook\_promotion\_resolves\_recovered\_patch\_from\_run\_id\_and\_aggregate\_path -- --quiet) (Passed)
- manual-verify-2: passed (cargo fmt --all --check) (Passed)
- manual-verify-3: passed (cargo check --workspace --all-targets -j2) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode orchestrated through Homeboy)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed run-ID versus aggregate-path source divergence, implemented canonical file-byte loading, added the public equivalence regression, and verified the rebased candidate.

## Source relationships
- Closes #14219
