### PR TITLE
feat(rig): add materialized rig resource contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
  "homeboy-lifecycle-contract",
  "homeboy-paths",
  "homeboy-product-identity",
+ "homeboy-rig-contract",
  "homeboy-runner-contract",
  "homeboy-stack",
  "libc",
@@ -1248,6 +1249,14 @@ dependencies = [
  "sha2",
  "shellexpand",
  "tempfile",
+]
+
+[[package]]
+name = "homeboy-rig-contract"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/contracts/homeboy-rig-contract/Cargo.toml
+++ b/crates/contracts/homeboy-rig-contract/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "homeboy-rig-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Chris Huber <chubes@extrachill.com>"]
+description = "Versioned materialized rig resource contract"
+repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
+
+[lib]
+name = "homeboy_rig_contract"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/contracts/homeboy-rig-contract/src/lib.rs
+++ b/crates/contracts/homeboy-rig-contract/src/lib.rs
@@ -1,0 +1,59 @@
+//! Versioned, behavior-free materialized rig resource contracts.
+
+use serde::{Deserialize, Serialize};
+
+pub const MATERIALIZED_RIG_RESOURCE_SCHEMA: &str = "homeboy/materialized-rig/v1";
+
+/// A normalized rig document paired with its stable identity and content digest.
+///
+/// `materialized_rig_json_sha256` is the SHA-256 of the canonical JSON bytes of
+/// `rig`: object keys are recursively sorted while array order is preserved.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MaterializedRigResource {
+    pub schema: String,
+    pub rig_id: String,
+    pub materialized_rig_json_sha256: String,
+    pub rig: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn materialized_rig_resource_has_a_versioned_golden_wire_shape() {
+        let resource = MaterializedRigResource {
+            schema: MATERIALIZED_RIG_RESOURCE_SCHEMA.to_string(),
+            rig_id: "example".to_string(),
+            materialized_rig_json_sha256: "sha256:abc123".to_string(),
+            rig: json!({ "id": "example", "settings": { "enabled": true } }),
+        };
+
+        let value = serde_json::to_value(&resource).expect("serialize resource");
+        assert_eq!(
+            value,
+            json!({
+                "schema": "homeboy/materialized-rig/v1",
+                "rig_id": "example",
+                "materialized_rig_json_sha256": "sha256:abc123",
+                "rig": { "id": "example", "settings": { "enabled": true } }
+            })
+        );
+        assert_eq!(
+            serde_json::from_value::<MaterializedRigResource>(value).expect("deserialize resource"),
+            resource
+        );
+    }
+
+    #[test]
+    fn materialized_rig_resource_requires_schema_and_identity() {
+        let error = serde_json::from_value::<MaterializedRigResource>(json!({
+            "materialized_rig_json_sha256": "sha256:abc123",
+            "rig": { "id": "example" }
+        }))
+        .expect_err("schema and rig identity are required");
+
+        assert!(error.to_string().contains("missing field `schema`"));
+    }
+}

--- a/crates/homeboy-cli/src/commands/rig/mod.rs
+++ b/crates/homeboy-cli/src/commands/rig/mod.rs
@@ -13,14 +13,13 @@ use homeboy::runner::runners;
 
 use self::output::{
     RigAppOutput, RigArtifactRegisterOutput, RigCheckOutput, RigDownOutput, RigInstallOutput,
-    RigInstalledStackSummary, RigInstalledSummary, RigListOutput, RigMaterializeOutput,
-    RigReleaseLockOutput, RigRepairOutput, RigRunOutput, RigShowOutput, RigSourceSummary,
-    RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput, RigUpPlanOutput, RigUpPlanStep,
-    RigUpdateOutput,
+    RigInstalledStackSummary, RigInstalledSummary, RigListOutput, RigReleaseLockOutput,
+    RigRepairOutput, RigRunOutput, RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary,
+    RigSyncOutput, RigUpOutput, RigUpPlanOutput, RigUpPlanStep, RigUpdateOutput,
 };
 use super::bench::RigRunBenchOptions;
 use super::utils::args::SettingArgs;
-use super::CmdResult;
+use super::{CmdResult, CommandReport};
 use crate::command_contract::{
     CommandPortabilityContract, LabCommandContract, LAB_NO_EXTRA_CAPABILITIES, RIG_CHECK_LAB_LABEL,
     RIG_RUN_LAB_LABEL, RIG_SOURCE_MANAGEMENT_LAB_LABEL,
@@ -431,14 +430,14 @@ fn materialize(
     rig_path: &std::path::Path,
     source_root: Option<&std::path::Path>,
 ) -> CmdResult<RigCommandOutput> {
-    let rig = match source_root {
-        Some(source_root) => rig::materialize_rig_spec(rig_path, source_root)?,
-        None => rig::materialize_rig_spec_with_default_source_root(rig_path)?,
+    let report = match source_root {
+        Some(source_root) => rig::materialize_rig_resource(rig_path, source_root)?,
+        None => rig::materialize_rig_resource_with_default_source_root(rig_path)?,
     };
     Ok((
-        RigCommandOutput::Materialize(RigMaterializeOutput {
+        RigCommandOutput::Materialize(CommandReport {
             command: "rig.materialize",
-            rig,
+            report,
         }),
         0,
     ))
@@ -1446,19 +1445,25 @@ mod tests {
         let (output, exit_code) = materialize(&rig_path, None).expect("materialize rig");
 
         assert_eq!(exit_code, 0);
+        let output = serde_json::to_value(output).expect("serialize output");
+        assert_eq!(output["variant"], "materialize");
+        assert_eq!(output["payload"]["command"], "rig.materialize");
         assert_eq!(
-            serde_json::to_value(output).expect("serialize output"),
+            output["payload"]["rig"],
             serde_json::json!({
-                "variant": "materialize",
-                "payload": {
-                    "command": "rig.materialize",
-                    "rig": {
-                        "id": "example",
-                        "settings": { "inherited": true }
-                    }
-                }
-            })
+                "id": "example",
+                "settings": { "inherited": true }
+            }),
+            "payload.rig remains the existing normalized rig document"
         );
+        assert_eq!(
+            output["payload"]["schema"],
+            rig::MATERIALIZED_RIG_RESOURCE_SCHEMA
+        );
+        assert_eq!(output["payload"]["rig_id"], "example");
+        assert!(output["payload"]["materialized_rig_json_sha256"]
+            .as_str()
+            .is_some_and(|digest| digest.starts_with("sha256:")));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/rig/output.rs
+++ b/crates/homeboy-cli/src/commands/rig/output.rs
@@ -15,7 +15,7 @@ use homeboy::rig::{self, RigResourcesSpec, RigSpec};
 pub enum RigCommandOutput {
     List(RigListOutput),
     Show(Box<RigShowOutput>),
-    Materialize(RigMaterializeOutput),
+    Materialize(CommandReport<rig::MaterializedRigResource>),
     Up(RigUpOutput),
     UpPlan(RigUpPlanOutput),
     Check(RigCheckOutput),
@@ -89,13 +89,6 @@ pub struct RigShowOutput {
     pub rig: RigSpec,
     #[serde(skip_serializing_if = "RigResourcesSpec::is_unset")]
     pub resources: RigResourcesSpec,
-}
-
-/// Canonical, inheritance-resolved rig JSON for package tooling.
-#[derive(Serialize)]
-pub struct RigMaterializeOutput {
-    pub command: &'static str,
-    pub rig: serde_json::Value,
 }
 
 pub type RigUpOutput = CommandReport<rig::UpReport>;
@@ -231,9 +224,14 @@ mod tests {
 
     #[test]
     fn rig_materialize_output_uses_the_machine_readable_variant() {
-        let output = RigCommandOutput::Materialize(RigMaterializeOutput {
+        let output = RigCommandOutput::Materialize(CommandReport {
             command: "rig.materialize",
-            rig: serde_json::json!({ "id": "example" }),
+            report: rig::MaterializedRigResource {
+                schema: rig::MATERIALIZED_RIG_RESOURCE_SCHEMA.to_string(),
+                rig_id: "example".to_string(),
+                materialized_rig_json_sha256: "sha256:abc123".to_string(),
+                rig: serde_json::json!({ "id": "example" }),
+            },
         });
 
         assert_eq!(
@@ -242,6 +240,9 @@ mod tests {
                 "variant": "materialize",
                 "payload": {
                     "command": "rig.materialize",
+                    "schema": "homeboy/materialized-rig/v1",
+                    "rig_id": "example",
+                    "materialized_rig_json_sha256": "sha256:abc123",
                     "rig": { "id": "example" }
                 }
             })

--- a/crates/homeboy-rig/Cargo.toml
+++ b/crates/homeboy-rig/Cargo.toml
@@ -15,6 +15,7 @@ homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-stack = { version = "0.1.0", path = "../homeboy-stack" }
 homeboy-extension-contract = { version = "0.1.0", path = "../contracts/homeboy-extension-contract" }
+homeboy-rig-contract = { version = "0.1.0", path = "../contracts/homeboy-rig-contract" }
 homeboy-runner-contract = { version = "0.1.0", path = "../contracts/homeboy-runner-contract" }
 homeboy-lifecycle-contract = { version = "0.1.0", path = "../contracts/homeboy-lifecycle-contract" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }

--- a/crates/homeboy-rig/src/install.rs
+++ b/crates/homeboy-rig/src/install.rs
@@ -373,6 +373,52 @@ pub fn materialize_rig_spec_with_default_source_root(path: &Path) -> Result<serd
     materialize_rig_spec(path, &default_materialize_source_root(path))
 }
 
+/// Materialize a rig into the shared, versioned resource contract.
+pub fn materialize_rig_resource_with_default_source_root(
+    path: &Path,
+) -> Result<homeboy_rig_contract::MaterializedRigResource> {
+    materialize_rig_resource(path, &default_materialize_source_root(path))
+}
+
+/// Materialize a rig into the shared, versioned resource contract.
+///
+/// The digest is computed over canonical, inheritance-resolved rig JSON so
+/// object key order cannot affect the resource identity.
+pub fn materialize_rig_resource(
+    path: &Path,
+    source_root: &Path,
+) -> Result<homeboy_rig_contract::MaterializedRigResource> {
+    let rig = materialize_rig_spec(path, source_root)?;
+    let rig_id = rig
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "id",
+                "Materialized rig must declare a non-empty id",
+                Some(path.to_string_lossy().to_string()),
+                None,
+            )
+        })?
+        .to_string();
+    let canonical =
+        homeboy_engine_primitives::canonical_json::canonical_json_bytes(&rig).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("canonicalize materialized rig".into()),
+            )
+        })?;
+    let digest = format!("sha256:{:x}", Sha256::digest(canonical));
+
+    Ok(homeboy_rig_contract::MaterializedRigResource {
+        schema: homeboy_rig_contract::MATERIALIZED_RIG_RESOURCE_SCHEMA.to_string(),
+        rig_id,
+        materialized_rig_json_sha256: digest,
+        rig,
+    })
+}
+
 /// Read and normalize a rig spec, resolving its local `extends` chain.
 ///
 /// `source_root` bounds inherited template paths. The result contains neither

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -61,8 +61,10 @@ pub use artifact_index::{RigRunArtifactRef, RigRunFailedStepRef};
 pub(crate) use artifact_index::for_run as artifact_index_for_run;
 
 pub use component_resolution::{component_ref, resolve_component, resolve_component_path};
+pub use homeboy_rig_contract::{MaterializedRigResource, MATERIALIZED_RIG_RESOURCE_SCHEMA};
 pub use install::{
-    default_materialize_source_root, discover_rigs, install, materialize_rig_spec,
+    default_materialize_source_root, discover_rigs, install, materialize_rig_resource,
+    materialize_rig_resource_with_default_source_root, materialize_rig_spec,
     materialize_rig_spec_with_default_source_root, read_source_metadata,
     read_source_metadata_in_root,
 };

--- a/docs/internals/developer-guide/architecture-overview.md
+++ b/docs/internals/developer-guide/architecture-overview.md
@@ -74,6 +74,20 @@ Config entities:
 - **Stacks**: Combined-fixes branch specifications
 - **Extensions**: Domain-specific behaviors and tools
 
+### Rig Boundaries
+
+Rigs compose portable rig specifications and produce resolved plans or
+materialized rig resources. They do not own a parallel run lifecycle.
+
+| Concern | Owner |
+|---|---|
+| Portable rig composition and planning | Rig specification and `homeboy-rig-contract` resources |
+| Local rig materialization, services, and local state | `homeboy-rig` |
+| Durable orchestration and run lifecycle | Control plane |
+| Runner transport and remote execution | Runner API |
+| Extension-defined platform behavior | Extension API |
+| Review, bench, fuzz, and trace workloads | Their respective domain engines |
+
 ### Storage Layer
 
 **Location:** `crates/homeboy-engine-primitives/src/local_files.rs`

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -3,8 +3,9 @@
 use crate::install::local_package_source_root_for_dependencies;
 use crate::{
     declared_id, default_materialize_source_root, discover_rigs, install, list, list_ids, load,
-    load_local_source, materialize_rig_spec, materialize_rig_spec_with_default_source_root,
-    read_source_metadata_in_root, read_stack_source_metadata_in_root, run_check, run_lint,
+    load_local_source, materialize_rig_resource, materialize_rig_spec,
+    materialize_rig_spec_with_default_source_root, read_source_metadata_in_root,
+    read_stack_source_metadata_in_root, run_check, run_lint, MATERIALIZED_RIG_RESOURCE_SCHEMA,
 };
 use homeboy_core::test_support::HomeGuard;
 use homeboy_core::ErrorCode;
@@ -185,6 +186,53 @@ mod materialization {
         assert_eq!(
             materialize_rig_spec_with_default_source_root(&rig).expect("materialize"),
             serde_json::json!({ "id": "example", "settings": { "inherited": true } })
+        );
+    }
+
+    #[test]
+    fn materialized_resource_resolves_inheritance_and_digests_canonical_json() {
+        let package = tempfile::tempdir().expect("package");
+        let template = package.path().join("template.json");
+        let first = package.path().join("first.json");
+        let reordered = package.path().join("reordered.json");
+        let changed = package.path().join("changed.json");
+        fs::write(
+            &template,
+            r#"{ "settings": { "inherited": true, "nested": { "a": 1, "b": 2 } } }"#,
+        )
+        .expect("template");
+        fs::write(
+            &first,
+            r#"{ "extends": "./template.json", "id": "example", "components": { "app": { "path": "./app", "branch": "main" } } }"#,
+        )
+        .expect("first rig");
+        fs::write(
+            &reordered,
+            r#"{ "components": { "app": { "branch": "main", "path": "./app" } }, "id": "example", "extends": "./template.json" }"#,
+        )
+        .expect("reordered rig");
+        fs::write(
+            &changed,
+            r#"{ "extends": "./template.json", "id": "example", "components": { "app": { "path": "./app", "branch": "next" } } }"#,
+        )
+        .expect("changed rig");
+
+        let first = materialize_rig_resource(&first, package.path()).expect("first resource");
+        let reordered =
+            materialize_rig_resource(&reordered, package.path()).expect("reordered resource");
+        let changed = materialize_rig_resource(&changed, package.path()).expect("changed resource");
+
+        assert_eq!(first.schema, MATERIALIZED_RIG_RESOURCE_SCHEMA);
+        assert_eq!(first.rig_id, "example");
+        assert_eq!(first.rig["settings"]["inherited"], true);
+        assert!(first.rig.get("extends").is_none());
+        assert_eq!(
+            first.materialized_rig_json_sha256, reordered.materialized_rig_json_sha256,
+            "object key order must not change the materialized rig digest"
+        );
+        assert_ne!(
+            first.materialized_rig_json_sha256, changed.materialized_rig_json_sha256,
+            "a changed materialized rig must have a different digest"
         );
     }
 


### PR DESCRIPTION
## Summary

- add a behavior-free `homeboy-rig-contract` leaf crate with a versioned materialized-rig resource
- compute a canonical inheritance-resolved JSON digest in the rig implementation layer
- migrate `homeboy rig materialize` while preserving the existing envelope and `payload.rig`
- document ownership boundaries for rig composition, execution, runners, extensions, and domain engines

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-rig-contract`
- `cargo test -p homeboy-rig install::install_test::materialization::materialized_resource_resolves_inheritance_and_digests_canonical_json`
- `cargo test -p homeboy-cli commands::rig`

Advances #14253.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the rig architecture, implemented the contract and consumer migration, added focused coverage, and assisted with review and verification. Chris Huber directed the scope and reviewed the resulting candidate.