### PR TITLE
fix(ssh): signal output drain before decoding

### DIFF
--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -91,8 +91,8 @@ fn collect_ssh_child_output(
     pid: u32,
     status: Option<std::io::Result<std::process::ExitStatus>>,
     stdin_failed: bool,
-    stdout: Option<Receiver<String>>,
-    stderr: Option<Receiver<String>>,
+    stdout: Option<Receiver<Vec<u8>>>,
+    stderr: Option<Receiver<Vec<u8>>>,
 ) -> CommandOutput {
     let wait_failed = status.as_ref().is_some_and(|status| status.is_err());
     let deadline = Instant::now() + PROCESS_CLEANUP_ALLOWANCE;
@@ -702,21 +702,24 @@ pub(super) fn run_command_with_stdin_source(
     collect_ssh_child_output(&mut child, pid, Some(status), stdin_failed, stdout, stderr)
 }
 
-fn read_stream(mut pipe: impl Read + Send + 'static) -> Receiver<String> {
+pub(super) fn read_stream(mut pipe: impl Read + Send + 'static) -> Receiver<Vec<u8>> {
     let (sender, receiver) = std::sync::mpsc::channel();
     thread::spawn(move || {
         let mut bytes = Vec::new();
         let _ = pipe.read_to_end(&mut bytes);
-        let _ = sender.send(String::from_utf8_lossy(&bytes).to_string());
+        // Signal EOF before decoding potentially large output. Snapshot metadata
+        // can be hundreds of megabytes, and UTF-8 conversion must not consume the
+        // process cleanup allowance after the SSH child has already succeeded.
+        let _ = sender.send(bytes);
     });
     receiver
 }
 
-fn collect_stream_before(receiver: Option<Receiver<String>>, deadline: Instant) -> (String, bool) {
+fn collect_stream_before(receiver: Option<Receiver<Vec<u8>>>, deadline: Instant) -> (String, bool) {
     match receiver {
         Some(receiver) => {
             match receiver.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
-                Ok(output) => (output, false),
+                Ok(output) => (String::from_utf8_lossy(&output).into_owned(), false),
                 Err(RecvTimeoutError::Timeout) => (String::new(), true),
                 Err(RecvTimeoutError::Disconnected) => (String::new(), false),
             }
@@ -726,8 +729,8 @@ fn collect_stream_before(receiver: Option<Receiver<String>>, deadline: Instant) 
 }
 
 fn collect_streams_before(
-    stdout: Option<Receiver<String>>,
-    stderr: Option<Receiver<String>>,
+    stdout: Option<Receiver<Vec<u8>>>,
+    stderr: Option<Receiver<Vec<u8>>>,
     deadline: Instant,
 ) -> (String, String, bool) {
     let (stdout, stdout_stalled) = collect_stream_before(stdout, deadline);

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -15,7 +15,7 @@ use super::local_exec::{
 };
 use super::ssh_client::{
     build_secret_env_stdin_block, execute_command_with_stdin_source_timeout,
-    execute_command_with_stdin_timeout, execute_command_with_writer_factory,
+    execute_command_with_stdin_timeout, execute_command_with_writer_factory, read_stream,
     run_command_with_stdin_source, run_ssh_with_child, wrap_command_with_secret_env_read_loop,
     wrap_owned_remote_command, SECRET_ENV_STDIN_SENTINEL,
 };
@@ -965,6 +965,18 @@ fn ssh_equivalent_untimed_piped_execution_reaps_remote_pipe_holder() {
         "piped SSH child leaked its descendant"
     );
     let _ = std::fs::remove_file(marker);
+}
+
+#[test]
+fn ssh_stream_reader_signals_eof_with_raw_large_output() {
+    let output = vec![0xff; 16 * 1024 * 1024];
+    let receiver = read_stream(Cursor::new(output.clone()));
+
+    let received = receiver
+        .recv_timeout(Duration::from_millis(250))
+        .expect("large stream bytes must arrive within the cleanup allowance");
+
+    assert_eq!(received, output);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- deliver raw SSH stdout/stderr bytes to the collector before UTF-8 decoding
- keep the existing 250 ms process and stuck-stream cleanup deadline unchanged
- cover a 16 MiB stream completing within that bounded handoff

## Root cause

The reader thread decoded and copied the complete output before signaling EOF. Large finite workspace snapshot metadata could therefore finish remotely but miss Homeboy's 250 ms cleanup deadline during local UTF-8 conversion, converting success into `StreamDrainTimedOut`.

Closes #14268.

## Verification
- `cargo test -p homeboy-core ssh_stream_reader_signals_eof_with_raw_large_output -- --nocapture`
- `cargo test -p homeboy-core ssh_equivalent_untimed_execution_reaps_remote_pipe_holder -- --nocapture`
- `cargo test -p homeboy-core timed_ssh_child_with_stuck_streams_fails_within_its_cleanup_bound -- --nocapture`
- `cargo test -p homeboy-lab-runner ssh_snapshot_listing_preserves_entries_and_isolates_invalid_metadata -- --nocapture`
- `cargo check -p homeboy-core -p homeboy-lab-runner`
- `cargo fmt --all --check`
- real `wpcom-codebox` Lab sync passed as persisted run `homeboy-14268-wpcom-codebox-sync`

## AI assistance disclosure

OpenAI GPT-5.6 Sol via OpenCode reproduced the large-output failure, traced the SSH reader lifecycle, implemented the raw-byte handoff, ran focused and real Lab verification, and prepared this pull request.