### PR TITLE
fix(agent-task): pin Cook preview base

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -8370,10 +8370,17 @@ fn provision_pending_cook_workspace(
             )])
         })
     };
+    // The CLI may have already observed an authoritative immutable base before
+    // this deferred native creation. Creating from that object preserves the
+    // preview contract even when the branch advances before admission.
+    let create_base = match options.workspace.task_base_sha.clone() {
+        Some(base_sha) => base_sha,
+        None => required("base")?.to_string(),
+    };
     let create_intent = homeboy_core::worktree_provider::WorktreeProvisionIntent {
         handle: options.workspace.to_worktree.clone(),
         repo: required("repo")?.to_string(),
-        base: required("base")?.to_string(),
+        base: create_base,
         head: required("head")?.to_string(),
         task_url: Some(required("task_url")?.to_string()),
     };

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -40,6 +40,8 @@ use homeboy_core::{Error, Result};
 use homeboy_engine_primitives::shell::quote_arg;
 
 use super::cook_activity::{CookActivityProbe, CookProviderActivity};
+
+const COOK_BASE_OBJECT_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(test)]
 use super::cook_baseline::materialize_follow_up_baseline;
 use super::cook_baseline::{
@@ -5332,6 +5334,12 @@ fn run_cook_spine(
             Value::String(options.identity.initial_run_id.clone());
         error
     })?;
+    if let (Some(workspace), Some(base_sha)) = (
+        options.workspace.source_worktree_path.as_deref(),
+        options.workspace.task_base_sha.as_deref(),
+    ) {
+        materialize_cook_base_object(workspace, base_sha)?;
+    }
     // Reject a known-invalid managed workspace before base capture reaches its
     // remote. Detached first handoffs have no local source path and remain
     // eligible for runner-owned materialization below.
@@ -7819,18 +7827,13 @@ fn preflight_cook_workspace_base_ancestry_with_provider(
     options: &CookRequest,
     adopted_dirty_candidate: bool,
 ) -> Result<Option<CookWorkspaceBaseValidation>> {
-    // Explicit CWDs are caller-owned and must remain untouched. Resolve their
-    // declared ref into an isolated scheduler snapshot instead of treating the
-    // persisted pin as authority to converge the caller's checkout.
-    let base = if cook_uses_explicit_cwd_workspace(options) {
-        &options.finalization.base
-    } else {
-        options
-            .workspace
-            .task_base_sha
-            .as_deref()
-            .unwrap_or(&options.finalization.base)
-    };
+    // Explicit CWDs remain caller-owned and are never converged, but their
+    // ancestry must still use the immutable base admitted for this Cook.
+    let base = options
+        .workspace
+        .task_base_sha
+        .as_deref()
+        .unwrap_or(&options.finalization.base);
     let ignored_evidence = explicit_cook_evidence_paths(options, target);
     match preflight_cook_workspace_base_ancestry(
         target,
@@ -7839,6 +7842,23 @@ fn preflight_cook_workspace_base_ancestry_with_provider(
         adopted_dirty_candidate,
     ) {
         Ok(snapshot) => Ok(snapshot.map(CookWorkspaceBaseValidation::Snapshot)),
+        Err(error)
+            if error.details["workspace_base_ancestry"]["direction"] == "behind"
+                && cook_uses_explicit_cwd_workspace(options) =>
+        {
+            let ancestry = &error.details["workspace_base_ancestry"];
+            Ok(Some(CookWorkspaceBaseValidation::Snapshot(
+                serde_json::json!({
+                    "schema": "homeboy/cook-workspace-base-snapshot/v1",
+                    "base": ancestry["base"],
+                    "resolved_base": ancestry["resolved_base"],
+                    "destination_head": ancestry["destination_head"],
+                    "base_only_commits": ancestry["base_only_commits"],
+                    "candidate_only_commits": ancestry["candidate_only_commits"],
+                    "mode": "isolated_attempt_snapshot",
+                }),
+            )))
+        }
         Err(error)
             if error.details["workspace_base_ancestry"]["direction"] == "behind"
                 && options.workspace.task_base_sha.is_some() =>
@@ -7906,9 +7926,7 @@ fn preflight_cook_workspace_base_ancestry(
     if !origin.status.success() {
         return Ok(None);
     }
-    let (declared_base, resolved_base) = if base.len() == 40
-        && base.bytes().all(|byte| byte.is_ascii_hexdigit())
-    {
+    let (declared_base, resolved_base) = if homeboy_core::git::is_full_object_id(base) {
         (
             base.to_string(),
             homeboy_core::git::run_git(
@@ -7989,7 +8007,7 @@ fn preflight_cook_workspace_base_ancestry(
         // A recipe-pinned base is controller authority to converge the managed
         // provider checkout. An unpinned declared ref instead authorizes an
         // isolated scheduler snapshot without mutating that checkout.
-        if base.len() == 40 && base.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        if homeboy_core::git::is_full_object_id(base) {
             let direction = "behind";
             let mut error = Error::validation_invalid_argument(
                 "base",
@@ -8357,6 +8375,49 @@ fn bind_materialized_cook_component_workspace(
 
 /// A deferred native lookup can prove absence only after Cook owns a durable
 /// identity. It then creates and records the native worktree lifecycle.
+fn materialize_cook_base_object(workspace: &Path, base_sha: &str) -> Result<()> {
+    if !homeboy_core::git::is_full_object_id(base_sha) {
+        return Err(Error::validation_invalid_argument(
+            "base-sha",
+            "Cook base pin must be a complete Git object ID",
+            Some(base_sha.to_string()),
+            None,
+        ));
+    }
+    if homeboy_core::git::output_optional_within(
+        workspace,
+        &["rev-parse", "--verify", &format!("{base_sha}^{{commit}}")],
+        COOK_BASE_OBJECT_FETCH_TIMEOUT,
+    )
+    .resolved()
+    .is_some()
+    {
+        return Ok(());
+    }
+    let remote = homeboy_core::git::resolve_default_remote(workspace);
+    homeboy_core::git::run_git_with_env_timeout(
+        workspace,
+        &[
+            "fetch",
+            "--no-tags",
+            "--no-write-fetch-head",
+            &remote,
+            base_sha,
+        ],
+        "materialize pinned Cook base",
+        &[],
+        COOK_BASE_OBJECT_FETCH_TIMEOUT,
+    )?;
+    homeboy_core::git::run_git_with_env_timeout(
+        workspace,
+        &["rev-parse", "--verify", &format!("{base_sha}^{{commit}}")],
+        "verify pinned Cook base",
+        &[],
+        COOK_BASE_OBJECT_FETCH_TIMEOUT,
+    )?;
+    Ok(())
+}
+
 fn provision_pending_cook_workspace(
     lifecycle_store: &AgentTaskLifecycleStore,
     options: &mut CookRequest,
@@ -8435,6 +8496,9 @@ fn provision_pending_cook_workspace(
         &options.identity.initial_run_id,
         &options.identity.initial_plan,
     )?;
+    if homeboy_core::git::is_full_object_id(&create_intent.base) {
+        materialize_cook_base_object(Path::new(&create_intent.repo), &create_intent.base)?;
+    }
     homeboy_core::worktree_provider::ensure_worktree_provision(
         &create_intent,
         &homeboy_core::worktree_provider::WorktreeProvisionLifecycle {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -8034,8 +8034,7 @@ fn preflight_cook_workspace_base_ancestry(
         ),
         Some(target.display().to_string()),
         Some(vec![format!(
-            "Update the destination with `{}` and rerun Cook; provider execution has not started.",
-            format!("git merge --ff-only {resolved_base}")
+            "Merge `{resolved_base}` into the destination or rebase its commits onto it, resolve any conflicts, and rerun Cook; provider execution has not started."
         )]),
     );
     error.details["workspace_base_ancestry"] = serde_json::json!({

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5068,6 +5068,18 @@ fn workspace_base_ancestry_preflight_converges_clean_behind_destination_at_pinne
             diverged.details["workspace_base_ancestry"]["candidate_only_commits"],
             1
         );
+        let guidance = diverged.details["tried"]
+            .as_array()
+            .expect("structured diverged recovery guidance")
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(!guidance.contains("--ff-only"), "{guidance}");
+        assert!(
+            guidance.contains("Merge") && guidance.contains("rebase"),
+            "{guidance}"
+        );
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -7276,17 +7276,6 @@ fn pending_cook_ensures_native_destination_after_durable_admission_idempotently(
             .status()
             .expect("push base")
             .success());
-        let previewed_base = String::from_utf8(
-            Command::new("git")
-                .args(["rev-parse", "HEAD"])
-                .current_dir(&source)
-                .output()
-                .expect("resolve previewed base")
-                .stdout,
-        )
-        .expect("previewed base SHA is UTF-8")
-        .trim()
-        .to_string();
         let upstream = tempfile::tempdir().expect("upstream checkout");
         assert!(Command::new("git")
             .args([
@@ -7342,6 +7331,17 @@ fn pending_cook_ensures_native_destination_after_durable_admission_idempotently(
         .expect("moving base SHA is UTF-8")
         .trim()
         .to_string();
+        assert_ne!(
+            Command::new("git")
+                .args(["rev-parse", "origin/main"])
+                .current_dir(&source)
+                .output()
+                .expect("resolve stale source tracking ref")
+                .stdout,
+            format!("{moving_base}\n").as_bytes(),
+            "the source lacks the previewed remote object before durable materialization"
+        );
+        let previewed_base = moving_base.clone();
         let cook_id = "native-provision";
         let run_id = "native-provision-run";
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
@@ -7404,10 +7404,6 @@ fn pending_cook_ensures_native_destination_after_durable_admission_idempotently(
         .expect("native destination SHA is UTF-8")
         .trim()
         .to_string();
-        assert_ne!(
-            destination_head, moving_base,
-            "remote advanced after preview"
-        );
         assert_eq!(destination_head, previewed_base);
 
         let record = homeboy_core::worktree::resolve_if_present(&options.workspace.to_worktree)

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -7276,6 +7276,17 @@ fn pending_cook_ensures_native_destination_after_durable_admission_idempotently(
             .status()
             .expect("push base")
             .success());
+        let previewed_base = String::from_utf8(
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(&source)
+                .output()
+                .expect("resolve previewed base")
+                .stdout,
+        )
+        .expect("previewed base SHA is UTF-8")
+        .trim()
+        .to_string();
         let upstream = tempfile::tempdir().expect("upstream checkout");
         assert!(Command::new("git")
             .args([
@@ -7336,6 +7347,7 @@ fn pending_cook_ensures_native_destination_after_durable_admission_idempotently(
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
         options.identity.initial_run_id = run_id.to_string();
         options.workspace.to_worktree = "fixture@native-provision".to_string();
+        options.workspace.task_base_sha = Some(previewed_base.clone());
         options.identity.initial_plan.metadata["cook_provision"] = serde_json::json!({
             "action": "lookup_pending",
             "kind": "provider",
@@ -7367,7 +7379,7 @@ fn pending_cook_ensures_native_destination_after_durable_admission_idempotently(
             .expect("ensure native Cook destination");
         assert_eq!(
             options.workspace.task_base_sha.as_deref(),
-            Some(moving_base.as_str())
+            Some(previewed_base.as_str())
         );
         let first_path = options
             .workspace
@@ -7392,7 +7404,11 @@ fn pending_cook_ensures_native_destination_after_durable_admission_idempotently(
         .expect("native destination SHA is UTF-8")
         .trim()
         .to_string();
-        assert_eq!(destination_head, moving_base);
+        assert_ne!(
+            destination_head, moving_base,
+            "remote advanced after preview"
+        );
+        assert_eq!(destination_head, previewed_base);
 
         let record = homeboy_core::worktree::resolve_if_present(&options.workspace.to_worktree)
             .expect("native lookup")

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -1175,6 +1175,10 @@ pub struct AgentTaskCookArgs {
     /// compatibility default when the provider has not materialized a checkout.
     #[arg(long, value_name = "BRANCH")]
     pub base: Option<String>,
+    /// Immutable remote base observed by a Cook preview. This is emitted only
+    /// in replay argv so execution can reject a changed base contract.
+    #[arg(long = "base-sha", value_name = "SHA", hide = true)]
+    pub base_sha: Option<String>,
     /// Head branch to push and open the PR from. Defaults to the branch the
     /// destination worktree is already on.
     #[arg(long, value_name = "BRANCH")]

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -475,6 +475,7 @@ fn cook_preview_resolved_request(args: &AgentTaskCookArgs, placement: Value) -> 
         "repository_identity": args.repository_identity,
         "worktree": args.to_worktree,
         "base": args.base,
+        "base_resolution": args.base_resolution,
         "head": args.head,
         "placement": placement,
         "workspace": null,
@@ -696,6 +697,7 @@ fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> PreviewReplayArgv {
             .collect::<Vec<_>>();
         rewrite_cook_identity_replay_argv(&mut replay, args);
         append_preview_lifecycle_replay_argv(&mut replay, args);
+        append_preview_base_replay_argv(&mut replay, args);
         return finalize_cook_preview_replay(replay, args);
     }
 
@@ -766,6 +768,9 @@ pub(crate) fn cook_replay_argv(args: &AgentTaskCookArgs) -> Vec<String> {
     }
     if let Some(base) = &args.base {
         argv.extend(["--base".to_string(), base.clone()]);
+    }
+    if let Some(base_sha) = &args.base_sha {
+        argv.extend(["--base-sha".to_string(), base_sha.clone()]);
     }
     if let Some(head) = &args.head {
         argv.extend(["--head".to_string(), head.clone()]);
@@ -871,6 +876,23 @@ fn append_preview_lifecycle_replay_argv(argv: &mut Vec<String>, args: &AgentTask
             ]);
         }
     }
+}
+
+fn append_preview_base_replay_argv(argv: &mut Vec<String>, args: &AgentTaskCookArgs) {
+    let Some(base_sha) = args.base_sha.as_ref() else {
+        return;
+    };
+    let mut index = 0;
+    while index < argv.len() {
+        if argv[index] == "--base-sha" {
+            argv.drain(index..(index + 2).min(argv.len()));
+        } else if argv[index].starts_with("--base-sha=") {
+            argv.remove(index);
+        } else {
+            index += 1;
+        }
+    }
+    argv.extend(["--base-sha".to_string(), base_sha.clone()]);
 }
 
 fn redact_preview_replay_argv(argv: impl IntoIterator<Item = String>) -> PreviewReplayArgv {
@@ -1089,6 +1111,99 @@ mod preview_tests {
             .windows(2)
             .any(|parts| parts == ["--provider-argv", "--repo"]));
         assert!(replay.iter().any(|arg| arg == "--placement=lab"));
+    }
+
+    #[test]
+    fn preview_base_pin_uses_newer_remote_not_stale_tracking_ref_and_survives_replay() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let remote = fixture.path().join("remote.git");
+        let seed = fixture.path().join("seed");
+        let checkout = fixture.path().join("checkout");
+        let git = |path: &std::path::Path, args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("run git");
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        };
+        git(
+            fixture.path(),
+            &[
+                "init",
+                "--bare",
+                "--initial-branch=main",
+                remote.to_str().unwrap(),
+            ],
+        );
+        git(
+            fixture.path(),
+            &["init", "--initial-branch=main", seed.to_str().unwrap()],
+        );
+        git(&seed, &["config", "user.email", "test@example.com"]);
+        git(&seed, &["config", "user.name", "Test"]);
+        git(&seed, &["commit", "--allow-empty", "-m", "initial"]);
+        git(
+            &seed,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        git(&seed, &["push", "-u", "origin", "main"]);
+        git(
+            fixture.path(),
+            &[
+                "clone",
+                remote.to_str().unwrap(),
+                checkout.to_str().unwrap(),
+            ],
+        );
+        let stale = git(&checkout, &["rev-parse", "origin/main"]);
+        git(&seed, &["commit", "--allow-empty", "-m", "new base"]);
+        git(&seed, &["push"]);
+        let authoritative = git(&seed, &["rev-parse", "HEAD"]);
+
+        let resolved = resolve_cook_destination(cook(&[
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "fix it",
+            "--backend",
+            "fixture",
+            "--repo",
+            "fixture",
+            "--to-worktree",
+            checkout.to_str().unwrap(),
+            "--base",
+            "main",
+            "--no-finalize",
+        ]))
+        .expect("preview resolution");
+        assert_ne!(stale, authoritative);
+        assert_eq!(resolved.base_sha.as_deref(), Some(authoritative.as_str()));
+        assert_eq!(
+            resolved.base_resolution.as_ref().unwrap()["authoritative"]["freshness"],
+            "checked"
+        );
+        let preview = cook_preview_resolved_request(&resolved, Value::Null);
+        assert_eq!(preview["base_resolution"]["sha"], authoritative);
+        assert_eq!(
+            preview["base_resolution"]["authoritative"]["admission"],
+            "admitted"
+        );
+
+        let replay = cook_replay_argv(&resolved);
+        let replay = replay.iter().map(String::as_str).collect::<Vec<_>>();
+        let replayed = resolve_cook_destination(cook(&replay)).expect("replay resolution");
+        assert_eq!(replayed.base_sha.as_deref(), Some(authoritative.as_str()));
+        assert_eq!(
+            replayed.base_resolution.as_ref().unwrap()["sha"],
+            authoritative
+        );
     }
 
     #[test]
@@ -3682,11 +3797,113 @@ fn resolve_cook_base(args: &mut AgentTaskCookArgs) -> homeboy::core::Result<()> 
         compatibility_fallback: Some("main"),
     })?;
     args.base = Some(resolution.base.clone());
-    args.base_resolution = Some(serde_json::to_value(resolution).map_err(|error| {
+    let mut resolution = serde_json::to_value(resolution).map_err(|error| {
         homeboy::core::Error::internal_unexpected(format!(
             "serialize Cook default-branch resolution: {error}"
         ))
-    })?);
+    })?;
+    resolve_authoritative_cook_base(args, &mut resolution)?;
+    args.base_resolution = Some(resolution);
+    Ok(())
+}
+
+/// Resolve the base from the remote without updating a caller-owned checkout.
+/// Preview and execution share this contract; when no checkout exists yet the
+/// output explicitly records that remote freshness is deferred.
+fn resolve_authoritative_cook_base(
+    args: &mut AgentTaskCookArgs,
+    resolution: &mut Value,
+) -> homeboy::core::Result<()> {
+    let path = args
+        .dispatch
+        .workspace
+        .as_deref()
+        .or(args.dispatch.cwd.as_deref())
+        .map(PathBuf::from)
+        .or_else(|| {
+            args.to_worktree
+                .as_deref()
+                .map(PathBuf::from)
+                .filter(|path| path.is_dir())
+        })
+        .or_else(|| {
+            cook_component_id(args).and_then(|repo| {
+                homeboy::core::component::registered_by_id(repo)
+                    .ok()
+                    .flatten()
+                    .map(|component| PathBuf::from(component.local_path))
+            })
+        });
+    let Some(path) = path else {
+        resolution["authoritative"] = serde_json::json!({
+            "schema": "homeboy/cook-base-authority/v1",
+            "freshness": "deferred",
+            "admission": "deferred",
+            "reason": "no_local_repository",
+        });
+        return Ok(());
+    };
+    let remote = homeboy::core::git::resolve_default_remote(&path);
+    let base = args.base.as_deref().expect("Cook base is resolved");
+    let reference = format!("refs/heads/{base}");
+    let expected = args.base_sha.clone();
+    let output = Command::new("git")
+        .args(["ls-remote", "--heads", &remote, &reference])
+        .current_dir(&path)
+        .output()
+        .map_err(|error| homeboy::core::Error::git_command_failed(error.to_string()))?;
+    let sha = output
+        .status
+        .success()
+        .then(|| {
+            String::from_utf8_lossy(&output.stdout)
+                .split_whitespace()
+                .next()
+                .filter(|sha| sha.len() == 40 && sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
+                .map(str::to_string)
+        })
+        .flatten();
+    let Some(sha) = sha else {
+        if let Some(expected) = expected {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "base-sha",
+                format!("could not revalidate pinned Cook base `{base}` from `{remote}`"),
+                Some(expected),
+                None,
+            ));
+        }
+        resolution["authoritative"] = serde_json::json!({
+            "schema": "homeboy/cook-base-authority/v1",
+            "remote": remote,
+            "reference": reference,
+            "freshness": "deferred",
+            "admission": "deferred",
+            "reason": "remote_unavailable",
+        });
+        return Ok(());
+    };
+    if let Some(expected) = expected.as_deref() {
+        if expected != sha {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "base-sha",
+                format!(
+                    "Cook replay base contract changed: `{base}` resolved to {sha}, expected {expected}"
+                ),
+                Some(expected.to_string()),
+                None,
+            ));
+        }
+    }
+    args.base_sha = Some(sha.clone());
+    resolution["sha"] = serde_json::json!(sha);
+    resolution["authoritative"] = serde_json::json!({
+        "schema": "homeboy/cook-base-authority/v1",
+        "remote": remote,
+        "reference": reference,
+        "sha": args.base_sha,
+        "freshness": "checked",
+        "admission": "admitted",
+    });
     Ok(())
 }
 
@@ -3748,6 +3965,36 @@ fn validate_cook_base_before_provisioning(args: &AgentTaskCookArgs) -> homeboy::
     Err(error)
 }
 
+/// Execution materializes the previewed immutable object without moving any
+/// tracking ref. The service then uses this SHA rather than resolving the
+/// branch again after provider admission begins.
+fn materialize_cook_base_pin(
+    args: &AgentTaskCookArgs,
+    provision: &Value,
+) -> homeboy::core::Result<()> {
+    let Some(base_sha) = args.base_sha.as_deref() else {
+        return Ok(());
+    };
+    let Some(path) = provision.get("path").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let remote = homeboy::core::git::resolve_default_remote(Path::new(path));
+    let output = Command::new("git")
+        .args(["fetch", "--no-tags", &remote, base_sha])
+        .current_dir(path)
+        .output()
+        .map_err(|error| homeboy::core::Error::git_command_failed(error.to_string()))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "base-sha",
+        format!("could not materialize pinned Cook base {base_sha} from `{remote}`"),
+        Some(base_sha.to_string()),
+        None,
+    ))
+}
+
 /// Build the correction as typed argv first. The rendered shell command is a
 /// display projection only, so branch and worktree values never become syntax.
 pub(crate) fn corrected_cook_base_replay_argv(
@@ -3766,7 +4013,7 @@ pub(crate) fn corrected_cook_base_replay_argv(
 pub(super) fn resolve_cook_preview_destination(
     args: AgentTaskCookArgs,
 ) -> homeboy::core::Result<(AgentTaskCookArgs, Value)> {
-    let mut args = resolve_cook_destination(args)?;
+    let args = resolve_cook_destination(args)?;
     let handle = args.to_worktree.clone().expect("preview destination set");
     let path = if let Some(cwd) = args.dispatch.cwd.as_deref() {
         let path = std::fs::canonicalize(cwd).map_err(|error| {
@@ -3837,7 +4084,6 @@ pub(super) fn resolve_cook_preview_destination(
             }),
         ));
     };
-    resolve_cook_base(&mut args)?;
     Ok((
         args,
         serde_json::json!({
@@ -4950,6 +5196,7 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
     // require a gate, but now say so with a copy-pasteable example instead of a
     // bare rejection.
     let provision = provision_cook_destination(&args)?;
+    materialize_cook_base_pin(&args, &provision)?;
 
     let mut dispatch_args = resolved_dispatch_args_for_cook(&args)?;
     let requested_cook_id = dispatch_args.run_id.clone();
@@ -5044,7 +5291,10 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
         .first()
         .and_then(|task| task.workspace.root.as_ref())
         .map(std::path::PathBuf::from);
-    let task_base_sha = source_worktree_path.as_deref().and_then(git_head_sha);
+    let task_base_sha = args
+        .base_sha
+        .clone()
+        .or_else(|| source_worktree_path.as_deref().and_then(git_head_sha));
     let title = default_loop_title(&args, source_worktree_path.as_deref());
     let commit_message = args
         .commit_message

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4007,10 +4007,8 @@ fn authoritative_cook_base_sha(output: &str, reference: &str) -> Option<String> 
     let [(sha, advertised_ref)] = advertised.as_slice() else {
         return None;
     };
-    (*advertised_ref == reference
-        && sha.len() == 40
-        && sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
-    .then(|| (*sha).to_string())
+    (*advertised_ref == reference && homeboy::core::git::is_full_object_id(sha))
+        .then(|| (*sha).to_string())
 }
 
 fn authoritative_cook_base_probe(
@@ -4083,36 +4081,6 @@ fn validate_cook_base_before_provisioning(args: &AgentTaskCookArgs) -> homeboy::
         error.details["correction_argv"] = serde_json::json!(argv);
     }
     Err(error)
-}
-
-/// Execution materializes the previewed immutable object without moving any
-/// tracking ref. The service then uses this SHA rather than resolving the
-/// branch again after provider admission begins.
-fn materialize_cook_base_pin(
-    args: &AgentTaskCookArgs,
-    provision: &Value,
-) -> homeboy::core::Result<()> {
-    let Some(base_sha) = args.base_sha.as_deref() else {
-        return Ok(());
-    };
-    let Some(path) = provision.get("path").and_then(Value::as_str) else {
-        return Ok(());
-    };
-    let remote = homeboy::core::git::resolve_default_remote(Path::new(path));
-    let output = Command::new("git")
-        .args(["fetch", "--no-tags", &remote, base_sha])
-        .current_dir(path)
-        .output()
-        .map_err(|error| homeboy::core::Error::git_command_failed(error.to_string()))?;
-    if output.status.success() {
-        return Ok(());
-    }
-    Err(homeboy::core::Error::validation_invalid_argument(
-        "base-sha",
-        format!("could not materialize pinned Cook base {base_sha} from `{remote}`"),
-        Some(base_sha.to_string()),
-        None,
-    ))
 }
 
 /// Build the correction as typed argv first. The rendered shell command is a
@@ -5316,7 +5284,6 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
     // require a gate, but now say so with a copy-pasteable example instead of a
     // bare rejection.
     let provision = provision_cook_destination(&args)?;
-    materialize_cook_base_pin(&args, &provision)?;
 
     let mut dispatch_args = resolved_dispatch_args_for_cook(&args)?;
     let requested_cook_id = dispatch_args.run_id.clone();

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -41,6 +41,7 @@ const MAX_PROMOTION_PROVIDER_REQUEST_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_PROVIDER_EVIDENCE_BYTES: u64 = 64 * 1024 * 1024;
 const PREVIEW_STDIN_TIMEOUT: Duration = Duration::from_secs(5);
 const PREVIEW_PROGRESS_HEARTBEAT: Duration = Duration::from_secs(5);
+const COOK_BASE_REMOTE_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn run_cook_explicit(
     request: agent_task_service::CookRequest,
@@ -1195,6 +1196,13 @@ mod preview_tests {
             preview["base_resolution"]["authoritative"]["admission"],
             "admitted"
         );
+        let mut deferred = resolved.clone();
+        deferred.to_worktree = Some("fixture@deferred-base-pin".to_string());
+        let provision = provision_cook_destination(&deferred).expect("defer native creation");
+        assert_eq!(
+            provision["provision_intent"]["base"], authoritative,
+            "deferred native creation must retain the previewed immutable base"
+        );
 
         let replay = cook_replay_argv(&resolved);
         let replay = replay.iter().map(String::as_str).collect::<Vec<_>>();
@@ -1203,6 +1211,97 @@ mod preview_tests {
         assert_eq!(
             replayed.base_resolution.as_ref().unwrap()["sha"],
             authoritative
+        );
+    }
+
+    #[test]
+    fn authoritative_base_accepts_only_one_exact_advertised_ref() {
+        let sha = "a".repeat(40);
+        let reference = "refs/heads/main";
+        assert_eq!(
+            authoritative_cook_base_sha(&format!("{sha}\t{reference}\n"), reference),
+            Some(sha.clone())
+        );
+        assert_eq!(
+            authoritative_cook_base_sha(
+                &format!("{sha}\trefs/heads/main-next\n{sha}\trefs/heads/main\n"),
+                reference
+            ),
+            None,
+            "a wildcard or prefix result is not an exact base identity"
+        );
+        assert_eq!(
+            authoritative_cook_base_sha(&format!("{sha}\trefs/heads/main-next\n"), reference),
+            None
+        );
+    }
+
+    #[test]
+    fn authoritative_base_timeout_is_deferred_not_unavailable() {
+        let (sha, reason) = authoritative_cook_base_probe(
+            homeboy::core::git::BoundedGitRead::TimedOut,
+            "refs/heads/main",
+        );
+        assert_eq!(sha, None);
+        assert_eq!(reason, "remote_timeout");
+    }
+
+    #[test]
+    fn authoritative_base_pattern_does_not_pin_a_matching_branch() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let remote = fixture.path().join("remote.git");
+        let checkout = fixture.path().join("checkout");
+        let git = |path: &std::path::Path, args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("run git");
+            assert!(output.status.success(), "git {args:?} failed");
+        };
+        git(
+            fixture.path(),
+            &[
+                "init",
+                "--bare",
+                "--initial-branch=main",
+                remote.to_str().unwrap(),
+            ],
+        );
+        git(
+            fixture.path(),
+            &["init", "--initial-branch=main", checkout.to_str().unwrap()],
+        );
+        git(&checkout, &["config", "user.email", "test@example.com"]);
+        git(&checkout, &["config", "user.name", "Test"]);
+        git(&checkout, &["commit", "--allow-empty", "-m", "initial"]);
+        git(
+            &checkout,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        git(&checkout, &["push", "-u", "origin", "main"]);
+
+        let resolved = resolve_cook_destination(cook(&[
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "fix it",
+            "--backend",
+            "fixture",
+            "--repo",
+            "fixture",
+            "--to-worktree",
+            checkout.to_str().unwrap(),
+            "--base",
+            "main*",
+            "--no-finalize",
+        ]))
+        .expect("pattern is deferred rather than resolved as a different branch");
+        assert_eq!(resolved.base_sha, None);
+        assert_eq!(
+            resolved.base_resolution.as_ref().unwrap()["authoritative"]["freshness"],
+            "deferred"
         );
     }
 
@@ -3615,7 +3714,7 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
         "handle": to_worktree,
         "provision_intent": {
             "repo": cook_provision_repository(args),
-            "base": args.base,
+            "base": args.base_sha.clone().or_else(|| args.base.clone()),
             "head": args.head,
             "task_url": args.dispatch.task_url,
         },
@@ -3847,22 +3946,12 @@ fn resolve_authoritative_cook_base(
     let base = args.base.as_deref().expect("Cook base is resolved");
     let reference = format!("refs/heads/{base}");
     let expected = args.base_sha.clone();
-    let output = Command::new("git")
-        .args(["ls-remote", "--heads", &remote, &reference])
-        .current_dir(&path)
-        .output()
-        .map_err(|error| homeboy::core::Error::git_command_failed(error.to_string()))?;
-    let sha = output
-        .status
-        .success()
-        .then(|| {
-            String::from_utf8_lossy(&output.stdout)
-                .split_whitespace()
-                .next()
-                .filter(|sha| sha.len() == 40 && sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
-                .map(str::to_string)
-        })
-        .flatten();
+    let probe = homeboy::core::git::output_optional_within(
+        &path,
+        &["ls-remote", "--heads", &remote, &reference],
+        COOK_BASE_REMOTE_TIMEOUT,
+    );
+    let (sha, deferred_reason) = authoritative_cook_base_probe(probe, &reference);
     let Some(sha) = sha else {
         if let Some(expected) = expected {
             return Err(homeboy::core::Error::validation_invalid_argument(
@@ -3878,7 +3967,7 @@ fn resolve_authoritative_cook_base(
             "reference": reference,
             "freshness": "deferred",
             "admission": "deferred",
-            "reason": "remote_unavailable",
+            "reason": deferred_reason,
         });
         return Ok(());
     };
@@ -3905,6 +3994,37 @@ fn resolve_authoritative_cook_base(
         "admission": "admitted",
     });
     Ok(())
+}
+
+/// `git ls-remote` treats its ref argument as a pattern. Accept only one
+/// advertised line whose ref exactly equals the declared heads ref, never a
+/// prefix or wildcard match.
+fn authoritative_cook_base_sha(output: &str, reference: &str) -> Option<String> {
+    let advertised = output
+        .lines()
+        .filter_map(|line| line.split_once('\t'))
+        .collect::<Vec<_>>();
+    let [(sha, advertised_ref)] = advertised.as_slice() else {
+        return None;
+    };
+    (*advertised_ref == reference
+        && sha.len() == 40
+        && sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    .then(|| (*sha).to_string())
+}
+
+fn authoritative_cook_base_probe(
+    probe: homeboy::core::git::BoundedGitRead,
+    reference: &str,
+) -> (Option<String>, &'static str) {
+    match probe {
+        homeboy::core::git::BoundedGitRead::Resolved(output) => (
+            authoritative_cook_base_sha(&output, reference),
+            "remote_unavailable",
+        ),
+        homeboy::core::git::BoundedGitRead::TimedOut => (None, "remote_timeout"),
+        homeboy::core::git::BoundedGitRead::Unresolved => (None, "remote_unavailable"),
+    }
 }
 
 fn validate_cook_base_before_provisioning(args: &AgentTaskCookArgs) -> homeboy::core::Result<()> {

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -98,10 +98,11 @@ pub use primitives::{
 };
 pub use primitives::{is_git_repo, is_tracked_path};
 pub use primitives_query::{
-    current_branch, head_sha, head_sha_short, head_sha_within, output_allow_empty, output_optional,
-    output_optional_bytes, output_optional_within, remote_origin_url, remote_url, repo_root,
-    rev_parse, short_head_revision, status_porcelain, status_porcelain_bytes,
-    status_porcelain_scoped, toplevel, BoundedGitRead, DEFAULT_GIT_READ_PROBE_TIMEOUT,
+    current_branch, head_sha, head_sha_short, head_sha_within, is_full_object_id,
+    output_allow_empty, output_optional, output_optional_bytes, output_optional_within,
+    remote_origin_url, remote_url, repo_root, rev_parse, short_head_revision, status_porcelain,
+    status_porcelain_bytes, status_porcelain_scoped, toplevel, BoundedGitRead,
+    DEFAULT_GIT_READ_PROBE_TIMEOUT,
 };
 
 use serde::{Deserialize, Serialize};

--- a/crates/homeboy-core/src/git/primitives_query.rs
+++ b/crates/homeboy-core/src/git/primitives_query.rs
@@ -20,6 +20,11 @@ use crate::engine::command as engine_command;
 /// below so a stuck repository degrades to a labelled partial instead.
 pub const DEFAULT_GIT_READ_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// A complete Git object ID for either SHA-1 or SHA-256 repositories.
+pub fn is_full_object_id(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
 /// Outcome of a bounded read-only git probe.
 ///
 /// `Unresolved` and `TimedOut` are deliberately distinct: the first is a normal
@@ -217,6 +222,17 @@ pub fn short_head_revision(dir: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn full_object_ids_accept_sha1_and_sha256_only() {
+        assert!(is_full_object_id(&"a".repeat(40)));
+        assert!(is_full_object_id(&"b".repeat(64)));
+        assert!(!is_full_object_id(&"c".repeat(39)));
+        assert!(!is_full_object_id(&format!(
+            "{}^{{commit}}",
+            "d".repeat(40)
+        )));
+    }
     use std::process::Command;
 
     fn git(path: &Path, args: &[&str]) {


### PR DESCRIPTION
## Summary
- resolve Cook bases through a bounded authoritative remote probe and report checked versus deferred freshness honestly
- require one exact advertised `refs/heads/<base>` result, rejecting wildcard or prefix matches
- materialize and verify preview-pinned objects only after Cook has a durable owner; deferred native worktrees fetch the exact object before `git worktree add`
- use the immutable admitted SHA for explicit-CWD ancestry while retaining isolated, non-mutating snapshots for caller-owned checkouts
- support complete SHA-1 and SHA-256 object IDs through the shared Git validator
- carry checked SHA replay contracts into execution and use merge/rebase guidance for diverged worktrees

Closes #14273

## Verification
- `cargo nextest run --profile quick -p homeboy-core --lib full_object_ids_accept_sha1_and_sha256_only`
- `cargo nextest run --profile quick -p homeboy-cli --lib preview_base_pin_uses_newer_remote_not_stale_tracking_ref_and_survives_replay`
- `cargo nextest run --profile quick -p homeboy-agents --lib pending_cook_ensures_native_destination_after_durable_admission_idempotently`
- `cargo nextest run --profile quick -p homeboy-agents --lib workspace_base_ancestry_preflight_converges_clean_behind_destination_at_pinned_moving_main`
- `cargo fmt --check`
- `cargo check -p homeboy-core -p homeboy-cli -p homeboy-agents`

## AI Assistance
OpenAI GPT-5.6 Terra through OpenCode assisted with inspecting the issue and independent reviews, implementing durable immutable-base materialization, bounded exact remote resolution, generic Git object-ID validation, and topology-safe recovery guidance, adding regression coverage, and running verification. The author reviewed the resulting changes and remains responsible for them.