### PR TITLE
Fence daemon replacement across Cook admission

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -29,7 +29,6 @@ use crate::process::{
     SIGNAL_KILL, SIGNAL_TERMINATE,
 };
 
-#[cfg(target_os = "linux")]
 use super::acquire_daemon_job_admission_fence;
 use super::{
     acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
@@ -2353,9 +2352,16 @@ fn start_or_return_live_unlocked_with_startup_token(
     start_or_return_live_with_operations(
         read_status,
         try_acquire_daemon_owner_lock,
-        || stop_unlocked().map(|_| ()),
+        stop_stale_generation_for_start,
         || spawn_and_wait_for_lease(addr, startup_token),
     )
+}
+
+/// Startup cleanup can retire a stale generation, so it must not pass a Cook
+/// that has verified that generation but not submitted.
+fn stop_stale_generation_for_start() -> Result<()> {
+    let _admission_fence = acquire_daemon_job_admission_fence()?;
+    stop_unlocked().map(|_| ())
 }
 
 /// A missing lease cannot authorize replacement when another foreground daemon

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -167,6 +167,10 @@ fn heartbeat_only_stall_reason(timeout: Duration) -> String {
 pub struct LocalControllerJobClient {
     endpoint: String,
     client: reqwest::blocking::Client,
+    // Keep the shared side until this client has durably handed off the job.
+    // Recovery takes the exclusive side before proving zero active jobs, so a
+    // different build cannot replace this generation after preflight.
+    _admission_guard: Option<File>,
 }
 
 /// The durable admission result for a typed controller job submission.
@@ -202,6 +206,7 @@ impl LocalControllerJobClient {
     /// can deserialize a request while applying stale ownership semantics. Fail
     /// before submission instead of handing new lifecycle records to it.
     pub fn connect_current_build() -> Result<Self> {
+        let admission_guard = acquire_daemon_admission_lock(DaemonAdmissionLockMode::Shared)?;
         let status = read_status()?;
         if status.reachable && !status.fresh {
             let daemon_identity = status
@@ -236,7 +241,7 @@ impl LocalControllerJobClient {
             });
             return Err(error);
         }
-        Self::connect()
+        Self::connect_with_admission_guard(Some(admission_guard))
     }
 
     /// Connect to the current daemon build, first applying its canonical idle
@@ -263,6 +268,10 @@ impl LocalControllerJobClient {
     }
 
     pub fn connect() -> Result<Self> {
+        Self::connect_with_admission_guard(None)
+    }
+
+    fn connect_with_admission_guard(admission_guard: Option<File>) -> Result<Self> {
         let daemon = ensure_running(DEFAULT_ADDR)?;
         let client = reqwest::blocking::Client::builder()
             .no_proxy()
@@ -274,6 +283,7 @@ impl LocalControllerJobClient {
         Ok(Self {
             endpoint: format!("http://{}", daemon.address),
             client,
+            _admission_guard: admission_guard,
         })
     }
 
@@ -6299,7 +6309,6 @@ pub(super) fn try_acquire_daemon_owner_lock() -> Result<Option<DaemonOwnerLock>>
 /// Prevent a recovery from observing idle work and then racing a new durable
 /// admission. Normal admissions take a shared lock; destructive recovery takes
 /// the exclusive side for its complete proof-and-signal interval.
-#[cfg(target_os = "linux")]
 pub(super) fn acquire_daemon_job_admission_fence() -> Result<DaemonAdmissionFence> {
     acquire_daemon_admission_lock(DaemonAdmissionLockMode::Exclusive).map(DaemonAdmissionFence)
 }
@@ -6311,7 +6320,6 @@ pub(super) fn with_daemon_job_admission<T>(operation: impl FnOnce() -> Result<T>
 
 enum DaemonAdmissionLockMode {
     Shared,
-    #[cfg(target_os = "linux")]
     Exclusive,
 }
 
@@ -6344,7 +6352,6 @@ fn acquire_daemon_admission_lock(mode: DaemonAdmissionLockMode) -> Result<File> 
             std::os::fd::AsRawFd::as_raw_fd(&file),
             match mode {
                 DaemonAdmissionLockMode::Shared => libc::LOCK_SH,
-                #[cfg(target_os = "linux")]
                 DaemonAdmissionLockMode::Exclusive => libc::LOCK_EX,
             },
         )
@@ -6364,7 +6371,6 @@ fn acquire_daemon_admission_lock(mode: DaemonAdmissionLockMode) -> Result<File> 
         let mut overlapped: OVERLAPPED = unsafe { std::mem::zeroed() };
         let flags = match mode {
             DaemonAdmissionLockMode::Shared => 0,
-            #[cfg(target_os = "linux")]
             DaemonAdmissionLockMode::Exclusive => LOCKFILE_EXCLUSIVE_LOCK,
         };
         if unsafe {
@@ -6464,10 +6470,8 @@ impl Drop for DaemonOwnerLock {
     }
 }
 
-#[cfg(target_os = "linux")]
 pub(super) struct DaemonAdmissionFence(File);
 
-#[cfg(target_os = "linux")]
 impl Drop for DaemonAdmissionFence {
     fn drop(&mut self) {
         #[cfg(unix)]

--- a/crates/homeboy-core/src/daemon/stop.rs
+++ b/crates/homeboy-core/src/daemon/stop.rs
@@ -19,6 +19,7 @@ pub fn stop() -> Result<DaemonStopResult> {
 /// caller supplied an explicit destructive force request.
 pub fn stop_with_force(force: bool) -> Result<DaemonStopResult> {
     let _lock = acquire_daemon_operation_lock()?;
+    let _admission_fence = acquire_daemon_job_admission_fence()?;
     stop_unlocked_with_force(force)
 }
 
@@ -30,6 +31,7 @@ pub fn stop_for_lease(expected_lease_id: &str) -> Result<DaemonStopResult> {
 /// This deliberately does not use the daemon HTTP lifecycle endpoint.
 pub fn force_stop_for_lease(expected_lease_id: &str) -> Result<DaemonStopResult> {
     let _lock = acquire_daemon_operation_lock()?;
+    let _admission_fence = acquire_daemon_job_admission_fence()?;
     force_stop_for_lease_unlocked(expected_lease_id)
 }
 
@@ -372,6 +374,7 @@ pub(super) fn stop_with_force_for_lease(
     force: bool,
 ) -> Result<DaemonStopResult> {
     let _lock = acquire_daemon_operation_lock()?;
+    let _admission_fence = acquire_daemon_job_admission_fence()?;
     let path = state_path()?;
     let validation = validate_lease_file(&path)?;
     if validation.invalid_pid.is_some()

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 #[cfg(unix)]
 use std::process::Command;
-use std::sync::{Arc, Barrier, Mutex};
+use std::sync::{mpsc, Arc, Barrier, Mutex};
 use std::time::Duration;
 #[cfg(target_os = "linux")]
 use std::time::Instant;
@@ -49,6 +49,41 @@ fn detached_daemon_owner_does_not_inherit_the_launcher_session() {
 struct FakeEnsureState {
     daemon: Option<super::DaemonStartResult>,
     starts: usize,
+}
+
+#[cfg(unix)]
+#[test]
+fn stale_start_cleanup_waits_for_cook_generation_admission() {
+    with_isolated_home(|_| {
+        let cook_preflight = super::super::acquire_daemon_admission_lock(
+            super::super::DaemonAdmissionLockMode::Shared,
+        )
+        .expect("Cook preflight acquires generation admission");
+        let (attempt_tx, attempt_rx) = mpsc::channel();
+        let (finished_tx, finished_rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            attempt_tx.send(()).expect("report startup cleanup attempt");
+            super::stop_stale_generation_for_start().expect("stale startup cleanup");
+            finished_tx
+                .send(())
+                .expect("report startup cleanup completion");
+        });
+
+        attempt_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("startup cleanup attempts admission");
+        assert!(
+            finished_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err(),
+            "stale startup cleanup must wait for Cook admission"
+        );
+
+        drop(cook_preflight);
+        finished_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("stale startup cleanup proceeds after Cook admission");
+    });
 }
 
 #[test]

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -3148,7 +3148,6 @@ fn routes_remote_runner_job_broker_lifecycle() {
     assert_eq!(finish.body["body"]["job"]["status"], "succeeded");
 }
 
-#[cfg(target_os = "linux")]
 #[test]
 fn reverse_runner_submission_cannot_persist_while_reconciliation_holds_admission_fence() {
     let _home = HomeGuard::new();
@@ -3188,6 +3187,75 @@ fn reverse_runner_submission_cannot_persist_while_reconciliation_holds_admission
         .expect("submission resumes after reconciliation");
     assert_eq!(response.status_code, 200);
     assert_eq!(store.list().len(), 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn parallel_build_recovery_cannot_replace_daemon_between_cook_preflight_and_admission() {
+    let _home = HomeGuard::new();
+    let store = JobStore::default();
+    let (started_tx, _started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    controller_job_driver::register_controller_job_driver(Arc::new(BlockingControllerDriver {
+        job_type: "test.parallel-build-admission",
+        started: started_tx,
+        release: Arc::new(Mutex::new(release_rx)),
+        cancellation_release: release_tx,
+        executions: Arc::new(AtomicUsize::new(0)),
+        cancellations: Arc::new(AtomicUsize::new(0)),
+    }))
+    .expect("register parallel-build controller driver");
+
+    // This is the guard retained by LocalControllerJobClient after it has
+    // verified the resident build but before it posts the Cook job.
+    let preflight_guard =
+        super::acquire_daemon_admission_lock(super::DaemonAdmissionLockMode::Shared)
+            .expect("Cook preflight acquires shared generation guard");
+    let (recovery_attempt_tx, recovery_attempt_rx) = mpsc::channel();
+    let (recovery_acquired_tx, recovery_acquired_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        recovery_attempt_tx
+            .send(())
+            .expect("report recovery attempt");
+        let fence = super::acquire_daemon_job_admission_fence()
+            .expect("parallel build acquires recovery fence");
+        recovery_acquired_tx
+            .send(())
+            .expect("report recovery fence");
+        drop(fence);
+    });
+    recovery_attempt_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("parallel build attempts recovery");
+    assert!(
+        recovery_acquired_rx
+            .recv_timeout(std::time::Duration::from_millis(100))
+            .is_err(),
+        "a sibling build must not replace the preflighted generation"
+    );
+
+    let admitted = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.parallel-build-admission",
+            "version": 1,
+            "idempotency_key": "parallel-cook",
+            "request": {}
+        })),
+        &store,
+    );
+    assert_eq!(admitted.status_code, 200);
+    assert_eq!(
+        store.list().len(),
+        1,
+        "Cook admission is durable before recovery"
+    );
+
+    drop(preflight_guard);
+    recovery_acquired_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("recovery can proceed after Cook admission");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- retain a shared daemon-generation admission guard from exact-build preflight through durable controller-job submission
- require destructive stop, lease stop, and stale-generation startup cleanup to acquire the exclusive fence
- enable the existing admission fence consistently across supported platforms
- cover parallel replacement and stale-start cleanup races deterministically

## Verification
- `cargo test -p homeboy-core stale_start_cleanup_waits_for_cook_generation_admission`
- `cargo test -p homeboy-core parallel_build_recovery_cannot_replace_daemon_between_cook_preflight_and_admission`
- `cargo test -p homeboy-core reverse_runner_submission_cannot_persist_while_reconciliation_holds_admission_fence`
- `cargo fmt --check`

Fixes #14229

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode implemented and independently reviewed the daemon generation fence, found the stale-start bypass, and added race coverage. Chris Huber directed the work and remains responsible.