### PR TITLE
Define the versioned Runner API claim operation

### DIFF
--- a/crates/contracts/homeboy-runner-contract/src/claim.rs
+++ b/crates/contracts/homeboy-runner-contract/src/claim.rs
@@ -1,0 +1,154 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    RunnerApiOperationFailure, RunnerApiVersion, RunnerExecutionEnvelope,
+    RunnerJobExecutionContextAssertion, RunnerJobExecutionProtocol, WorkspaceClaimBinding,
+    WorkspaceClaimProtocol, WorkspaceOwnerLease, WorkspaceOwnerLeaseProtocol,
+};
+
+pub const RUNNER_API_CLAIM_REQUEST_SCHEMA: &str = "homeboy/runner-api-claim-request/v1";
+pub const RUNNER_API_CLAIM_RESPONSE_SCHEMA: &str = "homeboy/runner-api-claim-response/v1";
+
+/// The transport-neutral request to claim one runner execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiClaimRequest {
+    pub schema: String,
+    pub api_version: RunnerApiVersion,
+    pub runner_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lease_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concurrency_limit: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_protocol: Option<RunnerJobExecutionProtocol>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_claim_protocol: Option<WorkspaceClaimProtocol>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_owner_lease_protocol: Option<WorkspaceOwnerLeaseProtocol>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiClaimResponse {
+    pub schema: String,
+    pub api_version: RunnerApiVersion,
+    pub outcome: RunnerApiClaimOutcome,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum RunnerApiClaimOutcome {
+    Claimed { claim: RunnerApiClaimedExecution },
+    Empty,
+    Rejected { failure: RunnerApiOperationFailure },
+}
+
+/// The canonical, core-free execution projection returned for a claimed job.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiClaimedExecution {
+    pub job_id: String,
+    pub claim_id: String,
+    pub claim_expires_at_ms: u64,
+    pub envelope: RunnerExecutionEnvelope,
+    /// The established protocol-v1 request projection. It is opaque only at
+    /// this boundary because its legacy shape remains implementation-owned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_request: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_claim_binding: Option<WorkspaceClaimBinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_owner_lease: Option<WorkspaceOwnerLease>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_context: Option<RunnerJobExecutionContextAssertion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_protocol: Option<RunnerJobExecutionProtocol>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_claim_protocol: Option<WorkspaceClaimProtocol>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_owner_lease_protocol: Option<WorkspaceOwnerLeaseProtocol>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RunnerApiVersion, RunnerExecutionEnvelope, RUNNER_API_V1};
+
+    #[test]
+    fn claim_request_is_strict_and_versioned() {
+        let request = RunnerApiClaimRequest {
+            schema: RUNNER_API_CLAIM_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            runner_id: "lab-1".to_string(),
+            project_id: None,
+            lease_ms: Some(30_000),
+            concurrency_limit: None,
+            execution_protocol: Some(RunnerJobExecutionProtocol::current()),
+            workspace_claim_protocol: None,
+            workspace_owner_lease_protocol: None,
+        };
+        let value = serde_json::to_value(&request).expect("claim request JSON");
+        assert_eq!(value["schema"], RUNNER_API_CLAIM_REQUEST_SCHEMA);
+        assert!(serde_json::from_value::<RunnerApiClaimRequest>(value).is_ok());
+        assert!(
+            serde_json::from_value::<RunnerApiClaimRequest>(serde_json::json!({
+                "schema": RUNNER_API_CLAIM_REQUEST_SCHEMA,
+                "api_version": { "major": 1 }, "runner_id": "lab-1", "unexpected": true,
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn claim_outcomes_pin_claimed_empty_and_rejected_wires() {
+        let claimed = RunnerApiClaimResponse {
+            schema: RUNNER_API_CLAIM_RESPONSE_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            outcome: RunnerApiClaimOutcome::Claimed {
+                claim: RunnerApiClaimedExecution {
+                    job_id: "job-1".to_string(),
+                    claim_id: "claim-1".to_string(),
+                    claim_expires_at_ms: 10,
+                    envelope: RunnerExecutionEnvelope::planned("run-1", "test"),
+                    legacy_request: None,
+                    workspace_claim_binding: None,
+                    workspace_owner_lease: None,
+                    execution_context: None,
+                    execution_protocol: Some(RunnerJobExecutionProtocol::current()),
+                    workspace_claim_protocol: None,
+                    workspace_owner_lease_protocol: None,
+                },
+            },
+        };
+        let encoded = serde_json::to_value(claimed).expect("claimed JSON");
+        assert_eq!(encoded["outcome"]["status"], "claimed");
+        assert!(encoded["outcome"]["claim"].get("legacy_request").is_none());
+        let empty = RunnerApiClaimResponse {
+            schema: RUNNER_API_CLAIM_RESPONSE_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            outcome: RunnerApiClaimOutcome::Empty,
+        };
+        assert_eq!(
+            serde_json::to_value(empty).expect("empty JSON")["outcome"],
+            serde_json::json!({ "status": "empty" })
+        );
+        let rejected = RunnerApiClaimResponse {
+            schema: RUNNER_API_CLAIM_RESPONSE_SCHEMA.to_string(),
+            api_version: RunnerApiVersion { major: 1 },
+            outcome: RunnerApiClaimOutcome::Rejected {
+                failure: RunnerApiOperationFailure {
+                    code: crate::RunnerApiOperationFailureCode::SubmissionRejected,
+                    message: "no".to_string(),
+                },
+            },
+        };
+        assert_eq!(
+            serde_json::to_value(rejected).expect("rejected JSON")["outcome"]["status"],
+            "rejected"
+        );
+    }
+}

--- a/crates/contracts/homeboy-runner-contract/src/execution_context.rs
+++ b/crates/contracts/homeboy-runner-contract/src/execution_context.rs
@@ -1,5 +1,62 @@
 //! Cross-process runner execution-context vocabulary.
 
+use serde::{Deserialize, Serialize};
+
+pub const RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA: &str = "homeboy/runner-job-execution-context/v1";
+pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY: &str = "runner-job-execution-context";
+pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION: u32 = 2;
+
+/// The worker capability negotiated before a claim can carry an execution
+/// context assertion.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerJobExecutionProtocol {
+    pub capability: String,
+    pub version: u32,
+}
+
+impl RunnerJobExecutionProtocol {
+    pub fn current() -> Self {
+        Self {
+            capability: RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY.to_string(),
+            version: RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION,
+        }
+    }
+
+    pub fn is_supported(&self) -> bool {
+        self.capability == RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY
+            && (1..=RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION).contains(&self.version)
+    }
+
+    pub fn uses_envelope_only_claim(&self) -> bool {
+        self.version >= 2
+    }
+}
+
+/// A transport assertion of a durable runner-job execution context.
+///
+/// This value is not live authority. The implementation that owns the durable
+/// claim must verify it before provider invocation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerJobExecutionContextAssertion {
+    pub schema: String,
+    pub id: String,
+    pub controller_run_id: String,
+    pub controller_attempt_id: String,
+    pub runner_id: String,
+    pub runner_job_id: String,
+    pub accepted_handoff_id: String,
+    pub runtime_id: String,
+    pub claim_ref: String,
+    pub dispatch_receipt: String,
+    pub verification: RunnerJobExecutionVerification,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerJobExecutionVerification {
+    pub state: String,
+    pub verified_at_ms: u64,
+}
+
 /// Set while a hosted exec runs inside a runner rather than the local host.
 pub const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
 

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod artifact;
 mod capability;
+mod claim;
 mod discovery;
 pub mod env_materialization_plan;
 mod execution_context;
@@ -23,6 +24,10 @@ pub use capability::{
     RunnerCapabilityPreflight, RunnerRequiredTool, RunnerToolCapabilityRequirement,
     RunnerToolchainReadinessProbe,
 };
+pub use claim::{
+    RunnerApiClaimOutcome, RunnerApiClaimRequest, RunnerApiClaimResponse,
+    RunnerApiClaimedExecution, RUNNER_API_CLAIM_REQUEST_SCHEMA, RUNNER_API_CLAIM_RESPONSE_SCHEMA,
+};
 pub use discovery::{
     RunnerApiCapabilitiesRequest, RunnerApiCapabilitiesResponse, RunnerApiCompatibility,
     RunnerApiCompatibilityFailure, RunnerApiCompatibilityFailureCode, RunnerApiCompatibilityStatus,
@@ -39,7 +44,10 @@ pub use discovery::{
     RUNNER_DESCRIPTOR_SCHEMA, RUNNER_INSPECTION_SCHEMA, RUNNER_READINESS_SCHEMA,
 };
 pub use execution_context::{
-    is_internal_control_env, RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV,
+    is_internal_control_env, RunnerJobExecutionContextAssertion, RunnerJobExecutionProtocol,
+    RunnerJobExecutionVerification, RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV,
+    RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY, RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION,
+    RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA, RUNNER_PLACEMENT_RESOLVED_ENV,
 };
 pub use lifecycle::{RunnerJobLifecycleMetadata, RunnerLifecycleOwner};
 pub use resource::{

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -27,8 +27,9 @@ use homeboy_lab_contract::lab::execution_envelope::{
     lab_runner_workload_from_execution_envelope, runner_execution_envelope_from_workload,
 };
 use homeboy_runner_contract::{
-    is_internal_control_env, RunnerApiSubmitRequest, RunnerMutationArtifacts,
-    RunnerResourceMetrics, RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_V1,
+    is_internal_control_env, RunnerApiClaimedExecution, RunnerApiSubmitRequest,
+    RunnerMutationArtifacts, RunnerResourceMetrics, RUNNER_API_SUBMIT_REQUEST_SCHEMA,
+    RUNNER_API_V1,
 };
 
 /// Broker metadata is durable queue input. Keep command-file payloads bounded
@@ -493,6 +494,43 @@ pub struct RemoteRunnerJobClaim {
     pub workspace_claim_protocol: Option<crate::workspace_claim::WorkspaceClaimProtocol>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_owner_lease_protocol: Option<crate::workspace_claim::WorkspaceOwnerLeaseProtocol>,
+}
+
+impl RemoteRunnerJobClaim {
+    /// Project durable core claim state into the transport-neutral runner API.
+    /// The legacy core shape remains available only for the compatibility route.
+    pub fn runner_api_claimed_execution(&self) -> Result<RunnerApiClaimedExecution> {
+        Ok(RunnerApiClaimedExecution {
+            job_id: self.job.id.to_string(),
+            claim_id: self.job.claim_id.clone().ok_or_else(|| {
+                Error::internal_unexpected("claimed remote runner job is missing a claim id")
+            })?,
+            claim_expires_at_ms: self.job.claim_expires_at_ms.ok_or_else(|| {
+                Error::internal_unexpected("claimed remote runner job is missing an expiry")
+            })?,
+            envelope: self.envelope.clone(),
+            legacy_request: self
+                .request
+                .as_ref()
+                .map(serde_json::to_value)
+                .transpose()
+                .map_err(|error| {
+                    Error::internal_json(
+                        error.to_string(),
+                        Some("serialize protocol-v1 claim projection".to_string()),
+                    )
+                })?,
+            workspace_claim_binding: self.workspace_claim_binding.clone(),
+            workspace_owner_lease: self.workspace_owner_lease.clone(),
+            execution_context: self
+                .execution_context
+                .as_ref()
+                .map(|context| context.assertion()),
+            execution_protocol: self.execution_protocol.clone(),
+            workspace_claim_protocol: self.workspace_claim_protocol.clone(),
+            workspace_owner_lease_protocol: self.workspace_owner_lease_protocol.clone(),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1423,15 +1461,8 @@ impl JobStore {
                 .next()
                 .map(|candidate| candidate.job.id)
             {
-                let (job, request, envelope, workspace_claim_binding, workspace_owner_lease) = {
-                    let stored = inner.jobs.get_mut(&job_id).expect("candidate exists");
-                    stored.job.status = JobStatus::Running;
-                    stored.job.updated_at_ms = now;
-                    stored.job.started_at_ms = Some(now);
-                    stored.job.claim_id = Some(Uuid::new_v4().to_string());
-                    stored.job.claimed_by_runner_id = Some(runner_id.to_string());
-                    stored.job.claimed_at_ms = Some(now);
-                    stored.job.claim_expires_at_ms = Some(now.saturating_add(lease_ms));
+                let (request, envelope, workspace_claim_binding, workspace_owner_lease) = {
+                    let stored = inner.jobs.get(&job_id).expect("candidate exists");
                     let remote_runner = stored
                         .remote_runner
                         .as_ref()
@@ -1442,53 +1473,75 @@ impl JobStore {
                     let request = execution_protocol
                         .is_none_or(|protocol| !protocol.uses_envelope_only_claim())
                         .then(|| {
-                            let mut request = remote_runner.protocol_v1_request()?.dispatch_request();
+                            let mut request =
+                                remote_runner.protocol_v1_request()?.dispatch_request();
                             request.workspace_claim_binding = workspace_claim_binding.clone();
                             request.workspace_owner_lease = workspace_owner_lease.clone();
                             Ok::<RemoteRunnerJobRequest, Error>(request)
                         })
                         .transpose()?;
                     (
-                        stored.job.clone(),
                         request,
                         envelope,
                         workspace_claim_binding,
                         workspace_owner_lease,
                     )
                 };
-                let execution_context = match execution_protocol {
+                match execution_protocol {
                     Some(protocol) => {
-                        protocol.verify()?;
-                        Some(
-                            crate::runner_job_execution_context::RunnerJobExecutionContext::from_claim(
-                                &job, &envelope,
-                            )?,
-                        )
+                        if !protocol.is_supported() {
+                            return Err(crate::runner_job_execution_context::rejected(
+                                "worker does not advertise the required execution-context protocol",
+                            ));
+                        }
                     }
                     None if envelope
                         .dispatch
                         .as_ref()
-                        .is_some_and(|dispatch| !dispatch.extension_env_providers.is_empty()) => {
+                        .is_some_and(|dispatch| !dispatch.extension_env_providers.is_empty()) =>
+                    {
                         return Err(crate::runner_job_execution_context::rejected(
                             "worker did not advertise the required execution-context protocol",
                         ));
                     }
-                    None => None,
-                };
+                    None => {}
+                }
                 if workspace_claim_binding.is_some() {
                     workspace_claim_protocol
-                        .ok_or_else(|| crate::runner_job_execution_context::rejected(
-                            "worker did not advertise the required workspace-claim protocol",
-                        ))?
+                        .ok_or_else(|| {
+                            crate::runner_job_execution_context::rejected(
+                                "worker did not advertise the required workspace-claim protocol",
+                            )
+                        })?
                         .verify()?;
                 }
                 if workspace_owner_lease.is_some() {
                     workspace_owner_lease_protocol
-                        .ok_or_else(|| crate::runner_job_execution_context::rejected(
+                        .ok_or_else(|| {
+                            crate::runner_job_execution_context::rejected(
                             "worker did not advertise the required workspace-owner-lease protocol",
-                        ))?
+                        )
+                        })?
                         .verify()?;
                 }
+                let job = {
+                    let stored = inner.jobs.get_mut(&job_id).expect("candidate exists");
+                    stored.job.status = JobStatus::Running;
+                    stored.job.updated_at_ms = now;
+                    stored.job.started_at_ms = Some(now);
+                    stored.job.claim_id = Some(Uuid::new_v4().to_string());
+                    stored.job.claimed_by_runner_id = Some(runner_id.to_string());
+                    stored.job.claimed_at_ms = Some(now);
+                    stored.job.claim_expires_at_ms = Some(now.saturating_add(lease_ms));
+                    stored.job.clone()
+                };
+                let execution_context = execution_protocol
+                    .map(|_| {
+                        crate::runner_job_execution_context::RunnerJobExecutionContext::from_claim(
+                            &job, &envelope,
+                        )
+                    })
+                    .transpose()?;
                 if let Some(context) = execution_context.as_ref() {
                     inner
                         .jobs

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -10,9 +10,10 @@ use crate::broker_auth::{BrokerAuthStore, BrokerScope};
 use crate::error::{Error, Result};
 use crate::paths;
 use homeboy_runner_contract::{
+    RunnerApiClaimOutcome, RunnerApiClaimRequest, RunnerApiClaimResponse,
     RunnerApiOperationFailure, RunnerApiOperationFailureCode, RunnerApiSubmitOutcome,
-    RunnerApiSubmitRequest, RunnerApiSubmitResponse, RUNNER_API_SUBMIT_RESPONSE_SCHEMA,
-    RUNNER_API_V1,
+    RunnerApiSubmitRequest, RunnerApiSubmitResponse, RUNNER_API_CLAIM_RESPONSE_SCHEMA,
+    RUNNER_API_SUBMIT_RESPONSE_SCHEMA, RUNNER_API_V1,
 };
 use homeboy_runner_contract::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 
@@ -735,6 +736,44 @@ fn submission_lookup(
 }
 
 fn claim(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
+    if let Some(value) = body.clone() {
+        if let Ok(request) = serde_json::from_value::<RunnerApiClaimRequest>(value) {
+            auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
+            touch_reverse_session(&request.runner_id)?;
+            let concurrency_limit = request.concurrency_limit.or_else(|| {
+                super::runner_workspace_root::runner_concurrency_limit(&request.runner_id)
+            });
+            let outcome = match job_store.claim_remote_runner_job_with_protocols(
+                &request.runner_id,
+                request.project_id.as_deref(),
+                request.lease_ms.unwrap_or(30_000),
+                concurrency_limit,
+                crate::api_jobs::RemoteRunnerClaimProtocols {
+                    execution: request.execution_protocol.as_ref(),
+                    workspace_claim: request.workspace_claim_protocol.as_ref(),
+                    workspace_owner_lease: request.workspace_owner_lease_protocol.as_ref(),
+                },
+            ) {
+                Ok(Some(claim)) => RunnerApiClaimOutcome::Claimed {
+                    claim: claim.runner_api_claimed_execution()?,
+                },
+                Ok(None) => RunnerApiClaimOutcome::Empty,
+                Err(error) => RunnerApiClaimOutcome::Rejected {
+                    failure: RunnerApiOperationFailure {
+                        code: RunnerApiOperationFailureCode::SubmissionRejected,
+                        message: error.message,
+                    },
+                },
+            };
+            return Ok(json!({
+                "response": RunnerApiClaimResponse {
+                    schema: RUNNER_API_CLAIM_RESPONSE_SCHEMA.to_string(),
+                    api_version: RUNNER_API_V1,
+                    outcome,
+                },
+            }));
+        }
+    }
     let request: ClaimRequest = parse_body(body, "remote runner claim request")?;
     auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
     touch_reverse_session(&request.runner_id)?;
@@ -1373,6 +1412,16 @@ mod auth_tests {
         })
     }
 
+    fn canonical_claim_body(execution_protocol: Value) -> Value {
+        json!({
+            "schema": "homeboy/runner-api-claim-request/v1",
+            "api_version": { "major": 1 },
+            "runner_id": "homeboy-lab",
+            "lease_ms": 30000,
+            "execution_protocol": execution_protocol,
+        })
+    }
+
     fn typed_result(run_id: &str) -> Value {
         json!({
             "exit_code": 0,
@@ -1695,6 +1744,128 @@ mod auth_tests {
         );
         assert_eq!(response.status_code, 401);
         assert_eq!(response.body["error"], "broker.auth_denied");
+    }
+
+    #[test]
+    fn canonical_claim_endpoint_returns_claimed_empty_and_rejected_outcomes() {
+        let _home = HomeGuard::new();
+        let store = JobStore::default();
+        let submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(submit_body()),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        let job_id = submit.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id")
+            .to_string();
+
+        let claimed = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(canonical_claim_body(json!(
+                crate::runner_job_execution_context::RunnerJobExecutionProtocol::current()
+            ))),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(claimed.status_code, 200, "claimed body: {}", claimed.body);
+        assert_eq!(
+            claimed.body["body"]["response"]["schema"],
+            "homeboy/runner-api-claim-response/v1"
+        );
+        assert_eq!(
+            claimed.body["body"]["response"]["outcome"]["status"],
+            "claimed"
+        );
+        assert_eq!(
+            claimed.body["body"]["response"]["outcome"]["claim"]["job_id"],
+            job_id
+        );
+        assert!(claimed.body["body"]["response"]["outcome"]["claim"]
+            .get("legacy_request")
+            .is_none());
+
+        let empty = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(canonical_claim_body(json!(
+                crate::runner_job_execution_context::RunnerJobExecutionProtocol::current()
+            ))),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(empty.status_code, 200, "empty body: {}", empty.body);
+        assert_eq!(
+            empty.body["body"]["response"]["outcome"],
+            json!({ "status": "empty" })
+        );
+
+        let rejected_store = JobStore::default();
+        let rejected_submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(submit_body()),
+            &rejected_store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        let rejected_job_id = rejected_submit.body["body"]["job"]["id"]
+            .as_str()
+            .expect("rejected job id");
+        let rejected = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(canonical_claim_body(json!({
+                "capability": "runner-job-execution-context", "version": 99
+            }))),
+            &rejected_store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(
+            rejected.status_code, 200,
+            "rejected body: {}",
+            rejected.body
+        );
+        assert_eq!(
+            rejected.body["body"]["response"]["outcome"]["status"],
+            "rejected"
+        );
+        assert_eq!(
+            rejected_store
+                .get(Uuid::parse_str(rejected_job_id).expect("valid rejected job id"))
+                .expect("rejected job remains queued")
+                .status,
+            crate::api_jobs::JobStatus::Queued
+        );
+    }
+
+    #[test]
+    fn legacy_claim_adapter_preserves_request_and_response_shape() {
+        let _home = HomeGuard::new();
+        let store = JobStore::default();
+        let submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(submit_body()),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        let job_id = submit.body["body"]["job"]["id"].clone();
+        let legacy_request = json!({ "runner_id": "homeboy-lab", "lease_ms": 30000 });
+        let claim = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(legacy_request),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(claim.status_code, 200, "legacy body: {}", claim.body);
+        assert_eq!(claim.body["body"]["command"], "api.runner.jobs.claim");
+        assert_eq!(claim.body["body"]["claim"]["job"]["id"], job_id);
+        assert!(claim.body["body"]["claim"].get("envelope").is_some());
+        assert!(claim.body["body"].get("response").is_none());
     }
 
     #[test]

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -12,8 +12,8 @@ use crate::paths;
 use homeboy_runner_contract::{
     RunnerApiClaimOutcome, RunnerApiClaimRequest, RunnerApiClaimResponse,
     RunnerApiOperationFailure, RunnerApiOperationFailureCode, RunnerApiSubmitOutcome,
-    RunnerApiSubmitRequest, RunnerApiSubmitResponse, RUNNER_API_CLAIM_RESPONSE_SCHEMA,
-    RUNNER_API_SUBMIT_RESPONSE_SCHEMA, RUNNER_API_V1,
+    RunnerApiSubmitRequest, RunnerApiSubmitResponse, RUNNER_API_CLAIM_REQUEST_SCHEMA,
+    RUNNER_API_CLAIM_RESPONSE_SCHEMA, RUNNER_API_SUBMIT_RESPONSE_SCHEMA, RUNNER_API_V1,
 };
 use homeboy_runner_contract::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 
@@ -736,43 +736,54 @@ fn submission_lookup(
 }
 
 fn claim(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
-    if let Some(value) = body.clone() {
-        if let Ok(request) = serde_json::from_value::<RunnerApiClaimRequest>(value) {
-            auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
-            touch_reverse_session(&request.runner_id)?;
-            let concurrency_limit = request.concurrency_limit.or_else(|| {
-                super::runner_workspace_root::runner_concurrency_limit(&request.runner_id)
-            });
-            let outcome = match job_store.claim_remote_runner_job_with_protocols(
-                &request.runner_id,
-                request.project_id.as_deref(),
-                request.lease_ms.unwrap_or(30_000),
-                concurrency_limit,
-                crate::api_jobs::RemoteRunnerClaimProtocols {
-                    execution: request.execution_protocol.as_ref(),
-                    workspace_claim: request.workspace_claim_protocol.as_ref(),
-                    workspace_owner_lease: request.workspace_owner_lease_protocol.as_ref(),
-                },
-            ) {
-                Ok(Some(claim)) => RunnerApiClaimOutcome::Claimed {
-                    claim: claim.runner_api_claimed_execution()?,
-                },
-                Ok(None) => RunnerApiClaimOutcome::Empty,
-                Err(error) => RunnerApiClaimOutcome::Rejected {
-                    failure: RunnerApiOperationFailure {
-                        code: RunnerApiOperationFailureCode::SubmissionRejected,
-                        message: error.message,
-                    },
-                },
-            };
-            return Ok(json!({
-                "response": RunnerApiClaimResponse {
-                    schema: RUNNER_API_CLAIM_RESPONSE_SCHEMA.to_string(),
-                    api_version: RUNNER_API_V1,
-                    outcome,
-                },
-            }));
+    let canonical = body
+        .as_ref()
+        .is_some_and(|value| value.get("schema").is_some() || value.get("api_version").is_some());
+    if canonical {
+        let request: RunnerApiClaimRequest = parse_body(body, "Runner API claim request")?;
+        if request.schema != RUNNER_API_CLAIM_REQUEST_SCHEMA || request.api_version != RUNNER_API_V1
+        {
+            return Err(Error::validation_invalid_argument(
+                "schema",
+                "unsupported Runner API claim request",
+                Some(request.schema),
+                None,
+            ));
         }
+        auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
+        touch_reverse_session(&request.runner_id)?;
+        let concurrency_limit = request
+            .concurrency_limit
+            .or_else(|| super::runner_workspace_root::runner_concurrency_limit(&request.runner_id));
+        let outcome = match job_store.claim_remote_runner_job_with_protocols(
+            &request.runner_id,
+            request.project_id.as_deref(),
+            request.lease_ms.unwrap_or(30_000),
+            concurrency_limit,
+            crate::api_jobs::RemoteRunnerClaimProtocols {
+                execution: request.execution_protocol.as_ref(),
+                workspace_claim: request.workspace_claim_protocol.as_ref(),
+                workspace_owner_lease: request.workspace_owner_lease_protocol.as_ref(),
+            },
+        ) {
+            Ok(Some(claim)) => RunnerApiClaimOutcome::Claimed {
+                claim: claim.runner_api_claimed_execution()?,
+            },
+            Ok(None) => RunnerApiClaimOutcome::Empty,
+            Err(error) => RunnerApiClaimOutcome::Rejected {
+                failure: RunnerApiOperationFailure {
+                    code: RunnerApiOperationFailureCode::SubmissionRejected,
+                    message: error.message,
+                },
+            },
+        };
+        return Ok(json!({
+            "response": RunnerApiClaimResponse {
+                schema: RUNNER_API_CLAIM_RESPONSE_SCHEMA.to_string(),
+                api_version: RUNNER_API_V1,
+                outcome,
+            },
+        }));
     }
     let request: ClaimRequest = parse_body(body, "remote runner claim request")?;
     auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
@@ -1839,6 +1850,52 @@ mod auth_tests {
                 .status,
             crate::api_jobs::JobStatus::Queued
         );
+    }
+
+    #[test]
+    fn canonical_claim_does_not_fall_back_to_the_legacy_adapter() {
+        let _home = HomeGuard::new();
+        for body in [
+            json!({
+                "schema": "homeboy/runner-api-claim-request/v1",
+                "runner_id": "homeboy-lab",
+            }),
+            json!({
+                "schema": "homeboy/runner-api-claim-request/v1",
+                "api_version": { "major": 2 },
+                "runner_id": "homeboy-lab",
+            }),
+        ] {
+            let store = JobStore::default();
+            let submit = route(
+                "POST",
+                "/runner/jobs",
+                Some(submit_body()),
+                &store,
+                &BrokerAuthContext::trusted_local(),
+            );
+            let job_id = submit.body["body"]["job"]["id"].as_str().expect("job id");
+
+            let response = route(
+                "POST",
+                "/runner/jobs/claim",
+                Some(body),
+                &store,
+                &BrokerAuthContext::trusted_local(),
+            );
+            assert_eq!(
+                response.status_code, 400,
+                "response body: {}",
+                response.body
+            );
+            assert_eq!(
+                store
+                    .get(Uuid::parse_str(job_id).expect("valid job id"))
+                    .expect("job remains queued")
+                    .status,
+                crate::api_jobs::JobStatus::Queued
+            );
+        }
     }
 
     #[test]

--- a/crates/homeboy-core/src/runner_job_execution_context.rs
+++ b/crates/homeboy-core/src/runner_job_execution_context.rs
@@ -6,6 +6,11 @@
 //! construct authority from them.
 
 use homeboy_engine_primitives::content_hash;
+use homeboy_runner_contract::{RunnerJobExecutionContextAssertion, RunnerJobExecutionVerification};
+pub use homeboy_runner_contract::{
+    RunnerJobExecutionProtocol, RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY,
+    RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::api_jobs::Job;
@@ -15,45 +20,10 @@ use crate::runner_execution_envelope::RunnerExecutionEnvelope;
 pub const RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA: &str = "homeboy/runner-job-execution-context/v1";
 pub const RUNNER_JOB_EXECUTION_CONTEXT_EVIDENCE_SCHEMA: &str =
     "homeboy/runner-job-execution-context-evidence/v1";
-pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY: &str = "runner-job-execution-context";
-pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION: u32 = 2;
 pub const RUNNER_JOB_ID_ENV: &str = "HOMEBOY_RUNNER_JOB_ID";
 pub const RUNNER_CHILD_RESERVATION_ENV: &str = "HOMEBOY_RUNNER_CHILD_RESERVATION";
 pub const RUNNER_JOB_EXECUTION_CONTEXT_ID_ENV: &str = "HOMEBOY_RUNNER_JOB_EXECUTION_CONTEXT_ID";
 const MAX_EVIDENCE_BYTES: usize = 8 * 1024;
-
-/// A worker must explicitly advertise this before the broker will hand it a
-/// context-bearing job. This prevents an older worker from ignoring the added
-/// claim field and executing an unauthenticated handoff.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerJobExecutionProtocol {
-    pub capability: String,
-    pub version: u32,
-}
-
-impl RunnerJobExecutionProtocol {
-    pub fn current() -> Self {
-        Self {
-            capability: RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY.to_string(),
-            version: RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION,
-        }
-    }
-
-    pub fn verify(&self) -> Result<()> {
-        if self.capability == RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY
-            && (1..=RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION).contains(&self.version)
-        {
-            return Ok(());
-        }
-        Err(rejected(
-            "worker does not advertise the required execution-context protocol",
-        ))
-    }
-
-    pub fn uses_envelope_only_claim(&self) -> bool {
-        self.version >= 2
-    }
-}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerJobExecutionContext {
@@ -69,7 +39,7 @@ pub struct RunnerJobExecutionContext {
     /// never crosses a durable evidence or provider-process boundary.
     claim_ref: String,
     dispatch_receipt: String,
-    verification: RunnerJobExecutionVerification,
+    verification: RunnerJobExecutionVerificationLocal,
     /// Authority is intentionally process-local. A wire value is only an
     /// assertion until it has been recomputed from the live durable claim.
     #[serde(skip)]
@@ -77,7 +47,7 @@ pub struct RunnerJobExecutionContext {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerJobExecutionVerification {
+pub struct RunnerJobExecutionVerificationLocal {
     state: String,
     verified_at_ms: u64,
 }
@@ -159,7 +129,7 @@ impl RunnerJobExecutionContext {
             runtime_id,
             claim_ref: claim_ref(&claim_id),
             dispatch_receipt,
-            verification: RunnerJobExecutionVerification {
+            verification: RunnerJobExecutionVerificationLocal {
                 state: "verified".to_string(),
                 verified_at_ms: job.updated_at_ms,
             },
@@ -181,7 +151,7 @@ impl RunnerJobExecutionContext {
             runtime_id,
             claim_ref: "local".to_string(),
             dispatch_receipt,
-            verification: RunnerJobExecutionVerification {
+            verification: RunnerJobExecutionVerificationLocal {
                 state: "local".to_string(),
                 verified_at_ms: 0,
             },
@@ -258,7 +228,7 @@ impl RunnerJobExecutionContext {
             runtime_id,
             claim_ref: claim_ref(&reservation_id),
             dispatch_receipt,
-            verification: RunnerJobExecutionVerification {
+            verification: RunnerJobExecutionVerificationLocal {
                 state: "verified".to_string(),
                 verified_at_ms: 0,
             },
@@ -286,6 +256,32 @@ impl RunnerJobExecutionContext {
         Ok(Self {
             authenticated: true,
             ..verified
+        })
+    }
+
+    /// Validate a received canonical claim assertion before the broker consumes
+    /// its durable receipt. Receipt consumption remains the live authority
+    /// check; this only binds the assertion to the claim projection.
+    pub fn verify_claimed_execution(
+        &self,
+        job_id: &str,
+        runner_id: &str,
+        claim_expires_at_ms: u64,
+    ) -> Result<Self> {
+        if claim_expires_at_ms <= crate::api_jobs::timestamp_ms()
+            || self.schema != RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA
+            || self.id != context_id(&self.dispatch_receipt)
+            || self.runner_job_id != job_id
+            || self.runner_id != runner_id
+            || self.verification.state != "verified"
+        {
+            return Err(rejected(
+                "execution context does not match the claimed runner job",
+            ));
+        }
+        Ok(Self {
+            authenticated: true,
+            ..self.clone()
         })
     }
 
@@ -318,6 +314,48 @@ impl RunnerJobExecutionContext {
 
     pub fn runtime_id(&self) -> &str {
         &self.runtime_id
+    }
+
+    /// Export the non-authoritative value that may cross the runner API.
+    pub fn assertion(&self) -> RunnerJobExecutionContextAssertion {
+        RunnerJobExecutionContextAssertion {
+            schema: self.schema.clone(),
+            id: self.id.clone(),
+            controller_run_id: self.controller_run_id.clone(),
+            controller_attempt_id: self.controller_attempt_id.clone(),
+            runner_id: self.runner_id.clone(),
+            runner_job_id: self.runner_job_id.clone(),
+            accepted_handoff_id: self.accepted_handoff_id.clone(),
+            runtime_id: self.runtime_id.clone(),
+            claim_ref: self.claim_ref.clone(),
+            dispatch_receipt: self.dispatch_receipt.clone(),
+            verification: RunnerJobExecutionVerification {
+                state: self.verification.state.clone(),
+                verified_at_ms: self.verification.verified_at_ms,
+            },
+        }
+    }
+
+    /// Rehydrate a transport assertion before verifying it against durable
+    /// claim state. This never grants authenticated authority by itself.
+    pub fn from_assertion(assertion: RunnerJobExecutionContextAssertion) -> Self {
+        Self {
+            schema: assertion.schema,
+            id: assertion.id,
+            controller_run_id: assertion.controller_run_id,
+            controller_attempt_id: assertion.controller_attempt_id,
+            runner_id: assertion.runner_id,
+            runner_job_id: assertion.runner_job_id,
+            accepted_handoff_id: assertion.accepted_handoff_id,
+            runtime_id: assertion.runtime_id,
+            claim_ref: assertion.claim_ref,
+            dispatch_receipt: assertion.dispatch_receipt,
+            verification: RunnerJobExecutionVerificationLocal {
+                state: assertion.verification.state,
+                verified_at_ms: assertion.verification.verified_at_ms,
+            },
+            authenticated: false,
+        }
     }
 
     pub fn is_local(&self) -> bool {

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -2255,6 +2255,38 @@ fn handle_reverse_broker_request(
         return ok(json!({ "result": store.lookup_remote_runner_submission(submission_key) }));
     }
     if request.method == "POST" && request.path == "/runner/jobs/claim" {
+        if let Ok(request) =
+            serde_json::from_value::<homeboy_runner_contract::RunnerApiClaimRequest>(request.body)
+        {
+            let claim = store
+                .claim_remote_runner_job_with_protocols(
+                    &request.runner_id,
+                    request.project_id.as_deref(),
+                    request.lease_ms.unwrap_or(30_000),
+                    request.concurrency_limit,
+                    crate::api_jobs::RemoteRunnerClaimProtocols {
+                        execution: request.execution_protocol.as_ref(),
+                        workspace_claim: request.workspace_claim_protocol.as_ref(),
+                        workspace_owner_lease: request.workspace_owner_lease_protocol.as_ref(),
+                    },
+                )
+                .expect("claim canonical broker job");
+            let outcome = match claim {
+                Some(claim) => homeboy_runner_contract::RunnerApiClaimOutcome::Claimed {
+                    claim: claim
+                        .runner_api_claimed_execution()
+                        .expect("project canonical broker claim"),
+                },
+                None => homeboy_runner_contract::RunnerApiClaimOutcome::Empty,
+            };
+            return ok(json!({
+                "response": homeboy_runner_contract::RunnerApiClaimResponse {
+                    schema: homeboy_runner_contract::RUNNER_API_CLAIM_RESPONSE_SCHEMA.to_string(),
+                    api_version: homeboy_runner_contract::RUNNER_API_V1,
+                    outcome,
+                },
+            }));
+        }
         let claim = store
             .claim_remote_runner_job(runner_id, None, 30_000, None)
             .expect("claim broker job");

--- a/crates/homeboy-lab-runner/src/worker/broker.rs
+++ b/crates/homeboy-lab-runner/src/worker/broker.rs
@@ -8,10 +8,13 @@ use std::time::Duration;
 use reqwest::blocking::Client;
 use serde_json::json;
 
-use homeboy_core::api_jobs::{Job, JobStatus, RemoteRunnerJobClaim, RemoteRunnerJobResult};
+use homeboy_core::api_jobs::{Job, JobStatus, RemoteRunnerJobResult};
 use homeboy_core::error::{Error, Result};
 use homeboy_runner_contract::{
-    WorkspaceClaimBinding, WorkspaceClaimProtocol, WorkspaceOwnerLease, WorkspaceOwnerLeaseProtocol,
+    RunnerApiClaimOutcome, RunnerApiClaimRequest, RunnerApiClaimResponse,
+    RunnerApiClaimedExecution, RunnerJobExecutionProtocol, WorkspaceClaimBinding,
+    WorkspaceClaimProtocol, WorkspaceOwnerLease, WorkspaceOwnerLeaseProtocol,
+    RUNNER_API_CLAIM_REQUEST_SCHEMA, RUNNER_API_V1,
 };
 
 use super::super::broker_http;
@@ -20,33 +23,43 @@ use super::types::ReverseRunnerWorkerOptions;
 pub(super) fn claim_job(
     client: &Client,
     options: &ReverseRunnerWorkerOptions,
-) -> Result<Option<RemoteRunnerJobClaim>> {
+) -> Result<Option<RunnerApiClaimedExecution>> {
     let data = broker_http::post_json(
         client,
         &options.broker_url,
         "/runner/jobs/claim",
-        json!({
-            "runner_id": options.runner_id,
-            "project_id": options.project_id,
-            "lease_ms": options.lease_ms.max(1),
-            "concurrency_limit": options.concurrency_limit,
-            "execution_protocol": homeboy_core::runner_job_execution_context::RunnerJobExecutionProtocol::current(),
-            "workspace_claim_protocol": WorkspaceClaimProtocol::current(),
-            "workspace_owner_lease_protocol": WorkspaceOwnerLeaseProtocol::current(),
-        }),
+        serde_json::to_value(RunnerApiClaimRequest {
+            schema: RUNNER_API_CLAIM_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            runner_id: options.runner_id.clone(),
+            project_id: options.project_id.clone(),
+            lease_ms: Some(options.lease_ms.max(1)),
+            concurrency_limit: options.concurrency_limit,
+            execution_protocol: Some(RunnerJobExecutionProtocol::current()),
+            workspace_claim_protocol: Some(WorkspaceClaimProtocol::current()),
+            workspace_owner_lease_protocol: Some(WorkspaceOwnerLeaseProtocol::current()),
+        })
+        .expect("runner API claim request serializes"),
         "claim reverse runner job",
         options.broker_token.as_deref(),
     )?;
-    let claim = data["claim"].clone();
-    if claim.is_null() {
-        return Ok(None);
+    let response: RunnerApiClaimResponse = serde_json::from_value(data["response"].clone())
+        .map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("parse reverse runner job claim".to_string()),
+            )
+        })?;
+    match response.outcome {
+        RunnerApiClaimOutcome::Claimed { claim } => Ok(Some(claim)),
+        RunnerApiClaimOutcome::Empty => Ok(None),
+        RunnerApiClaimOutcome::Rejected { failure } => Err(Error::validation_invalid_argument(
+            "claim",
+            failure.message,
+            None,
+            None,
+        )),
     }
-    serde_json::from_value(claim).map(Some).map_err(|err| {
-        Error::internal_json(
-            err.to_string(),
-            Some("parse reverse runner job claim".to_string()),
-        )
-    })
 }
 
 #[expect(
@@ -58,16 +71,16 @@ pub(super) fn append_progress_data(
     broker_url: &str,
     token: Option<&str>,
     runner_id: &str,
-    job: &Job,
+    claim: &RunnerApiClaimedExecution,
     data: serde_json::Value,
     workspace_claim_binding: Option<&WorkspaceClaimBinding>,
     workspace_owner_lease: Option<&WorkspaceOwnerLease>,
 ) -> Result<()> {
-    let claim_id = remote_runner_claim_id(job)?;
+    let claim_id = remote_runner_claim_id(claim);
     broker_http::post_json(
         client,
         broker_url,
-        &format!("/runner/jobs/{}/events", job.id),
+        &format!("/runner/jobs/{}/events", claim.job_id),
         json!({
             "runner_id": runner_id,
             "claim_id": claim_id,
@@ -91,16 +104,16 @@ pub(super) fn finish_job(
     broker_url: &str,
     token: Option<&str>,
     runner_id: &str,
-    job: &Job,
+    claim: &RunnerApiClaimedExecution,
     result: RemoteRunnerJobResult,
     workspace_claim_binding: Option<&WorkspaceClaimBinding>,
     workspace_owner_lease: Option<&WorkspaceOwnerLease>,
 ) -> Result<Job> {
-    let claim_id = remote_runner_claim_id(job)?;
+    let claim_id = remote_runner_claim_id(claim);
     let data = broker_http::post_json(
         client,
         broker_url,
-        &format!("/runner/jobs/{}/finish", job.id),
+        &format!("/runner/jobs/{}/finish", claim.job_id),
         json!({
             "runner_id": runner_id,
             "claim_id": claim_id,
@@ -129,16 +142,16 @@ pub(super) fn consume_execution(
     broker_url: &str,
     token: Option<&str>,
     runner_id: &str,
-    job: &Job,
+    claim: &RunnerApiClaimedExecution,
     context_id: &str,
     workspace_claim_binding: Option<&WorkspaceClaimBinding>,
     workspace_owner_lease: Option<&WorkspaceOwnerLease>,
 ) -> Result<Job> {
-    let claim_id = remote_runner_claim_id(job)?;
+    let claim_id = remote_runner_claim_id(claim);
     let data = broker_http::post_json(
         client,
         broker_url,
-        &format!("/runner/jobs/{}/consume", job.id),
+        &format!("/runner/jobs/{}/consume", claim.job_id),
         json!({
             "runner_id": runner_id,
             "claim_id": claim_id,
@@ -165,14 +178,14 @@ pub(super) fn validate_workspace_owner(
     broker_url: &str,
     token: Option<&str>,
     runner_id: &str,
-    job: &Job,
+    claim: &RunnerApiClaimedExecution,
     workspace_owner_lease: &WorkspaceOwnerLease,
 ) -> Result<()> {
-    let claim_id = remote_runner_claim_id(job)?;
+    let claim_id = remote_runner_claim_id(claim);
     let data = broker_http::post_json(
         client,
         broker_url,
-        &format!("/runner/jobs/{}/validate-owner", job.id),
+        &format!("/runner/jobs/{}/validate-owner", claim.job_id),
         json!({
             "runner_id": runner_id,
             "claim_id": claim_id,
@@ -185,7 +198,7 @@ pub(super) fn validate_workspace_owner(
         return Err(Error::validation_invalid_argument(
             "workspace_owner_lease",
             "reverse runner workspace owner lease is no longer live",
-            Some(job.id.to_string()),
+            Some(claim.job_id.clone()),
             None,
         ));
     }
@@ -201,16 +214,16 @@ fn renew_claim(
     broker_url: &str,
     token: Option<&str>,
     runner_id: &str,
-    job: &Job,
+    claim: &RunnerApiClaimedExecution,
     lease_ms: u64,
     workspace_claim_binding: Option<&WorkspaceClaimBinding>,
     workspace_owner_lease: Option<&WorkspaceOwnerLease>,
 ) -> Result<(Job, Option<WorkspaceOwnerLease>)> {
-    let claim_id = remote_runner_claim_id(job)?;
+    let claim_id = remote_runner_claim_id(claim);
     let data = broker_http::post_json(
         client,
         broker_url,
-        &format!("/runner/jobs/{}/heartbeat", job.id),
+        &format!("/runner/jobs/{}/heartbeat", claim.job_id),
         json!({
             "runner_id": runner_id,
             "claim_id": claim_id,
@@ -234,17 +247,17 @@ fn renew_claim(
 pub(super) fn start_claim_heartbeat(
     client: &Client,
     options: &ReverseRunnerWorkerOptions,
-    job: &Job,
+    claim: &RunnerApiClaimedExecution,
     workspace_claim_binding: Option<WorkspaceClaimBinding>,
     workspace_owner_lease: Option<WorkspaceOwnerLease>,
 ) -> Result<ClaimHeartbeat> {
-    remote_runner_claim_id(job)?;
+    remote_runner_claim_id(claim);
     let (stop, stopped) = mpsc::channel();
     let client = client.clone();
     let broker_url = options.broker_url.clone();
     let broker_token = options.broker_token.clone();
     let runner_id = options.runner_id.clone();
-    let job = job.clone();
+    let claim = claim.clone();
     let lease_ms = options.lease_ms.max(1);
     let interval = Duration::from_millis((lease_ms / 2).max(1));
     let current_owner = Arc::new(Mutex::new(workspace_owner_lease));
@@ -260,7 +273,7 @@ pub(super) fn start_claim_heartbeat(
             &broker_url,
             broker_token.as_deref(),
             &runner_id,
-            &job,
+            &claim,
             lease_ms,
             workspace_claim_binding.as_ref(),
             presented_owner.as_ref(),
@@ -276,7 +289,7 @@ pub(super) fn start_claim_heartbeat(
                         "event": "claim_heartbeat_failed",
                         "runner_id": runner_id,
                         "broker_url": broker_url,
-                        "job_id": job.id,
+                        "job_id": claim.job_id,
                         "error": err.to_string(),
                     })
                 );
@@ -317,12 +330,12 @@ pub(super) fn cancelled_job_snapshot(
     client: &Client,
     broker_url: &str,
     token: Option<&str>,
-    job: &Job,
+    claim: &RunnerApiClaimedExecution,
 ) -> Result<Option<Job>> {
     let data = broker_http::get_json(
         client,
         broker_url,
-        &format!("/jobs/{}", job.id),
+        &format!("/jobs/{}", claim.job_id),
         "inspect reverse runner job cancellation state",
         token,
     )?;
@@ -339,13 +352,6 @@ pub(super) fn cancelled_job_snapshot(
     }
 }
 
-pub(super) fn remote_runner_claim_id(job: &Job) -> Result<&str> {
-    job.claim_id.as_deref().ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "claim_id",
-            "claimed remote runner job is missing a claim id",
-            Some(job.id.to_string()),
-            None,
-        )
-    })
+pub(super) fn remote_runner_claim_id(claim: &RunnerApiClaimedExecution) -> &str {
+    &claim.claim_id
 }

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -216,16 +216,17 @@ fn run_once_output(
     // Every cancellation checkpoint in this claim lifecycle polls the broker for
     // the same claimed job snapshot through identical plumbing; funnel them
     // through one borrow-only helper so the three checkpoints stay in lockstep.
-    let poll_cancelled = |client: &Client,
-                          options: &ReverseRunnerWorkerOptions,
-                          job: &homeboy_core::api_jobs::Job| {
-        cancelled_job_snapshot(
-            client,
-            &options.broker_url,
-            options.broker_token.as_deref(),
-            job,
-        )
-    };
+    let poll_cancelled =
+        |client: &Client,
+         options: &ReverseRunnerWorkerOptions,
+         claim: &homeboy_runner_contract::RunnerApiClaimedExecution| {
+            cancelled_job_snapshot(
+                client,
+                &options.broker_url,
+                options.broker_token.as_deref(),
+                claim,
+            )
+        };
     let claim = claim_job(&client, &options)?;
     let Some(claim) = claim else {
         let loop_mode = options.loop_mode;
@@ -257,7 +258,7 @@ fn run_once_output(
         Error::validation_invalid_argument(
             "execution_context",
             "reverse runner claim predates authenticated execution context support",
-            Some(claim.job.id.to_string()),
+            Some(claim.job_id.clone()),
             Some(vec![
                 "Resubmit the handoff through a compatible controller before retrying.".to_string(),
             ]),
@@ -270,11 +271,20 @@ fn run_once_output(
             Error::validation_invalid_argument(
                 "execution_protocol",
                 "reverse runner claim predates execution-context protocol negotiation",
-                Some(claim.job.id.to_string()),
+                Some(claim.job_id.clone()),
                 None,
             )
         })?
-        .verify()?;
+        .is_supported()
+        .then_some(())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "execution_protocol",
+                "reverse runner claim has an unsupported execution-context protocol",
+                Some(claim.job_id.clone()),
+                None,
+            )
+        })?;
     if claim.workspace_claim_binding.is_some() {
         claim
             .workspace_claim_protocol
@@ -283,7 +293,7 @@ fn run_once_output(
                 Error::validation_invalid_argument(
                     "workspace_claim_protocol",
                     "reverse runner claim predates workspace-claim protocol negotiation",
-                    Some(claim.job.id.to_string()),
+                    Some(claim.job_id.clone()),
                     None,
                 )
             })?
@@ -297,20 +307,21 @@ fn run_once_output(
                 Error::validation_invalid_argument(
                     "workspace_owner_lease_protocol",
                     "reverse runner claim predates workspace owner lease protocol negotiation",
-                    Some(claim.job.id.to_string()),
+                    Some(claim.job_id.clone()),
                     None,
                 )
             })?
             .verify()?;
     }
-    let execution_context = execution_context.verify_claim(&claim.job, &claim.envelope)?;
+    let execution_context = RunnerJobExecutionContext::from_assertion(execution_context.clone())
+        .verify_claimed_execution(&claim.job_id, &options.runner_id, claim.claim_expires_at_ms)?;
 
     // Commit runner-owned evidence before materializing any broker input. The
     // controller persists the same identity in its claim event; keeping both
     // records lets either side recover after its own restart.
     persist_runner_execution_context(&options.runner_id, &execution_context)?;
 
-    if let Some(job) = poll_cancelled(&client, &options, &claim.job)? {
+    if let Some(job) = poll_cancelled(&client, &options, &claim)? {
         return Ok(cancelled_output(
             options,
             iterations,
@@ -329,7 +340,7 @@ fn run_once_output(
         &options.broker_url,
         options.broker_token.as_deref(),
         &options.runner_id,
-        &claim.job,
+        &claim,
         serde_json::json!({
             "phase": "runner_job_execution_context_verified",
             "runner_job_execution_context": execution_context.evidence_record()?,
@@ -340,7 +351,7 @@ fn run_once_output(
     let heartbeat = start_claim_heartbeat(
         &client,
         &options,
-        &claim.job,
+        &claim,
         claim.workspace_claim_binding.clone(),
         claim.workspace_owner_lease.clone(),
     )?;
@@ -372,16 +383,15 @@ fn run_once_output(
             &options.broker_url,
             options.broker_token.as_deref(),
             &options.runner_id,
-            &claim.job,
+            &claim,
             lease,
         )?;
     }
-    let _command_assets =
-        materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
+    let _command_assets = materialize_command_assets(&claim.job_id, &mut execution_envelope)?;
     let _private_at_files = verify_private_at_files(&mut execution_envelope)?;
     let _staged_workspace = materialize_staged_source_artifact(
         &options.runner_id,
-        &claim.job.id.to_string(),
+        &claim.job_id,
         &mut execution_envelope,
     )?;
     materialize_snapshot_git_baseline(&execution_envelope)?;
@@ -393,7 +403,7 @@ fn run_once_output(
             &options.broker_url,
             options.broker_token.as_deref(),
             &options.runner_id,
-            &claim.job,
+            &claim,
             result,
             claim.workspace_claim_binding.as_ref(),
             current_owner_lease
@@ -407,7 +417,7 @@ fn run_once_output(
     let claimed_run_id = claimed_job_run_id(&execution_envelope);
     let progress_client = client.clone();
     let progress_options = options.clone();
-    let progress_job = claim.job.clone();
+    let progress_claim = claim.clone();
     let progress_workspace_claim_binding = claim.workspace_claim_binding.clone();
     let progress_owner_lease = current_owner_lease.clone();
     let progress_sink = Arc::new(move |data| {
@@ -416,7 +426,7 @@ fn run_once_output(
             &progress_options.broker_url,
             progress_options.broker_token.as_deref(),
             &progress_options.runner_id,
-            &progress_job,
+            &progress_claim,
             data,
             progress_workspace_claim_binding.as_ref(),
             progress_owner_lease
@@ -432,7 +442,7 @@ fn run_once_output(
             capability_preflight,
             claimed_run_id,
             execution_context.clone(),
-            claim.job.id.to_string(),
+            claim.job_id.clone(),
         )?,
         || {
             verify_staged_workspace_before_execution(
@@ -447,7 +457,7 @@ fn run_once_output(
                 &options.broker_url,
                 options.broker_token.as_deref(),
                 &options.runner_id,
-                &claim.job,
+                &claim,
                 recovered.id(),
                 claim.workspace_claim_binding.as_ref(),
                 current_owner_lease
@@ -467,7 +477,7 @@ fn run_once_output(
                 return cancel_seen;
             }
             last_cancel_poll = Instant::now();
-            cancel_seen = poll_cancelled(&client, &options, &claim.job)
+            cancel_seen = poll_cancelled(&client, &options, &claim)
                 .map(|job| job.is_some())
                 .unwrap_or(false);
             cancel_seen
@@ -477,7 +487,7 @@ fn run_once_output(
     let (exec_output, exit_code) = match exec_result {
         Ok(result) => result,
         Err(err) => {
-            if let Some(job) = poll_cancelled(&client, &options, &claim.job)? {
+            if let Some(job) = poll_cancelled(&client, &options, &claim)? {
                 return Ok(cancelled_output(
                     options,
                     iterations,
@@ -519,7 +529,7 @@ fn run_once_output(
             ));
         }
     };
-    if let Some(job) = poll_cancelled(&client, &options, &claim.job)? {
+    if let Some(job) = poll_cancelled(&client, &options, &claim)? {
         return Ok(cancelled_output(
             options,
             iterations,

--- a/crates/homeboy-lab-runner/src/worker/tests/support.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/support.rs
@@ -82,14 +82,11 @@ where
 {
     spawn_custom_broker(store, 1, None, move |store, request| {
         if request.path == "/runner/jobs/claim" {
-            let claim = store
-                .claim_remote_runner_job("lab", None, 30_000, None)
-                .expect("claim job");
-            let mut claim = serde_json::to_value(claim).expect("serialize claim");
-            mutate_claim(&mut claim);
+            let mut response = canonical_claim_response(store, request);
+            mutate_claim(&mut response["outcome"]["claim"]);
             return serde_json::json!({
                 "success": true,
-                "data": { "body": { "claim": claim } }
+                "data": { "body": { "response": response } }
             });
         }
         handle_request(store, request)
@@ -103,17 +100,18 @@ pub(super) fn spawn_cancelling_after_claim_broker(
 ) -> (String, std::thread::JoinHandle<()>) {
     spawn_custom_broker(store, expected_requests, seen_paths, |store, request| {
         if request.path == "/runner/jobs/claim" {
-            let claim = store
-                .claim_remote_runner_job("lab", None, 30_000, None)
-                .expect("claim job");
-            if let Some(claim) = &claim {
+            let response = canonical_claim_response(store, request);
+            if let Some(job_id) = response["outcome"]["claim"]["job_id"].as_str() {
                 store
-                    .cancel(claim.job.id, "user requested")
+                    .cancel(
+                        uuid::Uuid::parse_str(job_id).expect("claimed job id"),
+                        "user requested",
+                    )
                     .expect("cancel job");
             }
             return serde_json::json!({
                 "success": true,
-                "data": { "body": { "claim": claim } }
+                "data": { "body": { "response": response } }
             });
         }
         handle_request(store, request)
@@ -310,12 +308,10 @@ fn handle_request(store: &JobStore, request: &MockRequest) -> Value {
         }
     }
     if request.path == "/runner/jobs/claim" {
-        let claim = store
-            .claim_remote_runner_job("lab", None, 30_000, None)
-            .expect("claim job");
+        let response = canonical_claim_response(store, request);
         return serde_json::json!({
             "success": true,
-            "data": { "body": { "claim": claim } }
+            "data": { "body": { "response": response } }
         });
     }
     if let Some(job_id) = request
@@ -385,6 +381,38 @@ fn handle_request(store: &JobStore, request: &MockRequest) -> Value {
         "success": false,
         "error": { "message": "unknown mock path" }
     })
+}
+
+fn canonical_claim_response(store: &JobStore, request: &MockRequest) -> Value {
+    let request: homeboy_runner_contract::RunnerApiClaimRequest =
+        serde_json::from_value(request.body.clone()).expect("parse canonical claim request");
+    let claim = store
+        .claim_remote_runner_job_with_protocols(
+            &request.runner_id,
+            request.project_id.as_deref(),
+            request.lease_ms.unwrap_or(30_000),
+            request.concurrency_limit,
+            homeboy_core::api_jobs::RemoteRunnerClaimProtocols {
+                execution: request.execution_protocol.as_ref(),
+                workspace_claim: request.workspace_claim_protocol.as_ref(),
+                workspace_owner_lease: request.workspace_owner_lease_protocol.as_ref(),
+            },
+        )
+        .expect("claim job");
+    let outcome = match claim {
+        Some(claim) => homeboy_runner_contract::RunnerApiClaimOutcome::Claimed {
+            claim: claim
+                .runner_api_claimed_execution()
+                .expect("project canonical claim"),
+        },
+        None => homeboy_runner_contract::RunnerApiClaimOutcome::Empty,
+    };
+    serde_json::to_value(homeboy_runner_contract::RunnerApiClaimResponse {
+        schema: homeboy_runner_contract::RUNNER_API_CLAIM_RESPONSE_SCHEMA.to_string(),
+        api_version: homeboy_runner_contract::RUNNER_API_V1,
+        outcome,
+    })
+    .expect("serialize canonical claim response")
 }
 
 fn write_response(stream: &mut std::net::TcpStream, body: Value) {

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -220,7 +220,7 @@ fn reverse_worker_restart_cannot_replay_a_consumed_receipt_and_keeps_context_evi
 #[test]
 fn reverse_provider_dispatch_rejects_runner_mismatch_before_provider_script() {
     assert_tampered_claim_rejects_before_provider(|claim| {
-        claim["job"]["claimed_by_runner_id"] = serde_json::json!("other-runner");
+        claim["execution_context"]["runner_id"] = serde_json::json!("other-runner");
     });
 }
 


### PR DESCRIPTION
## Summary
- add strict versioned Runner API claim request, response, and claimed/empty/rejected outcomes
- project durable core claim state into transport-neutral contract values without moving authority out of core
- migrate Lab worker claim traffic while preserving the exact legacy adapter shape
- reject malformed or unsupported canonical requests before queue mutation

## Verification
- `cargo test -p homeboy-runner-contract`
- `cargo test -p homeboy-core daemon::remote_runner::auth_tests --lib`
- `cargo test -p homeboy-lab-runner worker --lib`
- `cargo fmt --check`

Fixes #14225

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode implemented and independently reviewed the contract migration, compatibility adapter, authority boundaries, and regression coverage. Chris Huber directed the work and remains responsible.