### PR TITLE
Collapse agent-tool control-plane dispatch

### DIFF
--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -125,8 +125,7 @@ pub use super::agent_task_scheduler::{
 };
 
 pub use super::agent_tool_control_plane::{
-    dispatch_agent_tool_request, AgentToolControlPlaneDispatcher, AgentToolDispatchEvidence,
-    AgentToolDispatchOutcome, HomeboyAgentToolControlPlaneDispatcher,
+    dispatch_agent_tool_request, AgentToolDispatchEvidence, AgentToolDispatchOutcome,
     AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA,
 };
 

--- a/crates/homeboy-agents/src/agent_tool_control_plane.rs
+++ b/crates/homeboy-agents/src/agent_tool_control_plane.rs
@@ -55,22 +55,6 @@ mod capture {
 mod dispatch {
     use super::*;
 
-    pub trait AgentToolControlPlaneDispatcher {
-        fn dispatch(&self, request: &AgentToolRequest) -> AgentToolResult;
-    }
-
-    #[derive(Debug, Clone, Copy, Default)]
-    pub struct HomeboyAgentToolControlPlaneDispatcher;
-
-    impl AgentToolControlPlaneDispatcher for HomeboyAgentToolControlPlaneDispatcher {
-        fn dispatch(&self, request: &AgentToolRequest) -> AgentToolResult {
-            match dispatch_homeboy_control_plane_tool(request) {
-                Ok(output) => succeeded_tool_result(request, output),
-                Err(diagnostic) => failed_tool_result(request, diagnostic),
-            }
-        }
-    }
-
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
     pub struct AgentToolDispatchOutcome {
         pub location: AgentToolExecutionLocation,
@@ -95,7 +79,19 @@ mod dispatch {
     pub fn dispatch_agent_tool_request(
         policy: &AgentToolPolicy,
         request: &AgentToolRequest,
-        dispatcher: &impl AgentToolControlPlaneDispatcher,
+    ) -> AgentToolDispatchOutcome {
+        dispatch_agent_tool_request_with(policy, request, |request| {
+            match dispatch_homeboy_control_plane_tool(request) {
+                Ok(output) => succeeded_tool_result(request, output),
+                Err(diagnostic) => failed_tool_result(request, diagnostic),
+            }
+        })
+    }
+
+    pub(super) fn dispatch_agent_tool_request_with(
+        policy: &AgentToolPolicy,
+        request: &AgentToolRequest,
+        dispatch_control_plane: impl FnOnce(&AgentToolRequest) -> AgentToolResult,
     ) -> AgentToolDispatchOutcome {
         let location = policy.execution_location_for(&request.tool);
 
@@ -114,7 +110,7 @@ mod dispatch {
             Some(denial) => command_denied_tool_result(request, denial, location),
             None => match location {
                 AgentToolExecutionLocation::Disabled => disabled_tool_result(request),
-                AgentToolExecutionLocation::ControlPlane => dispatcher.dispatch(request),
+                AgentToolExecutionLocation::ControlPlane => dispatch_control_plane(request),
                 AgentToolExecutionLocation::Runner => runner_owned_tool_result(request),
             },
         };
@@ -972,22 +968,24 @@ mod tests {
         assert_eq!(data["stderr_capture"]["truncated"], json!(true));
     }
 
-    #[derive(Debug, Clone, Copy)]
-    struct EchoDispatcher;
-
-    impl AgentToolControlPlaneDispatcher for EchoDispatcher {
-        fn dispatch(&self, request: &AgentToolRequest) -> AgentToolResult {
-            AgentToolResult {
-                schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
-                request_id: request.request_id.clone(),
-                task_id: request.task_id.clone(),
-                tool: request.tool.clone(),
-                status: AgentToolResultStatus::Succeeded,
-                output: json!({ "token": "secret-output", "safe": true }),
-                diagnostics: Vec::new(),
-                metadata: json!({ "authorization": "Bearer result-secret" }),
-            }
+    fn echo_dispatch(request: &AgentToolRequest) -> AgentToolResult {
+        AgentToolResult {
+            schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+            request_id: request.request_id.clone(),
+            task_id: request.task_id.clone(),
+            tool: request.tool.clone(),
+            status: AgentToolResultStatus::Succeeded,
+            output: json!({ "token": "secret-output", "safe": true }),
+            diagnostics: Vec::new(),
+            metadata: json!({ "authorization": "Bearer result-secret" }),
         }
+    }
+
+    fn dispatch_with_echo(
+        policy: &AgentToolPolicy,
+        request: &AgentToolRequest,
+    ) -> AgentToolDispatchOutcome {
+        dispatch::dispatch_agent_tool_request_with(policy, request, echo_dispatch)
     }
 
     fn request(tool: &str) -> AgentToolRequest {
@@ -1040,10 +1038,9 @@ mod tests {
     fn denied_command_is_refused_before_the_dispatcher_runs() {
         let policy = build_denying_policy(&["cargo test", "cargo build"], "builds run in CI here");
 
-        let outcome = dispatch_agent_tool_request(
+        let outcome = dispatch_with_echo(
             &policy,
             &shell_request("timeout 1200 cargo test -q -p homeboy-agents"),
-            &EchoDispatcher,
         );
 
         assert_eq!(outcome.result.status, AgentToolResultStatus::Denied);
@@ -1059,8 +1056,7 @@ mod tests {
     fn denial_tells_the_agent_why_and_what_to_do_instead() {
         let policy = build_denying_policy(&["cargo build"], "this host routes builds to CI");
 
-        let outcome =
-            dispatch_agent_tool_request(&policy, &shell_request("cargo build"), &EchoDispatcher);
+        let outcome = dispatch_with_echo(&policy, &shell_request("cargo build"));
 
         let data = &outcome.result.diagnostics[0].data;
         assert_eq!(data["reason"], "this host routes builds to CI");
@@ -1079,8 +1075,7 @@ mod tests {
     fn command_denial_is_recorded_in_dispatch_evidence() {
         let policy = build_denying_policy(&["cargo test"], "shared host");
 
-        let outcome =
-            dispatch_agent_tool_request(&policy, &shell_request("cargo test"), &EchoDispatcher);
+        let outcome = dispatch_with_echo(&policy, &shell_request("cargo test"));
 
         let evidence = outcome.evidence;
         assert_eq!(evidence.result.status, AgentToolResultStatus::Denied);
@@ -1093,8 +1088,7 @@ mod tests {
     fn permitted_command_still_reaches_the_dispatcher() {
         let policy = build_denying_policy(&["cargo test"], "shared host");
 
-        let outcome =
-            dispatch_agent_tool_request(&policy, &shell_request("cargo fmt"), &EchoDispatcher);
+        let outcome = dispatch_with_echo(&policy, &shell_request("cargo fmt"));
 
         assert_eq!(outcome.result.status, AgentToolResultStatus::Succeeded);
         assert!(outcome.evidence.command_denial.is_none());
@@ -1105,8 +1099,7 @@ mod tests {
         let mut policy = build_denying_policy(&["cargo build"], "shared host");
         policy.default_location = AgentToolExecutionLocation::Runner;
 
-        let outcome =
-            dispatch_agent_tool_request(&policy, &shell_request("cargo build"), &EchoDispatcher);
+        let outcome = dispatch_with_echo(&policy, &shell_request("cargo build"));
 
         assert_eq!(outcome.location, AgentToolExecutionLocation::Runner);
         assert_eq!(outcome.result.status, AgentToolResultStatus::Denied);
@@ -1141,7 +1134,7 @@ mod tests {
     fn requests_without_a_command_payload_are_unaffected_by_the_command_policy() {
         let policy = build_denying_policy(&["cargo *"], "shared host");
 
-        let outcome = dispatch_agent_tool_request(&policy, &request("lookup"), &EchoDispatcher);
+        let outcome = dispatch_with_echo(&policy, &request("lookup"));
 
         assert_eq!(outcome.result.status, AgentToolResultStatus::Succeeded);
     }
@@ -1158,7 +1151,7 @@ mod tests {
             },
         );
 
-        let outcome = dispatch_agent_tool_request(&policy, &request("lookup"), &EchoDispatcher);
+        let outcome = dispatch_with_echo(&policy, &request("lookup"));
 
         assert_eq!(outcome.location, AgentToolExecutionLocation::ControlPlane);
         assert_eq!(outcome.result.status, AgentToolResultStatus::Succeeded);
@@ -1166,11 +1159,7 @@ mod tests {
 
     #[test]
     fn tool_policy_is_disabled_by_default() {
-        let outcome = dispatch_agent_tool_request(
-            &AgentToolPolicy::default(),
-            &request("lookup"),
-            &EchoDispatcher,
-        );
+        let outcome = dispatch_with_echo(&AgentToolPolicy::default(), &request("lookup"));
 
         assert_eq!(outcome.location, AgentToolExecutionLocation::Disabled);
         assert_eq!(outcome.result.status, AgentToolResultStatus::Denied);
@@ -1179,10 +1168,9 @@ mod tests {
 
     #[test]
     fn tool_dispatch_evidence_redacts_request_and_result() {
-        let outcome = dispatch_agent_tool_request(
+        let outcome = dispatch_with_echo(
             &policy(AgentToolExecutionLocation::ControlPlane),
             &request("lookup"),
-            &EchoDispatcher,
         );
 
         assert_eq!(outcome.evidence.schema, AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA);

--- a/crates/homeboy-cli/src/commands/agent_task/tool.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tool.rs
@@ -3,7 +3,6 @@ use std::io::Read;
 use clap::{Args, Subcommand};
 use homeboy::agents::agent_tasks::{
     dispatch_agent_tool_request, AgentToolPolicy, AgentToolRequest,
-    HomeboyAgentToolControlPlaneDispatcher,
 };
 use serde_json::Value;
 
@@ -47,8 +46,7 @@ fn dispatch_raw_result() -> Result<String, String> {
     let request: AgentToolRequest = serde_json::from_str(&stdin)
         .map_err(|error| format!("invalid agent tool request JSON: {error}"))?;
     let policy = policy_from_env()?;
-    let outcome =
-        dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher); // homeboy-audit: allow-thin-command-adapter
+    let outcome = dispatch_agent_tool_request(&policy, &request); // homeboy-audit: allow-thin-command-adapter
 
     serde_json::to_string(&outcome.result)
         .map_err(|error| format!("failed to serialize agent tool result JSON: {error}"))
@@ -96,8 +94,7 @@ mod tests {
         let request: AgentToolRequest =
             serde_json::from_value(request_json("create_github_issue")).expect("request");
 
-        let outcome =
-            dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher);
+        let outcome = dispatch_agent_tool_request(&policy, &request);
 
         assert_eq!(outcome.result.status, AgentToolResultStatus::Denied);
         assert_eq!(outcome.result.diagnostics[0].class, "agent_tool.disabled");
@@ -113,8 +110,7 @@ mod tests {
         let request: AgentToolRequest =
             serde_json::from_value(request_json("create_github_issue")).expect("request");
 
-        let outcome =
-            dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher);
+        let outcome = dispatch_agent_tool_request(&policy, &request);
 
         assert_eq!(outcome.result.status, AgentToolResultStatus::Failed);
         assert_eq!(outcome.result.diagnostics[0].class, "agent_tool.validation");


### PR DESCRIPTION
## Summary

- remove `AgentToolControlPlaneDispatcher` and its sole `HomeboyAgentToolControlPlaneDispatcher` implementation
- route `dispatch_agent_tool_request(policy, request)` directly to Homeboy native control-plane dispatch
- keep policy short-circuit and redaction coverage through a module-private closure seam
- remove dispatcher construction and facade exports from the CLI path

Final production call graph: CLI -> `dispatch_agent_tool_request` -> `dispatch_homeboy_control_plane_tool`. The change removes two public runtime concepts and 17 net lines without removing any control-plane tools, policy outcomes, diagnostics, or evidence.

Closes #14262

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents agent_tool_control_plane --lib` (13 passed)
- `cargo test -p homeboy-cli commands::agent_task::tool --lib` (3 passed)
- `cargo clippy -p homeboy-agents -p homeboy-cli --all-targets` (completed with existing warnings)

Broad package tests were also exercised concurrently as a diagnostic. The changed tests passed, while shared repository state produced 17 unrelated `homeboy-agents` failures after 2,247 passes and 24 unrelated CLI failures after 636 passes. Focused tests were rerun sequentially after rebasing onto current `main` and passed.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the production and test call graph, implemented the API collapse, ran focused and broad verification, reviewed the resulting diff, and prepared this pull request under Chris Huber's direction.