### PR TITLE
fix(agent-task): preserve timeout candidate provenance

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/candidate_adoption.rs
@@ -169,8 +169,23 @@ pub(super) fn finalize_candidate_artifacts(outcome: &mut AgentTaskOutcome, runni
     let Some(run_id) = running.run_id.as_deref() else {
         return;
     };
+    let timeout_or_recoverable = matches!(
+        outcome.status,
+        AgentTaskOutcomeStatus::Timeout | AgentTaskOutcomeStatus::CandidateRecoverable
+    ) || outcome.artifacts.iter().any(|artifact| {
+        artifact.metadata.get("incomplete") == Some(&serde_json::Value::Bool(true))
+    });
+    let provenance_root = running.source_workspace_root.as_deref().or_else(|| {
+        timeout_or_recoverable
+            .then_some(running.request.workspace.root.as_deref())
+            .flatten()
+    });
     let repository_identity =
-        canonical_repository_identity_for_root(running.source_workspace_root.as_deref());
+        canonical_repository_identity_for_root(provenance_root).or_else(|| {
+            timeout_or_recoverable
+                .then(|| local_repository_identity_for_root(provenance_root))
+                .flatten()
+        });
     let workspace_identity = running
         .source_provenance
         .as_ref()
@@ -269,7 +284,8 @@ fn sha256(content: &str) -> String {
 }
 
 fn canonical_repository_identity_for_root(root: Option<&str>) -> Option<String> {
-    let remote = homeboy_core::git::remote_origin_url(Path::new(root?))?;
+    let root = Path::new(root?);
+    let remote = homeboy_core::git::remote_origin_url(root)?;
     let repository = homeboy_core::git::release_download::parse_github_url(&remote)?;
     Some(format!(
         "github://{}/{}/{}",
@@ -277,4 +293,19 @@ fn canonical_repository_identity_for_root(root: Option<&str>) -> Option<String> 
         repository.owner.to_ascii_lowercase(),
         repository.repo.to_ascii_lowercase(),
     ))
+}
+
+fn local_repository_identity_for_root(root: Option<&str>) -> Option<String> {
+    let root = Path::new(root?);
+    // A local-only repository has no canonical remote, but its common Git
+    // directory still distinguishes it from another checkout at the same base.
+    let git_dir = Command::new("git")
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .current_dir(root)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())?;
+    let git_dir = String::from_utf8(git_dir.stdout).ok()?;
+    let git_dir = std::fs::canonicalize(git_dir.trim()).ok()?;
+    Some(format!("local://{}", sha256(&git_dir.to_string_lossy())))
 }

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -762,10 +762,9 @@ impl AgentTaskScheduleSupport {
                             // longer race its writes to the isolated attempt workspace.
                             Self::reconcile_timeout_artifacts(
                                 &mut recovered,
-                                &task.request,
+                                &task,
                                 "deferred_cleanup",
                             );
-                            super::finalize_candidate_artifacts(&mut recovered, &task);
                         }
                         let cleanup = harvest.and_then(|_| {
                             task._attempt_workspace
@@ -843,11 +842,7 @@ impl AgentTaskScheduleSupport {
             }
 
             if outcome.status == AgentTaskOutcomeStatus::Timeout {
-                Self::reconcile_timeout_artifacts(
-                    &mut outcome,
-                    &running.request,
-                    "provider_timeout",
-                );
+                Self::reconcile_timeout_artifacts(&mut outcome, running, "provider_timeout");
             }
         }
         outcome
@@ -1124,10 +1119,10 @@ impl AgentTaskScheduleSupport {
 
     pub(super) fn reconcile_timeout_artifacts(
         outcome: &mut AgentTaskOutcome,
-        request: &AgentTaskRequest,
+        running: &RunningTask,
         timeout_kind: &str,
     ) {
-        let discovery = TimeoutArtifactDiscovery::discover(request);
+        let discovery = TimeoutArtifactDiscovery::discover(&running.request);
         let has_runtime_evidence = discovery.has_runtime_evidence();
         outcome.diagnostics.extend(discovery.diagnostics);
         if !has_runtime_evidence {
@@ -1152,12 +1147,17 @@ impl AgentTaskScheduleSupport {
         // Required-artifact validation runs before timeout discovery. Re-run its
         // materialization after merging late evidence so a captured patch cannot
         // coexist with a false missing-artifact diagnosis.
-        Self::normalize_required_typed_artifacts(outcome, request);
-        if missing_required_typed_artifacts(outcome, request).is_empty() {
+        Self::normalize_required_typed_artifacts(outcome, &running.request);
+        if missing_required_typed_artifacts(outcome, &running.request).is_empty() {
             outcome.diagnostics.retain(|diagnostic| {
                 diagnostic.class != "agent_task.required_typed_artifacts_missing"
             });
         }
+
+        // Timeout discovery can append a provider-generated patch after the
+        // ordinary completion finalization. Bind it before this outcome can be
+        // selected as a recoverable candidate or persisted for continuation.
+        super::finalize_candidate_artifacts(outcome, running);
 
         let actionable_patch = outcome.metadata.get("actionable").and_then(Value::as_bool)
             != Some(false)

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -877,6 +877,81 @@ fn service_persists_timed_out_run_record_and_evidence_refs() {
 }
 
 #[test]
+fn persisted_timeout_candidate_is_admitted_for_continuation() {
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        create_git_repo(workspace.path());
+        let mut plan = test_plan();
+        plan.tasks[0].workspace.root = Some(workspace.path().display().to_string());
+        plan.tasks[0].limits.timeout_ms = Some(1);
+
+        let result = run_loaded_plan(
+            plan,
+            Some("service-timeout-candidate"),
+            Arc::new(TimeoutAfterWritingPatchExecutor),
+        )
+        .expect("timeout candidate run completed");
+        assert_eq!(result.exit_code, 0);
+
+        let lifecycle_store = test_lifecycle_store();
+        let aggregate = lifecycle_store
+            .read_aggregate("service-timeout-candidate")
+            .expect("persisted aggregate");
+        let outcome = aggregate.outcomes.first().expect("timeout outcome");
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::CandidateRecoverable);
+        let artifact = outcome
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.kind == "patch")
+            .expect("persisted timeout patch");
+        for key in [
+            "run_id",
+            "task_id",
+            "producer_attempt",
+            "base_ref",
+            "provider_backend",
+            "repository_identity",
+            "workspace_identity",
+        ] {
+            assert!(
+                artifact.metadata.get(key).is_some_and(|value| {
+                    value.as_str().is_some_and(|value| !value.is_empty()) || value.is_u64()
+                }),
+                "persisted timeout patch is missing {key}: {:#?}",
+                artifact.metadata
+            );
+        }
+        assert_eq!(artifact.metadata["run_id"], "service-timeout-candidate");
+        assert_eq!(artifact.metadata["task_id"], outcome.task_id);
+
+        let source = serde_json::to_string(&aggregate).expect("serialize persisted aggregate");
+        let admitted = crate::agent_task_promotion::preflight_recoverable_candidate_promotion_in_observation_store(
+            &crate::agent_task_promotion::AgentTaskPromotionOptions {
+                source,
+                source_run_id: Some("service-timeout-candidate".to_string()),
+                source_path: Some(lifecycle_store.aggregate_path("service-timeout-candidate")),
+                source_worktree_path: None,
+                base_ref: None,
+                task_base_sha: None,
+                candidate_ref: None,
+                to_worktree: "timeout-continuation-target".to_string(),
+                task_id: Some(outcome.task_id.clone()),
+                artifact_id: Some(artifact.id.clone()),
+                dry_run: false,
+                gates: crate::agent_task_gate::VerifyGateOptions::default(),
+                provider_command: None,
+                provider_invocation: None,
+            },
+            &lifecycle_store
+                .open_observation_initialized()
+                .expect("observation store"),
+        )
+        .expect("persisted timeout candidate is eligible for cook continuation");
+        assert_eq!(admitted.id, artifact.id);
+    });
+}
+
+#[test]
 fn service_normalizes_resolved_component_worktree_plan() {
     let mut plan = test_plan();
     plan.tasks[0].workspace.kind = Some("component-worktree".to_string());
@@ -3623,6 +3698,30 @@ impl AgentTaskExecutorAdapter for TimeoutExecutor {
                 message: "provider exceeded timeout_ms=50".to_string(),
                 data: serde_json::json!({ "timeout_ms": 50 }),
             }],
+            ..Default::default()
+        }
+    }
+}
+
+struct TimeoutAfterWritingPatchExecutor;
+
+impl AgentTaskExecutorAdapter for TimeoutAfterWritingPatchExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        let workspace = request.workspace.root.expect("attempt workspace");
+        std::fs::write(
+            Path::new(&workspace).join("timeout-candidate.txt"),
+            "recovered after timeout\n",
+        )
+        .expect("write candidate");
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        AgentTaskOutcome {
+            task_id: request.task_id,
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: Some("provider completed after its deadline".to_string()),
             ..Default::default()
         }
     }


### PR DESCRIPTION
## Summary

- finalize patches discovered during timeout reconciliation against the producing running task
- retain run, task, attempt, base, provider, repository, and workspace bindings in the durable aggregate
- preserve fail-closed candidate admission while supporting local-only repository identity
- prove persisted timeout candidates pass continuation preflight

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-agents agent_task_service::tests::persisted_timeout_candidate_is_admitted_for_continuation`
- `cargo test -p homeboy-agents agent_task_scheduler::tests::scheduling_tests::timeout::timeout_tests::timeout_after_writing_patch_reconciles_required_artifacts_and_authenticates_candidate`
- broader service and scheduler suites passed before rebasing

Closes #14261.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced timeout harvesting through persistence and promotion, implemented the provenance repair and regression coverage, and assisted with review and verification. Chris Huber directed the investigation and reviewed the resulting candidate.