### PR TITLE
fix(agent-task): unblock upgrades for runner-skewed Cooks

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -536,6 +536,10 @@ pub(crate) fn controller_upgrade_admission_for_records(
         // Durable terminal state is authoritative even when stale ownership
         // metadata remains from the process that produced it.
         .filter(|record| !record.state.is_terminal())
+        // A Cook that has not materialized any task and is blocked only by a
+        // stale runner needs this controller replacement to converge runtime.
+        // It owns no executable work, so it cannot safely block that upgrade.
+        .filter(|record| !is_unmaterialized_runtime_convergence_blocker(record))
         .filter_map(|record| {
             let liveness = liveness_for_record(record, now);
             let runner_unverified = record.runner_job_id().is_some()
@@ -658,6 +662,12 @@ pub(crate) fn controller_upgrade_admission_for_records(
         record_health: serde_json::to_value(record_health).unwrap_or(serde_json::Value::Null),
         blockers,
     }
+}
+
+fn is_unmaterialized_runtime_convergence_blocker(record: &AgentTaskRunRecord) -> bool {
+    record.tasks.is_empty()
+        && agent_task_lifecycle::is_unmaterialized_cook_admission(record)
+        && record.metadata["unmaterialized_cook_admission"]["state"] == "blocked_runner_stale"
 }
 
 struct AgentTaskControllerUpgradeAdmissionProvider;

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -2064,6 +2064,59 @@ fn upgrade_admission_dedupes_linked_parent_and_attempt_recovery_commands() {
 }
 
 #[test]
+fn upgrade_admission_allows_unmaterialized_cook_blocked_on_runner_convergence() {
+    with_isolated_home(|_| {
+        let stale_cook_id = "cook-blocked-on-runner-convergence";
+        let unavailable_cook_id = "cook-blocked-on-runner-unavailable";
+        for (cook_id, state) in [
+            (stale_cook_id, "blocked_runner_stale"),
+            (unavailable_cook_id, "blocked_runner_unavailable"),
+        ] {
+            agent_task_lifecycle::record_unmaterialized_cook_admission_in_store(
+                &test_lifecycle_store(),
+                cook_id,
+                serde_json::json!({ "placement": { "local_fallback": false } }),
+                state,
+                "waiting for Lab runner admission",
+            )
+            .expect("unmaterialized Cook admission");
+        }
+
+        let stale = agent_task_lifecycle::exact_record(stale_cook_id).expect("stale Cook");
+        assert_eq!(stale.state, AgentTaskRunState::Queued);
+        assert!(stale.tasks.is_empty());
+        assert_eq!(
+            stale.metadata["unmaterialized_cook_admission"]["state"],
+            "blocked_runner_stale"
+        );
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admission =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+
+        assert!(
+            !admission.allows_controller_replacement(),
+            "the unrelated unavailable runner remains fail-closed: {admission:?}"
+        );
+        assert_eq!(admission.blockers.len(), 1);
+        assert_eq!(admission.blockers[0].run_id, unavailable_cook_id);
+        assert!(
+            !admission
+                .blockers
+                .iter()
+                .any(|blocker| blocker.run_id == stale_cook_id),
+            "the zero-task runner-skew admission must not deadlock its controller upgrade"
+        );
+        assert_eq!(
+            agent_task_lifecycle::exact_record(stale_cook_id)
+                .expect("unchanged stale Cook")
+                .state,
+            AgentTaskRunState::Queued
+        );
+    });
+}
+
+#[test]
 fn upgrade_admission_inspects_an_ambiguous_removed_runner_record_locally() {
     with_isolated_home(|_| {
         let cook_id = "concurrent-first-cook-run";


### PR DESCRIPTION
## Summary
- admit zero-task unmaterialized Cooks blocked on stale runner runtime convergence during controller upgrade admission
- retain fail-closed admission for unavailable runners and materialized work
- add a deterministic regression test for the circular upgrade admission case

Fixes #14274

## Validation
- `cargo fmt --check`
- `cargo nextest run --profile quick -p homeboy-agents --lib upgrade_admission_allows_unmaterialized_cook_blocked_on_runner_convergence`
- `cargo check --release`
- `cargo nextest run --profile quick -p homeboy-agents --lib` *(fails in existing unrelated `agent_task_controller_service::tests::resume_tests::resume_recovers_running_action_with_stale_child_run`: stale-child metadata is `null` rather than `true`; reproduced in isolation)*

## AI Assistance
OpenCode using OpenAI `openai/gpt-5.6-terra` inspected the issue and code, implemented the fix, and added the regression test.