### PR TITLE
refactor(agent-task): remove inert side-effect seams

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -881,52 +881,8 @@ fn redact_diagnostic_text(text: &str) -> String {
         .collect()
 }
 
-/// The generic cook side-effect boundary the attempt loop drives its external
-/// effects through: promotion, moving-base recovery, and PR finalization.
-///
-/// Routing every external effect through one injectable object (rather than a
-/// mix of free-function calls and ad-hoc closures) gives durable exactly-once
-/// operation claims a single wiring point, and lets deterministic tests inject
-/// side effects without real Git/GitHub mutations (#8357). Promotion is wired
-/// through the claim primitive here (`promote_with_operation_claim`); retry
-/// dispatch and finalization follow as separate slices.
-pub trait CookSideEffectService {
-    /// Promote the successful candidate for `run_id`, or load the already-persisted
-    /// promotion when this attempt was interrupted after promoting.
-    fn promote(
-        &mut self,
-        lifecycle_store: &AgentTaskLifecycleStore,
-        options: &CookRequest,
-        run_id: &str,
-    ) -> Result<AgentTaskPromotionReport>;
-
-    /// Rebase and re-verify a candidate whose base moved under it.
-    fn recover_moving_base(
-        &mut self,
-        lifecycle_store: &AgentTaskLifecycleStore,
-        options: &CookRequest,
-        recovery: &MovingBaseCookRecovery,
-    ) -> Result<AgentTaskPromotionReport>;
-
-    /// Commit, push, and open/update the PR for a green promoted candidate, or
-    /// load the already-finalized PR when this attempt was interrupted after
-    /// finalizing.
-    fn finalize(
-        &mut self,
-        lifecycle_store: &AgentTaskLifecycleStore,
-        options: &CookRequest,
-        run_id: &str,
-        promotion: &AgentTaskPromotionReport,
-    ) -> Result<Value>;
-}
-
-/// The PR-finalization closure a cook side-effect boundary drives.
-///
-/// Boxed rather than carried as a type parameter so [`DefaultCookSideEffects`]
-/// is a concrete type that can live in a struct field — which is what lets one
-/// `CookContext` replace the former `run_cook*` wrapper family. The `'a` is
-/// load-bearing: the production finalizer closes over a `&CookRecipeStore`, so
-/// a `'static` bound would reject every real construction site.
+/// The PR-finalization closure driven by the Cook runtime. The lifetime is
+/// load-bearing because production finalizers borrow their recipe store.
 pub(crate) type CookFinalizeFn<'a> = Box<
     dyn FnMut(
             &AgentTaskLifecycleStore,
@@ -937,16 +893,34 @@ pub(crate) type CookFinalizeFn<'a> = Box<
         + 'a,
 >;
 
-/// Production cook side-effect boundary. Each method delegates to the existing
-/// promotion/finalization free functions, so behavior is identical to the prior
-/// direct calls; the trait only relocates the call sites behind one seam.
-pub(crate) struct DefaultCookSideEffects<'a> {
+#[cfg(test)]
+type TestCookPromoteFn<'a> = Box<
+    dyn FnMut(&AgentTaskLifecycleStore, &CookRequest, &str) -> Result<AgentTaskPromotionReport>
+        + 'a,
+>;
+
+#[cfg(test)]
+type TestCookRecoverFn<'a> = Box<
+    dyn FnMut(
+            &AgentTaskLifecycleStore,
+            &CookRequest,
+            &MovingBaseCookRecovery,
+        ) -> Result<AgentTaskPromotionReport>
+        + 'a,
+>;
+
+/// Concrete production side effects. Promotion and recovery have one native
+/// implementation; only finalization varies because callers bind different
+/// durable recipe stores and backends.
+pub(crate) struct CookSideEffects<'a> {
     finalize: CookFinalizeFn<'a>,
+    #[cfg(test)]
+    test_promote: Option<TestCookPromoteFn<'a>>,
+    #[cfg(test)]
+    test_recover: Option<TestCookRecoverFn<'a>>,
 }
 
-impl<'a> DefaultCookSideEffects<'a> {
-    /// Generic in the closure so existing construction sites are unchanged; the
-    /// type parameter is erased at the boundary and never reaches the struct.
+impl<'a> CookSideEffects<'a> {
     pub(crate) fn new<F>(finalize: F) -> Self
     where
         F: FnMut(
@@ -959,17 +933,49 @@ impl<'a> DefaultCookSideEffects<'a> {
     {
         Self {
             finalize: Box::new(finalize),
+            #[cfg(test)]
+            test_promote: None,
+            #[cfg(test)]
+            test_recover: None,
         }
     }
-}
 
-impl CookSideEffectService for DefaultCookSideEffects<'_> {
+    #[cfg(test)]
+    pub(crate) fn for_test<P, R, F>(promote: P, recover: R, finalize: F) -> Self
+    where
+        P: FnMut(&AgentTaskLifecycleStore, &CookRequest, &str) -> Result<AgentTaskPromotionReport>
+            + 'a,
+        R: FnMut(
+                &AgentTaskLifecycleStore,
+                &CookRequest,
+                &MovingBaseCookRecovery,
+            ) -> Result<AgentTaskPromotionReport>
+            + 'a,
+        F: FnMut(
+                &AgentTaskLifecycleStore,
+                &CookRequest,
+                &str,
+                &AgentTaskPromotionReport,
+            ) -> Result<Value>
+            + 'a,
+    {
+        Self {
+            finalize: Box::new(finalize),
+            test_promote: Some(Box::new(promote)),
+            test_recover: Some(Box::new(recover)),
+        }
+    }
+
     fn promote(
         &mut self,
         lifecycle_store: &AgentTaskLifecycleStore,
         options: &CookRequest,
         run_id: &str,
     ) -> Result<AgentTaskPromotionReport> {
+        #[cfg(test)]
+        if let Some(promote) = self.test_promote.as_mut() {
+            return promote(lifecycle_store, options, run_id);
+        }
         promote_with_operation_claim_in_store(lifecycle_store, options, run_id)
     }
 
@@ -979,6 +985,10 @@ impl CookSideEffectService for DefaultCookSideEffects<'_> {
         options: &CookRequest,
         recovery: &MovingBaseCookRecovery,
     ) -> Result<AgentTaskPromotionReport> {
+        #[cfg(test)]
+        if let Some(recover) = self.test_recover.as_mut() {
+            return recover(lifecycle_store, options, recovery);
+        }
         recover_moving_base_cook_candidate_in_store(lifecycle_store, options, recovery)
     }
 
@@ -998,70 +1008,6 @@ impl CookSideEffectService for DefaultCookSideEffects<'_> {
                 (self.finalize)(lifecycle_store, options, run_id, promotion)
             },
         )
-    }
-}
-
-/// Test cook side-effect boundary with injectable `finalize` and
-/// `recover_moving_base` closures, so recovery/finalization control flow can be
-/// exercised without real Git/GitHub mutations. `promote` delegates to the real
-/// promotion path (tests that need to intercept promotion persist a promotion
-/// first, exactly as before).
-#[cfg(test)]
-pub(crate) type TestCookFinalizeFn<'a> =
-    Box<dyn FnMut(&CookRequest, &str, &AgentTaskPromotionReport) -> Result<Value> + 'a>;
-
-#[cfg(test)]
-pub(crate) type TestCookRecoverFn<'a> =
-    Box<dyn FnMut(&CookRequest, &MovingBaseCookRecovery) -> Result<AgentTaskPromotionReport> + 'a>;
-
-#[cfg(test)]
-pub(crate) struct TestCookSideEffects<'a> {
-    finalize: TestCookFinalizeFn<'a>,
-    recover: TestCookRecoverFn<'a>,
-}
-
-#[cfg(test)]
-impl<'a> TestCookSideEffects<'a> {
-    pub(crate) fn new<F, R>(finalize: F, recover: R) -> Self
-    where
-        F: FnMut(&CookRequest, &str, &AgentTaskPromotionReport) -> Result<Value> + 'a,
-        R: FnMut(&CookRequest, &MovingBaseCookRecovery) -> Result<AgentTaskPromotionReport> + 'a,
-    {
-        Self {
-            finalize: Box::new(finalize),
-            recover: Box::new(recover),
-        }
-    }
-}
-
-#[cfg(test)]
-impl CookSideEffectService for TestCookSideEffects<'_> {
-    fn promote(
-        &mut self,
-        lifecycle_store: &AgentTaskLifecycleStore,
-        options: &CookRequest,
-        run_id: &str,
-    ) -> Result<AgentTaskPromotionReport> {
-        promote_or_load_attempt_in_store(lifecycle_store, options, run_id)
-    }
-
-    fn recover_moving_base(
-        &mut self,
-        _lifecycle_store: &AgentTaskLifecycleStore,
-        options: &CookRequest,
-        recovery: &MovingBaseCookRecovery,
-    ) -> Result<AgentTaskPromotionReport> {
-        (self.recover)(options, recovery)
-    }
-
-    fn finalize(
-        &mut self,
-        _lifecycle_store: &AgentTaskLifecycleStore,
-        options: &CookRequest,
-        run_id: &str,
-        promotion: &AgentTaskPromotionReport,
-    ) -> Result<Value> {
-        (self.finalize)(options, run_id, promotion)
     }
 }
 
@@ -3458,9 +3404,8 @@ where
             &format!("homeboy agent-task fanout resume {batch_id}"),
         )?;
     }
-    let side_effects = DefaultCookSideEffects::new(|_, options, run_id, promotion| {
-        finalize(options, run_id, promotion)
-    });
+    let side_effects =
+        CookSideEffects::new(|_, options, run_id, promotion| finalize(options, run_id, promotion));
     let store = CookRecipeStore::from_current_data_root()?;
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     Ok(CookService::run(
@@ -3469,7 +3414,7 @@ where
             executor,
             &store,
             &lifecycle_store,
-            Box::new(side_effects),
+            side_effects,
             &noop_cook_progress_observer,
         ),
         CookMode::Resume,
@@ -4622,19 +4567,19 @@ impl CookMode {
 /// bind every dependency explicitly; there are no environment-derived stores or
 /// optional side-effect/observer fallbacks in the execution API.
 pub struct CookRuntime<'a> {
-    pub executor: SharedAgentTaskExecutor,
-    pub store: &'a CookRecipeStore,
-    pub lifecycle_store: &'a AgentTaskLifecycleStore,
-    pub side_effects: Box<dyn CookSideEffectService + 'a>,
-    pub durable_observer: &'a CookProgressObserver<'a>,
+    executor: SharedAgentTaskExecutor,
+    store: &'a CookRecipeStore,
+    lifecycle_store: &'a AgentTaskLifecycleStore,
+    side_effects: CookSideEffects<'a>,
+    durable_observer: &'a CookProgressObserver<'a>,
 }
 
 impl<'a> CookRuntime<'a> {
-    pub fn new(
+    fn new(
         executor: SharedAgentTaskExecutor,
         store: &'a CookRecipeStore,
         lifecycle_store: &'a AgentTaskLifecycleStore,
-        side_effects: Box<dyn CookSideEffectService + 'a>,
+        side_effects: CookSideEffects<'a>,
         durable_observer: &'a CookProgressObserver<'a>,
     ) -> Self {
         Self {
@@ -4644,6 +4589,33 @@ impl<'a> CookRuntime<'a> {
             side_effects,
             durable_observer,
         }
+    }
+
+    /// Bind a caller-owned finalizer while retaining native promotion, recovery,
+    /// and durable operation-claim behavior.
+    pub fn with_finalizer<F>(
+        executor: SharedAgentTaskExecutor,
+        store: &'a CookRecipeStore,
+        lifecycle_store: &'a AgentTaskLifecycleStore,
+        finalize: F,
+        durable_observer: &'a CookProgressObserver<'a>,
+    ) -> Self
+    where
+        F: FnMut(
+                &AgentTaskLifecycleStore,
+                &CookRequest,
+                &str,
+                &AgentTaskPromotionReport,
+            ) -> Result<Value>
+            + 'a,
+    {
+        Self::new(
+            executor,
+            store,
+            lifecycle_store,
+            CookSideEffects::new(finalize),
+            durable_observer,
+        )
     }
 
     /// Explicit production wiring with the standard side-effect boundary and a
@@ -4671,17 +4643,15 @@ impl<'a> CookRuntime<'a> {
             executor,
             store,
             lifecycle_store,
-            Box::new(DefaultCookSideEffects::new(
-                move |lifecycle_store, options, run_id, promotion| {
-                    finalize_or_load_cook_pr_with_stores(
-                        store,
-                        lifecycle_store,
-                        options,
-                        run_id,
-                        promotion,
-                    )
-                },
-            )),
+            CookSideEffects::new(move |lifecycle_store, options, run_id, promotion| {
+                finalize_or_load_cook_pr_with_stores(
+                    store,
+                    lifecycle_store,
+                    options,
+                    run_id,
+                    promotion,
+                )
+            }),
             durable_observer,
         )
     }
@@ -4700,7 +4670,7 @@ pub(crate) struct CookContext<'a> {
     pub executor: SharedAgentTaskExecutor,
     pub store: Option<&'a CookRecipeStore>,
     pub lifecycle_store: Option<&'a AgentTaskLifecycleStore>,
-    pub side_effects: Option<Box<dyn CookSideEffectService + 'a>>,
+    pub side_effects: Option<CookSideEffects<'a>>,
     pub durable_observer: Option<&'a CookProgressObserver<'a>>,
     pub mode: CookMode,
 }
@@ -4731,17 +4701,15 @@ pub(crate) fn run_cook(ctx: CookContext<'_>) -> Result<AgentTaskRunResult<AgentT
         None => AgentTaskLifecycleStore::from_current_environment()?,
     };
     let mut side_effects = ctx.side_effects.unwrap_or_else(|| {
-        Box::new(DefaultCookSideEffects::new(
-            |lifecycle_store, options, run_id, promotion| {
-                finalize_or_load_cook_pr_with_stores(
-                    &store,
-                    lifecycle_store,
-                    options,
-                    run_id,
-                    promotion,
-                )
-            },
-        ))
+        CookSideEffects::new(|lifecycle_store, options, run_id, promotion| {
+            finalize_or_load_cook_pr_with_stores(
+                &store,
+                lifecycle_store,
+                options,
+                run_id,
+                promotion,
+            )
+        })
     });
     let observer = ctx.durable_observer.unwrap_or(&noop_cook_progress_observer);
     run_cook_with_runtime(
@@ -4749,7 +4717,7 @@ pub(crate) fn run_cook(ctx: CookContext<'_>) -> Result<AgentTaskRunResult<AgentT
         ctx.executor,
         &store,
         &lifecycle_store,
-        side_effects.as_mut(),
+        &mut side_effects,
         observer,
         ctx.mode,
     )
@@ -4776,7 +4744,7 @@ impl CookService {
             executor,
             store,
             lifecycle_store,
-            side_effects.as_mut(),
+            &mut side_effects,
             durable_observer,
             mode,
         )
@@ -4788,7 +4756,7 @@ fn run_cook_with_runtime(
     executor: SharedAgentTaskExecutor,
     store: &CookRecipeStore,
     lifecycle_store: &AgentTaskLifecycleStore,
-    side_effects: &mut dyn CookSideEffectService,
+    side_effects: &mut CookSideEffects<'_>,
     durable_observer: &CookProgressObserver<'_>,
     mode: CookMode,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
@@ -4866,7 +4834,7 @@ fn run_cook_reported(
     lifecycle_store: &AgentTaskLifecycleStore,
     options: CookRequest,
     executor: SharedAgentTaskExecutor,
-    side_effects: &mut dyn CookSideEffectService,
+    side_effects: &mut CookSideEffects<'_>,
     durable_observer: Option<&CookProgressObserver<'_>>,
     mode: CookMode,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
@@ -5189,7 +5157,7 @@ fn run_cook_spine(
     lifecycle_store: &AgentTaskLifecycleStore,
     mut options: CookRequest,
     executor: SharedAgentTaskExecutor,
-    side_effects: &mut dyn CookSideEffectService,
+    side_effects: &mut CookSideEffects<'_>,
     durable_observer: Option<&CookProgressObserver<'_>>,
     mode: CookMode,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -796,25 +796,23 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
                 options.identity.initial_run_id = run_id;
                 let mut result = super::cook::CookService::run(
                     options,
-                    super::cook::CookRuntime::new(
+                    super::cook::CookRuntime::with_finalizer(
                         executor,
                         recipe_store,
                         lifecycle_store,
-                        Box::new(super::cook::DefaultCookSideEffects::new(
-                            |_lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
-                             options: &_,
-                             run_id: &_,
-                             promotion: &_| {
-                                finalize_or_load_cook_pr_with_backend_with_stores(
-                                    recipe_store,
-                                    lifecycle_store,
-                                    options,
-                                    run_id,
-                                    promotion,
-                                    backend,
-                                )
-                            },
-                        )),
+                        |_lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+                         options: &_,
+                         run_id: &_,
+                         promotion: &_| {
+                            finalize_or_load_cook_pr_with_backend_with_stores(
+                                recipe_store,
+                                lifecycle_store,
+                                options,
+                                run_id,
+                                promotion,
+                                backend,
+                            )
+                        },
                         &|_| Ok(()),
                     ),
                     super::cook::CookMode::Adopt,

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -520,13 +520,6 @@ impl ClaimedCookContinuation {
     }
 }
 
-/// The consumer boundary is deliberately injected: status/reconciliation only
-/// writes durable signals and never invokes process-local closures.
-pub trait AgentTaskCookContinuationScheduler {
-    /// Returns true only when this call created the durable queue entry.
-    fn enqueue(&self, continuation: &AgentTaskCookContinuation) -> Result<bool>;
-}
-
 pub fn persist_initial_recipe(options: &CookRequest) -> Result<AgentTaskCookRecipe> {
     default_store()?.persist_initial_recipe(options)
 }
@@ -3314,12 +3307,6 @@ impl DurableCookContinuationQueue<'_> {
             Error::internal_io(error.to_string(), Some(path.display().to_string()))
         })?;
         Ok(true)
-    }
-}
-
-impl AgentTaskCookContinuationScheduler for DurableCookContinuationQueue<'_> {
-    fn enqueue(&self, continuation: &AgentTaskCookContinuation) -> Result<bool> {
-        self.enqueue(continuation, false)
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1877,131 +1877,68 @@ fn cook_selection_command_shell_round_trips_the_full_promotion_contract() {
     assert_eq!(toolchain_spec.probe_arguments, ["probe", "--format=json"]);
 }
 
-#[derive(Clone)]
-struct CanonicalSelectionSideEffects {
+fn canonical_selection_side_effects(
     promotions: Arc<AtomicUsize>,
     selected_artifact: Arc<Mutex<Option<String>>>,
+) -> CookSideEffects<'static> {
+    CookSideEffects::for_test(
+        move |_, options, run_id| {
+            promotions.fetch_add(1, Ordering::SeqCst);
+            let artifact = canonical_cook_patch_artifact_id_in_store(
+                &test_lifecycle_store(),
+                options,
+                run_id,
+            )?;
+            *selected_artifact.lock().unwrap() = artifact;
+            Ok(promotion(run_id))
+        },
+        |_, _, _| unreachable!("canonical selection stops before moving-base recovery"),
+        |_, _, _, _| unreachable!("no-finalize Cook must not finalize"),
+    )
 }
 
-impl CookSideEffectService for CanonicalSelectionSideEffects {
-    fn promote(
-        &mut self,
-        _lifecycle_store: &AgentTaskLifecycleStore,
-        options: &CookRequest,
-        run_id: &str,
-    ) -> Result<AgentTaskPromotionReport> {
-        self.promotions.fetch_add(1, Ordering::SeqCst);
-        let artifact =
-            canonical_cook_patch_artifact_id_in_store(&test_lifecycle_store(), options, run_id)?;
-        *self.selected_artifact.lock().unwrap() = artifact;
-        Ok(promotion(run_id))
-    }
-
-    fn recover_moving_base(
-        &mut self,
-        _lifecycle_store: &AgentTaskLifecycleStore,
-        _options: &CookRequest,
-        _recovery: &MovingBaseCookRecovery,
-    ) -> Result<AgentTaskPromotionReport> {
-        unreachable!("canonical selection stops before moving-base recovery")
-    }
-
-    fn finalize(
-        &mut self,
-        _lifecycle_store: &AgentTaskLifecycleStore,
-        _options: &CookRequest,
-        _run_id: &str,
-        _promotion: &AgentTaskPromotionReport,
-    ) -> Result<Value> {
-        unreachable!("no-finalize Cook must not finalize")
-    }
+fn selection_required_side_effects() -> CookSideEffects<'static> {
+    CookSideEffects::for_test(
+        |lifecycle_store, _, run_id| {
+            let aggregate = lifecycle_store.read_aggregate(run_id)?;
+            let choices = aggregate
+                .outcomes
+                .iter()
+                .flat_map(|outcome| outcome.artifacts.iter())
+                .map(|artifact| serde_json::json!({ "artifact_id": artifact.id }))
+                .collect::<Vec<_>>();
+            assert_eq!(choices.len(), 2, "rooted aggregate has distinct candidates");
+            Err(homeboy_core::Error::new(
+                homeboy_core::ErrorCode::ValidationInvalidArgument,
+                "Cook found distinct canonical patch candidates; select one before promotion",
+                serde_json::json!({
+                    "field": "artifact_id",
+                    "state": "selection_required",
+                    "selection_required": true,
+                    "choices": choices,
+                }),
+            ))
+        },
+        |_, _, _| unreachable!("selection-required Cook must not recover a moving base"),
+        |_, _, _, _| unreachable!("selection-required Cook must not finalize"),
+    )
 }
 
-struct SelectionRequiredSideEffects;
-
-impl CookSideEffectService for SelectionRequiredSideEffects {
-    fn promote(
-        &mut self,
-        lifecycle_store: &AgentTaskLifecycleStore,
-        _options: &CookRequest,
-        run_id: &str,
-    ) -> Result<AgentTaskPromotionReport> {
-        let aggregate = lifecycle_store.read_aggregate(run_id)?;
-        let choices = aggregate
-            .outcomes
-            .iter()
-            .flat_map(|outcome| outcome.artifacts.iter())
-            .map(|artifact| serde_json::json!({ "artifact_id": artifact.id }))
-            .collect::<Vec<_>>();
-        assert_eq!(choices.len(), 2, "rooted aggregate has distinct candidates");
-        Err(homeboy_core::Error::new(
-            homeboy_core::ErrorCode::ValidationInvalidArgument,
-            "Cook found distinct canonical patch candidates; select one before promotion",
-            serde_json::json!({
-                "field": "artifact_id",
-                "state": "selection_required",
-                "selection_required": true,
-                "choices": choices,
-            }),
-        ))
-    }
-
-    fn recover_moving_base(
-        &mut self,
-        _lifecycle_store: &AgentTaskLifecycleStore,
-        _options: &CookRequest,
-        _recovery: &MovingBaseCookRecovery,
-    ) -> Result<AgentTaskPromotionReport> {
-        unreachable!("selection-required Cook must not recover a moving base")
-    }
-
-    fn finalize(
-        &mut self,
-        _lifecycle_store: &AgentTaskLifecycleStore,
-        _options: &CookRequest,
-        _run_id: &str,
-        _promotion: &AgentTaskPromotionReport,
-    ) -> Result<Value> {
-        unreachable!("selection-required Cook must not finalize")
-    }
-}
-
-#[derive(Clone)]
-struct NoChangeSideEffects {
+fn no_change_side_effects(
     promotions: Arc<AtomicUsize>,
     finalizations: Arc<AtomicUsize>,
-}
-
-impl CookSideEffectService for NoChangeSideEffects {
-    fn promote(
-        &mut self,
-        _lifecycle_store: &AgentTaskLifecycleStore,
-        _options: &CookRequest,
-        _run_id: &str,
-    ) -> Result<AgentTaskPromotionReport> {
-        self.promotions.fetch_add(1, Ordering::SeqCst);
-        unreachable!("intentional no-change without a candidate must not promote")
-    }
-
-    fn recover_moving_base(
-        &mut self,
-        _lifecycle_store: &AgentTaskLifecycleStore,
-        _options: &CookRequest,
-        _recovery: &MovingBaseCookRecovery,
-    ) -> Result<AgentTaskPromotionReport> {
-        unreachable!("intentional no-change cannot enter moving-base recovery")
-    }
-
-    fn finalize(
-        &mut self,
-        _lifecycle_store: &AgentTaskLifecycleStore,
-        _options: &CookRequest,
-        _run_id: &str,
-        _promotion: &AgentTaskPromotionReport,
-    ) -> Result<Value> {
-        self.finalizations.fetch_add(1, Ordering::SeqCst);
-        unreachable!("intentional no-change without a candidate must not finalize")
-    }
+) -> CookSideEffects<'static> {
+    CookSideEffects::for_test(
+        move |_, _, _| {
+            promotions.fetch_add(1, Ordering::SeqCst);
+            unreachable!("intentional no-change without a candidate must not promote")
+        },
+        |_, _, _| unreachable!("intentional no-change cannot enter moving-base recovery"),
+        move |_, _, _, _| {
+            finalizations.fetch_add(1, Ordering::SeqCst);
+            unreachable!("intentional no-change without a candidate must not finalize")
+        },
+    )
 }
 
 fn run_intentional_no_change_cook(
@@ -2088,10 +2025,10 @@ fn run_intentional_no_change_cook(
     let finalizations = Arc::new(AtomicUsize::new(0));
     let resume_options = options.clone();
     let result = run_cook(CookContext {
-        side_effects: Some(Box::new(NoChangeSideEffects {
-            promotions: Arc::clone(&promotions),
-            finalizations: Arc::clone(&finalizations),
-        })),
+        side_effects: Some(no_change_side_effects(
+            Arc::clone(&promotions),
+            Arc::clone(&finalizations),
+        )),
         ..CookContext::new(options, Arc::new(UnusedExecutor))
     })
     .expect("finalize intentional no-change Cook");
@@ -2289,10 +2226,10 @@ fn cook_promotes_the_rotated_success_after_a_retained_timeout_with_aliases_colla
         let promotions = Arc::new(AtomicUsize::new(0));
         let selected_artifact = Arc::new(Mutex::new(None));
         let result = run_cook(CookContext {
-            side_effects: Some(Box::new(CanonicalSelectionSideEffects {
-                promotions: Arc::clone(&promotions),
-                selected_artifact: Arc::clone(&selected_artifact),
-            })),
+            side_effects: Some(canonical_selection_side_effects(
+                Arc::clone(&promotions),
+                Arc::clone(&selected_artifact),
+            )),
             ..CookContext::new(resumed_options, Arc::new(UnusedExecutor))
         })
         .unwrap();
@@ -2342,10 +2279,10 @@ fn cook_persists_selection_required_before_promotion_or_gates() {
         );
         let promotions = Arc::new(AtomicUsize::new(0));
         let result = run_cook(CookContext {
-            side_effects: Some(Box::new(CanonicalSelectionSideEffects {
-                promotions: Arc::clone(&promotions),
-                selected_artifact: Arc::new(Mutex::new(None)),
-            })),
+            side_effects: Some(canonical_selection_side_effects(
+                Arc::clone(&promotions),
+                Arc::new(Mutex::new(None)),
+            )),
             ..CookContext::new(options.clone(), Arc::new(UnusedExecutor))
         })
         .unwrap();
@@ -2441,7 +2378,7 @@ fn cook_selection_required_metadata_uses_supplied_lifecycle_store() {
         &supplied_store,
         options,
         Arc::new(UnusedExecutor),
-        &mut SelectionRequiredSideEffects,
+        &mut selection_required_side_effects(),
         None,
         CookMode::Resume,
     )
@@ -2866,7 +2803,7 @@ fn cook_spine_materializes_into_the_injected_stores_across_split_recipe_and_life
         &lifecycle_store,
         options,
         Arc::new(UnusedExecutor),
-        &mut DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
+        &mut CookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
         None,
         CookMode::Resume,
     )
@@ -3477,14 +3414,14 @@ fn moving_base_continuation_finalizes_without_a_second_provider_dispatch() {
         .unwrap();
 
         let first = run_cook(CookContext {
-            side_effects: Some(Box::new(DefaultCookSideEffects::new(|_, _, _, _| {
+            side_effects: Some(CookSideEffects::new(|_, _, _, _| {
                 Err(Error::validation_invalid_argument(
                     "base",
                     "HEAD is behind or diverged from resolved base `main`",
                     None,
                     None,
                 ))
-            }))),
+            })),
             ..CookContext::new(options.clone(), Arc::new(UnusedExecutor))
         })
         .unwrap();
@@ -3497,16 +3434,9 @@ fn moving_base_continuation_finalizes_without_a_second_provider_dispatch() {
         let rebase_count_for_recover = Arc::clone(&rebase_count);
         let finalization_count_for_finalize = Arc::clone(&finalization_count);
         let second = run_cook(CookContext {
-            side_effects: Some(Box::new(TestCookSideEffects::new(
-                move |_: &_, _: &_, promotion: &AgentTaskPromotionReport| {
-                    finalization_count_for_finalize.fetch_add(1, Ordering::SeqCst);
-                    assert_eq!(
-                        promotion.verified_base.as_ref().unwrap().sha,
-                        "pinned-refreshed-base"
-                    );
-                    Ok(serde_json::json!({"status":"review_ready", "run_id": run_id}))
-                },
-                move |options: &CookRequest, recovery: &MovingBaseCookRecovery| {
+            side_effects: Some(CookSideEffects::for_test(
+                |store, options, run_id| promote_or_load_attempt_in_store(store, options, run_id),
+                move |_, options: &CookRequest, recovery: &MovingBaseCookRecovery| {
                     rebase_count_for_recover.fetch_add(1, Ordering::SeqCst);
                     assert_eq!(
                         options.gates.private_gate_reveal,
@@ -3519,7 +3449,15 @@ fn moving_base_continuation_finalizes_without_a_second_provider_dispatch() {
                         serde_json::json!({"kind":"git","fingerprint":{"tree":"rebased"}});
                     Ok(refreshed)
                 },
-            ))),
+                move |_, _: &_, _: &_, promotion: &AgentTaskPromotionReport| {
+                    finalization_count_for_finalize.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(
+                        promotion.verified_base.as_ref().unwrap().sha,
+                        "pinned-refreshed-base"
+                    );
+                    Ok(serde_json::json!({"status":"review_ready", "run_id": run_id}))
+                },
+            )),
             ..CookContext::new(options.clone(), Arc::new(UnusedExecutor))
         })
         .unwrap();
@@ -3552,14 +3490,15 @@ fn moving_base_continuation_finalizes_without_a_second_provider_dispatch() {
         )
         .unwrap();
         let third = run_cook(CookContext {
-            side_effects: Some(Box::new(TestCookSideEffects::new(
-                |_: &_, _: &_, _: &_| panic!("failed rebased gates must not finalize"),
-                |_: &CookRequest, recovery: &MovingBaseCookRecovery| {
+            side_effects: Some(CookSideEffects::for_test(
+                |store, options, run_id| promote_or_load_attempt_in_store(store, options, run_id),
+                |_, _: &CookRequest, recovery: &MovingBaseCookRecovery| {
                     let mut failed = recovery.promotion.clone();
                     failed.status = AgentTaskPromotionStatus::GateFailed;
                     Ok(failed)
                 },
-            ))),
+                |_, _: &_, _: &_, _: &_| panic!("failed rebased gates must not finalize"),
+            )),
             ..CookContext::new(options, Arc::new(UnusedExecutor))
         })
         .unwrap();
@@ -3760,14 +3699,14 @@ fn moving_base_recovery_rebases_real_authenticated_candidate_and_refuses_diverge
         })
         .unwrap();
         let first = run_cook(CookContext {
-            side_effects: Some(Box::new(DefaultCookSideEffects::new(|_, _, _, _| {
+            side_effects: Some(CookSideEffects::new(|_, _, _, _| {
                 Err(Error::validation_invalid_argument(
                     "base",
                     "HEAD is behind or diverged from resolved base `main`",
                     None,
                     None,
                 ))
-            }))),
+            })),
             ..CookContext::new(options.clone(), Arc::new(UnusedExecutor))
         })
         .unwrap();
@@ -3780,14 +3719,12 @@ fn moving_base_recovery_rebases_real_authenticated_candidate_and_refuses_diverge
         let finalization_calls_for_finalizer = Arc::clone(&finalization_calls);
         let expected_base = advanced_base.clone();
         let second = run_cook(CookContext {
-            side_effects: Some(Box::new(DefaultCookSideEffects::new(
-                move |_, _, _, recovered| {
-                    finalization_calls_for_finalizer.fetch_add(1, Ordering::SeqCst);
-                    assert_eq!(recovered.status, AgentTaskPromotionStatus::Applied);
-                    assert_eq!(recovered.verified_base.as_ref().unwrap().sha, expected_base);
-                    Ok(serde_json::json!({"status": "review_ready"}))
-                },
-            ))),
+            side_effects: Some(CookSideEffects::new(move |_, _, _, recovered| {
+                finalization_calls_for_finalizer.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(recovered.status, AgentTaskPromotionStatus::Applied);
+                assert_eq!(recovered.verified_base.as_ref().unwrap().sha, expected_base);
+                Ok(serde_json::json!({"status": "review_ready"}))
+            })),
             ..CookContext::new(options.clone(), Arc::new(UnusedExecutor))
         })
         .unwrap();
@@ -6040,9 +5977,7 @@ fn run_concurrent_first_cooks_recipe_creator_fixture() -> String {
             run_cook(CookContext {
                 store: Some(&store),
                 lifecycle_store: Some(&lifecycle_store),
-                side_effects: Some(Box::new(DefaultCookSideEffects::new(|_, _, _, _| {
-                    Ok(serde_json::json!({}))
-                }))),
+                side_effects: Some(CookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})))),
                 ..CookContext::new(winner, Arc::new(UnusedExecutor))
             })
         });
@@ -6050,9 +5985,7 @@ fn run_concurrent_first_cooks_recipe_creator_fixture() -> String {
             run_cook(CookContext {
                 store: Some(&store),
                 lifecycle_store: Some(&lifecycle_store),
-                side_effects: Some(Box::new(DefaultCookSideEffects::new(|_, _, _, _| {
-                    Ok(serde_json::json!({}))
-                }))),
+                side_effects: Some(CookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})))),
                 ..CookContext::new(loser, Arc::new(UnusedExecutor))
             })
         });
@@ -7088,13 +7021,11 @@ fn continuation_finalizes_applied_green_candidate_despite_recoverable_artifact_d
         let finalizations = Arc::new(AtomicUsize::new(0));
         let observed = Arc::clone(&finalizations);
         let result = run_cook(CookContext {
-            side_effects: Some(Box::new(DefaultCookSideEffects::new(
-                move |_, _, finalized_run, _| {
-                    observed.fetch_add(1, Ordering::SeqCst);
-                    assert_eq!(finalized_run, run_id);
-                    Ok(serde_json::json!({"status": "review_ready"}))
-                },
-            ))),
+            side_effects: Some(CookSideEffects::new(move |_, _, finalized_run, _| {
+                observed.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(finalized_run, run_id);
+                Ok(serde_json::json!({"status": "review_ready"}))
+            })),
             ..CookContext::new(options, Arc::new(UnusedExecutor))
         })
         .expect("continue through finalization");
@@ -9450,7 +9381,7 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
             &ambient_lifecycle_store,
             options.clone(),
             Arc::new(UnusedExecutor),
-            &mut DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
+            &mut CookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
             None,
             CookMode::Resume,
         )
@@ -9467,7 +9398,7 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
             &ambient_lifecycle_store,
             options,
             Arc::new(UnusedExecutor),
-            &mut DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
+            &mut CookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
             None,
             CookMode::Resume,
         )
@@ -9605,8 +9536,7 @@ fn concurrent_missing_task_base_capture_serializes_and_reuses_its_sha() {
         let (winner, loser) = std::thread::scope(|scope| {
             let winner = scope.spawn(|| {
                 barrier.wait();
-                let mut side_effects =
-                    DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})));
+                let mut side_effects = CookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})));
                 run_cook_spine(
                     &store,
                     &lifecycle_store,
@@ -9619,8 +9549,7 @@ fn concurrent_missing_task_base_capture_serializes_and_reuses_its_sha() {
             });
             let loser = scope.spawn(|| {
                 barrier.wait();
-                let mut side_effects =
-                    DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})));
+                let mut side_effects = CookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})));
                 run_cook_spine(
                     &store,
                     &lifecycle_store,
@@ -13191,16 +13120,14 @@ fn detached_adoption_follow_up_records_before_dispatch_then_finalizes_once_witho
             |_| Ok(Some(dispatcher.clone())),
             |options| {
                 run_cook(CookContext {
-                    side_effects: Some(Box::new(DefaultCookSideEffects::new(
-                        |_, options, run_id, promotion| {
-                            finalize_cook_pr_with_backend(
-                                options,
-                                run_id,
-                                promotion,
-                                &mut resumed_backend,
-                            )
-                        },
-                    ))),
+                    side_effects: Some(CookSideEffects::new(|_, options, run_id, promotion| {
+                        finalize_cook_pr_with_backend(
+                            options,
+                            run_id,
+                            promotion,
+                            &mut resumed_backend,
+                        )
+                    })),
                     ..CookContext::new(options, Arc::new(UnusedExecutor))
                 })
                 .map(|result| result.exit_code)
@@ -15839,7 +15766,7 @@ fn baseline_comparison_is_persisted_before_feedback_finalization() {
             Ok(())
         };
         let result = run_cook(CookContext {
-            side_effects: Some(Box::new(DefaultCookSideEffects::new(
+            side_effects: Some(CookSideEffects::new(
                 move |_, _, received_run, promotion| {
                     finalization_count.fetch_add(1, Ordering::SeqCst);
                     assert_eq!(received_run, expected_run_id);
@@ -15860,7 +15787,7 @@ fn baseline_comparison_is_persisted_before_feedback_finalization() {
                     );
                     Ok(serde_json::json!({"status": "review_ready"}))
                 },
-            ))),
+            )),
             durable_observer: Some(&observer),
             ..CookContext::new(options, Arc::new(UnusedExecutor))
         })
@@ -16090,7 +16017,7 @@ fn promotion_claim_and_replay_isolate_identical_ids_across_lifecycle_stores() {
             .record_promotion(run_id, serde_json::to_value(rooted_promotion).unwrap())
             .unwrap();
 
-        let mut side_effects = DefaultCookSideEffects::new(|_, _, _, _| {
+        let mut side_effects = CookSideEffects::new(|_, _, _, _| {
             unreachable!("promotion isolation does not finalize")
         });
         let first = side_effects.promote(store, &options, run_id).unwrap();
@@ -16336,7 +16263,7 @@ fn review_form_follow_up_finalization_replays_its_durable_claim_after_restart() 
 fn duplicate_controller_passes_revalidate_one_promoted_candidate() {
     // #8357 acceptance (AC5 + AC7): duplicate/concurrent controller passes over
     // the same candidate must produce exactly one promotion checkpoint and
-    // revalidate one published candidate. Drive the PRODUCTION `DefaultCookSideEffects`
+    // revalidate one published candidate. Drive the production `CookSideEffects`
     // boundary (which routes promote/finalize through the durable operation
     // claims) with an injected finalize effect, so no real Git/GitHub mutation
     // occurs. Promotion is seeded as already-applied so `promote` takes its load
@@ -16378,7 +16305,7 @@ fn duplicate_controller_passes_revalidate_one_promoted_candidate() {
         let lifecycle_store = AgentTaskLifecycleStore::from_current_environment().unwrap();
         for _ in 0..3 {
             let calls = Arc::clone(&finalize_calls);
-            let mut side_effects = DefaultCookSideEffects::new(
+            let mut side_effects = CookSideEffects::new(
                 move |_: &AgentTaskLifecycleStore,
                       _: &CookRequest,
                       rid: &str,

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -127,7 +127,7 @@ pub use super::agent_task_scheduler::{
 pub use super::agent_tool_control_plane::{
     dispatch_agent_tool_request, AgentToolControlPlaneDispatcher, AgentToolDispatchEvidence,
     AgentToolDispatchOutcome, HomeboyAgentToolControlPlaneDispatcher,
-    UnsupportedAgentToolControlPlaneDispatcher, AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA,
+    AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA,
 };
 
 // Matrix expansion is `pub(crate)` on the implementation module; expose it

--- a/crates/homeboy-agents/src/agent_tool_control_plane.rs
+++ b/crates/homeboy-agents/src/agent_tool_control_plane.rs
@@ -60,15 +60,6 @@ mod dispatch {
     }
 
     #[derive(Debug, Clone, Copy, Default)]
-    pub struct UnsupportedAgentToolControlPlaneDispatcher;
-
-    impl AgentToolControlPlaneDispatcher for UnsupportedAgentToolControlPlaneDispatcher {
-        fn dispatch(&self, request: &AgentToolRequest) -> AgentToolResult {
-            unsupported_control_plane_result(request)
-        }
-    }
-
-    #[derive(Debug, Clone, Copy, Default)]
     pub struct HomeboyAgentToolControlPlaneDispatcher;
 
     impl AgentToolControlPlaneDispatcher for HomeboyAgentToolControlPlaneDispatcher {
@@ -243,23 +234,6 @@ mod results {
                 data: json!({ "tool": request.tool }),
             }],
             metadata: json!({ "execution_location": "runner" }),
-        }
-    }
-
-    pub(crate) fn unsupported_control_plane_result(request: &AgentToolRequest) -> AgentToolResult {
-        AgentToolResult {
-            schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
-            request_id: request.request_id.clone(),
-            task_id: request.task_id.clone(),
-            tool: request.tool.clone(),
-            status: AgentToolResultStatus::Failed,
-            output: Value::Null,
-            diagnostics: vec![AgentTaskDiagnostic {
-                class: "agent_tool.control_plane_dispatch_unsupported".to_string(),
-                message: "control-plane tool dispatch is selected by policy, but no dispatcher is registered for this provider execution".to_string(),
-                data: json!({ "tool": request.tool }),
-            }],
-            metadata: json!({ "execution_location": "control_plane" }),
         }
     }
 
@@ -1219,26 +1193,6 @@ mod tests {
         assert_eq!(
             outcome.evidence.result.metadata["authorization"],
             "[REDACTED]"
-        );
-    }
-
-    #[test]
-    fn unsupported_control_plane_dispatch_returns_explicit_diagnostic() {
-        let outcome = dispatch_agent_tool_request(
-            &policy(AgentToolExecutionLocation::ControlPlane),
-            &request("lookup"),
-            &UnsupportedAgentToolControlPlaneDispatcher,
-        );
-
-        assert_eq!(outcome.location, AgentToolExecutionLocation::ControlPlane);
-        assert_eq!(outcome.result.status, AgentToolResultStatus::Failed);
-        assert_eq!(
-            outcome.result.diagnostics[0].class,
-            "agent_tool.control_plane_dispatch_unsupported"
-        );
-        assert_eq!(
-            outcome.evidence.result.diagnostics[0].class,
-            "agent_tool.control_plane_dispatch_unsupported"
         );
     }
 }


### PR DESCRIPTION
## Summary

- replace the one-implementation `CookSideEffectService` trait and boxed dynamic dispatch with a concrete Cook effect runner
- keep promotion and moving-base recovery on their sole native implementations while exposing `CookRuntime::with_finalizer` for the one caller-owned variation
- keep finalizer test injection beneath the durable finalization claim and confine promotion/recovery overrides to test builds
- delete the uncalled continuation scheduler trait and the unused unsupported control-plane dispatcher, helper, test, and facade export

The resulting call graph has one production promotion path, one production moving-base recovery path, and three finalizer bindings (standard Cook, batch resume, and adoption). The diff removes 426 lines and adds 260, for a net deletion of 166 lines.

This intentionally narrows the Rust source API: consumers that implemented `CookSideEffectService` should use `CookRuntime::production`, `production_with_observer`, or `with_finalizer`. Durable records, CLI/JSON output, operation identities, retry semantics, and exactly-once claims are unchanged.

Closes #14258

## Verification

- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents --lib --no-run`
- focused promotion claim/replay, finalization claim/revalidation, duplicate-controller, moving-base recovery, candidate selection, intentional-no-change, adoption, durable continuation queue, and all agent-tool control-plane tests
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

The broad `cargo test -p homeboy-agents --lib` run passed 2,248 tests and reported 16 shared-state/timing fixture failures. The sole Cook failure (`retryable_pre_provider_retry_concurrently_claims_one_successor_across_processes`) passed when rerun in isolation; all directly affected paths passed in isolation before and after rebasing onto current `main`. Strict Clippy remains blocked by existing repository-wide warnings unrelated to this diff.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode mapped the call graph, implemented the deletion-focused refactor, ran compilation and lifecycle verification, and performed two review passes. Chris Huber selected the target and directed the change.