### PR TITLE
fix(cleanup): reclaim runtime-temp locks from exited owners

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -59,6 +59,9 @@ const CLEANUP_CHILD_TERMINATION_ALLOWANCE: Duration = Duration::from_secs(5);
 const CLEANUP_CATEGORY_HEARTBEAT: Duration = Duration::from_secs(5);
 /// Time reserved for the repo-artifact category to report after its last root.
 const REPO_ARTIFACT_REPORTING_HEADROOM: Duration = Duration::from_secs(2);
+/// Time reserved for the runtime-temp category to release its cleanup lock and
+/// serialize its report after the sweep stops.
+const RUNTIME_TMP_REPORTING_HEADROOM: Duration = Duration::from_secs(2);
 const CLEANUP_CATEGORY_OUTPUT_LIMIT: usize = 4 * 1024 * 1024;
 #[cfg(any(test, feature = "test-support"))]
 const CLEANUP_CATEGORY_FIXTURE_ENV: &str = "HOMEBOY_TEST_CLEANUP_CATEGORY_FIXTURE";
@@ -919,6 +922,7 @@ fn retained_storage_report(
             run_max_bytes: policy.runtime_run_max_bytes,
             run_max_count: policy.runtime_run_max_count,
             cursor: None,
+            deadline: None,
         })?;
     let runtime_tmp_continuation = runtime_tmp.next_cursor.as_ref().map(|cursor| {
         format!(
@@ -2363,6 +2367,10 @@ fn cleanup_inventory_with_deadline(
                         run_max_bytes: policy.runtime_run_max_bytes,
                         run_max_count: policy.runtime_run_max_count,
                         cursor: args.cursor.as_deref(),
+                        // Stop at an entry boundary while there is still time to
+                        // report, rather than being killed at the category wall
+                        // with the cleanup lock still on disk (#14221).
+                        deadline: runtime_tmp_scan_deadline(deadline),
                     },
                 )?;
                 engine::temp::present_runtime_temp_cleanup(
@@ -3729,6 +3737,20 @@ fn repo_artifact_roots(
 /// every root gets a bounded slice and stops at a worktree boundary with its
 /// progress intact. Previously each root scanned unbounded until the category
 /// wall killed the process, discarding everything it had reclaimed (#12727).
+/// Convert the aggregate's category wall into a sweep budget that expires
+/// early enough for runtime-temp to release its lock and report.
+///
+/// Reaching the category wall itself is fatal to the lock: the supervisor
+/// SIGKILLs the category child, no destructor runs, and the `.cleanup.lock`
+/// directory survives with a now-dead owner PID recorded in it (#14221).
+fn runtime_tmp_scan_deadline(deadline: Option<SystemTime>) -> Option<Instant> {
+    let remaining = deadline?
+        .duration_since(SystemTime::now())
+        .unwrap_or(Duration::ZERO)
+        .saturating_sub(RUNTIME_TMP_REPORTING_HEADROOM);
+    Instant::now().checked_add(remaining)
+}
+
 fn apply_repo_artifact_scan_budget(
     roots: &mut [(&'static str, ArtifactCleanupOptions)],
     deadline: Option<SystemTime>,

--- a/crates/homeboy-cli/src/commands/self_cmd.rs
+++ b/crates/homeboy-cli/src/commands/self_cmd.rs
@@ -265,6 +265,7 @@ pub fn run(args: SelfArgs) -> CmdResult<Value> {
                     run_max_bytes: policy.runtime_run_max_bytes,
                     run_max_count: policy.runtime_run_max_count,
                     cursor: args.cursor.as_deref(),
+                    deadline: None,
                 },
             )?;
             let mut json = serde_json::to_value(output)

--- a/crates/homeboy-core/src/cleanup/automatic_retention.rs
+++ b/crates/homeboy-core/src/cleanup/automatic_retention.rs
@@ -218,6 +218,7 @@ fn cleanup_runtime_tmp_retention(
         run_max_bytes: retention.runtime_run_max_bytes,
         run_max_count: retention.runtime_run_max_count,
         cursor,
+        deadline: None,
     })?;
     let managed_bytes = cleanup
         .rows

--- a/crates/homeboy-core/src/cleanup/degraded.rs
+++ b/crates/homeboy-core/src/cleanup/degraded.rs
@@ -317,6 +317,7 @@ pub fn degraded_cleanup(
             run_max_bytes: u64::MAX,
             run_max_count: usize::MAX,
             cursor: None,
+            deadline: None,
         }) {
             Ok(outcome) => DegradedCleanupCategory {
                 category: "runtime-tmp",

--- a/crates/homeboy-core/src/engine/run_dir.rs
+++ b/crates/homeboy-core/src/engine/run_dir.rs
@@ -637,6 +637,7 @@ mod tests {
                 run_max_bytes: 1024 * 1024,
                 run_max_count: 10,
                 cursor: None,
+                deadline: None,
             },
         )
         .expect("cleanup inventory");

--- a/crates/homeboy-core/src/engine/temp/implementation.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 mod contract {
     use super::*;
@@ -20,7 +20,19 @@ mod contract {
     pub(super) const RUN_OWNER_FILE: &str = ".homeboy-run-owner-v1.json";
     pub(super) const RUN_OWNER_SCHEMA: &str = "homeboy/runtime-run-owner/v1";
     pub(super) const CLEANUP_LOCK_DIR: &str = ".cleanup.lock";
+    /// Lease a live cleanup owner renews on every heartbeat.
+    ///
+    /// This bounds only the case where the owner's process identity cannot be
+    /// disproved. An owner whose recorded identity has demonstrably exited is
+    /// reclaimed without waiting this out — see `acquire_cleanup_lock_with_policy`.
     pub(super) const CLEANUP_LOCK_STALE_AFTER: Duration = Duration::from_secs(300);
+    /// Contention tolerance for a *live* holder: ~2s of retries.
+    ///
+    /// Deliberately far shorter than [`CLEANUP_LOCK_STALE_AFTER`]. Waiting out a
+    /// 300s lease inside one acquisition would turn a busy lock into a 300s
+    /// hang, and it is unnecessary: reclaim is driven by process identity, not
+    /// by the lease, so an abandoned lock is recovered on the first attempt
+    /// rather than after the lease expires.
     pub(super) const CLEANUP_LOCK_ATTEMPTS: usize = 100;
     pub(super) const CLEANUP_LOCK_SLEEP: Duration = Duration::from_millis(20);
     pub(super) const CLEANUP_LOCK_OWNER_FILE: &str = "owner.json";
@@ -246,6 +258,22 @@ pub struct RuntimeTempCleanupOptions<'a> {
     pub run_max_bytes: u64,
     pub run_max_count: usize,
     pub cursor: Option<&'a str>,
+    /// Wall-clock budget for this sweep. When it is spent the sweep stops at an
+    /// entry boundary and returns what it already reclaimed, with `has_more`
+    /// and a resumable `next_cursor`.
+    ///
+    /// Without it, a caller that imposes its own deadline — the aggregate
+    /// `cleanup` per-category wall — can only *kill* the sweep. That discards
+    /// every reclaimed byte and, because a killed process runs no destructor,
+    /// abandons the cleanup lock directory on every run (#14221).
+    pub deadline: Option<Instant>,
+}
+
+impl RuntimeTempCleanupOptions<'_> {
+    fn budget_spent(&self) -> bool {
+        self.deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+    }
 }
 
 #[derive(Debug)]
@@ -1014,6 +1042,7 @@ pub fn cleanup_runtime_tmp(
         run_max_bytes: u64::MAX,
         run_max_count: usize::MAX,
         cursor: None,
+        deadline: None,
     })
 }
 
@@ -1048,7 +1077,10 @@ fn cleanup_runtime_tmp_bounded_with_remover(
         // a bounded report. Exhausting it here defers the drain to the next
         // invocation rather than silently dropping it.
         let remaining = options.limit.max(1).saturating_sub(output.rows.len());
-        if remaining == 0 {
+        // The wall-clock budget is shared across roots for the same reason the
+        // row bound is: the drain must defer to the next invocation rather than
+        // push the sweep past the caller's deadline and be killed (#14221).
+        if remaining == 0 || options.budget_spent() {
             output.has_more = true;
             break;
         }
@@ -1201,17 +1233,31 @@ fn cleanup_runtime_tmp_root(
     let page_end = start
         .saturating_add(options.limit.max(1))
         .min(managed.len());
-    let managed_has_more = page_end < managed.len();
-    let page_last_name = managed
+    let mut managed_has_more = page_end < managed.len();
+    let mut page_last_name = managed
         .get(page_end.saturating_sub(1))
         .map(|entry| entry.file_name().to_string_lossy().to_string());
     let managed = managed.into_iter().skip(start).take(options.limit.max(1));
 
     let mut managed_inspections = Vec::new();
+    // Resume point for a budget-truncated page: the last entry this invocation
+    // actually finished with, so the next one starts at the first it did not.
+    let mut last_inspected_name: Option<String> = None;
     for entry in managed {
+        // Inspecting an entry recursively measures its storage, which on a
+        // large runtime root is the dominant cost of the whole sweep. Stopping
+        // here — at an entry boundary, before that walk — is what lets the
+        // sweep return normally, release its lock, and hand the caller a
+        // resumable cursor instead of being killed mid-scan (#14221).
+        if options.budget_spent() {
+            managed_has_more = true;
+            page_last_name = last_inspected_name.clone().or(page_last_name);
+            break;
+        }
         lock.heartbeat()?;
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().to_string();
+        last_inspected_name = Some(name.clone());
         if options
             .prefix
             .is_some_and(|prefix| !name.starts_with(prefix))
@@ -1379,6 +1425,12 @@ fn cleanup_runtime_tmp_root(
     });
     for (inspection, eligibility_reason) in managed_decisions.into_iter().take(options.limit.max(1))
     {
+        // Removal is the phase that actually reclaims bytes, so a spent budget
+        // stops it rather than abandoning the rows it already applied.
+        if options.budget_spent() {
+            managed_has_more = true;
+            break;
+        }
         lock.heartbeat()?;
         output.totals.inspected_count += 1;
         let mut row = RuntimeTempCleanupRow {
@@ -1484,15 +1536,20 @@ fn cleanup_runtime_tmp_root(
             .to_string_lossy()
             .to_string()
     });
+    let mut unmanaged_truncated_at = None;
     for entry in unmanaged
         .into_iter()
         .skip(unmanaged_start)
         .take(unmanaged_capacity)
     {
+        if options.budget_spent() {
+            break;
+        }
         lock.heartbeat()?;
         output.totals.inspected_count += 1;
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().to_string();
+        unmanaged_truncated_at = Some(name.clone());
         let mut row = RuntimeTempCleanupRow {
             path: path.display().to_string(),
             name: name.clone(),
@@ -1569,15 +1626,23 @@ fn cleanup_runtime_tmp_root(
         output.rows.push(row);
     }
 
+    // A budget-truncated unmanaged page resumes from the last entry it actually
+    // reached, not from the page end it never got to.
+    let unmanaged_resume = if options.budget_spent() {
+        unmanaged_truncated_at.or(unmanaged_last_name)
+    } else {
+        unmanaged_last_name
+    };
+    let unmanaged_has_more = unmanaged_end < unmanaged_len || options.budget_spent();
     if managed_has_more {
         output.has_more = true;
         output.next_cursor = page_last_name
             .map(|name| format_runtime_cursor("managed", &name, retained_count, retained_bytes));
-    } else if unmanaged_end < unmanaged_len {
+    } else if unmanaged_has_more {
         output.has_more = true;
         output.next_cursor = Some(format_runtime_cursor(
             "unmanaged",
-            unmanaged_last_name.as_deref().unwrap_or(""),
+            unmanaged_resume.as_deref().unwrap_or(""),
             retained_count,
             retained_bytes,
         ));
@@ -1710,10 +1775,24 @@ mod cleanup_support {
                         .and_then(|raw| {
                             serde_json::from_str::<RuntimeTempCleanupLockOwner>(&raw).ok()
                         });
+                    // An owner whose recorded process identity has demonstrably
+                    // exited holds nothing: there is no process left to finish
+                    // the operation or release the directory. Requiring its
+                    // lease to *also* expire made the documented reclaim
+                    // unreachable in the case it exists for. The lease is 300s
+                    // but acquisition only retries for ~2s, so a dead owner's
+                    // lock could never be reclaimed by any invocation — every
+                    // run timed out and leaked another dead-owner lock on top
+                    // of it, permanently blocking the category (#14221).
+                    //
+                    // The lease still governs the *unverifiable* case, where
+                    // the identity can be neither confirmed live nor proven
+                    // dead. There, expiry is the only evidence available.
                     let stale = owner.as_ref().is_some_and(|owner| {
-                        unix_time_ms().saturating_sub(owner.heartbeat_unix_ms)
-                            > stale_after.as_millis() as u64
-                            && process_identity_is_stale(owner)
+                        process_identity_is_stale(owner)
+                            || (process_identity_is_unverifiable(owner)
+                                && unix_time_ms().saturating_sub(owner.heartbeat_unix_ms)
+                                    > stale_after.as_millis() as u64)
                     }) || owner.is_none()
                         && fs::metadata(&path)
                             .ok()
@@ -1844,11 +1923,24 @@ mod cleanup_support {
         )
     }
 
+    /// The recorded owner has provably exited, or the PID now belongs to a
+    /// different process. Either way nothing is holding the lock.
     fn process_identity_is_stale(owner: &RuntimeTempCleanupLockOwner) -> bool {
         matches!(
             process_identity_state(owner),
             crate::process::ProcessIdentityState::Dead
                 | crate::process::ProcessIdentityState::IdentityMismatch
+        )
+    }
+
+    /// The owner's liveness cannot be determined — an unreadable `/proc` entry,
+    /// an owner recorded on another host, or a platform without identity
+    /// inspection. Lease expiry is the only evidence available for these, so
+    /// they alone still have to wait out [`CLEANUP_LOCK_STALE_AFTER`].
+    fn process_identity_is_unverifiable(owner: &RuntimeTempCleanupLockOwner) -> bool {
+        matches!(
+            process_identity_state(owner),
+            crate::process::ProcessIdentityState::Unverifiable
         )
     }
 
@@ -2091,6 +2183,7 @@ mod tests {
             run_max_bytes: 1024 * 1024 * 1024,
             run_max_count: 100,
             cursor: None,
+            deadline: None,
         }
     }
 

--- a/crates/homeboy-core/src/engine/temp/implementation/tests/retention_tests.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation/tests/retention_tests.rs
@@ -478,6 +478,138 @@ fn stale_cleanup_lock_from_exited_owner_is_reclaimed() {
     drop(reclaimed);
 }
 
+/// The exact production shape from #14221: a lock left behind by a category
+/// timeout, whose owner PID is gone but whose 300s lease is still in the
+/// future. Reclaim must not wait the lease out — the owner is dead, so nothing
+/// will ever release the lock or renew the lease.
+///
+/// Before the fix this needed BOTH lease expiry and a dead identity, and the
+/// acquirer only retries for ~2s against a 300s lease, so the reclaim branch
+/// was unreachable and every invocation leaked another dead-owner lock.
+#[test]
+fn cleanup_lock_from_exited_owner_is_reclaimed_while_its_lease_is_still_live() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let first =
+        super::super::cleanup_support::acquire_cleanup_lock(root.path(), "runtime-temp.cleanup")
+            .expect("first lock");
+    let owner_path = first.path.join(CLEANUP_LOCK_OWNER_FILE);
+    let mut owner: RuntimeTempCleanupLockOwner =
+        serde_json::from_slice(&fs::read(&owner_path).expect("owner record")).expect("owner json");
+    owner.pid = exited_pid();
+    owner.linux_starttime_ticks = None;
+    owner.process_start_identity = None;
+    // Heartbeated moments ago, so the lease has almost its full 300s left.
+    owner.heartbeat_unix_ms = super::super::cleanup_support::unix_time_ms();
+    owner.lease_deadline_unix_ms = owner
+        .heartbeat_unix_ms
+        .saturating_add(CLEANUP_LOCK_STALE_AFTER.as_millis() as u64);
+    super::super::cleanup_support::write_cleanup_lock_owner(&owner_path, &owner)
+        .expect("dead owner with a live lease");
+    std::mem::forget(first);
+
+    let reclaimed = super::super::cleanup_support::acquire_cleanup_lock_with_policy(
+        root.path(),
+        "test.reclaimer",
+        CLEANUP_LOCK_ATTEMPTS,
+        CLEANUP_LOCK_STALE_AFTER,
+    )
+    .expect("a dead owner must be reclaimed without waiting out its lease");
+    drop(reclaimed);
+}
+
+/// The self-perpetuating half of #14221: each leaked lock must not block the
+/// next invocation. Two successive acquisitions, each abandoning a dead-owner
+/// lock, must both succeed.
+#[test]
+fn successive_leaked_dead_owner_locks_do_not_block_later_cleanups() {
+    let root = tempfile::tempdir().expect("tempdir");
+    for _ in 0..3 {
+        let lock = super::super::cleanup_support::acquire_cleanup_lock_with_policy(
+            root.path(),
+            "runtime-temp.cleanup",
+            CLEANUP_LOCK_ATTEMPTS,
+            CLEANUP_LOCK_STALE_AFTER,
+        )
+        .expect("each invocation reclaims the previous leaked lock");
+        let owner_path = lock.path.join(CLEANUP_LOCK_OWNER_FILE);
+        let mut owner: RuntimeTempCleanupLockOwner =
+            serde_json::from_slice(&fs::read(&owner_path).expect("owner")).expect("owner json");
+        // Simulate the SIGKILL at the category wall: the owner process is gone
+        // and no destructor ran, so the directory is still on disk.
+        owner.pid = exited_pid();
+        owner.linux_starttime_ticks = None;
+        owner.process_start_identity = None;
+        super::super::cleanup_support::write_cleanup_lock_owner(&owner_path, &owner)
+            .expect("dead owner");
+        std::mem::forget(lock);
+    }
+    assert!(root.path().join(CLEANUP_LOCK_DIR).exists());
+}
+
+/// A live owner is still protected. The relaxed reclaim must not let a
+/// contender steal a lock whose recorded process is genuinely running.
+#[test]
+fn live_owner_is_not_reclaimed_by_the_relaxed_staleness_rule() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let first =
+        super::super::cleanup_support::acquire_cleanup_lock(root.path(), "runtime-temp.cleanup")
+            .expect("first lock");
+    let owner_path = first.path.join(CLEANUP_LOCK_OWNER_FILE);
+    let mut owner: RuntimeTempCleanupLockOwner =
+        serde_json::from_slice(&fs::read(&owner_path).expect("owner")).expect("owner json");
+    // Lease long expired, but this process is demonstrably alive.
+    owner.heartbeat_unix_ms = 0;
+    owner.lease_deadline_unix_ms = 0;
+    super::super::cleanup_support::write_cleanup_lock_owner(&owner_path, &owner)
+        .expect("expired lease, live owner");
+
+    let error = super::super::cleanup_support::acquire_cleanup_lock_with_policy(
+        root.path(),
+        "test.contender",
+        2,
+        Duration::from_secs(0),
+    )
+    .expect_err("a live owner keeps its lock even with an expired lease");
+    assert!(error.message.contains("timed out acquiring"));
+    assert!(owner_path.exists(), "live owner's lock must survive");
+    drop(first);
+}
+
+/// The lock is released when the sweep stops on its wall-clock budget, which
+/// is the path the category timeout now takes instead of being SIGKILLed.
+#[test]
+fn budget_truncated_sweep_releases_its_cleanup_lock_and_resumes() {
+    let _guard = home_env_guard();
+    let root = tempfile::tempdir().expect("tempdir");
+    env::set_var(runtime_tmpdir_env(), root.path());
+    for index in 0..4 {
+        let path = failed_run(&format!("homeboy-run-budget-{index}"), 64);
+        assert!(path.exists());
+    }
+
+    let mut options = bounded_options(true, None);
+    options.older_than_days = 0;
+    // Already spent: the sweep must stop at the first entry boundary.
+    options.deadline = Some(std::time::Instant::now());
+    let output = cleanup_runtime_tmp_bounded(options).expect("budget-truncated sweep returns");
+
+    assert!(
+        output.has_more,
+        "a truncated sweep must report that work remains"
+    );
+    assert!(
+        !root.path().join(CLEANUP_LOCK_DIR).exists(),
+        "the cleanup lock must not survive a budget-truncated sweep"
+    );
+
+    // And the next invocation, with budget, still makes progress.
+    options.deadline = None;
+    let resumed = cleanup_runtime_tmp_bounded(options).expect("resumed sweep");
+    assert!(resumed.removed_count > 0);
+    assert!(!root.path().join(CLEANUP_LOCK_DIR).exists());
+    env::remove_var(runtime_tmpdir_env());
+}
+
 fn exited_pid() -> u32 {
     let mut child = std::process::Command::new("true")
         .spawn()

--- a/crates/homeboy-core/src/extension/invoke/deadline_process.rs
+++ b/crates/homeboy-core/src/extension/invoke/deadline_process.rs
@@ -15,6 +15,7 @@ pub(crate) struct DeadlineProcessOutput {
     pub stderr: Vec<u8>,
 }
 
+#[derive(Debug)]
 pub(crate) struct DeadlineProcessFailure {
     pub message: String,
 }

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -1013,6 +1013,7 @@ mod tests {
             run_max_bytes: u64::MAX,
             run_max_count: usize::MAX,
             cursor: None,
+            deadline: None,
         };
         let active = homeboy_core::engine::temp::cleanup_runtime_tmp_bounded(options)
             .expect("active cleanup preview");


### PR DESCRIPTION
## Summary

`homeboy cleanup --include runtime-tmp` was permanently unusable on this host. Every run timed out at the 25s category budget and leaked a **new** lock directory owned by an already-dead PID, which the next run could not reclaim. Self-perpetuating: three distinct dead owner PIDs were observed across successive runs (2068979 → 2070478 → 2091904), the last with `heartbeat_age_ms: 5367353` (~89 min) and the PID confirmed gone.

Fixes #14221

## Root cause

Two defects, and the first is not where it looks.

**1. Stale reclaim was unreachable, not broken.** The predicate required lease expiry **AND** a dead process identity:

```rust
now - heartbeat_unix_ms > stale_after && process_identity_is_stale(owner)
```

Those are contradictory in practice. `stale_after` for this lock is `CLEANUP_LOCK_STALE_AFTER` = **300s**, but acquisition retries `100 × 20ms` ≈ **2s**. A dead owner's lock could therefore never be reclaimed by *any* invocation — the acquirer always gave up ~298s before the lease could expire.

> Note: the brief for this fix cited the 30s at lines 34/42 as `stale_after`. Those belong to the separate `FsIndexLock` **claim**, not this lock. The real gap is 2s vs 300s — an order of magnitude worse. The issue's own first trace confirms it: `identity_state: "Dead"` with `retry_after_ms: 275237`.

A dead owner holds nothing — no process remains to finish the operation or release the directory — so **identity alone is now sufficient**. Lease expiry still governs the `Unverifiable` case (unreadable `/proc`, owner recorded on another host, platform without identity inspection), where expiry is the only evidence available. A `Live` owner is still protected regardless of lease age.

**2. The lock outlived the process because the process was killed.** At the category wall the supervisor SIGKILLs the category child (`terminate_and_reap` → `SIGTERM`, then `SIGKILL`). A killed process runs no destructor, so `RuntimeTempCleanupLock::Drop` — which is correct and does release the lock — never ran. Releasing "on the abort path" is not implementable via `Drop` here; the fix is to **not reach the wall**.

`RuntimeTempCleanupOptions` gains a `deadline`. The sweep checks it at entry boundaries (before the recursive storage walk that dominates cost), stops, and returns `has_more` with a resumable `next_cursor`. The CLI derives it from the category deadline minus a 2s reporting headroom. This mirrors the existing `max_scan_duration` precedent from #12727.

This second half is load-bearing: the runtime root held **403 entries / 8.6G**, so the scan legitimately exceeds 25s. Fixing reclaim alone would leave the category timing out forever, just without the leak.

## Verification

Four regression tests in `retention_tests.rs`, following existing patterns:

- `cleanup_lock_from_exited_owner_is_reclaimed_while_its_lease_is_still_live` — the exact production shape: dead PID, ~300s of lease remaining. **Fails before this change.**
- `successive_leaked_dead_owner_locks_do_not_block_later_cleanups` — the self-perpetuating half; three successive leaked locks must each be reclaimed.
- `live_owner_is_not_reclaimed_by_the_relaxed_staleness_rule` — guards against over-correction: expired lease + live owner must **not** be stolen.
- `budget_truncated_sweep_releases_its_cleanup_lock_and_resumes` — asserts no `.cleanup.lock` survives a budget-truncated sweep, and the next invocation still makes progress.

```
cargo test -p homeboy-core temp::   42 passed (5/5 runs, stable)
cargo test -p homeboy-cli cleanup   85 passed
cargo check --workspace --all-targets   clean
```

## Decisions made at forks

- **Kept `CLEANUP_LOCK_ATTEMPTS` at ~2s rather than raising it to exceed `stale_after`.** Reconciling the budget by *waiting out* a 300s lease would turn every busy lock into a 300s hang. Reclaim is now identity-driven, so an abandoned lock is recovered on the first attempt — the budget and the lease no longer need to relate. Both constants are now documented with why they differ.
- **Implemented the #9482-style resumability, minimally.** Scoped to the deadline check plus cursor truncation; no new pagination model. It is required, not optional — see above.
- **Left `Drop` as-is.** It is correct; it just cannot run under SIGKILL.

## Incidental

`DeadlineProcessFailure` now derives `Debug`. This is unrelated to the bug but was **already breaking `cargo test -p homeboy-core` compilation on `origin/main`** (verified by stashing this change), which blocked the required verification gate. One-line, trivially correct, flagged here rather than split into a separate PR so the gate is runnable.

Pre-existing flaky failures in `cleanup::tests::*` / `cargo_targets` are environmental (SQLite `disk I/O error`, host at high disk usage) — failure count varies 1–3 across identical runs and the runtime-temp one passes 5/5 in isolation. Not caused by this change.

`cargo fmt --check` and `cargo clippy` could not be run: `rustfmt`/`clippy` are not installed in the available toolchain and the rustup dir is root-owned read-only on this host. Diff was hand-verified for trailing whitespace and line length; CI should confirm.