### PR TITLE
fix(agent-task): preserve native Cook worktree ownership

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4418,6 +4418,8 @@ pub fn preflight_cook_continuation_admission_for_observation(
     record: &agent_task_lifecycle::AgentTaskRunRecord,
     aggregate: Option<&AgentTaskAggregate>,
 ) -> Result<Vec<&'static str>> {
+    let mut options = options.clone();
+    canonicalize_native_cook_workspace(&mut options)?;
     let moving_base_continuation = record.metadata.get("cook_moving_base_recovery").is_some();
     let verification_pending_continuation = record
         .metadata
@@ -9943,6 +9945,9 @@ fn rebind_baseline_continuation_workspace(
 /// Safety remains a separate admission check so a retained dirty candidate can
 /// still prove itself against its durable promotion baseline.
 fn canonicalize_cook_provider_workspace(options: &mut CookRequest) -> Result<()> {
+    if canonicalize_native_cook_workspace(options)? {
+        return Ok(());
+    }
     let path = options
         .workspace
         .source_worktree_path
@@ -9974,6 +9979,42 @@ fn canonicalize_cook_provider_workspace(options: &mut CookRequest) -> Result<()>
     options.identity.initial_plan.metadata["cook_provision"]["workspace_identity"] =
         serde_json::to_value(identity).expect("provider identity serializes");
     Ok(())
+}
+
+fn canonicalize_native_cook_workspace(options: &mut CookRequest) -> Result<bool> {
+    let path = options
+        .workspace
+        .source_worktree_path
+        .as_deref()
+        .or_else(|| {
+            std::path::Path::new(&options.workspace.to_worktree)
+                .is_dir()
+                .then_some(std::path::Path::new(&options.workspace.to_worktree))
+        });
+    let Some(path) = path else {
+        return Ok(false);
+    };
+    if let Some(target) =
+        homeboy_core::worktree_provider::resolve_native_worktree_mutation_target_by_path(
+            path,
+            homeboy_core::worktree_provider::WorktreeMutationContext::default(),
+        )?
+    {
+        if !std::path::Path::new(&options.workspace.to_worktree).is_dir()
+            && options.workspace.to_worktree != target.handle
+        {
+            return Err(Error::validation_invalid_argument(
+                "to_worktree",
+                "Cook source path and native worktree handle identify different worktrees",
+                Some(options.workspace.to_worktree.clone()),
+                None,
+            ));
+        }
+        options.workspace.to_worktree = target.handle;
+        options.workspace.source_worktree_path = Some(target.path);
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 #[cfg(test)]

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5954,6 +5954,69 @@ fn explicit_cook_workspace_cleanliness_is_an_initial_admission_check() {
 }
 
 #[test]
+fn native_explicit_cwd_persists_its_managed_handle_and_rejects_mismatch() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let primary = tempfile::tempdir_in(home.path()).expect("primary repository");
+        let target = home.path().join("native-cook-cwd");
+        let git = |cwd: &std::path::Path, args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .output()
+                .expect("run git");
+            assert!(output.status.success(), "git {:?} failed", args);
+        };
+        git(primary.path(), &["init", "--initial-branch=main"]);
+        git(
+            primary.path(),
+            &["config", "user.email", "agent@example.test"],
+        );
+        git(primary.path(), &["config", "user.name", "Agent"]);
+        std::fs::write(primary.path().join("tracked.txt"), "base\n").expect("write base");
+        git(primary.path(), &["add", "tracked.txt"]);
+        git(primary.path(), &["commit", "-m", "base"]);
+        git(
+            primary.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "fix/native-cook-cwd",
+                target.to_str().expect("target path"),
+            ],
+        );
+        homeboy_core::worktree::record_active_for_test("fixture@native-cook-cwd", &target);
+
+        let mut options = batch_cook_options(
+            "native-explicit-cwd",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.workspace.to_worktree = target.display().to_string();
+        options.workspace.source_worktree_path = Some(target.clone());
+        options.identity.initial_plan.tasks[0].metadata["worktree_provision"] =
+            serde_json::json!({ "kind": "explicit_cwd" });
+
+        canonicalize_cook_provider_workspace(&mut options)
+            .expect("native explicit CWD is admitted through its managed handle");
+        assert_eq!(options.workspace.to_worktree, "fixture@native-cook-cwd");
+        let recipe = super::super::cook_recipe::persist_initial_recipe(&options)
+            .expect("persist canonical Cook recipe");
+        assert_eq!(
+            recipe.finalization["to_worktree"],
+            "fixture@native-cook-cwd"
+        );
+
+        let mut mismatch = options.clone();
+        mismatch.workspace.to_worktree = "fixture@other".to_string();
+        mismatch.workspace.source_worktree_path = Some(target);
+        let error = canonicalize_cook_provider_workspace(&mut mismatch)
+            .expect_err("different native handle must not be admitted");
+        assert_eq!(error.details["field"], "to_worktree");
+        assert!(error.message.contains("identify different worktrees"));
+    });
+}
+
+#[test]
 fn dirty_explicit_cwd_blocks_detached_provider_dispatch() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let primary = tempfile::tempdir().expect("primary repository");

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4406,6 +4406,19 @@ pub(crate) fn resolve_cook_destination(
         resolve_cook_base(&mut args)?;
         return Ok(args);
     }
+    if let Some(to_worktree) = args.to_worktree.as_deref() {
+        let path = Path::new(to_worktree);
+        if path.is_dir() {
+            if let Some(target) =
+                homeboy::core::worktree_provider::resolve_native_worktree_mutation_target_by_path(
+                    path,
+                    homeboy::core::worktree_provider::WorktreeMutationContext::default(),
+                )?
+            {
+                args.to_worktree = Some(target.handle);
+            }
+        }
+    }
     if args.to_worktree.is_some() {
         resolve_cook_base(&mut args)?;
         return Ok(args);
@@ -4415,10 +4428,21 @@ pub(crate) fn resolve_cook_destination(
             homeboy::core::Error::internal_io(error.to_string(), Some(cwd.to_string()))
         })?;
         let config = defaults::load_config();
-        args.to_worktree = Some(match homeboy::core::worktree_provider::resolve_configured_worktree_exact_identity_by_path_from_config(&cwd, &config)? {
-            Some(identity) => identity.handle,
-            None => cwd.display().to_string(),
-        });
+        args.to_worktree = Some(
+            if let Some(target) =
+                homeboy::core::worktree_provider::resolve_native_worktree_mutation_target_by_path(
+                    &cwd,
+                    homeboy::core::worktree_provider::WorktreeMutationContext::default(),
+                )?
+            {
+                target.handle
+            } else {
+                match homeboy::core::worktree_provider::resolve_configured_worktree_exact_identity_by_path_from_config(&cwd, &config)? {
+                    Some(identity) => identity.handle,
+                    None => cwd.display().to_string(),
+                }
+            },
+        );
         resolve_cook_base(&mut args)?;
         return Ok(args);
     }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -2526,6 +2526,47 @@ fn cook_cwd_is_authoritative_when_provider_lookup_times_out() {
 }
 
 #[test]
+fn cook_cwd_uses_native_managed_handle_before_recipe_admission() {
+    with_isolated_home(|_| {
+        let primary = tempfile::tempdir().expect("primary checkout");
+        init_runtime_component_checkout(primary.path());
+        let worktree_root = tempfile::tempdir().expect("worktree root");
+        let cwd = worktree_root.path().join("native-task");
+        assert!(Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "fix/native-cook-cwd",
+                cwd.to_str().expect("worktree path"),
+                "HEAD",
+            ])
+            .current_dir(primary.path())
+            .status()
+            .expect("create linked worktree")
+            .success());
+        homeboy::core::worktree::record_active_for_test("fixture@native-cook-cwd", &cwd);
+
+        let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "use native cwd".to_string(),
+            "--cwd".to_string(),
+            cwd.display().to_string(),
+            "--repo".to_string(),
+            "fixture".to_string(),
+            "--task-url".to_string(),
+            "https://github.com/example/fixture/issues/14188".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("resolve native explicit CWD");
+        assert_eq!(args.to_worktree.as_deref(), Some("fixture@native-cook-cwd"));
+    });
+}
+
+#[test]
 fn cook_rejects_mismatched_cwd_and_destination() {
     with_isolated_home(|_| {
         let primary = tempfile::tempdir().expect("primary checkout");

--- a/crates/homeboy-core/src/worktree_provider.rs
+++ b/crates/homeboy-core/src/worktree_provider.rs
@@ -726,6 +726,34 @@ impl WorktreeMutationProvider for NativeWorktreeProvider {
     }
 }
 
+impl NativeWorktreeProvider {
+    /// Resolve an active native workspace by its exact filesystem identity.
+    /// Paths are accepted at the CLI boundary, but provider mutations must use
+    /// the registry handle that owns the linked task worktree.
+    fn resolve_for_mutation_by_path(
+        &self,
+        path: &Path,
+        context: WorktreeMutationContext<'_>,
+    ) -> Result<WorktreeMutationLookup> {
+        let path = std::fs::canonicalize(path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?;
+        for record in worktree::list_workspace_refs()? {
+            if !matches!(record, worktree::WorkspaceRefRecord::Task(_)) {
+                continue;
+            }
+            let registered = Path::new(record.path());
+            let Ok(registered) = std::fs::canonicalize(registered) else {
+                continue;
+            };
+            if registered == path {
+                return self.resolve_for_mutation(record.handle(), context);
+            }
+        }
+        Ok(WorktreeMutationLookup::NotFound)
+    }
+}
+
 impl WorktreeProvisionProvider for NativeWorktreeProvider {
     fn admit(
         &self,
@@ -1787,6 +1815,21 @@ pub fn resolve_native_worktree_mutation_target(
     )
 }
 
+/// Resolve an active native mutation target from an exact linked-worktree path.
+/// This is intentionally native-only: configured providers retain their own
+/// path identity contract and are resolved through their configured commands.
+pub fn resolve_native_worktree_mutation_target_by_path(
+    path: &Path,
+    context: WorktreeMutationContext<'_>,
+) -> Result<Option<WorktreeMutationTarget>> {
+    Ok(
+        match NativeWorktreeProvider.resolve_for_mutation_by_path(path, context)? {
+            WorktreeMutationLookup::Found(target) => Some(target),
+            WorktreeMutationLookup::NotFound => None,
+        },
+    )
+}
+
 /// Resolve a mutation target through configured command-provider authority
 /// only. This is used when durable task evidence already selected configured
 /// ownership and native fallback would violate that binding.
@@ -2348,6 +2391,20 @@ mod tests {
                 WorktreeProviderIdentity::Native,
                 &path,
             );
+            let by_path = resolve_native_worktree_mutation_target_by_path(
+                &path,
+                WorktreeMutationContext::default(),
+            )
+            .expect("native path lookup")
+            .expect("native path is registry-owned");
+            assert_eq!(by_path.handle, "fixture@native");
+            assert_eq!(by_path.path, path);
+            assert!(resolve_native_worktree_mutation_target_by_path(
+                source.path(),
+                WorktreeMutationContext::default(),
+            )
+            .expect("primary path lookup")
+            .is_none());
             assert_provision_admission_conformance(
                 &NativeWorktreeProvider,
                 "fixture@native",


### PR DESCRIPTION
## Summary

Canonicalize exact active native task-worktree paths to their managed handles before Cook recipe admission and continuation. This keeps one ownership identity through provider dispatch, promotion, and finalization instead of accepting `--cwd` and rejecting the same path after provider work completes.

Closes #14188.

## What changed

- Resolve registered native task-worktree paths to their canonical Homeboy handles at the CLI boundary.
- Persist canonical native ownership in Cook recipes and recover it before continuation preflight.
- Reject mismatched path/handle pairs while preserving configured-provider and unowned-checkout behavior.
- Add focused CLI, agent-service, and core regression coverage.

## Verification

- `cargo test -p homeboy-cli commands::agent_task::tests::dispatch::cook_cwd_uses_native_managed_handle_before_recipe_admission -- --exact --nocapture`
- `cargo test -p homeboy-agents agent_task_service::cook::tests::native_explicit_cwd_persists_its_managed_handle_and_rejects_mismatch -- --exact --nocapture`
- `cargo test -p homeboy-core worktree_provider::tests::native_provider_conforms_to_shared_lookup_contract -- --exact --nocapture`
- `cargo fmt --all -- --check`

All passed on the candidate merged with current `main`. Replacement gate proof is retained on Cook `cook-detached-2239a15b-716a-46c1-adb4-6194499d3195`.

## AI assistance

OpenAI GPT-5.6 Terra was used through Homeboy and OpenCode to trace the path-versus-handle ownership loss, implement canonical native worktree identity, and add focused regression coverage. GPT-5.6 Sol was used through OpenCode to diagnose the live Cook failures, validate the candidate, and orchestrate final verification and PR publication.