### PR TITLE
fix(runner): project refresh typed failures

### DIFF
--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -605,6 +605,9 @@ fn bounded_refresh_error_projection(
             "error": {
                 "code": error.code.as_str(),
                 "message": bounded_refresh_text(&error.message),
+                "details": {
+                    "_homeboy_actions": bounded_refresh_error_actions(error),
+                },
             },
             "artifacts": error.details.get("artifacts").cloned().unwrap_or_else(|| serde_json::json!({
                 "output": output_file,
@@ -614,6 +617,32 @@ fn bounded_refresh_error_projection(
         }),
         exit_code,
     )
+}
+
+/// Keep executable recovery actions in the bounded envelope without admitting
+/// arbitrary error detail or action evidence beyond the stdout budget.
+fn bounded_refresh_error_actions(error: &homeboy::core::Error) -> Vec<Value> {
+    error
+        .details
+        .get(homeboy::core::error::ACTIONS_DETAILS_KEY)
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .take(4)
+        .filter_map(|action| {
+            let action = action.as_object()?;
+            Some(serde_json::json!({
+                "id": action.get("id")?.as_str().map(bounded_refresh_text),
+                "label": action.get("label")?.as_str().map(bounded_refresh_text),
+                "program": action.get("program")?.as_str().map(bounded_refresh_text),
+                "args": action.get("args").and_then(Value::as_array).into_iter().flatten()
+                    .filter_map(Value::as_str).take(16).map(bounded_refresh_text).collect::<Vec<_>>(),
+                "safety": action.get("safety")?.as_str().map(bounded_refresh_text),
+                "required_confirmations": action.get("required_confirmations").and_then(Value::as_array).into_iter().flatten()
+                    .filter_map(Value::as_str).take(4).map(bounded_refresh_text).collect::<Vec<_>>(),
+            }))
+        })
+        .collect()
 }
 
 /// Enforce the budget after command-envelope rendering, because lifted action
@@ -1408,6 +1437,13 @@ mod tests {
             "run_id": "run-1",
             "error_log": "homeboy://run/run-1/artifact/error-log-run-1",
         });
+        error.details["_homeboy_actions"] = serde_json::json!([{
+            "id": "inspect-runner-status",
+            "label": "inspect runner admission",
+            "program": "homeboy",
+            "args": ["runner", "status", "homeboy-lab"],
+            "safety": "read_only"
+        }]);
 
         let projection = bounded_refresh_error_projection(&error, 2, None);
         assert!(
@@ -1415,6 +1451,10 @@ mod tests {
                 <= MAX_REFRESH_PROJECTION_BYTES
         );
         assert_eq!(projection["artifacts"]["run_id"], "run-1");
+        assert_eq!(
+            projection["error"]["details"]["_homeboy_actions"][0]["program"],
+            "homeboy"
+        );
         assert!(!serde_json::to_string(&projection)
             .unwrap()
             .contains(&"x".repeat(512)));

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -757,6 +757,9 @@ fn failure_diagnostics_for_data(
     if let Some(failure) = declared_failure(data) {
         return Some(declared_failure_diagnostics(exit_code, failure, "/failure"));
     }
+    if let Some(failure) = bounded_refresh_typed_error(data) {
+        return Some(declared_failure_diagnostics(exit_code, failure, "/error"));
+    }
     if let Some(failure) = unresolved_provider_workspace_failure(data) {
         return Some(declared_failure_diagnostics(
             exit_code,
@@ -924,7 +927,21 @@ struct DeclaredFailure {
 /// causal subprocess failures here; unrelated nested historical records are
 /// data and must not be attributed to this command invocation.
 fn declared_failure(data: &Value) -> Option<DeclaredFailure> {
-    let object = data.get("failure")?.as_object()?;
+    declared_failure_object(data.get("failure")?.as_object()?)
+}
+
+/// The bounded refresh projection keeps a typed command error under `error`.
+/// Lift it only from that schema so arbitrary nested error records remain data.
+fn bounded_refresh_typed_error(data: &Value) -> Option<DeclaredFailure> {
+    if data.get("schema").and_then(Value::as_str)
+        != Some("homeboy/runner-refresh-homeboy-bounded-output/v1")
+    {
+        return None;
+    }
+    declared_failure_object(data.get("error")?.as_object()?)
+}
+
+fn declared_failure_object(object: &Map<String, Value>) -> Option<DeclaredFailure> {
     let message = ["message", "problem", "summary"]
         .into_iter()
         .find_map(|key| object.get(key).and_then(Value::as_str))
@@ -978,10 +995,18 @@ fn declared_failure(data: &Value) -> Option<DeclaredFailure> {
             .and_then(Value::as_array)
             .into_iter()
             .flatten()
-            .take(4)
             .filter_map(|action| serde_json::from_value(action.clone()).ok())
-            .collect::<Vec<_>>()
-            .into_iter()
+            .chain(
+                details
+                    .get(ACTIONS_DETAILS_KEY)
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|action| {
+                        serde_json::from_value::<ExecutableAction>(action.clone()).ok()
+                    })
+                    .map(CommandNextAction::from_action),
+            )
             .chain(failure_replay_action(&details))
             .take(4)
             .collect(),
@@ -2617,6 +2642,69 @@ mod tests {
             .as_str()
             .expect("summary")
             .contains("earlier attempt"));
+    }
+
+    #[test]
+    fn bounded_refresh_typed_errors_are_promoted_for_nonzero_exits() {
+        for (exit_code, code, message) in [
+            (
+                1,
+                "runner.policy_denied",
+                "runner rotation is blocked by the current admission policy",
+            ),
+            (
+                2,
+                "validation.invalid_argument",
+                "Invalid argument reconnect: runner cannot bootstrap over diagnostic SSH until its authoritative admission snapshot permits daemon rotation",
+            ),
+        ] {
+            let payload = json!({
+                "schema": "homeboy/runner-refresh-homeboy-bounded-output/v1",
+                "command": "runner.refresh_homeboy",
+                "exit_code": exit_code,
+                "error": {
+                    "code": code,
+                    "message": message,
+                    "details": {
+                        "argument": "reconnect",
+                        "_homeboy_actions": [{
+                            "id": "inspect-runner-status",
+                            "label": "inspect runner admission",
+                            "program": "homeboy",
+                            "args": ["runner", "status", "homeboy-lab"],
+                            "safety": "read_only"
+                        }]
+                    }
+                },
+                "artifacts": { "run_id": "refresh-run" },
+            });
+            let response = cli_response_for_json_result_for_identity(
+                &Ok(payload.clone()),
+                exit_code,
+                &CommandIdentity::with_operation("runner", "refresh-homeboy"),
+                None,
+            );
+            let value = serde_json::to_value(response).expect("serialize response");
+
+            assert_eq!(value["diagnostics"]["code"], code, "exit {exit_code}");
+            assert_eq!(value["summary"], message, "exit {exit_code}");
+            assert_eq!(
+                value["diagnostics"]["failure_digest"]["summary"],
+                message,
+                "exit {exit_code}"
+            );
+            assert_eq!(
+                value["diagnostics"]["details"]["source_pointer"],
+                "/error",
+                "exit {exit_code}"
+            );
+            assert_eq!(
+                value["next_actions"][0]["command"],
+                "homeboy runner status homeboy-lab",
+                "exit {exit_code}"
+            );
+            assert_eq!(value["data"], payload, "exit {exit_code} keeps all evidence");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- promote typed `data.error` from bounded `refresh-homeboy` failures into top-level diagnostics, summary, and failure digest
- preserve bounded executable recovery actions while retaining the lossless result in `--output`
- cover typed nested failures deterministically for exits 1 and 2

Closes #14276

## Tests
- `cargo test -p homeboy-cli --lib bounded_refresh_typed_errors_are_promoted_for_nonzero_exits`
- `cargo test -p homeboy-cli --lib refresh_homeboy_error_projection_is_bounded_and_keeps_durable_artifacts`
- `cargo fmt --check`
- `cargo check -p homeboy-cli`

## AI Assistance
OpenCode with `openai/gpt-5.6-terra` implemented this change with human-directed requirements and review.