### PR TITLE
Refresh stale auto Cook placement before fallback

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -2897,17 +2897,12 @@ fn preflight_hot_command_with_input(
             // A cached/projection-based inventory is enough for normal routing,
             // but not for a terminal local-resource refusal. A stale inventory
             // receives exactly one bounded runner-owned refresh before placement.
-            if hot_command.lab_offload_supported
-                && cli.runner.is_none()
-                && !matches!(cli.placement, crate::cli_surface::Placement::Local)
-                && !nonlocal_cook_requires_durable_admission(cli)
-                && resource_policy::evaluate_with_runner_hint(
-                    hot_command,
-                    &resources,
-                    lab_readiness.as_ref(),
-                )
-                .is_some()
-            {
+            if should_refresh_terminal_lab_inventory(
+                cli,
+                hot_command,
+                &resources,
+                lab_readiness.as_ref(),
+            ) {
                 if let Some(observed) = lab_readiness.take() {
                     let (resolved, diagnostic) = resolve_terminal_lab_inventory(
                         observed,
@@ -3115,6 +3110,22 @@ fn preflight_hot_command_with_input(
     }
 
     None
+}
+
+fn should_refresh_terminal_lab_inventory(
+    cli: &Cli,
+    hot_command: resource_policy::HotCommand,
+    resources: &crate::commands::resources::DoctorOutput,
+    lab_readiness: Option<&crate::runner::runners::LabRunnerReadiness>,
+) -> bool {
+    hot_command.lab_offload_supported
+        && cli.runner.is_none()
+        && !matches!(cli.placement, crate::cli_surface::Placement::Local)
+        && lab_readiness.is_some_and(|readiness| {
+            readiness.state == crate::runner::runners::LabRunnerReadinessState::Stale
+        })
+        && resource_policy::evaluate_with_runner_hint(hot_command, resources, lab_readiness)
+            .is_some()
 }
 
 fn parsed_lab_readiness_snapshot(
@@ -4507,6 +4518,156 @@ mod tests {
         assert_eq!(diagnostic.source_freshness.as_deref(), Some("stale"));
         assert_eq!(diagnostic.refreshed_at_ms, Some(200));
         assert_eq!(diagnostic.terminal_reason, "ready_after_refresh");
+    }
+
+    #[test]
+    fn auto_cook_refreshes_stale_disconnected_inventory_then_uses_local_fallback() {
+        use crate::core::parsed_command_preflight::{
+            FallbackDirective, ParsedCommandPolicySnapshot,
+        };
+        use homeboy_lab_runner_contract::EffectiveExecutionPlacement;
+
+        let auto = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "route after runner refresh",
+            "--to-worktree",
+            "fixture@stale-disconnected",
+            "--verify",
+            "true",
+        ]);
+        let explicit_runner = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "homeboy-lab",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "do not substitute local execution",
+            "--to-worktree",
+            "fixture@explicit-disconnected",
+            "--verify",
+            "true",
+        ]);
+        let mut resources = hot_resources();
+        resources.load.one = Some(0.5);
+        resources.load.five = Some(0.5);
+        resources.load.cpu_count = 2;
+        let command = cook_hot_command();
+
+        // Fresh inventory is authoritative, while stale auto placement gets one
+        // bounded refresh before the durable placement decision is captured.
+        assert!(should_refresh_terminal_lab_inventory(
+            &auto,
+            command,
+            &resources,
+            Some(&lab_readiness(
+                crate::runner::runners::LabRunnerReadinessState::Stale
+            )),
+        ));
+        for state in [
+            crate::runner::runners::LabRunnerReadinessState::ConnectedReady,
+            crate::runner::runners::LabRunnerReadinessState::Disconnected,
+        ] {
+            assert!(!should_refresh_terminal_lab_inventory(
+                &auto,
+                command,
+                &resources,
+                Some(&lab_readiness(state)),
+            ));
+        }
+        assert!(!should_refresh_terminal_lab_inventory(
+            &explicit_runner,
+            command,
+            &resources,
+            Some(&lab_readiness(
+                crate::runner::runners::LabRunnerReadinessState::Stale
+            )),
+        ));
+
+        let (disconnected, diagnostic) = resolve_terminal_lab_inventory(
+            lab_readiness(crate::runner::runners::LabRunnerReadinessState::Stale),
+            100,
+            || {
+                Ok((
+                    lab_readiness(crate::runner::runners::LabRunnerReadinessState::Disconnected),
+                    200,
+                ))
+            },
+        );
+        assert!(diagnostic.refresh_attempted);
+        assert_eq!(diagnostic.refreshed_state.as_deref(), Some("disconnected"));
+        assert!(disconnected.selected_runner_id.is_none());
+        assert!(resource_policy::admits_auto_local_capacity_fallback(
+            command,
+            &resources,
+            Some(&disconnected),
+            auto.placement,
+        ));
+
+        let context = resource_policy::resource_policy_context_from_evaluation(
+            command,
+            &resources,
+            None,
+            false,
+            true,
+            Some(&disconnected),
+            false,
+        );
+        let input = resource_policy::parsed_command_preflight_input(&auto, &[]);
+        let result = crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
+            Vec::new(),
+            input,
+            ParsedCommandPolicySnapshot {
+                resource_admission_evidence: resource_policy::resource_admission_evidence(
+                    &resources,
+                ),
+                resource_policy: Some(context),
+                lab_readiness: Some(parsed_lab_readiness_snapshot(&auto, &disconnected)),
+                selected_runner_id: None,
+                generic_route: generic_route_policy_snapshot(&auto, None),
+                deferred_pressure_refusal: false,
+                runner_admitted: false,
+                runner_incompatible: false,
+                auto_local_capacity_fallback: true,
+            },
+        )
+        .expect("auto placement permits its audited local fallback");
+        assert_eq!(
+            result.placement.selected,
+            EffectiveExecutionPlacement::Local
+        );
+        assert!(result.placement.runner.is_none());
+        assert_eq!(result.fallback, FallbackDirective::LocalCapacity);
+
+        let input = resource_policy::parsed_command_preflight_input(&explicit_runner, &[]);
+        let error = crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
+            Vec::new(),
+            input,
+            ParsedCommandPolicySnapshot {
+                resource_admission_evidence: resource_policy::resource_admission_evidence(
+                    &resources,
+                ),
+                resource_policy: None,
+                lab_readiness: Some(parsed_lab_readiness_snapshot(
+                    &explicit_runner,
+                    &disconnected,
+                )),
+                selected_runner_id: Some("homeboy-lab".to_string()),
+                generic_route: generic_route_policy_snapshot(
+                    &explicit_runner,
+                    Some("homeboy-lab".to_string()),
+                ),
+                deferred_pressure_refusal: false,
+                runner_admitted: false,
+                runner_incompatible: false,
+                auto_local_capacity_fallback: false,
+            },
+        )
+        .expect_err("an explicit disconnected runner must fail closed");
+        assert_eq!(error.details["field"], "selected_runner_id");
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -208,8 +208,9 @@ pub(crate) fn route_after_parse_with_provenance(
                 .map(|runner| runner.runner_id.clone())
         })
         .flatten();
-    if detached_cook_requires_deferred_admission(cli) && !is_unmaterialized_replay_worker() {
-        // Persist before any bounded refresh. The scoped replay selector owns
+    if cook_requires_unmaterialized_admission(cli, &preflight) && !is_unmaterialized_replay_worker()
+    {
+        // Persist before provider execution. The scoped replay selector owns
         // ready and reverse-capacity admission after this durable boundary.
         return admit_unmaterialized_cook(
             cli,
@@ -957,19 +958,33 @@ fn split_placement_coordinator_label(command: &Commands) -> Option<&'static str>
     }
 }
 
-/// Deferred replay is only needed after an explicitly detached Cook loses its
-/// Lab route. Attached Cooks continue to observe their terminal execution, and
-/// `lab-or-local` continues through its authorized controller fallback.
-fn detached_cook_requires_deferred_admission(cli: &Cli) -> bool {
-    cli.detach_after_handoff
-        && !cli.placement.allows_local_fallback()
-        && !matches!(cli.placement, homeboy::cli_surface::Placement::Local)
-        && matches!(
-            cli.command,
-            Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
-                command: crate::commands::agent_task::AgentTaskCommand::Cook(_),
-            })
-        )
+/// Preserve durable Cook admission when no provider route is currently
+/// executable. Automatic local execution under pressure needs the separately
+/// audited local-capacity fallback; a stale or failed runner refresh is not it.
+fn cook_requires_unmaterialized_admission(
+    cli: &Cli,
+    preflight: &homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult,
+) -> bool {
+    let is_cook = matches!(
+        cli.command,
+        Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+            command: crate::commands::agent_task::AgentTaskCommand::Cook(_),
+        })
+    );
+    is_cook
+        && ((cli.detach_after_handoff
+            && !cli.placement.allows_local_fallback()
+            && !matches!(cli.placement, homeboy::cli_surface::Placement::Local))
+            || (matches!(cli.placement, homeboy::cli_surface::Placement::Auto)
+                && preflight.selected_runner_id.is_none()
+                && matches!(
+                    preflight.resource_admission,
+                    homeboy::core::parsed_command_preflight::ResourceAdmissionDecision::Rejected { .. }
+                )
+                && !matches!(
+                    preflight.fallback,
+                    homeboy::core::parsed_command_preflight::FallbackDirective::LocalCapacity
+                )))
 }
 
 fn admission_digest(value: impl AsRef<[u8]>) -> String {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -3173,7 +3173,33 @@ fn split_placement_cook_accepts_lab_placement_when_a_runner_is_selected() {
 }
 
 #[test]
-fn only_detached_cook_without_local_fallback_enters_deferred_admission() {
+fn cook_requires_unmaterialized_admission_when_detached_or_local_is_not_authorized() {
+    use homeboy::core::parsed_command_preflight::{
+        DeferredWorkloadDecision, FallbackDirective, ParsedCommandPreflightResult,
+        ResourceAdmissionDecision, ResourceAdmissionEvidence, ResourceHeat,
+    };
+
+    let preflight = |cli: &Cli, fallback| {
+        let normalized = vec!["homeboy".to_string()];
+        let mut result = ParsedCommandPreflightResult::new(
+            normalized.clone(),
+            resource_policy::parsed_command_preflight_input(cli, &normalized),
+            None,
+            None,
+            DeferredWorkloadDecision::NotApplicable,
+            fallback,
+            crate::cli_runtime::placement_directive(cli, None, false),
+            None,
+        );
+        result.resource_admission = ResourceAdmissionDecision::Rejected {
+            label: "cook".to_string(),
+            engages_at: ResourceHeat::Warm,
+            evidence: ResourceAdmissionEvidence::Observed {
+                pressure: ResourceHeat::Warm,
+            },
+        };
+        result
+    };
     let queued = Cli::parse_from([
         "homeboy",
         "--detach-after-handoff",
@@ -3186,7 +3212,10 @@ fn only_detached_cook_without_local_fallback_enters_deferred_admission() {
         "--prompt",
         "queue this on Lab",
     ]);
-    assert!(detached_cook_requires_deferred_admission(&queued));
+    assert!(cook_requires_unmaterialized_admission(
+        &queued,
+        &preflight(&queued, FallbackDirective::None),
+    ));
 
     let local = Cli::parse_from([
         "homeboy",
@@ -3202,7 +3231,10 @@ fn only_detached_cook_without_local_fallback_enters_deferred_admission() {
         "--prompt",
         "remain local",
     ]);
-    assert!(!detached_cook_requires_deferred_admission(&local));
+    assert!(!cook_requires_unmaterialized_admission(
+        &local,
+        &preflight(&local, FallbackDirective::None),
+    ));
 
     let fallback = Cli::parse_from([
         "homeboy",
@@ -3218,7 +3250,30 @@ fn only_detached_cook_without_local_fallback_enters_deferred_admission() {
         "--prompt",
         "run locally when Lab is unavailable",
     ]);
-    assert!(!detached_cook_requires_deferred_admission(&fallback));
+    assert!(!cook_requires_unmaterialized_admission(
+        &fallback,
+        &preflight(&fallback, FallbackDirective::None),
+    ));
+
+    let automatic = Cli::parse_from([
+        "homeboy",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "fixture@stale-refresh-timeout",
+        "--verify",
+        "true",
+        "--prompt",
+        "wait for a confirmed placement",
+    ]);
+    assert!(cook_requires_unmaterialized_admission(
+        &automatic,
+        &preflight(&automatic, FallbackDirective::None),
+    ));
+    assert!(!cook_requires_unmaterialized_admission(
+        &automatic,
+        &preflight(&automatic, FallbackDirective::LocalCapacity),
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- refresh stale automatic Cook runner inventory once before terminal placement
- preserve explicit runner fail-closed behavior and audited local-capacity fallback
- defer unconfirmed automatic placement into durable Cook admission instead of launching locally
- cover stale-disconnected, refresh-failure, explicit, and local fallback paths

## Verification
- `cargo test -p homeboy-cli auto_cook_refreshes_stale_disconnected_inventory_then_uses_local_fallback`
- `cargo test -p homeboy-cli nonlocal_cook_persists_before_hot_resource_admission`
- `cargo test -p homeboy-cli cook_requires_unmaterialized_admission_when_detached_or_local_is_not_authorized`
- route dispatch module started 103 tests and exceeded 120 seconds without a related failure
- `cargo fmt --check`

Fixes #13527

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode implemented and independently reviewed stale inventory refresh, auto placement, durable admission, and local fallback authorization. Chris Huber directed the work and remains responsible.