### PR TITLE
fix(runner): avoid unsafe ahead guidance

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/controller_ancestry.rs
+++ b/crates/homeboy-cli/src/commands/runner/controller_ancestry.rs
@@ -38,7 +38,7 @@ const PROBE: &str = "controller_git_ancestry";
 const MAX_DETAIL_CHARS: usize = 400;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum CommitAncestry {
+pub(crate) enum CommitAncestry {
     Ancestor,
     NotAncestor,
     Unavailable,
@@ -49,7 +49,7 @@ pub(super) enum CommitAncestry {
 /// An unavailable probe remains distinct from a real "not an ancestor" answer:
 /// recovery guidance must not turn an unknown build relationship into a
 /// potentially downgrading controller refresh.
-pub(super) fn commits_are_ancestral(older: &str, newer: &str) -> CommitAncestry {
+pub(crate) fn commits_are_ancestral(older: &str, newer: &str) -> CommitAncestry {
     // `output()` captures both child streams. `status()` would inherit them and
     // print git's `fatal:` line straight past the structured envelope.
     ancestry_from_probe(
@@ -224,7 +224,7 @@ mod tests {
     fn the_probe_never_inherits_the_parent_streams() {
         let source = include_str!("controller_ancestry.rs");
         let start = source
-            .find("pub(super) fn commits_are_ancestral")
+            .find("pub(crate) fn commits_are_ancestral")
             .expect("probe entry point");
         let end = source[start..]
             .find("fn ancestry_from_probe")

--- a/crates/homeboy-cli/src/commands/runner/doctor/checks.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/checks.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::commands::runner::controller_ancestry::{commits_are_ancestral, CommitAncestry};
 use types::{RunnerCheck, RunnerDoctorStatus, RunnerRepairAction, ToolProbe};
 
 pub(crate) fn tool_check(spec: RunnerToolSpec, probe: &ToolProbe) -> RunnerCheck {
@@ -132,6 +133,24 @@ pub(crate) fn homeboy_version_skew_check(
     runner_id: &str,
     server_id: &str,
 ) -> Option<RunnerCheck> {
+    homeboy_version_skew_check_with(
+        local_version,
+        local_build_identity,
+        remote_build_identity,
+        runner_id,
+        server_id,
+        commits_are_ancestral,
+    )
+}
+
+pub(super) fn homeboy_version_skew_check_with(
+    local_version: &str,
+    local_build_identity: &str,
+    remote_build_identity: &str,
+    runner_id: &str,
+    server_id: &str,
+    mut ancestry: impl FnMut(&str, &str) -> CommitAncestry,
+) -> Option<RunnerCheck> {
     let local_version = local_version.trim();
     let local_build_identity = normalize_homeboy_build_identity(local_build_identity);
     let remote_build_identity = normalize_homeboy_build_identity(remote_build_identity);
@@ -154,30 +173,70 @@ pub(crate) fn homeboy_version_skew_check(
         "remote_version".to_string(),
         remote_build_identity.to_string(),
     );
-    let quoted_runner_id = shell::quote_arg(runner_id);
-    let refresh_ref = homeboy_product_identity::build_identity()
-        .git_commit
-        .unwrap_or_else(|| format!("v{local_version}"));
-    Some(
-        warning_with_details(
-            "homeboy.version_skew",
-            format!(
-                "Local Homeboy {local_build_identity} differs from remote runner Homeboy {remote_build_identity}"
-            ),
-            Some(format!(
-                "Align runner `{runner_id}` to this controller with `homeboy runner refresh-homeboy {quoted_runner_id} --ref {refresh_ref} --reconnect`; if that fails, inspect the remote runner with `homeboy ssh {server_id} -- homeboy --version`"
-            )),
-            details,
-        )
-        // Every argument in the sentence above is already known here. Carrying
-        // it typed as well is the difference between a fix a person retypes and
-        // one a repair loop can run: `refresh_ref` is the same value in both,
-        // pinned by `version_skew_action_and_prose_carry_the_same_ref`.
-        .with_action(RunnerRepairAction::RefreshHomeboy {
-            git_ref: Some(refresh_ref.clone()),
-            allow_downgrade: false,
-        }),
-    )
+    let controller_commit = build_identity_commit(local_build_identity);
+    let runner_commit = build_identity_commit(remote_build_identity);
+    let message = format!(
+        "Local Homeboy {local_build_identity} differs from remote runner Homeboy {remote_build_identity}"
+    );
+    match (controller_commit, runner_commit) {
+        (Some(controller), Some(runner))
+            if ancestry(controller, runner) == CommitAncestry::Ancestor =>
+        {
+            details.insert("direction".to_string(), "runner_ahead".to_string());
+            Some(warning_with_details(
+                "homeboy.version_skew",
+                message,
+                Some(format!(
+                    "Runner `{runner_id}` is ahead of this controller. Upgrade the controller, then rerun `homeboy runner doctor {runner_id}`; alternatively select a common newer published or source revision. Do not refresh the runner to the older controller revision. Inspect it with `homeboy ssh {server_id} -- homeboy --version`"
+                )),
+                details,
+            ))
+        }
+        (Some(controller), Some(runner))
+            if ancestry(runner, controller) == CommitAncestry::Ancestor =>
+        {
+            details.insert("direction".to_string(), "controller_ahead".to_string());
+            let quoted_runner_id = shell::quote_arg(runner_id);
+            let refresh_ref = homeboy_product_identity::build_identity()
+                .git_commit
+                .unwrap_or_else(|| format!("v{local_version}"));
+            Some(
+                warning_with_details(
+                    "homeboy.version_skew",
+                    message,
+                    Some(format!(
+                        "Align runner `{runner_id}` to this controller with `homeboy runner refresh-homeboy {quoted_runner_id} --ref {refresh_ref} --reconnect`; if that fails, inspect the remote runner with `homeboy ssh {server_id} -- homeboy --version`"
+                    )),
+                    details,
+                )
+                .with_action(RunnerRepairAction::RefreshHomeboy {
+                    git_ref: Some(refresh_ref),
+                    allow_downgrade: false,
+                }),
+            )
+        }
+        _ => {
+            details.insert(
+                "direction".to_string(),
+                "diverged_or_unverified".to_string(),
+            );
+            Some(warning_with_details(
+                "homeboy.version_skew",
+                message,
+                Some(format!(
+                    "Controller and runner commits are divergent or cannot be compared. Select a common published or source revision before refreshing runner `{runner_id}`; use `--allow-downgrade` only for an intentional rollback authorized by an operator. Inspect it with `homeboy ssh {server_id} -- homeboy --version`"
+                )),
+                details,
+            ))
+        }
+    }
+}
+
+fn build_identity_commit(identity: &str) -> Option<&str> {
+    let commit = identity.rsplit_once('+')?.1;
+    let commit = commit.strip_suffix("-dirty").unwrap_or(commit);
+    (commit.len() >= 7 && commit.len() <= 64 && commit.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .then_some(commit)
 }
 
 fn normalize_homeboy_build_identity(identity: &str) -> &str {

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/homeboy_path.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/homeboy_path.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use crate::commands::runner::controller_ancestry::CommitAncestry;
 use std::collections::BTreeMap;
 use types::{HomeboyProbe, RunnerDoctorStatus, RunnerRepairAction};
 
@@ -240,12 +241,17 @@ fn homeboy_version_skew_check_is_absent_for_matching_build_identities() {
 /// which is worse than either being wrong alone. This is that tie (#13551).
 #[test]
 fn version_skew_action_and_prose_carry_the_same_ref() {
-    let check = checks::homeboy_version_skew_check(
+    let check = checks::homeboy_version_skew_check_with(
         "0.290.0",
-        "homeboy 0.290.0+00d2756ef115",
-        "0.290.0+differentbuild",
+        "homeboy 0.290.0+ccccccc",
+        "homeboy 0.290.0+aaaaaaa",
         "lab",
         "lab",
+        |older, newer| {
+            (older == "aaaaaaa" && newer == "ccccccc")
+                .then_some(CommitAncestry::Ancestor)
+                .unwrap_or(CommitAncestry::NotAncestor)
+        },
     )
     .expect("version skew warning");
 
@@ -286,12 +292,13 @@ fn a_check_without_an_automatic_repair_carries_no_action() {
 
 #[test]
 fn homeboy_version_skew_check_warns_for_different_build_identities() {
-    let check = checks::homeboy_version_skew_check(
+    let check = checks::homeboy_version_skew_check_with(
         "0.290.0",
         "homeboy 0.290.0+00d2756ef115",
         "0.290.0+differentbuild",
         "lab",
         "lab",
+        |_, _| CommitAncestry::Unavailable,
     )
     .expect("version skew warning");
 
@@ -314,15 +321,95 @@ fn homeboy_version_skew_check_warns_for_different_build_identities() {
         check.details.get("remote_version").map(String::as_str),
         Some("0.290.0+differentbuild")
     );
-    let expected_ref = homeboy_product_identity::build_identity()
-        .git_commit
-        .unwrap_or_else(|| "v0.290.0".to_string());
     assert!(check
         .remediation
         .as_deref()
-        .is_some_and(|value| value.contains(&format!(
-            "homeboy runner refresh-homeboy lab --ref {expected_ref} --reconnect"
-        ))));
+        .is_some_and(|value| value.contains("common published or source revision")));
+    assert!(check.remediation_action.is_none());
+}
+
+#[test]
+fn homeboy_version_skew_recommends_refresh_only_when_controller_is_ahead() {
+    let check = checks::homeboy_version_skew_check_with(
+        "0.290.0",
+        "homeboy 0.290.0+ccccccc",
+        "homeboy 0.290.0+aaaaaaa",
+        "lab",
+        "lab",
+        |older, newer| {
+            (older == "aaaaaaa" && newer == "ccccccc")
+                .then_some(CommitAncestry::Ancestor)
+                .unwrap_or(CommitAncestry::NotAncestor)
+        },
+    )
+    .expect("version skew warning");
+
+    assert_eq!(
+        check.details.get("direction").map(String::as_str),
+        Some("controller_ahead")
+    );
+    assert!(check
+        .remediation
+        .as_deref()
+        .is_some_and(|value| value.contains("refresh-homeboy")));
+    assert!(matches!(
+        check.remediation_action,
+        Some(RunnerRepairAction::RefreshHomeboy {
+            allow_downgrade: false,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn homeboy_version_skew_keeps_a_runner_ahead_of_the_controller() {
+    let check = checks::homeboy_version_skew_check_with(
+        "0.290.0",
+        "homeboy 0.290.0+ccccccc",
+        "homeboy 0.290.0+aaaaaaa",
+        "lab",
+        "lab",
+        |older, newer| {
+            (older == "ccccccc" && newer == "aaaaaaa")
+                .then_some(CommitAncestry::Ancestor)
+                .unwrap_or(CommitAncestry::NotAncestor)
+        },
+    )
+    .expect("version skew warning");
+
+    assert_eq!(
+        check.details.get("direction").map(String::as_str),
+        Some("runner_ahead")
+    );
+    assert!(check
+        .remediation
+        .as_deref()
+        .is_some_and(|value| value.contains("Upgrade the controller")));
+    assert!(check.remediation_action.is_none());
+}
+
+#[test]
+fn homeboy_version_skew_withholds_refresh_for_diverged_commits() {
+    let check = checks::homeboy_version_skew_check_with(
+        "0.290.0",
+        "homeboy 0.290.0+ccccccc",
+        "homeboy 0.290.0+aaaaaaa",
+        "lab",
+        "lab",
+        |_, _| CommitAncestry::NotAncestor,
+    )
+    .expect("version skew warning");
+
+    assert_eq!(
+        check.details.get("direction").map(String::as_str),
+        Some("diverged_or_unverified")
+    );
+    assert!(
+        check.remediation.as_deref().is_some_and(
+            |value| value.contains("--allow-downgrade` only for an intentional rollback")
+        )
+    );
+    assert!(check.remediation_action.is_none());
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -419,6 +419,7 @@ pub fn plan_homeboy_binary_refresh(
                 &target_dir,
                 &binary_path,
                 options.allow_downgrade,
+                &[],
             );
             Ok(HomeboyBinaryRefreshPlan {
                 runner_id: runner_id.clone(),
@@ -438,7 +439,7 @@ pub fn plan_homeboy_binary_refresh(
 pub fn refresh_homeboy_binary(
     options: HomeboyBinaryRefreshOptions,
 ) -> Result<(HomeboyBinaryRefreshOutput, i32)> {
-    let plan = plan_homeboy_binary_refresh(&options)?;
+    let mut plan = plan_homeboy_binary_refresh(&options)?;
     if options.dry_run {
         return Ok((
             HomeboyBinaryRefreshOutput {
@@ -482,6 +483,23 @@ pub fn refresh_homeboy_binary(
     // with a new observation that can include this recovery operation's records.
     let admission = reconciled_refresh_admission(&plan.runner_id)?;
     let connection_status = admission.status.clone();
+    if plan.mode == "materialize" {
+        let authorities = refresh_promotion_authorities(&plan.runner_id, &connection_status)?;
+        plan.script = materialize_script(
+            plan.source
+                .as_deref()
+                .expect("materialize plans have a source"),
+            plan.git_ref
+                .as_deref()
+                .expect("materialize plans have a ref"),
+            plan.target_dir
+                .as_deref()
+                .expect("materialize plans have a target directory"),
+            &plan.binary_path,
+            options.allow_downgrade,
+            &refresh_authority_commits(&authorities),
+        );
+    }
     let execution_route = refresh_execution_route(&runner, &admission)?;
     let diagnostic_ssh_bootstrap = execution_route.uses_diagnostic_ssh();
     let exec_options =
@@ -1865,6 +1883,17 @@ fn refresh_promotion_authorities(
     })
 }
 
+fn refresh_authority_commits(authorities: &RefreshPromotionAuthorities) -> Vec<&str> {
+    [
+        authorities.controller.as_deref(),
+        authorities.active_daemon.as_deref(),
+        authorities.configured_selected.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
 fn validate_refresh_promotion<IsAncestor>(
     plan: &HomeboyBinaryRefreshPlan,
     candidate: &Value,
@@ -2452,6 +2481,7 @@ fn materialize_script(
     target_dir: &str,
     binary_path: &str,
     allow_downgrade: bool,
+    authority_commits: &[&str],
 ) -> String {
     let mut script = format!(
         "set -e\nsource={}\nref={}\ndir={}\nbinary={}\nallow_downgrade={}\nhash_binary() {{ (sha256sum \"$1\" 2>/dev/null || shasum -a 256 \"$1\") | awk '{{print $1}}'; }}\nmkdir -p \"$(dirname \"$dir\")\"\ncheckout_existed=false\nif [ -d \"$dir/.git\" ]; then\n  checkout_existed=true\nelse\n  git clone \"$source\" \"$dir\"\nfi\ncurrent_remote=$(git -C \"$dir\" config --get remote.origin.url 2>/dev/null || true)\nif [ \"$current_remote\" != \"$source\" ]; then\n  git -C \"$dir\" remote set-url origin \"$source\" 2>/dev/null || git -C \"$dir\" remote add origin \"$source\"\nfi\ngit -C \"$dir\" fetch --prune origin\nrequested=$(git -C \"$dir\" rev-parse --verify --quiet \"origin/$ref\" || git -C \"$dir\" rev-parse --verify --quiet \"$ref\")\nif [ -z \"$requested\" ]; then\n  echo \"Homeboy ref not found: $ref\" >&2\n  exit 1\nfi\ntarget=$(git -C \"$dir\" rev-parse --verify --quiet \"${{requested}}^{{commit}}\")\ncurrent=\nif [ \"$checkout_existed\" = true ]; then\n  current=$(git -C \"$dir\" rev-parse --verify --quiet HEAD || true)\nfi\nif [ -n \"$current\" ] && [ \"$current\" != \"$target\" ] && git -C \"$dir\" merge-base --is-ancestor \"$target\" \"$current\"; then\n  echo \"HOMEBOY_REFRESH_DOWNGRADE_PREVIOUS=$current\" >&2\n  echo \"HOMEBOY_REFRESH_DOWNGRADE_REQUESTED=$ref\" >&2\n  echo \"HOMEBOY_REFRESH_DOWNGRADE_RESOLVED=$target\" >&2\n  if [ \"$allow_downgrade\" != true ]; then\n    echo \"Refusing Homeboy runner downgrade; use --allow-downgrade only for an intentional rollback\" >&2\n    exit 1\n  fi\nfi\ngit -C \"$dir\" checkout --quiet --force --detach \"$target\"\ngit -C \"$dir\" reset --hard \"$target\"\necho \"HOMEBOY_REFRESH_SOURCE_SHA=$target\"\ncargo build --release --bin homeboy --manifest-path \"$dir/Cargo.toml\"\nbinary_sha=$(hash_binary \"$binary\")\nif [ -z \"$binary_sha\" ]; then\n  echo \"could not hash materialized Homeboy binary\" >&2\n  exit 1\nfi\nslot_dir=\"$(dirname \"$dir\")/homeboy-$binary_sha\"\nimmutable_binary=\"$slot_dir/homeboy\"\nmkdir -p \"$slot_dir\"\nif [ -e \"$immutable_binary\" ]; then\n  existing_sha=$(hash_binary \"$immutable_binary\")\n  if [ \"$existing_sha\" != \"$binary_sha\" ]; then\n    echo \"immutable Homeboy binary slot hash mismatch\" >&2\n    exit 1\n  fi\nelse\n  staged_binary=$(mktemp \"$slot_dir/.homeboy.XXXXXX\")\n  trap 'rm -f \"$staged_binary\"' EXIT HUP INT TERM\n  cp \"$binary\" \"$staged_binary\"\n  chmod 0755 \"$staged_binary\"\n  staged_sha=$(hash_binary \"$staged_binary\")\n  if [ \"$staged_sha\" != \"$binary_sha\" ]; then\n    echo \"staged Homeboy binary hash mismatch\" >&2\n    exit 1\n  fi\n  if ! ln \"$staged_binary\" \"$immutable_binary\"; then\n    if [ ! -e \"$immutable_binary\" ] || [ \"$(hash_binary \"$immutable_binary\")\" != \"$binary_sha\" ]; then\n      echo \"immutable Homeboy binary slot publication failed\" >&2\n      exit 1\n    fi\n  fi\n  rm -f \"$staged_binary\"\n  trap - EXIT HUP INT TERM\nfi\necho \"HOMEBOY_REFRESH_BINARY_SHA256=$binary_sha\"\necho \"HOMEBOY_REFRESH_BINARY_PATH=$immutable_binary\"\n",
@@ -2460,6 +2490,15 @@ fn materialize_script(
         quote_path(target_dir),
         quote_path(binary_path),
         allow_downgrade,
+    );
+    let authority_commits = quote_path(&authority_commits.join(" "));
+    let downgrade_guard = format!(
+        "preflight=$(mktemp -d)\ntrap 'rm -rf \"$preflight\"' EXIT HUP INT TERM\ngit -C \"$preflight\" init --bare --quiet\nif ! git -C \"$preflight\" fetch --quiet \"$source\" \"$ref\"; then\n  echo \"Homeboy ref not found: $ref\" >&2\n  exit 1\nfi\ntarget=$(git -C \"$preflight\" rev-parse --verify --quiet FETCH_HEAD^{{commit}})\nif [ -z \"$target\" ]; then\n  echo \"Homeboy ref did not resolve to a commit: $ref\" >&2\n  exit 1\nfi\nfor authority in {authority_commits}; do\n  if [ -z \"$authority\" ] || [ \"$authority\" = \"$target\" ]; then\n    continue\n  fi\n  if ! git -C \"$preflight\" fetch --quiet \"$source\" \"$authority\"; then\n    if [ \"$allow_downgrade\" != true ]; then\n      echo \"Cannot prove requested Homeboy ref is not a downgrade; use --allow-downgrade only for an intentional rollback\" >&2\n      exit 1\n    fi\n    continue\n  fi\n  if git -C \"$preflight\" merge-base --is-ancestor \"$target\" \"$authority\"; then\n    echo \"HOMEBOY_REFRESH_DOWNGRADE_PREVIOUS=$authority\" >&2\n    echo \"HOMEBOY_REFRESH_DOWNGRADE_REQUESTED=$ref\" >&2\n    echo \"HOMEBOY_REFRESH_DOWNGRADE_RESOLVED=$target\" >&2\n    if [ \"$allow_downgrade\" != true ]; then\n      echo \"Refusing Homeboy runner downgrade; use --allow-downgrade only for an intentional rollback\" >&2\n      exit 1\n    fi\n  fi\ndone\nrm -rf \"$preflight\"\ntrap - EXIT HUP INT TERM\n"
+    );
+    script = script.replacen(
+        "mkdir -p \"$(dirname \"$dir\")\"",
+        &format!("{downgrade_guard}mkdir -p \"$(dirname \"$dir\")\""),
+        1,
     );
     script.push_str(
         r#"identity=$("$immutable_binary" self identity)

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -566,6 +566,7 @@ fn materialize_plan_uses_clean_runner_cache() {
             "/runner/ws/homeboy-clean",
             "/runner/ws/homeboy-clean/target/release/homeboy",
             false,
+            &[],
         ),
         reconnect: false,
         followup_commands: refresh_followups("lab", false),
@@ -591,6 +592,7 @@ fn materialize_plan_rejects_implicit_git_ancestry_downgrades() {
         "/runner/ws/homeboy-clean",
         "/runner/ws/homeboy-clean/target/release/homeboy",
         false,
+        &["newer-authority"],
     );
     assert_eq!(
         script.matches("self identity").count(),
@@ -604,10 +606,22 @@ fn materialize_plan_rejects_implicit_git_ancestry_downgrades() {
         );
     }
 
-    assert!(script.contains("merge-base --is-ancestor \"$target\" \"$current\""));
-    assert!(script.contains("HOMEBOY_REFRESH_DOWNGRADE_PREVIOUS=$current"));
+    assert!(script.contains("for authority in 'newer-authority'; do"));
+    assert!(script.contains("HOMEBOY_REFRESH_DOWNGRADE_PREVIOUS=$authority"));
     assert!(script.contains("--allow-downgrade only for an intentional rollback"));
     assert!(script.contains("checkout --quiet --force --detach \"$target\""));
+    assert!(
+        script
+            .find("for authority in 'newer-authority'; do")
+            .unwrap()
+            < script.find("git clone \"$source\" \"$dir\"").unwrap()
+    );
+    assert!(
+        script
+            .find("for authority in 'newer-authority'; do")
+            .unwrap()
+            < script.find("cargo build --release --bin homeboy").unwrap()
+    );
 }
 
 #[test]
@@ -618,6 +632,7 @@ fn materialize_plan_allows_an_explicit_git_ancestry_downgrade() {
         "/runner/ws/homeboy-clean",
         "/runner/ws/homeboy-clean/target/release/homeboy",
         true,
+        &["newer-authority"],
     );
 
     assert!(script.contains("allow_downgrade=true"));
@@ -1055,6 +1070,7 @@ fn materialize_script_records_the_peeled_commit_for_tags_and_direct_commits() {
             target_dir.to_str().expect("target path"),
             binary_path.to_str().expect("binary path"),
             false,
+            &[],
         );
         let output = fixture_build_shell(&script)
             .output()
@@ -1172,6 +1188,7 @@ fn managed_slot_materialization_publishes_verified_select_authority() {
         build.to_str().expect("build path"),
         binary.to_str().expect("binary path"),
         false,
+        &[],
     );
     let mut materialize = fixture_build_shell(&script);
     materialize.env(
@@ -1658,6 +1675,7 @@ fn default_target_dir_is_ref_scoped() {
         &target_dir,
         &format!("{target_dir}/target/release/homeboy"),
         false,
+        &[],
     );
     assert!(script.contains("slot_dir=\"$(dirname \"$dir\")/homeboy-$binary_sha\""));
     assert!(!script.contains("_homeboy_binaries/$binary_sha"));


### PR DESCRIPTION
## Summary
- classify controller/runner build direction before offering runner refresh remediation
- withhold automatic refresh for runner-ahead, diverged, and unverified commits
- preflight materialized refs against promotion authorities before the runner workspace clone, while retaining post-build race protection

Fixes #14278

## Testing
- cargo fmt --check
- cargo test -p homeboy-cli homeboy_version_skew --no-fail-fast
- cargo test -p homeboy-cli controller_ancestry --no-fail-fast
- cargo test -p homeboy-lab-runner materialize_plan --no-fail-fast
- cargo test -p homeboy-lab-runner rollback --no-fail-fast
- cargo check -p homeboy-cli -p homeboy-lab-runner

## AI Assistance
Implemented with OpenCode using openai/gpt-5.6-terra.