### PR TITLE
Retry terminal unmaterialized Cook admissions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -670,6 +670,24 @@ pub fn record_unmaterialized_cook_admission_in_store(
     state: &str,
     reason: &str,
 ) -> Result<AgentTaskRunRecord> {
+    record_unmaterialized_cook_admission_with_metadata_in_store(
+        lifecycle_store,
+        cook_id,
+        binding,
+        state,
+        reason,
+        serde_json::Map::new(),
+    )
+}
+
+pub(crate) fn record_unmaterialized_cook_admission_with_metadata_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    binding: Value,
+    state: &str,
+    reason: &str,
+    metadata: serde_json::Map<String, Value>,
+) -> Result<AgentTaskRunRecord> {
     lifecycle_store.with_config_lock(|| {
         record_unmaterialized_cook_admission_locked(
             lifecycle_store,
@@ -677,6 +695,7 @@ pub fn record_unmaterialized_cook_admission_in_store(
             binding,
             state,
             reason,
+            metadata,
         )
     })
 }
@@ -687,6 +706,7 @@ fn record_unmaterialized_cook_admission_locked(
     binding: Value,
     state: &str,
     reason: &str,
+    metadata: serde_json::Map<String, Value>,
 ) -> Result<AgentTaskRunRecord> {
     const SCHEMA: &str = "homeboy/unmaterialized-cook-admission/v1";
     if !matches!(
@@ -712,7 +732,7 @@ fn record_unmaterialized_cook_admission_locked(
     let cook_id = sanitize_run_id(cook_id);
     if lifecycle_store.read_record(&cook_id).is_err() {
         let plan = AgentTaskPlan::new(format!("detached-cook-handoff-{cook_id}"), Vec::new());
-        let mut submission_metadata = serde_json::Map::new();
+        let mut submission_metadata = metadata;
         submission_metadata.insert(
             "detached_cook_handoff".to_string(),
             json!({
@@ -5672,6 +5692,170 @@ pub(crate) fn mark_resuming_in_store(
 pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRunRecord> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     retry_in_store(&lifecycle_store, run_id, requested_run_id)
+}
+
+/// Reserve a new controller-owned admission for a terminal Cook that never
+/// materialized an executable task plan. Its replay inputs were already made
+/// durable by the original admission, so retry rebinds that immutable intent to
+/// a fresh Cook id instead of inventing a workspace root.
+pub fn retry_unmaterialized_cook_admission_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    source_run_id: &str,
+    retry_run_id: &str,
+    force: bool,
+) -> Result<(AgentTaskRunRecord, bool)> {
+    with_retry_lineage_reservation_in_store(lifecycle_store, source_run_id, || {
+        retry_unmaterialized_cook_admission_locked(
+            lifecycle_store,
+            source_run_id,
+            retry_run_id,
+            force,
+        )
+    })
+}
+
+fn retry_unmaterialized_cook_admission_locked(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    source_run_id: &str,
+    retry_run_id: &str,
+    force: bool,
+) -> Result<(AgentTaskRunRecord, bool)> {
+    let source = lifecycle_store.read_record(&sanitize_run_id(source_run_id))?;
+    if !source.state.is_terminal() || !is_unmaterialized_cook_admission(&source) {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "retry requires a terminal unmaterialized Cook admission",
+            Some(source.run_id),
+            None,
+        ));
+    }
+    let root_run_id = retry_root_run_id_in_store(lifecycle_store, &source)?;
+    let mut retry_run_id = retry_run_id.to_string();
+    if let Ok(existing) = lifecycle_store.read_record(&retry_run_id) {
+        let source_request_ref =
+            source.metadata["unmaterialized_cook_admission"]["binding"]["request_ref"].as_str();
+        let existing_request_ref =
+            existing.metadata["unmaterialized_cook_admission"]["binding"]["request_ref"].as_str();
+        if is_unmaterialized_cook_admission(&existing)
+            && existing.metadata["unmaterialized_cook_admission"]["binding"]["retry_of"]
+                == source.run_id
+            && existing.metadata["unmaterialized_cook_admission"]["binding"]["worktree_ref"]
+                == source.metadata["unmaterialized_cook_admission"]["binding"]["worktree_ref"]
+            && source_request_ref.is_some()
+            && source_request_ref == existing_request_ref
+        {
+            if !force && !existing.state.is_terminal() {
+                return Ok((existing, false));
+            }
+            if force {
+                retry_run_id = format!("retry-{}", uuid::Uuid::new_v4());
+            }
+        } else {
+            return Err(Error::validation_invalid_argument(
+                "run_id",
+                "retry run id already belongs to a different durable admission",
+                Some(retry_run_id.to_string()),
+                None,
+            ));
+        }
+    }
+    let mut successors = lifecycle_store
+        .read_records()?
+        .into_iter()
+        .filter(|record| record.run_id != root_run_id)
+        .filter(|record| {
+            retry_root_run_id_in_store(lifecycle_store, record)
+                .ok()
+                .as_deref()
+                == Some(&root_run_id)
+        })
+        .collect::<Vec<_>>();
+    successors.sort_by(|left, right| left.run_id.cmp(&right.run_id));
+    if let Some(active) = successors.iter().find(|record| !record.state.is_terminal()) {
+        if !force {
+            return Err(active_retry_successor_error(active));
+        }
+        if retry_run_id == active.run_id {
+            retry_run_id = format!("retry-{}", uuid::Uuid::new_v4());
+        }
+    }
+    if !successors.is_empty() && !force {
+        return Err(Error::validation_invalid_argument(
+            "force",
+            format!(
+                "retry lineage rooted at '{}' already has terminal successor(s); use --force to create another retry",
+                root_run_id
+            ),
+            Some(root_run_id.clone()),
+            None,
+        ));
+    }
+    let mut binding = source.metadata["unmaterialized_cook_admission"]["binding"].clone();
+    let intent = binding
+        .get_mut("replay_intent")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_admission.replay_intent",
+                "terminal unmaterialized Cook admission has no replay intent",
+                Some(source.run_id.clone()),
+                None,
+            )
+        })?;
+    intent.insert("cook_id".to_string(), json!(retry_run_id));
+    let argv = intent
+        .get_mut("argv")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_admission.replay_intent",
+                "terminal unmaterialized Cook admission has no replay argv",
+                Some(source.run_id.clone()),
+                None,
+            )
+        })?;
+    let mut rewritten = false;
+    for index in 0..argv.len() {
+        let Some(argument) = argv[index].as_str() else {
+            continue;
+        };
+        if argument == "--run-id" {
+            if let Some(value) = argv.get_mut(index + 1) {
+                *value = json!(retry_run_id);
+                rewritten = true;
+            }
+            break;
+        }
+        if argument.starts_with("--run-id=") {
+            argv[index] = json!(format!("--run-id={retry_run_id}"));
+            rewritten = true;
+            break;
+        }
+    }
+    if !rewritten {
+        argv.extend([json!("--run-id"), json!(retry_run_id)]);
+    }
+    binding["retry_of"] = json!(source.run_id);
+    let record = record_unmaterialized_cook_admission_with_metadata_in_store(
+        lifecycle_store,
+        &retry_run_id,
+        binding,
+        "queued",
+        "retrying terminal unmaterialized Cook admission",
+        serde_json::Map::from_iter([
+            ("retry_of".to_string(), json!(source.run_id)),
+            ("retried_from".to_string(), json!(source.run_id)),
+            ("retry_root".to_string(), json!(root_run_id)),
+            ("retry_requested_at".to_string(), json!(now_timestamp())),
+        ]),
+    )?;
+    persist_retry_lineage_in_store(
+        lifecycle_store,
+        &source.run_id,
+        &root_run_id,
+        &record.run_id,
+    )?;
+    Ok((record, true))
 }
 
 /// Retry a run inside an explicitly rooted store through the reserved lifecycle

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -13,7 +13,7 @@ use homeboy_core::api_jobs::JobStore;
 use homeboy_core::test_support::with_isolated_home;
 use sha2::Digest;
 use std::process::Command;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex};
 
 /// The tests below drive the store-rooted entry points. Resolving the store
 /// once here keeps the ambient lookup in one place and lets the ambient
@@ -309,6 +309,267 @@ fn unmaterialized_cook_admission_is_typed_secret_free_and_idempotent() {
     assert!(replay.metadata["unmaterialized_cook_admission"]["commands"]
         .get("run")
         .is_none());
+}
+
+#[test]
+fn unmaterialized_admission_initial_submission_includes_retry_lineage_metadata() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let store = AgentTaskLifecycleStore::new(context.path_roots());
+    let source_run_id = "unmaterialized-lineage-source";
+    let binding = json!({
+        "schema": "homeboy/unmaterialized-cook-binding/v1",
+        "request_ref": "sha256:request",
+        "worktree_ref": "repo@branch",
+        "replay_intent": { "cook_id": source_run_id, "argv": ["cook"] },
+    });
+    record_unmaterialized_cook_admission_in_store(
+        &store,
+        source_run_id,
+        binding.clone(),
+        "queued",
+        "source admission",
+    )
+    .expect("persist source admission");
+
+    let record = record_unmaterialized_cook_admission_with_metadata_in_store(
+        &store,
+        "unmaterialized-lineage-child",
+        binding,
+        "queued",
+        "retry admission",
+        serde_json::Map::from_iter([
+            ("retry_of".to_string(), json!(source_run_id)),
+            ("retried_from".to_string(), json!(source_run_id)),
+            ("retry_root".to_string(), json!(source_run_id)),
+            (
+                "retry_requested_at".to_string(),
+                json!("2026-09-02T00:00:00Z"),
+            ),
+        ]),
+    )
+    .expect("persist retry admission");
+
+    assert_eq!(record.metadata["retry_of"], source_run_id);
+    assert_eq!(record.metadata["retried_from"], source_run_id);
+    assert_eq!(record.metadata["retry_root"], source_run_id);
+    assert_eq!(
+        record.metadata["retry_requested_at"],
+        "2026-09-02T00:00:00Z"
+    );
+}
+
+#[test]
+fn concurrent_unmaterialized_retries_reserve_one_non_force_successor() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let store = Arc::new(AgentTaskLifecycleStore::new(context.path_roots()));
+    let source_run_id = "terminal-unmaterialized-source";
+    record_unmaterialized_cook_admission_in_store(
+        &store,
+        source_run_id,
+        json!({
+            "schema": "homeboy/unmaterialized-cook-binding/v1",
+            "request_ref": "sha256:request",
+            "worktree_ref": "repo@branch",
+            "provider_runtime_refs": { "backend": "fixture" },
+            "retry": { "provider_rotations": 0 },
+            "replay_intent": { "cook_id": source_run_id, "argv": ["cook"] },
+        }),
+        "blocked_runner_unavailable",
+        "runner unavailable",
+    )
+    .expect("persist source admission");
+    store
+        .mutate_record(source_run_id, |record| {
+            record.metadata["detached_cook_handoff"]["state"] = json!("exited_before_handoff");
+            set_run_state(record, AgentTaskRunState::Failed);
+            true
+        })
+        .expect("terminalize source admission");
+
+    let barrier = Arc::new(Barrier::new(2));
+    let retry_ids = ["concurrent-retry-a", "concurrent-retry-b"];
+    let outcomes = std::thread::scope(|scope| {
+        let handles = retry_ids.map(|retry_id| {
+            let store = Arc::clone(&store);
+            let barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                barrier.wait();
+                retry_unmaterialized_cook_admission_in_store(&store, source_run_id, retry_id, false)
+            })
+        });
+        handles.map(|handle| handle.join().expect("retry thread"))
+    });
+
+    assert_eq!(outcomes.iter().filter(|outcome| outcome.is_ok()).count(), 1);
+    assert_eq!(
+        outcomes.iter().filter(|outcome| outcome.is_err()).count(),
+        1
+    );
+    let successors = store
+        .read_records()
+        .expect("read retry records")
+        .into_iter()
+        .filter(|record| {
+            record.run_id != source_run_id && record.metadata["retry_root"] == source_run_id
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(successors.len(), 1);
+}
+
+#[test]
+fn unmaterialized_retry_lineage_requires_force_and_retains_its_root() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let store = Arc::new(AgentTaskLifecycleStore::new(context.path_roots()));
+    let source_run_id = "unmaterialized-lineage-root";
+    record_unmaterialized_cook_admission_in_store(
+        &store,
+        source_run_id,
+        json!({
+            "schema": "homeboy/unmaterialized-cook-binding/v1",
+            "request_ref": "sha256:request",
+            "worktree_ref": "repo@branch",
+            "provider_runtime_refs": { "backend": "fixture" },
+            "retry": { "provider_rotations": 0 },
+            "replay_intent": { "cook_id": source_run_id, "argv": ["cook"] },
+        }),
+        "blocked_runner_unavailable",
+        "runner unavailable",
+    )
+    .expect("persist source admission");
+    store
+        .mutate_record(source_run_id, |record| {
+            record.metadata["detached_cook_handoff"]["state"] = json!("exited_before_handoff");
+            set_run_state(record, AgentTaskRunState::Failed);
+            true
+        })
+        .expect("terminalize source admission");
+
+    let (first, created) = retry_unmaterialized_cook_admission_in_store(
+        &store,
+        source_run_id,
+        "unmaterialized-lineage-first",
+        false,
+    )
+    .expect("create first successor");
+    assert!(created);
+    store
+        .mutate_record(&first.run_id, |record| {
+            set_run_state(record, AgentTaskRunState::Failed);
+            true
+        })
+        .expect("terminalize first successor");
+
+    let error = retry_unmaterialized_cook_admission_in_store(
+        &store,
+        source_run_id,
+        "unmaterialized-lineage-without-force",
+        false,
+    )
+    .expect_err("terminal successor requires force");
+    assert!(error.message.contains("terminal successor(s); use --force"));
+
+    let (descendant, created) = retry_unmaterialized_cook_admission_in_store(
+        &store,
+        &first.run_id,
+        "unmaterialized-lineage-descendant",
+        true,
+    )
+    .expect("retry terminal descendant with force");
+    assert!(created);
+    assert_eq!(first.metadata["retry_root"], source_run_id);
+    assert_eq!(descendant.metadata["retry_of"], first.run_id);
+    assert_eq!(descendant.metadata["retry_root"], source_run_id);
+    assert_eq!(
+        descendant.metadata["unmaterialized_cook_admission"]["binding"]["retry_of"],
+        first.run_id
+    );
+}
+
+#[test]
+fn concurrent_unmaterialized_retries_from_root_and_descendant_share_the_root_lock() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let store = Arc::new(AgentTaskLifecycleStore::new(context.path_roots()));
+    let source_run_id = "cross-entry-lineage-root";
+    record_unmaterialized_cook_admission_in_store(
+        &store,
+        source_run_id,
+        json!({
+            "schema": "homeboy/unmaterialized-cook-binding/v1",
+            "request_ref": "sha256:request",
+            "worktree_ref": "repo@branch",
+            "provider_runtime_refs": { "backend": "fixture" },
+            "retry": { "provider_rotations": 0 },
+            "replay_intent": { "cook_id": source_run_id, "argv": ["cook"] },
+        }),
+        "blocked_runner_unavailable",
+        "runner unavailable",
+    )
+    .expect("persist source admission");
+    store
+        .mutate_record(source_run_id, |record| {
+            record.metadata["detached_cook_handoff"]["state"] = json!("exited_before_handoff");
+            set_run_state(record, AgentTaskRunState::Failed);
+            true
+        })
+        .expect("terminalize source admission");
+    let (first, _) = retry_unmaterialized_cook_admission_in_store(
+        &store,
+        source_run_id,
+        "cross-entry-terminal-descendant",
+        false,
+    )
+    .expect("create terminal descendant");
+    store
+        .mutate_record(&first.run_id, |record| {
+            set_run_state(record, AgentTaskRunState::Failed);
+            true
+        })
+        .expect("terminalize descendant");
+
+    let barrier = Arc::new(Barrier::new(2));
+    let outcomes = std::thread::scope(|scope| {
+        let root_store = Arc::clone(&store);
+        let root_barrier = Arc::clone(&barrier);
+        let root = scope.spawn(move || {
+            root_barrier.wait();
+            retry_unmaterialized_cook_admission_in_store(
+                &root_store,
+                source_run_id,
+                "cross-entry-root-retry",
+                true,
+            )
+        });
+        let descendant_store = Arc::clone(&store);
+        let descendant_barrier = Arc::clone(&barrier);
+        let descendant = scope.spawn(move || {
+            descendant_barrier.wait();
+            retry_unmaterialized_cook_admission_in_store(
+                &descendant_store,
+                &first.run_id,
+                "cross-entry-descendant-retry",
+                false,
+            )
+        });
+        [
+            root.join().expect("root retry thread"),
+            descendant.join().expect("descendant retry thread"),
+        ]
+    });
+
+    assert_eq!(outcomes.iter().filter(|outcome| outcome.is_ok()).count(), 1);
+    assert_eq!(
+        outcomes.iter().filter(|outcome| outcome.is_err()).count(),
+        1
+    );
+    let active = store
+        .read_records()
+        .expect("read retry records")
+        .into_iter()
+        .filter(|record| {
+            record.metadata["retry_root"] == source_run_id && !record.state.is_terminal()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(active.len(), 1);
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -1147,17 +1147,20 @@ pub fn retry(
     run: bool,
     force: bool,
 ) -> Result<AgentTaskRetryServiceResult> {
-    retry_with_preflight_and_timeout(run_id, new_run_id, run, force, None, None, |plan| {
-        if plan.metadata.get("generic_lab_command_replay").is_some() {
-            return Err(Error::validation_invalid_argument(
-                "generic_lab_command_replay",
-                "generic Lab replay requires controller workspace preflight",
-                Some(plan.plan_id.clone()),
-                None,
-            ));
-        }
-        Ok(())
-    })
+    let mut retry =
+        retry_with_preflight_and_timeout(run_id, new_run_id, run, force, None, None, |plan| {
+            if plan.metadata.get("generic_lab_command_replay").is_some() {
+                return Err(Error::validation_invalid_argument(
+                    "generic_lab_command_replay",
+                    "generic Lab replay requires controller workspace preflight",
+                    Some(plan.plan_id.clone()),
+                    None,
+                ));
+            }
+            Ok(())
+        })?;
+    reconcile_unmaterialized_cook_retry(&mut retry, run)?;
+    Ok(retry)
 }
 
 /// Reserve a new Cook attempt with an explicit operator-approved provider
@@ -1211,7 +1214,7 @@ pub fn retry_with_provider_route_override(
     if route_override.is_empty() {
         return retry(run_id, new_run_id, run, force);
     }
-    retry_with_preflight_and_timeout(
+    let mut retry = retry_with_preflight_and_timeout(
         run_id,
         new_run_id,
         run,
@@ -1229,7 +1232,21 @@ pub fn retry_with_provider_route_override(
             }
             Ok(())
         },
-    )
+    )?;
+    reconcile_unmaterialized_cook_retry(&mut retry, run)?;
+    Ok(retry)
+}
+
+fn reconcile_unmaterialized_cook_retry(
+    retry: &mut AgentTaskRetryServiceResult,
+    run: bool,
+) -> Result<()> {
+    if run && agent_task_lifecycle::is_unmaterialized_cook_admission(&retry.record) {
+        agent_task_lifecycle::rearm_unmaterialized_cook_admission(&retry.record.run_id)?;
+        crate::agent_task_service::reconcile_unmaterialized_cook_admission(&retry.record.run_id)?;
+        retry.record = agent_task_lifecycle::exact_record(&retry.record.run_id)?;
+    }
+    Ok(())
 }
 
 pub(super) fn deferred_cleanup_receipt_is_terminal(
@@ -1304,6 +1321,28 @@ where
     let source_plan =
         agent_task_lifecycle::load_controller_plan_in_store(&lifecycle_store, &source.run_id)?;
     preflight(&source_plan)?;
+    if source.state.is_terminal() && agent_task_lifecycle::is_unmaterialized_cook_admission(&source)
+    {
+        if let Some(route_override) = route_override.filter(|override_| !override_.is_empty()) {
+            validate_unmaterialized_replay_route_override(&source, route_override)?;
+        }
+        let retry_run_id = new_run_id
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("retry-{}", uuid::Uuid::new_v4()));
+        let (record, created) = agent_task_lifecycle::retry_unmaterialized_cook_admission_in_store(
+            &lifecycle_store,
+            &source.run_id,
+            &retry_run_id,
+            force,
+        )?;
+        return Ok(AgentTaskRetryServiceResult {
+            record,
+            // An admission is reconciled by the controller, never executed as
+            // the empty task plan a generic retry would otherwise submit.
+            run: false,
+            created,
+        });
+    }
     let recovered_replacement = config::with_config_lock(|| {
         let Some(mut cook_retry) = retryable_cook_attempt(&lifecycle_store, &source)? else {
             return Ok(None);
@@ -1524,6 +1563,65 @@ where
         run,
         created: false,
     })
+}
+
+fn validate_unmaterialized_replay_route_override(
+    source: &agent_task_lifecycle::AgentTaskRunRecord,
+    route_override: &CookProviderRouteOverride,
+) -> Result<()> {
+    let binding = &source.metadata["unmaterialized_cook_admission"]["binding"];
+    let runtime = &binding["provider_runtime_refs"];
+    for (name, requested, persisted) in [
+        (
+            "backend",
+            route_override.backend.as_ref(),
+            runtime["backend"].as_str(),
+        ),
+        (
+            "selector",
+            route_override.selector.as_ref(),
+            runtime["selector"].as_str(),
+        ),
+        (
+            "model",
+            route_override.model.as_ref(),
+            runtime["model"].as_str(),
+        ),
+    ] {
+        if requested.is_some_and(|value| Some(value.as_str()) != persisted) {
+            return Err(unmaterialized_replay_route_override_error(
+                &source.run_id,
+                name,
+            ));
+        }
+    }
+    let persisted_rotations = binding["retry"]["provider_rotations"]
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok());
+    if route_override
+        .provider_rotations
+        .is_some_and(|value| Some(value) != persisted_rotations)
+        || route_override
+            .allow_provider_rotation
+            .is_some_and(|value| Some(value) != persisted_rotations.map(|value| value > 0))
+    {
+        return Err(unmaterialized_replay_route_override_error(
+            &source.run_id,
+            "provider rotation policy",
+        ));
+    }
+    Ok(())
+}
+
+fn unmaterialized_replay_route_override_error(run_id: &str, field: &str) -> Error {
+    Error::validation_invalid_argument(
+        "provider-route",
+        format!(
+            "terminal unmaterialized Cook retry cannot change persisted {field}; submit a fresh Cook for a new provider route or policy"
+        ),
+        Some(run_id.to_string()),
+        None,
+    )
 }
 
 fn apply_cook_timeout_override(

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -4612,7 +4612,9 @@ fn controller_owns_agent_task_lifecycle_command(cli: &Cli) -> homeboy::core::Res
                 false,
             )?
             .record;
-            return Ok(record.metadata["cook_id"].is_string());
+            return Ok(record.metadata["cook_id"].is_string()
+                || (record.state.is_terminal()
+                    && agent_task_lifecycle::is_unmaterialized_cook_admission(&record)));
         }
     }
     Ok(true)

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -174,6 +174,8 @@ fn failed_detached_bench_retry_replays_the_persisted_workspace_and_inputs() {
         .expect("persist pre-provider failure");
         let retry_args = [
             "homeboy",
+            "--placement",
+            "lab",
             "agent-task",
             "retry",
             "bench-pre-provider-failure",
@@ -2452,7 +2454,7 @@ fn detached_cook_without_a_lab_runner_does_not_fall_back_to_local_execution() {
 }
 
 #[test]
-fn lab_cook_defers_provider_destination_and_retry_refuses_unbound_plan() {
+fn lab_cook_retry_recovers_terminal_unmaterialized_admission_without_a_workspace() {
     crate::test_support::with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");
         git_init(workspace.path());
@@ -2573,27 +2575,227 @@ fn lab_cook_defers_provider_destination_and_retry_refuses_unbound_plan() {
             plan.tasks[0].metadata["worktree_provision"]["handle"],
             "homeboy@fix-issue-11291-homeboy"
         );
-        agent_task_lifecycle::submit_plan(&plan, Some("failed-run")).expect("submit plan");
-        agent_task_lifecycle::record_pre_execution_failure(
+        let admission_args = [
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--repo",
+            "homeboy",
+            "--task-url",
+            "https://github.com/Extra-Chill/homeboy/issues/11291",
+            "--verify",
+            "true",
+            "--backend",
+            "fixture",
+            "--prompt",
+            "retry this task",
+            "--run-id",
             "failed-run",
-            &plan,
-            "lab_handoff_preacceptance",
-            &Error::internal_unexpected("Lab rejected the initial attempt"),
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let staged = stage_unmaterialized_cook_replay_intent(&admission_args, "failed-run", None)
+            .expect("stage replay intent");
+        let intent = staged
+            .intent
+            .as_ref()
+            .expect("staged replay intent")
+            .clone();
+        let binding = serde_json::json!({
+            "schema": "homeboy/unmaterialized-cook-binding/v1",
+            "request_ref": "sha256:failed-run-request",
+            "source": { "repository": "homeboy" },
+            "base": "main",
+            "head": "fix/issue-11291-homeboy",
+            "worktree_ref": "homeboy@fix-issue-11291-homeboy",
+            "provider_runtime_refs": {
+                "backend": "fixture",
+                "selector": null,
+                "model": null,
+            },
+            "retry": { "provider_rotations": 0 },
+            "replay_intent": intent,
+            "input_publication": {
+                "state": "staged",
+                "staging_root": staged.staging_root,
+                "published_root": staged.published_root,
+            },
+        });
+        agent_task_lifecycle::prepare_unmaterialized_cook_admission(
+            "failed-run",
+            binding.clone(),
+            "blocked_runner_unavailable",
+            "Lab rejected the initial attempt",
         )
-        .expect("persist failed attempt");
+        .expect("submit unmaterialized admission");
+        staged.retain_for_recovery();
+        agent_task_lifecycle::recover_unmaterialized_cook_input_publication("failed-run")
+            .expect("publish replay inputs");
+        agent_task_lifecycle::fail_detached_cook_handoff_parent(
+            "failed-run",
+            "bounded Lab admission retry budget exhausted",
+        )
+        .expect("terminalize exhausted admission");
 
-        let retry_args = ["homeboy", "agent-task", "retry", "failed-run", "--run"]
-            .into_iter()
-            .map(str::to_string)
-            .collect::<Vec<_>>();
+        let retry_args = [
+            "homeboy",
+            "--placement",
+            "lab",
+            "agent-task",
+            "retry",
+            "failed-run",
+            "--new-run-id",
+            "recovered-run",
+            "--run",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
         let retry_cli = Cli::parse_from(&retry_args);
-        let error = match materialize_agent_task_retry_handoff(&retry_cli, &retry_args) {
-            Err(error) => error,
-            Ok(_) => {
-                panic!("retry must not substitute the controller cwd for an unresolved workspace")
-            }
-        };
-        assert!(error.message.contains("original persisted plan has none"));
+        assert_eq!(
+            route_after_parse_with_provenance(&retry_cli, &retry_args, None, None)
+                .expect("terminal admission retry stays controller-owned"),
+            None
+        );
+        homeboy::agents::orchestration::execute_action_from_current_environment(
+            "failed-run",
+            &homeboy_control_plane_contract::ControlPlaneActionRequest {
+                schema: homeboy_control_plane_contract::CONTROL_PLANE_ACTION_REQUEST_SCHEMA
+                    .to_string(),
+                action: homeboy_control_plane_contract::ControlPlaneAction::Retry,
+                idempotency_key: "recover-terminal-admission".to_string(),
+                actor: "homeboy-cli".to_string(),
+                expected_updated_at: None,
+                parameters: homeboy_control_plane_contract::ControlPlaneActionPayload {
+                    schema: homeboy_control_plane_contract::CONTROL_PLANE_RETRY_PARAMETERS_SCHEMA
+                        .to_string(),
+                    data: serde_json::json!({
+                        "new_run_id": "recovered-run",
+                        "force": false,
+                    }),
+                },
+                confirmed: true,
+            },
+        )
+        .expect("recover terminal admission through the control plane");
+        let recovered =
+            agent_task_lifecycle::exact_record("recovered-run").expect("replacement admission");
+        assert!(recovered.tasks.is_empty());
+        assert_eq!(
+            recovered.metadata["unmaterialized_cook_admission"]["binding"]["worktree_ref"],
+            "homeboy@fix-issue-11291-homeboy"
+        );
+        assert_eq!(
+            recovered.metadata["unmaterialized_cook_admission"]["binding"]["retry_of"],
+            "failed-run"
+        );
+        assert_eq!(
+            recovered.metadata["unmaterialized_cook_admission"]["binding"]["request_ref"],
+            "sha256:failed-run-request"
+        );
+        assert_eq!(
+            recovered.metadata["unmaterialized_cook_admission"]["binding"]["input_publication"]
+                ["published_root"],
+            binding["input_publication"]["published_root"]
+        );
+        assert!(
+            recovered.metadata["unmaterialized_cook_admission"]["admission_attempts"]
+                .as_u64()
+                .expect("admission attempts")
+                > 0,
+            "the control-plane retry rearms and reconciles the fresh admission"
+        );
+        assert_eq!(
+            recovered.metadata["unmaterialized_cook_admission"]["binding"]["replay_intent"]
+                ["cook_id"],
+            "recovered-run"
+        );
+        assert!(
+            recovered.metadata["unmaterialized_cook_admission"]["binding"]["replay_intent"]["argv"]
+                .as_array()
+                .expect("replay argv")
+                .windows(2)
+                .any(|pair| pair == ["--run-id", "recovered-run"])
+        );
+
+        let equivalent_override =
+            homeboy::agents::agent_task_service::retry_with_provider_route_override(
+                "failed-run",
+                Some("equivalent-override-run"),
+                true,
+                true,
+                homeboy::agents::agent_task_service::CookProviderRouteOverride {
+                    backend: Some("fixture".to_string()),
+                    allow_provider_rotation: Some(false),
+                    provider_rotations: Some(0),
+                    ..Default::default()
+                },
+            )
+            .expect("accept an equivalent provider route override");
+        assert!(!equivalent_override.run);
+        assert!(
+            equivalent_override.record.metadata["unmaterialized_cook_admission"]
+                ["admission_attempts"]
+                .as_u64()
+                .expect("admission attempts")
+                > 0,
+            "--run with an equivalent provider override reconciles the replacement admission"
+        );
+        for (run_id, override_) in [
+            (
+                "changed-backend-run",
+                homeboy::agents::agent_task_service::CookProviderRouteOverride {
+                    backend: Some("other".to_string()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "changed-model-run",
+                homeboy::agents::agent_task_service::CookProviderRouteOverride {
+                    model: Some("other-model".to_string()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "changed-rotation-run",
+                homeboy::agents::agent_task_service::CookProviderRouteOverride {
+                    provider_rotations: Some(1),
+                    ..Default::default()
+                },
+            ),
+        ] {
+            let error = homeboy::agents::agent_task_service::retry_with_provider_route_override(
+                "failed-run",
+                Some(run_id),
+                false,
+                true,
+                override_,
+            )
+            .expect_err("route changes require a fresh Cook");
+            assert!(error.message.contains("submit a fresh Cook"));
+            assert!(agent_task_lifecycle::exact_record(run_id).is_err());
+        }
+
+        let mut unrelated_binding = binding.clone();
+        unrelated_binding["request_ref"] = serde_json::json!("sha256:other-request");
+        agent_task_lifecycle::prepare_unmaterialized_cook_admission(
+            "requested-id-collision",
+            unrelated_binding,
+            "queued",
+            "unrelated admission",
+        )
+        .expect("persist unrelated admission");
+        let error = homeboy::agents::agent_task_service::retry(
+            "failed-run",
+            Some("requested-id-collision"),
+            false,
+            true,
+        )
+        .expect_err("unrelated requested retry id is rejected");
+        assert!(error
+            .message
+            .contains("already belongs to a different durable admission"));
     });
 }
 


### PR DESCRIPTION
## Summary

- replay terminal pre-materialization Cook admissions from their durable binding instead of treating their empty plan as a Lab workspace
- publish complete retry lineage identity atomically and serialize retries across root/descendant entry points
- preserve equivalent provider policy while rejecting route changes that require newly resolved runtime capabilities
- rearm and reconcile `retry --run` immediately without substituting the controller checkout

Closes #14242.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-agents unmaterialized --lib` (11 passed)
- `cargo test -p homeboy-cli lab_cook_retry_recovers_terminal_unmaterialized_admission_without_a_workspace --lib`
- `cargo test -p homeboy-cli unmaterialized_cook_run_stays_controller_local_before_lab_workspace_selection --lib`
- `git diff --check`

Coverage includes atomic initial lineage publication, requested-ID collision rejection, terminal-successor force policy, concurrent retries from root and descendant records, durable replay input retention, equivalent provider options, changed-route rejection, controller ownership, and immediate admission reconciliation.

AI assistance disclosure: OpenAI GPT-5.6 Sol via OpenCode was used to reproduce the failed Cook recovery, trace lifecycle and routing invariants, implement the repair through iterative review, and run deterministic verification.
