### PR TITLE
fix(agent-task): align retry projection with admission

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/action_eligibility.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/action_eligibility.rs
@@ -163,6 +163,24 @@ fn retry_availability(
     }) {
         return unavailable("acceptance rejection repair budget is exhausted for this lineage");
     }
+    if record.metadata["cook_id"].is_string() {
+        match crate::agent_task_service::retry_admission_for_projection(&record.run_id) {
+            Ok(crate::agent_task_service::RetryProjectionAdmission::DurableCook) => {
+                return available(
+                "durable Cook retry is admitted; runtime admission will be revalidated before execution",
+            )
+            }
+            Ok(crate::agent_task_service::RetryProjectionAdmission::GenericLifecycle) => {
+                return available(
+                    "generic lifecycle retry is admitted; runtime admission will be revalidated before execution",
+                )
+            }
+            Err(error) => return unavailable(format!(
+                "durable Cook retry is unavailable: {}; inspect this exact attempt with: homeboy agent-task status {}",
+                error.message, record.run_id
+            )),
+        }
+    }
     match plan {
         Some(plan) if super::plan_has_retry_materialization_identity(plan) => {
             indeterminate(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8121,6 +8121,8 @@ fn retryable_pre_provider_retry_accepts_runner_rebound_workspace_identity() {
 
 #[test]
 fn retryable_pre_provider_retry_without_a_recipe_uses_legacy_lifecycle_retry() {
+    use homeboy_control_plane_contract::{ControlPlaneAction, ControlPlaneActionAvailability};
+
     homeboy_core::test_support::with_isolated_home(|_| {
         let options = batch_cook_options(
             "cook-legacy-retry",
@@ -8145,12 +8147,125 @@ fn retryable_pre_provider_retry_without_a_recipe_uses_legacy_lifecycle_retry() {
         )
         .expect("record retryable legacy failure");
 
+        let status = crate::orchestration::run_from_current_environment(run_id)
+            .expect("project legacy generic retry");
+        let retry_action = status
+            .action_eligibility
+            .as_ref()
+            .expect("action eligibility")
+            .actions
+            .iter()
+            .find(|action| action.action == ControlPlaneAction::Retry)
+            .expect("retry action");
+        assert_eq!(
+            retry_action.availability,
+            ControlPlaneActionAvailability::Available,
+            "legacy Cook metadata must retain generic retry projection"
+        );
+        assert_eq!(
+            retry_action.reason,
+            "generic lifecycle retry is admitted; runtime admission will be revalidated before execution"
+        );
+
         let retry = crate::agent_task_service::retry(run_id, Some("legacy-retry"), false, false)
             .expect("legacy retry remains supported");
 
         assert_eq!(retry.record.run_id, "legacy-retry");
         assert_eq!(retry.record.metadata["retry_of"], run_id);
         assert!(retry.record.metadata["cook_id"].is_null());
+    });
+}
+
+#[test]
+fn cook_lab_workspace_stage_retry_eligibility_matches_durable_admission() {
+    use homeboy_control_plane_contract::{ControlPlaneAction, ControlPlaneActionAvailability};
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_lab_pre_provider_cook(
+            "cook-workspace-stage-retry-eligibility",
+            "fixture retryable Lab workspace staging failure",
+        );
+        let run_id = &options.identity.initial_run_id;
+        let lifecycle_store = test_lifecycle_store();
+        let mut plan =
+            agent_task_lifecycle::load_controller_plan_in_store(&lifecycle_store, run_id)
+                .expect("load Cook plan");
+        plan.metadata["execution_placement_decision"] = serde_json::json!({ "fixture": true });
+        agent_task_lifecycle::persist_controller_plan_in_store(&lifecycle_store, run_id, &plan)
+            .expect("seed legacy placement decision on plan only");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record
+                .metadata
+                .as_object_mut()
+                .expect("record metadata")
+                .remove("execution_placement_decision");
+        })
+        .expect("remove legacy placement decision from record");
+        let before_projection = agent_task_lifecycle::exact_record(run_id)
+            .expect("read Cook-owned failed attempt before status projection");
+        let status = crate::orchestration::run_from_current_environment(run_id)
+            .expect("project Cook-owned failed attempt");
+        assert_eq!(
+            agent_task_lifecycle::exact_record(run_id)
+                .expect("read Cook-owned failed attempt after status projection"),
+            before_projection,
+            "status projection must not normalize or otherwise mutate retry metadata"
+        );
+        let retry = status
+            .action_eligibility
+            .as_ref()
+            .expect("action eligibility")
+            .actions
+            .iter()
+            .find(|action| action.action == ControlPlaneAction::Retry)
+            .expect("retry action");
+
+        assert_eq!(
+            retry.availability,
+            ControlPlaneActionAvailability::Available
+        );
+        let replay = crate::agent_task_service::retry(run_id, None, false, false)
+            .expect("advertised Cook retry is admitted");
+        assert_eq!(replay.record.metadata["cook_id"], options.identity.cook_id);
+        assert_eq!(replay.record.metadata["retry_of"], *run_id);
+        assert_eq!(replay.record.metadata["provider_executions_consumed"], 0);
+    });
+}
+
+#[test]
+fn unbound_cook_workspace_stage_failure_does_not_advertise_retry() {
+    use homeboy_control_plane_contract::{ControlPlaneAction, ControlPlaneActionAvailability};
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let source = retryable_lab_pre_provider_cook(
+            "cook-unbound-workspace-stage-source",
+            "fixture retryable Lab workspace staging failure",
+        );
+        let owner = retryable_pre_provider_cook("cook-unbound-workspace-stage-owner", 2);
+        let run_id = &source.identity.initial_run_id;
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["cook_id"] = serde_json::json!(owner.identity.cook_id);
+        })
+        .expect("make the terminal record Cook-owned but unbound");
+
+        let status = crate::orchestration::run_from_current_environment(run_id)
+            .expect("project unbound Cook-owned failed attempt");
+        let retry = status
+            .action_eligibility
+            .as_ref()
+            .expect("action eligibility")
+            .actions
+            .iter()
+            .find(|action| action.action == ControlPlaneAction::Retry)
+            .expect("retry action");
+
+        assert_eq!(
+            retry.availability,
+            ControlPlaneActionAvailability::Unavailable
+        );
+        assert!(retry.reason.contains("homeboy agent-task status"));
+        assert!(retry.reason.contains(run_id));
+        assert!(crate::agent_task_service::retry(run_id, None, false, false).is_err());
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -2569,17 +2569,44 @@ struct CookRetryAttempt {
 /// Recipe-backed Cook runs cannot fall back to generic lifecycle retry because
 /// that would lose the Cook's authenticated lineage.
 pub fn retry_admission(run_id: &str) -> Result<()> {
-    retry_admission_with_preflight(run_id, |plan| {
-        if plan.metadata.get("generic_lab_command_replay").is_some() {
-            return Err(Error::validation_invalid_argument(
-                "generic_lab_command_replay",
-                "generic Lab replay requires controller workspace preflight",
-                Some(plan.plan_id.clone()),
-                None,
-            ));
-        }
-        Ok(())
-    })
+    retry_admission_with_preflight(run_id, retry_plan_supported_by_generic_action)
+}
+
+/// Read-only Cook retry admission for control-plane projections. Unlike the
+/// executable admission path, this deliberately does not normalize placement
+/// metadata while rendering status.
+pub(crate) enum RetryProjectionAdmission {
+    DurableCook,
+    GenericLifecycle,
+}
+
+/// Read-only retry admission for control-plane projections of records that
+/// carry Cook metadata. Legacy metadata without a durable recipe follows the
+/// same generic lifecycle preflight as executable retry.
+pub(crate) fn retry_admission_for_projection(run_id: &str) -> Result<RetryProjectionAdmission> {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    let source = agent_task_lifecycle::exact_record_in_store(&lifecycle_store, run_id)?;
+    if let Some(retry) = retry_admission_in_store(&lifecycle_store, &source, true)? {
+        retry_plan_supported_by_generic_action(&retry.plan)?;
+        return Ok(RetryProjectionAdmission::DurableCook);
+    }
+    let plan =
+        agent_task_lifecycle::load_controller_plan_in_store(&lifecycle_store, &source.run_id)?;
+    retry_plan_supported_by_generic_action(&plan)?;
+    Ok(RetryProjectionAdmission::GenericLifecycle)
+}
+
+fn retry_plan_supported_by_generic_action(plan: &AgentTaskPlan) -> Result<()> {
+    if plan.metadata.get("generic_lab_command_replay").is_some() {
+        return Err(Error::validation_invalid_argument(
+            "generic_lab_command_replay",
+            "generic Lab replay requires controller workspace preflight",
+            Some(plan.plan_id.clone()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 /// Verify retry admission using the caller's execution-specific preflight.

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1549,7 +1549,9 @@ fn cook_retry_run_recovers_a_historical_runtime_after_zero_provider_executions()
                 initial_plan: plan.clone(),
             },
             workspace: homeboy::agents::agent_task_service::CookWorkspace {
-                to_worktree: "fixture@pre-execution-runtime-recovery".to_string(),
+                // The recovery must use the same verified linked worktree rather
+                // than an unregistered legacy handle.
+                to_worktree: workspace.to_string_lossy().into_owned(),
                 source_worktree_path: Some(workspace.clone()),
                 task_base_sha: None,
                 source_refs: Vec::new(),
@@ -1613,7 +1615,7 @@ fn cook_retry_run_recovers_a_historical_runtime_after_zero_provider_executions()
         .expect("persist historical local recipe");
 
         let executor = Arc::new(CountingCookExecutor::default());
-        let retried = retry_with(
+        let (retried, exit_code) = retry_with(
             RetryArgs {
                 run_id: run_id.to_string(),
                 new_run_id: None,
@@ -1631,6 +1633,10 @@ fn cook_retry_run_recovers_a_historical_runtime_after_zero_provider_executions()
         )
         .expect("queued retry recovers under the current runtime");
 
+        // Provider execution succeeded, but this fixture produces no patch
+        // artifact, so Cook must retain its durable failure exit contract.
+        assert_eq!(exit_code, 1, "{retried:#?}");
+        assert_eq!(retried["status"], "durable_failure");
         assert_eq!(
             executor.executions.load(Ordering::SeqCst),
             1,


### PR DESCRIPTION
## Summary
- derive Cook retry presentation from the same durable admission used by execution
- keep status projection read-only while preserving legacy generic retry behavior
- cover durable, legacy, unbound, and historical runtime recovery paths

Closes #13253.

## Verification
- `cargo test -p homeboy-cli cook_retry`
- focused `homeboy-agents` Cook/action eligibility tests
- `cargo check -p homeboy-agents -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI assistance disclosure
OpenAI GPT-5.6 Terra via OpenCode implemented and iteratively corrected the retry admission/projection changes. OpenAI GPT-5.6 Sol via OpenCode reviewed the behavior, identified status/execution contradictions, and ran the final verification and publication workflow.