### PR TITLE
Preserve provider rotation causes in Cook failures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_notify_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_notify_tests.rs
@@ -104,6 +104,23 @@ fn intentional_no_change_terminal_notifications_match_policy_outcome() {
 }
 
 #[test]
+fn rotation_exhaustion_notification_preserves_the_terminal_cause() {
+    let mut report = report("provider_failure", None);
+    report.terminal_phase = Some("provider".to_string());
+    report.terminal_failure_classification = Some("provider_rotation_exhausted".to_string());
+    report.stop_reason = Some(
+        "provider rotation exhausted without a candidate: xai/grok-4.6: provider_account_blocked; zai-coding-plan/glm-5.3: rate_limited; opencode-go/kimi-k3: stalled".to_string(),
+    );
+
+    let payload = terminal_payload(&report, None, 1);
+    let body = payload.render_body();
+    assert!(body.contains("Failure classification: provider_rotation_exhausted"));
+    assert!(body.contains("xai/grok-4.6: provider_account_blocked"));
+    assert!(body.contains("zai-coding-plan/glm-5.3: rate_limited"));
+    assert!(body.contains("opencode-go/kimi-k3: stalled"));
+}
+
+#[test]
 fn failed_cook_forwards_its_own_legal_recovery_commands() {
     let mut failed = report("durable_failure", None);
     failed.failure_context = Some(failure_context());

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -882,6 +882,17 @@ fn truncate_diagnostic_text(text: &str) -> String {
     }
 }
 
+/// A preceding `key: ` can make the prose redactor consume a following
+/// `token=value` as ordinary text. Redact each whitespace-delimited fragment a
+/// second time so provider-produced diagnostic prose cannot bypass it.
+fn redact_diagnostic_text(text: &str) -> String {
+    let redacted = homeboy_core::redaction::redact_string(text);
+    redacted
+        .split_inclusive(char::is_whitespace)
+        .map(homeboy_core::redaction::redact_string)
+        .collect()
+}
+
 /// The generic cook side-effect boundary the attempt loop drives its external
 /// effects through: promotion, moving-base recovery, and PR finalization.
 ///
@@ -4222,11 +4233,12 @@ fn make_provider_rotation_actionable(
     }) else {
         return;
     };
-    let mut diagnostic_value = serde_json::json!({
+    let diagnostic_message = redact_diagnostic_text(&diagnostic.message);
+    let mut diagnostic_value = homeboy_core::redaction::redact_json(&serde_json::json!({
         "class": diagnostic.class,
-        "message": diagnostic.message,
+        "message": diagnostic_message,
         "data": diagnostic.data,
-    });
+    }));
     bound_diagnostic_value(&mut diagnostic_value, 0);
     let routes = provider_rotation_attempts(outcome)
         .unwrap_or_default()
@@ -4246,16 +4258,21 @@ fn make_provider_rotation_actionable(
         })
         .collect::<Vec<_>>();
     let routes = if routes.is_empty() {
-        truncate_diagnostic_text(&diagnostic.message)
+        truncate_diagnostic_text(&diagnostic_message)
     } else {
-        truncate_diagnostic_text(&routes.join("; "))
+        truncate_diagnostic_text(&redact_diagnostic_text(&routes.join("; ")))
     };
     let budget = aggregate
         .outcomes
         .iter()
         .flat_map(|outcome| &outcome.diagnostics)
         .find(|diagnostic| diagnostic.class == "agent_task.execution_budget_exhausted")
-        .map(|diagnostic| format!("; {}", truncate_diagnostic_text(&diagnostic.message)))
+        .map(|diagnostic| {
+            format!(
+                "; {}",
+                truncate_diagnostic_text(&redact_diagnostic_text(&diagnostic.message))
+            )
+        })
         .unwrap_or_default();
     report.value.terminal_phase = Some("provider".to_string());
     report.value.terminal_failure_classification = Some("provider_rotation_exhausted".to_string());
@@ -4268,7 +4285,7 @@ fn make_provider_rotation_actionable(
         operation: "route_selection".to_string(),
         phase: "provider".to_string(),
         exit_code: 1,
-        stderr_excerpt: truncate_diagnostic_text(&diagnostic.message),
+        stderr_excerpt: truncate_diagnostic_text(&diagnostic_message),
         evidence_ref: format!("homeboy://agent-task/run/{run_id}/status"),
         next_action: AgentTaskCookRecoveryAction {
             action: "diagnose".to_string(),

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -58,8 +58,8 @@ use super::cook_pre_execution::materialize_initial_cook_attempt_with_stores;
 use super::cook_pre_execution::{
     materialize_cook_attempt_with_stores, materialize_initial_cook_attempt_with_stores_outcome,
     pre_execution_failure_details, pre_execution_failure_phase, pre_execution_failure_report,
-    record_pre_execution_failure, retryable_pre_execution_failure, terminal_executor_matches,
-    with_pre_execution_phase, CookExecutionPreparation,
+    provider_rotation_attempts, record_pre_execution_failure, retryable_pre_execution_failure,
+    terminal_executor_matches, with_pre_execution_phase, CookExecutionPreparation,
 };
 use super::cook_promotion::{
     attempt_needs_execution_with_store, cook_report, finalize_or_load_cook_pr,
@@ -1851,7 +1851,7 @@ pub struct AgentTaskCookRecoveryAction {
     pub command: String,
 }
 
-/// Bounded primary cause for a provider command that failed before dispatch.
+/// Bounded primary cause for a terminal provider failure.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct AgentTaskCookPrimaryFailure {
     pub schema: &'static str,
@@ -1862,6 +1862,10 @@ pub struct AgentTaskCookPrimaryFailure {
     pub stderr_excerpt: String,
     pub evidence_ref: String,
     pub next_action: AgentTaskCookRecoveryAction,
+    /// The typed terminal diagnostic when provider execution, rather than
+    /// pre-execution setup, exhausted its available routes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<Value>,
 }
 
 /// A bounded collection of independently durable cooks. Each cook retains the
@@ -4198,6 +4202,84 @@ fn make_provider_timeout_actionable(
                 context.next_actions.push(action);
             }
         }
+    }
+}
+
+/// Project the scheduler's already-normalized rotation evidence onto every
+/// terminal Cook surface. The aggregate remains the complete record; this is a
+/// bounded top-level explanation for the no-candidate terminal path.
+fn make_provider_rotation_actionable(
+    report: &mut AgentTaskRunResult<AgentTaskCookReport>,
+    aggregate: &AgentTaskAggregate,
+    run_id: &str,
+) {
+    let Some((outcome, diagnostic)) = aggregate.outcomes.iter().find_map(|outcome| {
+        outcome
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.class == "agent_task.provider_rotation_exhausted")
+            .map(|diagnostic| (outcome, diagnostic))
+    }) else {
+        return;
+    };
+    let mut diagnostic_value = serde_json::json!({
+        "class": diagnostic.class,
+        "message": diagnostic.message,
+        "data": diagnostic.data,
+    });
+    bound_diagnostic_value(&mut diagnostic_value, 0);
+    let routes = provider_rotation_attempts(outcome)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|attempt| {
+            let model = attempt
+                .candidate_producing_model
+                .or(attempt.attempted_model)
+                .or(attempt.model)
+                .unwrap_or_else(|| "default model".to_string());
+            let classification = attempt
+                .failure_classification
+                .and_then(|classification| serde_json::to_value(classification).ok())
+                .and_then(|classification| classification.as_str().map(str::to_string))
+                .unwrap_or_else(|| "unclassified_failure".to_string());
+            format!("{}/{}: {classification}", attempt.backend, model)
+        })
+        .collect::<Vec<_>>();
+    let routes = if routes.is_empty() {
+        truncate_diagnostic_text(&diagnostic.message)
+    } else {
+        truncate_diagnostic_text(&routes.join("; "))
+    };
+    let budget = aggregate
+        .outcomes
+        .iter()
+        .flat_map(|outcome| &outcome.diagnostics)
+        .find(|diagnostic| diagnostic.class == "agent_task.execution_budget_exhausted")
+        .map(|diagnostic| format!("; {}", truncate_diagnostic_text(&diagnostic.message)))
+        .unwrap_or_default();
+    report.value.terminal_phase = Some("provider".to_string());
+    report.value.terminal_failure_classification = Some("provider_rotation_exhausted".to_string());
+    report.value.stop_reason = Some(format!(
+        "provider rotation exhausted without a candidate: {routes}{budget}"
+    ));
+    report.value.primary_failure = Some(AgentTaskCookPrimaryFailure {
+        schema: "homeboy/agent-task-cook-primary-failure/v1",
+        provider_id: "provider_rotation".to_string(),
+        operation: "route_selection".to_string(),
+        phase: "provider".to_string(),
+        exit_code: 1,
+        stderr_excerpt: truncate_diagnostic_text(&diagnostic.message),
+        evidence_ref: format!("homeboy://agent-task/run/{run_id}/status"),
+        next_action: AgentTaskCookRecoveryAction {
+            action: "diagnose".to_string(),
+            command: format!("homeboy agent-task diagnose {run_id} --full"),
+        },
+        diagnostic: Some(diagnostic_value.clone()),
+    });
+    if let Some(context) = report.value.failure_context.as_mut() {
+        context.phase = "provider".to_string();
+        context.reason_code = "provider_rotation_exhausted".to_string();
+        context.diagnostic = Some(diagnostic_value);
     }
 }
 
@@ -6697,6 +6779,7 @@ fn run_cook_spine(
                 )
                 .unwrap_or(true),
             );
+            make_provider_rotation_actionable(&mut report, &aggregate, &run_id);
             if report.value.terminal_phase.is_none() {
                 if let Some((phase, classification, _)) = pre_provider_diagnostic_cause(
                     record.metadata["provider_executions_consumed"]

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -654,6 +654,7 @@ fn provider_primary_failure(
             action: action.to_string(),
             command,
         },
+        diagnostic: None,
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -963,8 +963,9 @@ fn provider_rotation_terminal_projection_retains_heterogeneous_route_causes() {
         AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     };
 
+    const SECRET: &str = "rotation-projection-secret";
     let attempts = serde_json::json!([
-        {"attempt": 1, "rotation_index": 0, "backend": "xai", "model": "grok-4.6", "attempted_model": "grok-4.6", "status": "failed", "failure_classification": "provider_account_blocked"},
+        {"attempt": 1, "rotation_index": 0, "backend": "xai", "model": "grok-4.6", "attempted_model": "grok-4.6", "status": "failed", "failure_classification": "provider_account_blocked", "summary": "token=rotation-projection-secret"},
         {"attempt": 2, "rotation_index": 1, "backend": "zai-coding-plan", "model": "glm-5.3", "attempted_model": "glm-5.3", "status": "failed", "failure_classification": "rate_limited"},
         {"attempt": 3, "rotation_index": 2, "backend": "opencode-go", "model": "kimi-k3", "attempted_model": "kimi-k3", "status": "failed", "failure_classification": "stalled"},
         {"attempt": 4, "rotation_index": 3, "backend": "anthropic", "model": "claude-sonnet-5", "attempted_model": "claude-sonnet-5", "status": "failed", "failure_classification": "stalled"}
@@ -984,8 +985,8 @@ fn provider_rotation_terminal_projection_retains_heterogeneous_route_causes() {
             diagnostics: vec![
                 AgentTaskDiagnostic {
                     class: "agent_task.provider_rotation_exhausted".to_string(),
-                    message: "all configured provider routes were rejected".to_string(),
-                    data: serde_json::json!({ "attempts": attempts }),
+                    message: "all configured provider routes were rejected: token=rotation-projection-secret".to_string(),
+                    data: serde_json::json!({ "attempts": attempts, "token": SECRET }),
                 },
                 AgentTaskDiagnostic {
                     class: "agent_task.execution_budget_exhausted".to_string(),
@@ -1072,11 +1073,24 @@ fn provider_rotation_terminal_projection_retains_heterogeneous_route_causes() {
             "missing {route}: {stop_reason}"
         );
     }
-    let context = report.value.failure_context.expect("failure context");
+    let context = report
+        .value
+        .failure_context
+        .as_ref()
+        .expect("failure context");
     assert_eq!(context.reason_code, "provider_rotation_exhausted");
     assert_eq!(
-        context.diagnostic.expect("diagnostic")["class"],
+        context.diagnostic.as_ref().expect("diagnostic")["class"],
         "agent_task.provider_rotation_exhausted"
+    );
+    let rendered = serde_json::to_string(&report.value).expect("rotation report serializes");
+    assert!(
+        !rendered.contains(SECRET),
+        "rotation report leaked {SECRET}"
+    );
+    assert!(
+        rendered.contains("[REDACTED]"),
+        "rotation report was not redacted"
     );
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -957,6 +957,130 @@ fn provider_timeout_report_surfaces_budget_and_exact_recovery() {
 }
 
 #[test]
+fn provider_rotation_terminal_projection_retains_heterogeneous_route_causes() {
+    use crate::agent_task::{AgentTaskDiagnostic, AgentTaskOutcome, AgentTaskOutcomeStatus};
+    use crate::agent_task_scheduler::{
+        AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
+    };
+
+    let attempts = serde_json::json!([
+        {"attempt": 1, "rotation_index": 0, "backend": "xai", "model": "grok-4.6", "attempted_model": "grok-4.6", "status": "failed", "failure_classification": "provider_account_blocked"},
+        {"attempt": 2, "rotation_index": 1, "backend": "zai-coding-plan", "model": "glm-5.3", "attempted_model": "glm-5.3", "status": "failed", "failure_classification": "rate_limited"},
+        {"attempt": 3, "rotation_index": 2, "backend": "opencode-go", "model": "kimi-k3", "attempted_model": "kimi-k3", "status": "failed", "failure_classification": "stalled"},
+        {"attempt": 4, "rotation_index": 3, "backend": "anthropic", "model": "claude-sonnet-5", "attempted_model": "claude-sonnet-5", "status": "failed", "failure_classification": "stalled"}
+    ]);
+    let aggregate = AgentTaskAggregate {
+        schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+        plan_id: "rotation-projection".to_string(),
+        status: AgentTaskAggregateStatus::Failed,
+        totals: AgentTaskAggregateTotals {
+            failed: 1,
+            ..Default::default()
+        },
+        outcomes: vec![AgentTaskOutcome {
+            task_id: "rotation-task".to_string(),
+            status: AgentTaskOutcomeStatus::Failed,
+            metadata: serde_json::json!({ "provider_rotation": { "attempts": attempts } }),
+            diagnostics: vec![
+                AgentTaskDiagnostic {
+                    class: "agent_task.provider_rotation_exhausted".to_string(),
+                    message: "all configured provider routes were rejected".to_string(),
+                    data: serde_json::json!({ "attempts": attempts }),
+                },
+                AgentTaskDiagnostic {
+                    class: "agent_task.execution_budget_exhausted".to_string(),
+                    message: "provider execution stopped because its configured execution budget was exhausted".to_string(),
+                    data: serde_json::json!({ "exhausted_budget": "max_provider_rotations" }),
+                },
+            ],
+            ..Default::default()
+        }],
+        events: Vec::new(),
+        artifact_lineage: Vec::new(),
+        child_runs: Vec::new(),
+        artifact_bindings: Vec::new(),
+        queue: Default::default(),
+    };
+    let mut report = AgentTaskRunResult {
+        value: AgentTaskCookReport {
+            schema: "homeboy/agent-task-cook/v1",
+            cook_id: "rotation-projection".to_string(),
+            latest_run_id: Some("rotation-run".to_string()),
+            history_run_ids: vec!["rotation-run".to_string()],
+            invocation_run_ids: vec!["rotation-run".to_string()],
+            status: "provider_failure".to_string(),
+            disposition: CookDisposition::Terminal,
+            attempts: Vec::new(),
+            finalization: None,
+            intentional_no_change: None,
+            selected_candidate: None,
+            stop_reason: None,
+            terminal_phase: None,
+            terminal_failure_classification: None,
+            primary_failure: None,
+            moving_base_recovery: None,
+            failure_context: Some(AgentTaskCookFailureContext {
+                cook_id: "rotation-projection".to_string(),
+                latest_run_id: "rotation-run".to_string(),
+                selected_run_id: None,
+                selected_task_id: None,
+                selected_artifact_id: None,
+                promotion_provenance: None,
+                durable_recipe_ref: "recipe".to_string(),
+                lifecycle_state: "failed".to_string(),
+                phase: "provider".to_string(),
+                reason_code: "failed".to_string(),
+                diagnostic: None,
+                continuation_admission: None,
+                blocking_claim: None,
+                provider_budget_consumed: true,
+                provider_executions_consumed: 4,
+                recovery_legal: false,
+                recovery_reason: "provider budget exhausted".to_string(),
+                next_actions: Vec::new(),
+                legal_actions: Vec::new(),
+            }),
+        },
+        exit_code: 1,
+    };
+
+    make_provider_rotation_actionable(&mut report, &aggregate, "rotation-run");
+
+    assert_eq!(
+        report.value.terminal_failure_classification.as_deref(),
+        Some("provider_rotation_exhausted")
+    );
+    assert_eq!(
+        report
+            .value
+            .primary_failure
+            .as_ref()
+            .and_then(|failure| failure.diagnostic.as_ref())
+            .and_then(|diagnostic| diagnostic.get("class"))
+            .and_then(Value::as_str),
+        Some("agent_task.provider_rotation_exhausted")
+    );
+    let stop_reason = report.value.stop_reason.as_deref().expect("stop reason");
+    for route in [
+        "xai/grok-4.6: provider_account_blocked",
+        "zai-coding-plan/glm-5.3: rate_limited",
+        "opencode-go/kimi-k3: stalled",
+        "anthropic/claude-sonnet-5: stalled",
+    ] {
+        assert!(
+            stop_reason.contains(route),
+            "missing {route}: {stop_reason}"
+        );
+    }
+    let context = report.value.failure_context.expect("failure context");
+    assert_eq!(context.reason_code, "provider_rotation_exhausted");
+    assert_eq!(
+        context.diagnostic.expect("diagnostic")["class"],
+        "agent_task.provider_rotation_exhausted"
+    );
+}
+
+#[test]
 fn review_form_timeout_after_selected_candidate_is_not_a_provider_timeout() {
     let mut plan = compile_options("review-form-timeout-report")
         .identity


### PR DESCRIPTION
## Summary
- project persisted provider rotation exhaustion into terminal Cook classification, primary failure, stop reason, and recovery context
- retain heterogeneous route/model failure causes in notifications
- redact and bound provider-controlled diagnostic messages and data before serialization
- keep diagnose as the canonical full-evidence recovery action

## Verification
- `cargo test -p homeboy-agents provider_rotation_terminal_projection_retains_heterogeneous_route_causes`
- `cargo test -p homeboy-agents rotation_exhaustion_notification_preserves_the_terminal_cause`
- isolated readiness fixture passed after a broader Cook module run timed out
- `cargo fmt --check`

Fixes #13871

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode implemented and independently reviewed terminal root-cause projection, notification fidelity, diagnostic bounds, and redaction. Chris Huber directed the work and remains responsible.