### PR TITLE
Fix rig workload fuzz inventory planning

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -91,6 +91,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     let target_inventory = build_target_inventory(
         &ctx.component_id,
         &workloads,
+        selected_workload,
         args.run_id.clone(),
         args.inventory.as_deref(),
     )?;

--- a/crates/homeboy-cli/src/commands/fuzz/planning.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/planning.rs
@@ -81,6 +81,7 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
     let target_inventory = build_target_inventory(
         &ctx.component_id,
         &workloads,
+        selected_workload,
         args.run.run_id.clone(),
         args.run.inventory.as_deref(),
     )?;
@@ -1214,10 +1215,18 @@ fn operation_skip_reason(
     filters: &BTreeSet<String>,
     workload_operations: &BTreeSet<String>,
 ) -> Option<&'static str> {
+    let explicitly_scoped = workload_operations.contains(&operation.id)
+        || workload_operations.contains(&operation.kind);
     if matches!(safety_class, FuzzSafetyClass::Destructive) && !destructive_allowed {
         return Some("destructive");
     }
-    if family.is_none() {
+    if family.is_none()
+        && !(explicitly_scoped
+            && matches!(
+                strategy,
+                FuzzPlanStrategy::All | FuzzPlanStrategy::CoverageGaps
+            ))
+    {
         return Some("unsupported");
     }
     if !workload_operations.is_empty()
@@ -1232,7 +1241,7 @@ fn operation_skip_reason(
     if !filters.is_empty() && !operation_matches_filters(operation, family, filters) {
         return Some("unsupported");
     }
-    if !strategy_matches_operation(strategy, family.expect("family checked above")) {
+    if family.is_some_and(|family| !strategy_matches_operation(strategy, family)) {
         return Some("unsupported");
     }
     if requires_isolated_mutation(family, safety_class) && !isolation_requested {

--- a/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
@@ -25,8 +25,8 @@ use super::types::{
     FuzzRunnerContract, FuzzValidateArgs, FuzzWorkloadOutput,
 };
 use super::workloads::{
-    fuzz_workloads, resolve_component_id, resolve_fuzz_context, resolve_profile_workload_id,
-    rig_component_for_fuzz, select_workload, FuzzRigContext,
+    build_target_inventory, fuzz_workloads, resolve_component_id, resolve_fuzz_context,
+    resolve_profile_workload_id, rig_component_for_fuzz, select_workload, FuzzRigContext,
 };
 use super::{run_contract, run_discover, FuzzArgs};
 use crate::cli_surface::{Cli, Commands};

--- a/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
@@ -3,6 +3,114 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 #[test]
+fn selected_rig_workload_projects_plannable_inventory_without_inventory_file() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workload_path = temp.path().join("component-fuzz.json");
+    fs::write(
+        &workload_path,
+        serde_json::json!({
+            "schema": "homeboy/fuzz-workload/v1",
+            "id": "component-fuzz",
+            "safety_class": "read_only",
+            "surface_ids": ["component-runtime"],
+            "operations": ["query", "domain.verify"],
+            "target": {
+                "type": "service",
+                "component": "component-a",
+                "slug": "component-a"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write workload");
+    let workload = FuzzWorkloadOutput {
+        id: "component-fuzz".to_string(),
+        label: None,
+        description: None,
+        source: format!("rig_workloads:generic:{}", workload_path.display()),
+        manifest_path: Some(workload_path.to_string_lossy().to_string()),
+    };
+
+    let inventory = build_target_inventory(
+        "component-a",
+        std::slice::from_ref(&workload),
+        Some(&workload),
+        Some("proof-1".to_string()),
+        None,
+    )
+    .expect("project workload inventory");
+
+    assert_eq!(inventory.workloads.len(), 1);
+    assert_eq!(inventory.workloads[0].id, "component-fuzz");
+    assert_eq!(inventory.targets.len(), 1);
+    assert_eq!(inventory.targets[0].id, "component-a");
+    assert_eq!(inventory.targets[0].kind, "service");
+    assert_eq!(inventory.targets[0].operations.len(), 2);
+    assert_eq!(inventory.surfaces[0].id, "component-runtime");
+    assert_eq!(
+        inventory.metadata["workload_inventory_source"],
+        workload_path.to_string_lossy().as_ref()
+    );
+
+    let mut args = planner_args();
+    args.run.workload_id = Some("component-fuzz".to_string());
+    let metadata = plan_inventory_selection(&args, &inventory, None).expect("plan inventory");
+
+    assert_eq!(
+        metadata["selection"]["target_ids"],
+        serde_json::json!(["component-a"])
+    );
+    assert_eq!(
+        metadata["selection"]["operations"]
+            .as_array()
+            .expect("selected operations")
+            .len(),
+        2
+    );
+    assert_eq!(
+        metadata["sampling"]["operation_strata"][1]["values"],
+        serde_json::json!(["query", "domain.verify"])
+    );
+
+    args.strategy = FuzzPlanStrategy::CoverageGaps;
+    let coverage_gaps =
+        plan_inventory_selection(&args, &inventory, None).expect("plan coverage gaps");
+    assert!(coverage_gaps["selection"]["operations"]
+        .as_array()
+        .expect("selected operations")
+        .iter()
+        .any(|operation| operation["operation_id"] == "domain.verify"));
+
+    let explicit_path = temp.path().join("explicit-inventory.json");
+    let explicit_inventory = FuzzTargetInventory::from_value(serde_json::json!({
+        "id": "explicit-inventory",
+        "targets": [{
+            "id": "explicit-target",
+            "kind": "service",
+            "operations": [{ "id": "read", "kind": "read" }]
+        }]
+    }))
+    .expect("explicit inventory");
+    write_inventory(&explicit_path, &explicit_inventory);
+    let inventory = build_target_inventory(
+        "component-a",
+        &[workload.clone()],
+        Some(&workload),
+        Some("proof-2".to_string()),
+        Some(&explicit_path),
+    )
+    .expect("use explicit inventory");
+
+    assert_eq!(inventory.targets.len(), 1);
+    assert_eq!(inventory.targets[0].id, "explicit-target");
+    assert!(inventory.workloads.is_empty());
+    assert!(inventory
+        .metadata
+        .get("workload_inventory_source")
+        .is_none());
+}
+
+#[test]
 fn fuzz_workloads_include_rig_declared_paths() {
     let spec: RigSpec = serde_json::from_value(serde_json::json!({
         "id": "package-fuzz",

--- a/crates/homeboy-cli/src/commands/fuzz/workloads.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/workloads.rs
@@ -6,7 +6,7 @@ use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::fuzz::{
     merge_fuzz_target_inventory, parse_fuzz_target_inventory_file, FuzzTargetInventory,
-    FUZZ_CONTRACT_VERSION, FUZZ_TARGET_INVENTORY_SCHEMA,
+    FuzzWorkload, FUZZ_CONTRACT_VERSION, FUZZ_TARGET_INVENTORY_SCHEMA,
 };
 use homeboy::rig::{self, RigSpec};
 use homeboy_core;
@@ -525,6 +525,7 @@ pub(super) fn select_workload<'a>(
 pub(super) fn build_target_inventory(
     component_id: &str,
     workloads: &[FuzzWorkloadOutput],
+    selected_workload: Option<&FuzzWorkloadOutput>,
     run_id: Option<String>,
     inventory_path: Option<&Path>,
 ) -> homeboy::core::Result<FuzzTargetInventory> {
@@ -548,7 +549,93 @@ pub(super) fn build_target_inventory(
         inventory.metadata["inventory_file"] =
             serde_json::Value::String(path.to_string_lossy().to_string());
         merge_fuzz_target_inventory(&mut inventory, discovered);
+    } else if let Some(workload) = selected_workload {
+        project_workload_inventory(&mut inventory, component_id, workload)?;
     }
 
     Ok(inventory)
+}
+
+fn project_workload_inventory(
+    inventory: &mut FuzzTargetInventory,
+    component_id: &str,
+    workload: &FuzzWorkloadOutput,
+) -> homeboy::core::Result<()> {
+    let Some(path) = workload.manifest_path.as_deref().map(Path::new) else {
+        return Ok(());
+    };
+    let contents = std::fs::read_to_string(path).map_err(|error| {
+        homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
+    })?;
+    let value: serde_json::Value = serde_json::from_str(&contents).map_err(|error| {
+        homeboy::core::Error::validation_invalid_json(
+            error,
+            Some(format!("parse fuzz workload file {}", path.display())),
+            Some(contents),
+        )
+    })?;
+    let contract = FuzzWorkload::from_value(value.clone()).map_err(|message| {
+        homeboy::core::Error::invalid_argument_for("workload", message, path.display().to_string())
+    })?;
+    let target = value.get("target").and_then(serde_json::Value::as_object);
+    let target_id = target
+        .and_then(|target| {
+            ["id", "component", "slug"]
+                .iter()
+                .find_map(|key| target.get(*key))
+        })
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(component_id);
+    let target_kind = target
+        .and_then(|target| ["kind", "type"].iter().find_map(|key| target.get(*key)))
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("component");
+    let operations = contract
+        .operations
+        .iter()
+        .map(|operation| {
+            serde_json::json!({
+                "id": operation,
+                "kind": operation,
+                "target_id": target_id,
+            })
+        })
+        .collect::<Vec<_>>();
+    let surfaces = contract
+        .surface_ids
+        .iter()
+        .map(|surface_id| {
+            serde_json::json!({
+                "id": surface_id,
+                "kind": target_kind,
+                "target": target_id,
+                "safety_class": contract.safety_class,
+            })
+        })
+        .collect::<Vec<_>>();
+    let projected = FuzzTargetInventory::from_value(serde_json::json!({
+        "id": format!("{}-workload-inventory", contract.id),
+        "surfaces": surfaces,
+        "targets": [{
+            "id": target_id,
+            "kind": target_kind,
+            "locator": target.and_then(|target| target.get("slug")),
+            "operations": operations,
+            "source_refs": [path.to_string_lossy()],
+        }],
+        "workloads": [contract],
+    }))
+    .map_err(|message| {
+        homeboy::core::Error::invalid_argument_for(
+            "workload.inventory",
+            message,
+            path.display().to_string(),
+        )
+    })?;
+    merge_fuzz_target_inventory(inventory, projected);
+    inventory.metadata["workload_inventory_source"] =
+        serde_json::Value::String(path.to_string_lossy().to_string());
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- parse the selected rig fuzz workload into Homeboy's typed workload contract when no explicit inventory is supplied
- project its generic target, surfaces, and stable operation IDs into the planning inventory
- allow explicitly workload-scoped custom operation IDs under `all` and `coverage-gaps` while preserving unsupported unscoped operation behavior
- preserve explicit `--inventory` precedence and component-script behavior

Closes #14244.

## Verification

- `cargo test -p homeboy-cli commands::fuzz` (162 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- built the candidate `homeboy` binary and ran it against the real MDI `full` rig profile; the generated request selected one target and all nine declared operations with the 256-case/300-second workload budgets
- `cargo clippy -p homeboy-cli --all-targets -- -D warnings` reaches an unrelated existing `large_enum_variant` warning in `homeboy-runner-contract`

## AI assistance

OpenAI GPT-5.6-sol via OpenCode traced the persisted fuzz evidence, designed and implemented the generic inventory projection, ran the focused and real-rig verification, and prepared this PR. Chris Huber directed and reviewed the repair.