### PR TITLE
Fix capability probe false missing-tool reports

### DIFF
--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -9,7 +9,8 @@ use homeboy_core::engine::shell;
 use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_core::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
 use homeboy_core::server::{
-    self, execute_local_command_in_dir, execute_local_command_in_dir_with_timeout, SshClient,
+    self, execute_local_command_in_dir, execute_local_command_in_dir_with_timeout, CommandOutput,
+    SshClient,
 };
 
 use super::runner_probe_gate::{deduplicated_probe, deduplicated_probe_until};
@@ -264,14 +265,23 @@ pub(crate) fn validate_runner_capability_preflight(
         "schema": "homeboy/runner-capability-failure/v1",
         "runner_id": runner_id,
         "command": command,
-        "predicates": missing_tool_requirements.iter().map(|requirement| serde_json::json!({
+        "predicates": missing_tools.iter().filter_map(|tool| {
+            capabilities.tool_probe_evidence.get(tool).map(|evidence| serde_json::json!({
+                "kind": "runner_tool",
+                "tool": tool.id(),
+                "command": evidence.command,
+                "exit_status": evidence.exit_status,
+                "output": evidence.output,
+                "satisfied": false,
+            }))
+        }).chain(missing_tool_requirements.iter().map(|requirement| serde_json::json!({
             "kind": "runner_tool_capability",
             "tool": requirement.tool,
             "command": requirement.command,
             "env": requirement.env,
             "capabilities": requirement.capabilities,
             "satisfied": false,
-        })).chain(failed_toolchain_probes.iter().map(|failure| serde_json::json!({
+        }))).chain(failed_toolchain_probes.iter().map(|failure| serde_json::json!({
             "kind": "extension_toolchain_readiness",
             "id": failure.split(':').next().unwrap_or(failure),
             "detail": failure,
@@ -306,6 +316,7 @@ pub(crate) fn preflight_runner_toolchain_readiness(
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RunnerCapabilitySnapshot {
     tools: BTreeSet<RunnerRequiredTool>,
+    tool_probe_evidence: BTreeMap<RunnerRequiredTool, RunnerToolProbeEvidence>,
     commands: BTreeSet<String>,
     tool_capabilities: BTreeSet<String>,
     failed_toolchain_probes: HashMap<String, String>,
@@ -426,6 +437,7 @@ impl RunnerCapabilitySnapshot {
             let probe = Self::local_batch_probe(runner, preflight)?;
             return Ok(Self {
                 tools: probe.tools,
+                tool_probe_evidence: probe.tool_probe_evidence,
                 commands: probe.commands,
                 tool_capabilities: probe.tool_capabilities,
                 failed_toolchain_probes: probe.failed_toolchain_probes,
@@ -438,6 +450,7 @@ impl RunnerCapabilitySnapshot {
 
         Ok(Self {
             tools: probe.tools,
+            tool_probe_evidence: probe.tool_probe_evidence,
             commands: probe.commands,
             tool_capabilities: probe.tool_capabilities,
             failed_toolchain_probes: probe.failed_toolchain_probes,
@@ -511,13 +524,15 @@ impl RunnerCapabilitySnapshot {
                     }),
                 ));
             }
-            Ok(parse_batch_probe_output(
-                &output.stdout,
+            parse_batch_probe_output(
+                runner,
+                &script,
+                &output,
                 &tool_probes,
                 &command_names,
                 &capability_probes,
                 &preflight.required_toolchain_probes,
-            ))
+            )
         };
         match preflight.timeout {
             Some(timeout) => deduplicated_probe_until(
@@ -555,14 +570,15 @@ impl RunnerCapabilitySnapshot {
                 execute_local_command_in_dir_with_timeout(&script, None, Some(&env), timeout)
             })
             .unwrap_or_else(|| execute_local_command_in_dir(&script, None, Some(&env)));
-        let stdout = output.stdout;
-        Ok(parse_batch_probe_output(
-            &stdout,
+        parse_batch_probe_output(
+            runner,
+            &script,
+            &output,
             &tool_probes,
             &command_names,
             &capability_probes,
             &preflight.required_toolchain_probes,
-        ))
+        )
     }
 
     fn ssh_client_for_runner(runner: &Runner) -> Result<SshClient> {
@@ -623,6 +639,7 @@ fn runner_tool_probes(
 #[derive(Debug, Clone, Default)]
 struct RunnerCapabilityProbeResult {
     tools: BTreeSet<RunnerRequiredTool>,
+    tool_probe_evidence: BTreeMap<RunnerRequiredTool, RunnerToolProbeEvidence>,
     commands: BTreeSet<String>,
     tool_capabilities: BTreeSet<String>,
     failed_toolchain_probes: HashMap<String, String>,
@@ -633,6 +650,13 @@ struct RunnerToolProbe {
     tool: RunnerRequiredTool,
     command: String,
     version_args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RunnerToolProbeEvidence {
+    command: String,
+    exit_status: i32,
+    output: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -671,7 +695,7 @@ fn batch_probe_script(
         // Only invoke an executable when its registry definition supplies a
         // non-empty, read-only version probe. A bare required command retains
         // the prior presence check rather than starting an interactive tool.
-        let condition = if probe.version_args.is_empty() {
+        let command = if probe.version_args.is_empty() {
             format!(
                 "command -v {} >/dev/null 2>&1",
                 shell::quote_arg(&probe.command)
@@ -682,10 +706,9 @@ fn batch_probe_script(
                 .map(|arg| shell::quote_arg(arg))
                 .collect::<Vec<_>>()
                 .join(" ")
-                + " >/dev/null 2>&1"
         };
         lines.push(format!(
-            "if {condition}; then printf 'T\\t{index}\\t1\\n'; else printf 'T\\t{index}\\t0\\n'; fi"
+            "__homeboy_probe_output=$({{ {command}; }} 2>&1); __homeboy_probe_status=$?; printf 'T\\t{index}\\t%s\\t%s\\n' \"$__homeboy_probe_status\" \"$__homeboy_probe_output\""
         ));
     }
     for (index, command) in command_names.iter().enumerate() {
@@ -723,14 +746,16 @@ fn tool_capability_probe_script(index: usize, probe: &RunnerToolCapabilityProbe)
 }
 
 fn parse_batch_probe_output(
-    stdout: &str,
+    runner: &Runner,
+    script: &str,
+    output: &CommandOutput,
     tool_probes: &[RunnerToolProbe],
     command_names: &[String],
     capability_probes: &[RunnerToolCapabilityProbe],
     toolchain_probes: &[RunnerToolchainReadinessProbe],
-) -> RunnerCapabilityProbeResult {
+) -> Result<RunnerCapabilityProbeResult> {
     let mut result = RunnerCapabilityProbeResult::default();
-    for line in stdout.lines() {
+    for line in output.stdout.lines() {
         let mut fields = line.split('\t');
         let Some(kind) = fields.next() else {
             continue;
@@ -738,16 +763,35 @@ fn parse_batch_probe_output(
         let Some(index) = fields.next().and_then(|value| value.parse::<usize>().ok()) else {
             continue;
         };
-        let succeeded = fields.next() == Some("1");
+        let status = fields.next();
+        let succeeded = status == Some("1");
+        if kind == "T" {
+            let Some(probe) = tool_probes.get(index) else {
+                continue;
+            };
+            let Some(exit_status) = status.and_then(|value| value.parse::<i32>().ok()) else {
+                continue;
+            };
+            let Some(captured) = fields.next() else {
+                continue;
+            };
+            result.tool_probe_evidence.insert(
+                probe.tool.clone(),
+                RunnerToolProbeEvidence {
+                    command: rendered_tool_probe_command(probe),
+                    exit_status,
+                    output: captured.to_string(),
+                },
+            );
+            if exit_status == 0 {
+                result.tools.insert(probe.tool.clone());
+            }
+            continue;
+        }
         if !succeeded && kind != "R" {
             continue;
         }
         match kind {
-            "T" => {
-                if let Some(probe) = tool_probes.get(index) {
-                    result.tools.insert(probe.tool.clone());
-                }
-            }
             "C" => {
                 if let Some(command) = command_names.get(index) {
                     result.commands.insert(command.clone());
@@ -769,7 +813,67 @@ fn parse_batch_probe_output(
             _ => {}
         }
     }
-    result
+    if !output.success
+        || output.observation != homeboy_core::server::CommandObservation::Complete
+        || tool_probes
+            .iter()
+            .any(|probe| !result.tool_probe_evidence.contains_key(&probe.tool))
+    {
+        return Err(capability_probe_transport_error(
+            runner,
+            script,
+            output,
+            &result,
+            tool_probes,
+        ));
+    }
+    Ok(result)
+}
+
+fn rendered_tool_probe_command(probe: &RunnerToolProbe) -> String {
+    if probe.version_args.is_empty() {
+        return format!("command -v {}", shell::quote_arg(&probe.command));
+    }
+    std::iter::once(&probe.command)
+        .chain(probe.version_args.iter())
+        .map(|arg| shell::quote_arg(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn capability_probe_transport_error(
+    runner: &Runner,
+    script: &str,
+    output: &CommandOutput,
+    result: &RunnerCapabilityProbeResult,
+    tool_probes: &[RunnerToolProbe],
+) -> Error {
+    let missing_records = tool_probes
+        .iter()
+        .filter(|probe| !result.tool_probe_evidence.contains_key(&probe.tool))
+        .map(|probe| probe.tool.id())
+        .collect::<Vec<_>>();
+    Error::new(
+        ErrorCode::RunnerLabTransportFailure,
+        format!(
+            "Runner '{}' capability probe did not produce usable evidence",
+            runner.id
+        ),
+        json!({
+            "runner_id": runner.id,
+            "probe": {
+                "command": script,
+                "exit_status": output.exit_code,
+                "success": output.success,
+                "observation": output.observation.code(),
+                "timed_out": output.timed_out,
+                "stdout": output.stdout,
+                "stderr": output.stderr,
+                "missing_tool_records": missing_records,
+            },
+        }),
+    )
+    .with_retryable(true)
 }
 
 fn evaluate_lab_runner_capabilities(
@@ -1191,9 +1295,16 @@ mod tests {
             server_id: None,
             workspace_root: None,
             settings: RunnerSettings::default(),
-            env: [("PATH".to_string(), fixture.path().display().to_string())]
-                .into_iter()
-                .collect(),
+            env: [(
+                "PATH".to_string(),
+                format!(
+                    "{}:{}",
+                    fixture.path().display(),
+                    std::env::var("PATH").unwrap_or_default()
+                ),
+            )]
+            .into_iter()
+            .collect(),
             secret_env: Default::default(),
             resources: Default::default(),
             policy: RunnerPolicy::default(),
@@ -1211,11 +1322,15 @@ mod tests {
         };
         let started = std::time::Instant::now();
 
-        let snapshot = RunnerCapabilitySnapshot::from_runner_probe(&runner, &preflight)
-            .expect("bounded preflight returns a capability snapshot");
+        let error = RunnerCapabilitySnapshot::from_runner_probe(&runner, &preflight)
+            .expect_err("incomplete timed-out evidence must not become an empty inventory");
 
         assert!(started.elapsed() < Duration::from_secs(1));
-        assert!(snapshot.tool_capabilities.is_empty());
+        assert!(matches!(
+            error.code,
+            ErrorCode::RemoteCommandTimeout | ErrorCode::RunnerLabTransportFailure
+        ));
+        assert_eq!(error.retryable, Some(true));
     }
 
     #[test]
@@ -1246,6 +1361,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
+            tool_probe_evidence: BTreeMap::new(),
             commands: BTreeSet::new(),
             tool_capabilities: BTreeSet::new(),
             failed_toolchain_probes: HashMap::new(),
@@ -1275,6 +1391,7 @@ mod tests {
         };
         let capabilities = RunnerCapabilitySnapshot {
             tools: [RunnerRequiredTool::git()].into_iter().collect(),
+            tool_probe_evidence: BTreeMap::new(),
             commands: BTreeSet::new(),
             tool_capabilities: BTreeSet::new(),
             failed_toolchain_probes: HashMap::new(),
@@ -1320,6 +1437,7 @@ mod tests {
             &plan,
             &RunnerCapabilitySnapshot {
                 tools: [RunnerRequiredTool::git()].into_iter().collect(),
+                tool_probe_evidence: BTreeMap::new(),
                 commands: BTreeSet::new(),
                 tool_capabilities: BTreeSet::new(),
                 failed_toolchain_probes: HashMap::new(),
@@ -1380,6 +1498,7 @@ mod tests {
         };
         let capabilities = RunnerCapabilitySnapshot {
             tools: [RunnerRequiredTool::git()].into_iter().collect(),
+            tool_probe_evidence: BTreeMap::new(),
             commands: BTreeSet::new(),
             tool_capabilities: BTreeSet::new(),
             failed_toolchain_probes: HashMap::new(),
@@ -1423,6 +1542,7 @@ mod tests {
         };
         let capabilities = RunnerCapabilitySnapshot {
             tools: [RunnerRequiredTool::git()].into_iter().collect(),
+            tool_probe_evidence: BTreeMap::new(),
             commands: BTreeSet::new(),
             tool_capabilities: BTreeSet::new(),
             failed_toolchain_probes: HashMap::new(),
@@ -1499,6 +1619,7 @@ mod tests {
             tools: [RunnerRequiredTool::new("playwright")]
                 .into_iter()
                 .collect(),
+            tool_probe_evidence: BTreeMap::new(),
             commands: BTreeSet::new(),
             tool_capabilities: BTreeSet::new(),
             failed_toolchain_probes: HashMap::new(),
@@ -1541,6 +1662,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
+            tool_probe_evidence: BTreeMap::new(),
             commands: ["zip".to_string()].into_iter().collect(),
             tool_capabilities: BTreeSet::new(),
             failed_toolchain_probes: HashMap::new(),
@@ -1615,7 +1737,11 @@ mod tests {
         validate_runner_capability_preflight("local", &preflight, &capabilities, &HashMap::new())
             .expect("successful configured Homeboy and Git probes satisfy handoff preflight");
 
-        fs::write(&git, "#!/bin/sh\nexit 1\n").expect("make git version probe fail");
+        fs::write(
+            &git,
+            "#!/bin/sh\nprintf 'configured git failed\\n' >&2\nexit 1\n",
+        )
+        .expect("make git version probe fail");
         let unavailable = runner_capability_snapshot_for_preflight(&runner, &preflight)
             .expect("capability snapshot");
         let error = validate_runner_capability_preflight(
@@ -1626,6 +1752,15 @@ mod tests {
         )
         .expect_err("an unusable Git executable blocks handoff before provider execution");
         assert!(error.message.contains("tools: git"));
+        let predicate = &error.details["runner_capability_failure"]["predicates"][0];
+        assert_eq!(predicate["kind"], "runner_tool");
+        assert_eq!(predicate["tool"], "git");
+        assert_eq!(
+            predicate["command"],
+            format!("{} configured-version", git.display())
+        );
+        assert_eq!(predicate["exit_status"], 1);
+        assert_eq!(predicate["output"], "configured git failed");
 
         fs::write(
             &git,
@@ -1802,6 +1937,37 @@ mod tests {
 
         assert!(script.contains("command -v interactive-tool >/dev/null 2>&1"));
         assert!(!script.contains("if interactive-tool >/dev/null 2>&1"));
+    }
+
+    #[test]
+    fn incomplete_tool_probe_output_is_a_transport_failure_with_transcript() {
+        let runner = ssh_runner();
+        let probes = vec![RunnerToolProbe {
+            tool: RunnerRequiredTool::git(),
+            command: "git".to_string(),
+            version_args: vec!["--version".to_string()],
+        }];
+        let script = batch_probe_script(&probes, &[], &[], &[]);
+        let output = CommandOutput {
+            stdout: "unframed output".to_string(),
+            stderr: "transport warning".to_string(),
+            success: true,
+            exit_code: 0,
+            timed_out: false,
+            observation: homeboy_core::server::CommandObservation::Complete,
+            child_resource: None,
+        };
+
+        let error = parse_batch_probe_output(&runner, &script, &output, &probes, &[], &[], &[])
+            .expect_err("missing tool frame must not become an empty inventory");
+
+        assert_eq!(error.code, ErrorCode::RunnerLabTransportFailure);
+        assert_eq!(error.retryable, Some(true));
+        assert_eq!(error.details["probe"]["command"], script);
+        assert_eq!(error.details["probe"]["exit_status"], 0);
+        assert_eq!(error.details["probe"]["stdout"], "unframed output");
+        assert_eq!(error.details["probe"]["stderr"], "transport warning");
+        assert_eq!(error.details["probe"]["missing_tool_records"][0], "git");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Closes #14166

## Summary
- frame each required-tool probe with its real exit status and captured output
- retain failed tool evidence in the capability failure predicates
- classify incomplete or unusable batch output as a retryable transport failure with the full probe transcript instead of an empty capability inventory

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner capabilities --lib` (37 passed)
- live ignored diagnostic against `homeboy-lab` through the production `SshClient` path (passed; diagnostic test removed before commit)
- full `cargo test -p homeboy-lab-runner --lib` advanced through the changed capability/offload coverage without failures but exceeded the 20-minute local command budget in unrelated long-running staging-controller tests
- `cargo clippy -p homeboy-lab-runner --lib -- -D warnings` is blocked by the pre-existing `clippy::large_enum_variant` finding in `homeboy-runner-contract/src/claim.rs`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced the regression, implemented the framed probe/evidence handling, and ran the focused and live verification. Chris Huber directed and owns the change.