### PR TITLE
fix(agent-task): recover missing review forms

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -3112,6 +3112,8 @@ fn cook_finalization_options_with_stores_and_review_form(
             promotion.deterministic_gates.len()
         )
     };
+    let review_profile = resolve_review_profile(None, &path)?;
+    review_dossier.validate(&review_profile)?;
     Ok(AgentTaskPrFinalizationOptions {
         path: path.clone(),
         run_id: successful_run_id.to_string(),
@@ -3149,7 +3151,7 @@ fn cook_finalization_options_with_stores_and_review_form(
         ai_used_for,
         review_dossier,
         composed_ai_model_disclosure,
-        review_profile: resolve_review_profile(None, &path)?,
+        review_profile,
         manual_finalization: false,
         expected_candidate_sha: None,
         verified_candidate_sha: None,
@@ -3750,10 +3752,9 @@ fn persist_supplied_recovery_review_form(
     promotion: &AgentTaskPromotionReport,
     options: &CookRequest,
 ) -> Result<()> {
-    if resolve_supplied_recovery_review_form(run_id, None)?.is_some() {
-        return Ok(());
-    }
-    agent_task_lifecycle::record_metadata_value(
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    lifecycle_store.compare_and_set_metadata_value(
         run_id,
         "recovery_review_form",
         serde_json::json!({

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -4913,8 +4913,8 @@ fn cook_review_dossier_with_stores_and_review_form(
                 // Deterministic: the orchestrator knows whether/what tool+model ran,
                 // and attributes Homeboy as the harness that drove the change.
                 used: true,
-                tool: review_form.map_or(lineage.tool, |form| form.tool.clone()),
-                model: review_form.map_or(lineage.model, |form| form.model.clone()),
+                tool: lineage.tool,
+                model: lineage.model,
                 used_for: lineage.used_for,
             },
             source_relationships: Vec::new(),

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -9,6 +9,7 @@
 //! terminal provider result and publish controller-owned state; grouping them
 //! keeps the promote → finalize boundary in one place.
 
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -2986,7 +2987,7 @@ fn cook_finalization_options_with_review_form(
     successful_run_id: &str,
     promotion: &AgentTaskPromotionReport,
     overrides: Vec<AgentTaskReviewOverride>,
-    review_form: Option<&crate::agent_task_review_dossier::AiFilledReviewForm>,
+    review_form: Option<&AgentTaskSuppliedReviewForm>,
 ) -> Result<AgentTaskPrFinalizationOptions> {
     let store = super::cook_recipe::CookRecipeStore::from_current_data_root()?;
     let lifecycle_store =
@@ -3028,7 +3029,7 @@ fn cook_finalization_options_with_stores_and_review_form(
     successful_run_id: &str,
     promotion: &AgentTaskPromotionReport,
     overrides: Vec<AgentTaskReviewOverride>,
-    review_form: Option<&crate::agent_task_review_dossier::AiFilledReviewForm>,
+    review_form: Option<&AgentTaskSuppliedReviewForm>,
 ) -> Result<AgentTaskPrFinalizationOptions> {
     let path = promotion
         .provenance
@@ -3440,11 +3441,51 @@ pub fn recover_cook_pr(
     recover_cook_pr_with_review_form(run_or_cook_id, None, overrides, preflight)
 }
 
+/// Auditable authorship for a review form supplied outside provider execution.
+/// The Cook controller owns the surrounding deterministic dossier, while this
+/// records who authored the non-deterministic reviewer prose.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskSuppliedReviewForm {
+    pub form: crate::agent_task_review_dossier::AiFilledReviewForm,
+    pub tool: String,
+    pub model: String,
+    pub operator: String,
+}
+
+impl AgentTaskSuppliedReviewForm {
+    fn validate(&self) -> Result<()> {
+        self.form.validate()?;
+        for (field, value) in [
+            ("review_form.tool", &self.tool),
+            ("review_form.model", &self.model),
+            ("review_form.operator", &self.operator),
+        ] {
+            if value.trim().is_empty() {
+                return Err(Error::validation_invalid_argument(
+                    field,
+                    "supplied review form provenance must not be empty",
+                    None,
+                    None,
+                ));
+            }
+        }
+        if concrete_provider_model(Some(&self.model)).is_none() {
+            return Err(Error::validation_invalid_argument(
+                "review_form.model",
+                "supplied review form provenance requires a concrete authoring model",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Recover publication using an operator-supplied form only when the immutable
 /// candidate's historical provider outcome did not retain one.
 pub fn recover_cook_pr_with_review_form(
     run_or_cook_id: &str,
-    review_form: Option<crate::agent_task_review_dossier::AiFilledReviewForm>,
+    review_form: Option<AgentTaskSuppliedReviewForm>,
     overrides: Vec<AgentTaskReviewOverride>,
     preflight: bool,
 ) -> Result<Value> {
@@ -3474,7 +3515,7 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
 
 pub(crate) fn recover_cook_pr_with_backend_and_review_form<B: AgentTaskPrFinalizationBackend>(
     run_or_cook_id: &str,
-    review_form: Option<crate::agent_task_review_dossier::AiFilledReviewForm>,
+    review_form: Option<AgentTaskSuppliedReviewForm>,
     overrides: Vec<AgentTaskReviewOverride>,
     preflight: bool,
     backend: &mut B,
@@ -3624,20 +3665,35 @@ pub(crate) fn recover_cook_pr_with_backend_and_review_form<B: AgentTaskPrFinaliz
             None,
         ));
     }
-    let supplied_form_replaces_recorded_form = review_form.is_some()
+    let supplied_review_form = resolve_supplied_recovery_review_form(&run_id, review_form)?;
+    if supplied_review_form.is_some()
         && review_form_for_finalization_in_store(
             &agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?,
             &run_id,
         )
-        .is_ok();
+        .is_ok()
+    {
+        return Err(Error::validation_invalid_argument(
+            "review_form",
+            "recovery already has a valid recorded review form; --review-form is only for missing historical forms and cannot replace it",
+            Some(run_id),
+            None,
+        ));
+    }
     let finalization = cook_finalization_options_with_review_form(
         &options,
         &run_id,
         &promotion,
         overrides,
-        review_form.as_ref(),
+        supplied_review_form.as_ref(),
     )?;
     if !preflight {
+        if let Some(submission) = &supplied_review_form {
+            // Record the exact validated submission before publication. A retry
+            // reuses this immutable receipt rather than losing provenance after
+            // an interrupted finalization.
+            persist_supplied_recovery_review_form(&run_id, submission, &promotion, &options)?;
+        }
         agent_task_lifecycle::record_promotion(
             &run_id,
             serde_json::to_value(&promotion).unwrap_or(Value::Null),
@@ -3651,31 +3707,67 @@ pub(crate) fn recover_cook_pr_with_backend_and_review_form<B: AgentTaskPrFinaliz
     let value = serde_json::to_value(&report).unwrap_or(Value::Null);
     if !preflight {
         agent_task_lifecycle::record_cook_finalization(&run_id, value.clone())?;
-        if let Some(form) = review_form {
-            agent_task_lifecycle::record_metadata_value(
-                &run_id,
-                "recovery_review_form",
-                serde_json::json!({
-                    "schema": "homeboy/agent-task-recovery-review-form/v1",
-                    "form": form,
-                    "provenance": {
-                        "source": "operator_supplied_recovery",
-                        "operator": "homeboy agent-task finalize-pr",
-                        "run_id": run_id,
-                        "replaces_recorded_form": supplied_form_replaces_recorded_form,
-                        "patch_sha256": promotion.patch_artifact.sha256,
-                        "source_refs": options.workspace.source_refs,
-                        "deterministic_gates": promotion.deterministic_gates,
-                        "authoring": {
-                            "tool": report.review_dossier.ai_assistance.tool,
-                            "model": report.review_dossier.ai_assistance.model,
-                        },
-                    },
-                }),
-            )?;
-        }
     }
     Ok(value)
+}
+
+fn resolve_supplied_recovery_review_form(
+    run_id: &str,
+    supplied: Option<AgentTaskSuppliedReviewForm>,
+) -> Result<Option<AgentTaskSuppliedReviewForm>> {
+    let record = agent_task_lifecycle::reconcile_status(run_id)?;
+    let persisted = record
+        .metadata
+        .get("recovery_review_form")
+        .map(|value| {
+            serde_json::from_value::<AgentTaskSuppliedReviewForm>(value["submission"].clone())
+                .map_err(|_| {
+                    Error::validation_invalid_argument(
+                        "recovery_review_form",
+                        "persisted supplied review form is malformed",
+                        Some(run_id.to_string()),
+                        None,
+                    )
+                })
+        })
+        .transpose()?;
+    match (supplied, persisted) {
+        (Some(submitted), Some(existing)) if submitted != existing => Err(Error::validation_invalid_argument(
+            "review_form",
+            "recovery already has a different supplied review form receipt; retry with the recorded submission",
+            Some(run_id.to_string()),
+            None,
+        )),
+        (Some(submitted), _) => Ok(Some(submitted)),
+        (None, Some(existing)) => Ok(Some(existing)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn persist_supplied_recovery_review_form(
+    run_id: &str,
+    submission: &AgentTaskSuppliedReviewForm,
+    promotion: &AgentTaskPromotionReport,
+    options: &CookRequest,
+) -> Result<()> {
+    if resolve_supplied_recovery_review_form(run_id, None)?.is_some() {
+        return Ok(());
+    }
+    agent_task_lifecycle::record_metadata_value(
+        run_id,
+        "recovery_review_form",
+        serde_json::json!({
+            "schema": "homeboy/agent-task-recovery-review-form/v1",
+            "submission": submission,
+            "provenance": {
+                "source": "operator_supplied_recovery",
+                "run_id": run_id,
+                "patch_sha256": promotion.patch_artifact.sha256,
+                "source_refs": options.workspace.source_refs,
+                "deterministic_gates": promotion.deterministic_gates,
+            },
+        }),
+    )
 }
 
 /// Resolve an ordinary durable retry back to the Cook attempt whose policy it
@@ -4642,7 +4734,7 @@ fn cook_review_dossier_with_stores_and_review_form(
     options: &CookRequest,
     promotion: &AgentTaskPromotionReport,
     successful_run_id: &str,
-    review_form: Option<&crate::agent_task_review_dossier::AiFilledReviewForm>,
+    review_form: Option<&AgentTaskSuppliedReviewForm>,
 ) -> Result<(AgentTaskReviewDossier, bool, bool)> {
     // A form-only run owns reviewer metadata but carries forward the durable
     // gate proof while its authenticated source owns candidate scope.
@@ -4711,7 +4803,7 @@ fn cook_review_dossier_with_stores_and_review_form(
     // forward. Resolve the persisted Cook lineage so that follow-up prose cannot
     // erase the implementation attempt that produced the delivered patch.
     let terminal_form = match review_form {
-        Some(form) => form.clone(),
+        Some(form) => form.form.clone(),
         None => review_form_for_finalization_in_store(lifecycle_store, successful_run_id)?,
     };
     let verified_commands = terminal_form.verify_against_promotion(verification_promotion)?;
@@ -4749,6 +4841,15 @@ fn cook_review_dossier_with_stores_and_review_form(
             url: None,
         },
     ];
+    if let Some(form) = review_form {
+        evidence.push(AgentTaskReviewEvidence {
+            summary: format!(
+                "Review form provenance: supplied by {} using {} ({}) rather than a recorded provider outcome.",
+                form.operator, form.tool, form.model
+            ),
+            url: None,
+        });
+    }
     // Form-only continuations may substitute the implementation promotion for
     // candidate metadata; the persisted terminal record remains recovery proof.
     if let Some(replacement) = lifecycle_store
@@ -4811,8 +4912,8 @@ fn cook_review_dossier_with_stores_and_review_form(
                 // Deterministic: the orchestrator knows whether/what tool+model ran,
                 // and attributes Homeboy as the harness that drove the change.
                 used: true,
-                tool: lineage.tool,
-                model: lineage.model,
+                tool: review_form.map_or(lineage.tool, |form| form.tool.clone()),
+                model: review_form.map_or(lineage.model, |form| form.model.clone()),
                 used_for: lineage.used_for,
             },
             source_relationships: Vec::new(),

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2965,22 +2965,40 @@ pub(crate) fn finalize_cook_pr_with_backend_with_stores<B: AgentTaskPrFinalizati
         .map(|report| serde_json::to_value(report).unwrap_or(Value::Null))
 }
 
+#[cfg(test)]
 pub(crate) fn cook_finalization_options(
     options: &CookRequest,
     successful_run_id: &str,
     promotion: &AgentTaskPromotionReport,
     overrides: Vec<AgentTaskReviewOverride>,
 ) -> Result<AgentTaskPrFinalizationOptions> {
+    cook_finalization_options_with_review_form(
+        options,
+        successful_run_id,
+        promotion,
+        overrides,
+        None,
+    )
+}
+
+fn cook_finalization_options_with_review_form(
+    options: &CookRequest,
+    successful_run_id: &str,
+    promotion: &AgentTaskPromotionReport,
+    overrides: Vec<AgentTaskReviewOverride>,
+    review_form: Option<&crate::agent_task_review_dossier::AiFilledReviewForm>,
+) -> Result<AgentTaskPrFinalizationOptions> {
     let store = super::cook_recipe::CookRecipeStore::from_current_data_root()?;
     let lifecycle_store =
         agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
-    cook_finalization_options_with_stores(
+    cook_finalization_options_with_stores_and_review_form(
         &store,
         &lifecycle_store,
         options,
         successful_run_id,
         promotion,
         overrides,
+        review_form,
     )
 }
 
@@ -2991,6 +3009,26 @@ pub(crate) fn cook_finalization_options_with_stores(
     successful_run_id: &str,
     promotion: &AgentTaskPromotionReport,
     overrides: Vec<AgentTaskReviewOverride>,
+) -> Result<AgentTaskPrFinalizationOptions> {
+    cook_finalization_options_with_stores_and_review_form(
+        store,
+        lifecycle_store,
+        options,
+        successful_run_id,
+        promotion,
+        overrides,
+        None,
+    )
+}
+
+fn cook_finalization_options_with_stores_and_review_form(
+    store: &super::cook_recipe::CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    options: &CookRequest,
+    successful_run_id: &str,
+    promotion: &AgentTaskPromotionReport,
+    overrides: Vec<AgentTaskReviewOverride>,
+    review_form: Option<&crate::agent_task_review_dossier::AiFilledReviewForm>,
 ) -> Result<AgentTaskPrFinalizationOptions> {
     let path = promotion
         .provenance
@@ -3028,12 +3066,13 @@ pub(crate) fn cook_finalization_options_with_stores(
             )
         })?;
     let (mut review_dossier, composed_ai_model_disclosure, preserve_used_for_disclosure) =
-        cook_review_dossier_with_stores(
+        cook_review_dossier_with_stores_and_review_form(
             store,
             lifecycle_store,
             options,
             promotion,
             successful_run_id,
+            review_form,
         )?;
     review_dossier.overrides = overrides;
     // A non-empty option is an explicit operator disclosure. Otherwise retain
@@ -3398,8 +3437,20 @@ pub fn recover_cook_pr(
     overrides: Vec<AgentTaskReviewOverride>,
     preflight: bool,
 ) -> Result<Value> {
-    recover_cook_pr_with_backend(
+    recover_cook_pr_with_review_form(run_or_cook_id, None, overrides, preflight)
+}
+
+/// Recover publication using an operator-supplied form only when the immutable
+/// candidate's historical provider outcome did not retain one.
+pub fn recover_cook_pr_with_review_form(
+    run_or_cook_id: &str,
+    review_form: Option<crate::agent_task_review_dossier::AiFilledReviewForm>,
+    overrides: Vec<AgentTaskReviewOverride>,
+    preflight: bool,
+) -> Result<Value> {
+    recover_cook_pr_with_backend_and_review_form(
         run_or_cook_id,
+        review_form,
         overrides,
         preflight,
         &mut RealAgentTaskPrFinalizationBackend,
@@ -3412,6 +3463,25 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     preflight: bool,
     backend: &mut B,
 ) -> Result<Value> {
+    recover_cook_pr_with_backend_and_review_form(
+        run_or_cook_id,
+        None,
+        overrides,
+        preflight,
+        backend,
+    )
+}
+
+pub(crate) fn recover_cook_pr_with_backend_and_review_form<B: AgentTaskPrFinalizationBackend>(
+    run_or_cook_id: &str,
+    review_form: Option<crate::agent_task_review_dossier::AiFilledReviewForm>,
+    overrides: Vec<AgentTaskReviewOverride>,
+    preflight: bool,
+    backend: &mut B,
+) -> Result<Value> {
+    if let Some(form) = &review_form {
+        form.validate()?;
+    }
     let (recipe, recovered_retry) = if super::cook_recipe::recipe_exists(run_or_cook_id)? {
         (super::cook_recipe::load_recipe(run_or_cook_id)?, false)
     } else if let Some(recipe) = super::cook_recipe::load_recipe_for_attempt(run_or_cook_id)? {
@@ -3554,7 +3624,19 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             None,
         ));
     }
-    let finalization = cook_finalization_options(&options, &run_id, &promotion, overrides)?;
+    let supplied_form_replaces_recorded_form = review_form.is_some()
+        && review_form_for_finalization_in_store(
+            &agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?,
+            &run_id,
+        )
+        .is_ok();
+    let finalization = cook_finalization_options_with_review_form(
+        &options,
+        &run_id,
+        &promotion,
+        overrides,
+        review_form.as_ref(),
+    )?;
     if !preflight {
         agent_task_lifecycle::record_promotion(
             &run_id,
@@ -3566,9 +3648,32 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     } else {
         finalize_pr_with_backend(finalization, backend)?
     };
-    let value = serde_json::to_value(report).unwrap_or(Value::Null);
+    let value = serde_json::to_value(&report).unwrap_or(Value::Null);
     if !preflight {
         agent_task_lifecycle::record_cook_finalization(&run_id, value.clone())?;
+        if let Some(form) = review_form {
+            agent_task_lifecycle::record_metadata_value(
+                &run_id,
+                "recovery_review_form",
+                serde_json::json!({
+                    "schema": "homeboy/agent-task-recovery-review-form/v1",
+                    "form": form,
+                    "provenance": {
+                        "source": "operator_supplied_recovery",
+                        "operator": "homeboy agent-task finalize-pr",
+                        "run_id": run_id,
+                        "replaces_recorded_form": supplied_form_replaces_recorded_form,
+                        "patch_sha256": promotion.patch_artifact.sha256,
+                        "source_refs": options.workspace.source_refs,
+                        "deterministic_gates": promotion.deterministic_gates,
+                        "authoring": {
+                            "tool": report.review_dossier.ai_assistance.tool,
+                            "model": report.review_dossier.ai_assistance.model,
+                        },
+                    },
+                }),
+            )?;
+        }
     }
     Ok(value)
 }
@@ -4531,12 +4636,13 @@ fn validate_manual_preflight_report(
     })
 }
 
-fn cook_review_dossier_with_stores(
+fn cook_review_dossier_with_stores_and_review_form(
     store: &super::cook_recipe::CookRecipeStore,
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     options: &CookRequest,
     promotion: &AgentTaskPromotionReport,
     successful_run_id: &str,
+    review_form: Option<&crate::agent_task_review_dossier::AiFilledReviewForm>,
 ) -> Result<(AgentTaskReviewDossier, bool, bool)> {
     // A form-only run owns reviewer metadata but carries forward the durable
     // gate proof while its authenticated source owns candidate scope.
@@ -4604,7 +4710,10 @@ fn cook_review_dossier_with_stores(
     // A form-only follow-up owns reviewer metadata, not the candidate it carries
     // forward. Resolve the persisted Cook lineage so that follow-up prose cannot
     // erase the implementation attempt that produced the delivered patch.
-    let terminal_form = review_form_for_finalization_in_store(lifecycle_store, successful_run_id)?;
+    let terminal_form = match review_form {
+        Some(form) => form.clone(),
+        None => review_form_for_finalization_in_store(lifecycle_store, successful_run_id)?,
+    };
     let verified_commands = terminal_form.verify_against_promotion(verification_promotion)?;
     let lineage = cook_ai_lineage_with_stores(
         store,
@@ -5454,7 +5563,7 @@ fn review_form_for_finalization_in_store(
             Error::validation_invalid_argument(
                 "review_form",
                 format!(
-                    "cook finalization requires an AI-authored review form on run {run_id}; none was recorded. {}",
+                    "cook finalization requires an AI-authored review form on run {run_id}; none was recorded. Supply a complete replacement with `homeboy agent-task finalize-pr --recover {run_id} --review-form @FORM.json`. {}",
                     crate::agent_task_review_dossier::AiFilledReviewForm::requirement_feedback()
                 ),
                 None,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -18661,6 +18661,22 @@ fn recovery_supplies_missing_historical_review_form_without_provider_dispatch() 
             .record_run_aggregate(run_id, &options.identity.initial_plan, &existing_form)
             .unwrap();
 
+        let mut invalid_provenance = supplied_test_review_form();
+        invalid_provenance.tool = "OpenCode\ninvalid".to_string();
+        recover_cook_pr_with_backend_and_review_form(
+            cook_id,
+            Some(invalid_provenance),
+            Vec::new(),
+            false,
+            &mut CaptureBackend::default(),
+        )
+        .expect_err("invalid reviewer-visible provenance cannot create a receipt");
+        assert!(agent_task_lifecycle::reconcile_status(run_id)
+            .unwrap()
+            .metadata
+            .get("recovery_review_form")
+            .is_none());
+
         agent_task_lifecycle::fail_next_record_write_for_test();
         let mut failed_persistence_backend = CaptureBackend {
             synthetic_gate_proof: Some(applied.clone()),
@@ -18728,6 +18744,43 @@ fn recovery_supplies_missing_historical_review_form_without_provider_dispatch() 
             serde_json::to_value(&record.metadata["latest_promotion"]["deterministic_gates"])
                 .unwrap()
         );
+    });
+}
+
+#[test]
+fn concurrent_conflicting_recovery_receipts_admit_only_one_submission() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let run_id = "cook-9866-concurrent-attempt-1";
+        let plan = AgentTaskPlan::new("cook-9866-concurrent", Vec::new());
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+        let store = test_lifecycle_store();
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let left_store = store.clone();
+        let right_store = store.clone();
+        let left_barrier = barrier.clone();
+        let right_barrier = barrier.clone();
+        let left = std::thread::spawn(move || {
+            left_barrier.wait();
+            left_store.compare_and_set_metadata_value(
+                run_id,
+                "recovery_review_form",
+                serde_json::json!({ "submission": { "operator": "operator-a" } }),
+            )
+        });
+        let right = std::thread::spawn(move || {
+            right_barrier.wait();
+            right_store.compare_and_set_metadata_value(
+                run_id,
+                "recovery_review_form",
+                serde_json::json!({ "submission": { "operator": "operator-b" } }),
+            )
+        });
+        let left = left.join().unwrap();
+        let right = right.join().unwrap();
+        assert!(left.is_ok() ^ right.is_ok());
+        let record = agent_task_lifecycle::reconcile_status(run_id).unwrap();
+        let operator = &record.metadata["recovery_review_form"]["submission"]["operator"];
+        assert!(operator == "operator-a" || operator == "operator-b");
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -23,8 +23,8 @@ use super::super::cook_promotion::{
     record_replacement_gate_proof, recover_cook_pr_with_backend,
     recover_cook_pr_with_backend_and_review_form, recover_moving_base_cook_candidate_in_store,
     refreshed_moving_base_recovery, replacement_gate_execution_started,
-    selected_candidate_task_id_in_store, verify_replacement_gates, CookReportInput,
-    MovingBaseCookRecovery,
+    selected_candidate_task_id_in_store, verify_replacement_gates, AgentTaskSuppliedReviewForm,
+    CookReportInput, MovingBaseCookRecovery,
 };
 use super::super::cook_recipe::{
     load_recipe, persist_initial_recipe, set_initial_recipe_creation_barrier_for_test,
@@ -276,6 +276,15 @@ fn test_review_form() -> crate::agent_task_review_dossier::AiFilledReviewForm {
         compatibility: "Internal-only change; no compatibility impact.".to_string(),
         verification: Vec::new(),
         used_for: "Reproduced the failure, isolated the reload path, added a guard, and verified with the recorded deterministic gate before finalizing.".to_string(),
+    }
+}
+
+fn supplied_test_review_form() -> AgentTaskSuppliedReviewForm {
+    AgentTaskSuppliedReviewForm {
+        form: test_review_form(),
+        tool: "OpenCode".to_string(),
+        model: "openai/gpt-5.6-terra".to_string(),
+        operator: "fixture-operator".to_string(),
     }
 }
 
@@ -18603,7 +18612,7 @@ fn recovery_supplies_missing_historical_review_form_without_provider_dispatch() 
         };
         let preflight = recover_cook_pr_with_backend_and_review_form(
             cook_id,
-            Some(test_review_form()),
+            Some(supplied_test_review_form()),
             Vec::new(),
             true,
             &mut preflight_backend,
@@ -18614,9 +18623,78 @@ fn recovery_supplies_missing_historical_review_form_without_provider_dispatch() 
             preflight["review_dossier"]["summary"],
             "Close the issue by guarding the reload path."
         );
+        assert_eq!(
+            preflight["review_dossier"]["ai_assistance"]["tool"],
+            "OpenCode"
+        );
+        assert_eq!(
+            preflight["review_dossier"]["ai_assistance"]["model"],
+            "openai/gpt-5.6-terra"
+        );
+        assert!(preflight["review_dossier"]["evidence"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|evidence| evidence["summary"]
+                .as_str()
+                .is_some_and(|summary| summary.contains("fixture-operator"))));
         assert!(!preflight_backend.committed);
         assert!(!preflight_backend.pushed);
         assert!(!preflight_backend.created);
+
+        let mut existing_form = agent_task_lifecycle::read_aggregate(run_id).unwrap();
+        existing_form.outcomes[0].outputs = test_review_form_outputs();
+        test_lifecycle_store()
+            .record_run_aggregate(run_id, &options.identity.initial_plan, &existing_form)
+            .unwrap();
+        let error = recover_cook_pr_with_backend_and_review_form(
+            cook_id,
+            Some(supplied_test_review_form()),
+            Vec::new(),
+            true,
+            &mut CaptureBackend::default(),
+        )
+        .expect_err("a valid recorded form cannot be replaced");
+        assert_eq!(error.details["field"], "review_form");
+        existing_form.outcomes[0].outputs = Value::Null;
+        test_lifecycle_store()
+            .record_run_aggregate(run_id, &options.identity.initial_plan, &existing_form)
+            .unwrap();
+
+        agent_task_lifecycle::fail_next_record_write_for_test();
+        let mut failed_persistence_backend = CaptureBackend {
+            synthetic_gate_proof: Some(applied.clone()),
+            ..Default::default()
+        };
+        recover_cook_pr_with_backend_and_review_form(
+            cook_id,
+            Some(supplied_test_review_form()),
+            Vec::new(),
+            false,
+            &mut failed_persistence_backend,
+        )
+        .expect_err("provenance persistence fails before publication");
+        assert!(!failed_persistence_backend.created);
+
+        let mut failed_publication_backend = CaptureBackend {
+            synthetic_gate_proof: Some(applied.clone()),
+            commit_error: true,
+            ..Default::default()
+        };
+        recover_cook_pr_with_backend_and_review_form(
+            cook_id,
+            Some(supplied_test_review_form()),
+            Vec::new(),
+            false,
+            &mut failed_publication_backend,
+        )
+        .expect_err("publication failure retains the prior supplied-form receipt");
+        assert_eq!(
+            agent_task_lifecycle::reconcile_status(run_id)
+                .unwrap()
+                .metadata["recovery_review_form"]["submission"]["operator"],
+            "fixture-operator"
+        );
 
         let mut publish_backend = CaptureBackend {
             synthetic_gate_proof: Some(applied),
@@ -18624,7 +18702,7 @@ fn recovery_supplies_missing_historical_review_form_without_provider_dispatch() 
         };
         let published = recover_cook_pr_with_backend_and_review_form(
             cook_id,
-            Some(test_review_form()),
+            None,
             Vec::new(),
             false,
             &mut publish_backend,
@@ -18638,8 +18716,12 @@ fn recovery_supplies_missing_historical_review_form_without_provider_dispatch() 
             "operator_supplied_recovery"
         );
         assert_eq!(
-            record.metadata["recovery_review_form"]["provenance"]["authoring"]["model"],
+            record.metadata["recovery_review_form"]["submission"]["model"],
             "openai/gpt-5.6-terra"
+        );
+        assert_eq!(
+            record.metadata["recovery_review_form"]["submission"]["operator"],
+            "fixture-operator"
         );
         assert_eq!(
             record.metadata["recovery_review_form"]["provenance"]["deterministic_gates"],

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -282,8 +282,8 @@ fn test_review_form() -> crate::agent_task_review_dossier::AiFilledReviewForm {
 fn supplied_test_review_form() -> AgentTaskSuppliedReviewForm {
     AgentTaskSuppliedReviewForm {
         form: test_review_form(),
-        tool: "OpenCode".to_string(),
-        model: "openai/gpt-5.6-terra".to_string(),
+        tool: "review-form-tool".to_string(),
+        model: "openai/gpt-5.6-sol".to_string(),
         operator: "fixture-operator".to_string(),
     }
 }
@@ -18625,7 +18625,7 @@ fn recovery_supplies_missing_historical_review_form_without_provider_dispatch() 
         );
         assert_eq!(
             preflight["review_dossier"]["ai_assistance"]["tool"],
-            "OpenCode"
+            "Homeboy (fixture)"
         );
         assert_eq!(
             preflight["review_dossier"]["ai_assistance"]["model"],
@@ -18635,9 +18635,13 @@ fn recovery_supplies_missing_historical_review_form_without_provider_dispatch() 
             .as_array()
             .unwrap()
             .iter()
-            .any(|evidence| evidence["summary"]
-                .as_str()
-                .is_some_and(|summary| summary.contains("fixture-operator"))));
+            .any(
+                |evidence| evidence["summary"].as_str().is_some_and(|summary| {
+                    summary.contains("fixture-operator")
+                        && summary.contains("review-form-tool")
+                        && summary.contains("openai/gpt-5.6-sol")
+                })
+            ));
         assert!(!preflight_backend.committed);
         assert!(!preflight_backend.pushed);
         assert!(!preflight_backend.created);
@@ -18733,7 +18737,7 @@ fn recovery_supplies_missing_historical_review_form_without_provider_dispatch() 
         );
         assert_eq!(
             record.metadata["recovery_review_form"]["submission"]["model"],
-            "openai/gpt-5.6-terra"
+            "openai/gpt-5.6-sol"
         );
         assert_eq!(
             record.metadata["recovery_review_form"]["submission"]["operator"],

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -21,9 +21,10 @@ use super::super::cook_promotion::{
     persisted_promotion_for_attempt, persisted_promotion_for_attempt_in_store,
     preflight_cook_promotion_in_store, prepare_manual_finalization_identity,
     record_replacement_gate_proof, recover_cook_pr_with_backend,
-    recover_moving_base_cook_candidate_in_store, refreshed_moving_base_recovery,
-    replacement_gate_execution_started, selected_candidate_task_id_in_store,
-    verify_replacement_gates, CookReportInput, MovingBaseCookRecovery,
+    recover_cook_pr_with_backend_and_review_form, recover_moving_base_cook_candidate_in_store,
+    refreshed_moving_base_recovery, replacement_gate_execution_started,
+    selected_candidate_task_id_in_store, verify_replacement_gates, CookReportInput,
+    MovingBaseCookRecovery,
 };
 use super::super::cook_recipe::{
     load_recipe, persist_initial_recipe, set_initial_recipe_creation_barrier_for_test,
@@ -18556,6 +18557,95 @@ fn recovered_cook_finalization_uses_latest_resumed_gate_contract() {
         );
         assert!(!report.to_string().contains("stale-original-contract"));
         assert!(!report.to_string().contains("private stale gate"));
+    });
+}
+
+#[test]
+fn recovery_supplies_missing_historical_review_form_without_provider_dispatch() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-9866";
+        let run_id = "cook-9866-attempt-1";
+        let target = tempfile::tempdir().expect("fixture target");
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.identity.initial_run_id = run_id.to_string();
+        options.identity.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
+        persist_initial_recipe(&options).expect("persist recipe");
+        agent_task_lifecycle::submit_plan(&options.identity.initial_plan, Some(run_id))
+            .expect("submit run");
+        agent_task_lifecycle::record_cook_attempt_in_store(
+            &test_lifecycle_store(),
+            cook_id,
+            1,
+            run_id,
+        )
+        .expect("link recipe attempt");
+        seed_substantive_candidate_aggregate(
+            run_id,
+            &options.identity.initial_plan,
+            &target.path().join("candidate.patch"),
+            "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        );
+        assert!(
+            agent_task_lifecycle::read_aggregate(run_id)
+                .unwrap()
+                .outcomes
+                .iter()
+                .all(|outcome| outcome.outputs.get("review_form").is_none()),
+            "fixture must model the missing historical form"
+        );
+        let applied = promotion_with_existing_path(run_id, target.path());
+        agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(&applied).unwrap())
+            .expect("record applied promotion");
+
+        let mut preflight_backend = CaptureBackend {
+            synthetic_gate_proof: Some(applied.clone()),
+            ..Default::default()
+        };
+        let preflight = recover_cook_pr_with_backend_and_review_form(
+            cook_id,
+            Some(test_review_form()),
+            Vec::new(),
+            true,
+            &mut preflight_backend,
+        )
+        .expect("supplied form recovers immutable candidate without dispatch");
+        assert_eq!(preflight["status"], "validated");
+        assert_eq!(
+            preflight["review_dossier"]["summary"],
+            "Close the issue by guarding the reload path."
+        );
+        assert!(!preflight_backend.committed);
+        assert!(!preflight_backend.pushed);
+        assert!(!preflight_backend.created);
+
+        let mut publish_backend = CaptureBackend {
+            synthetic_gate_proof: Some(applied),
+            ..Default::default()
+        };
+        let published = recover_cook_pr_with_backend_and_review_form(
+            cook_id,
+            Some(test_review_form()),
+            Vec::new(),
+            false,
+            &mut publish_backend,
+        )
+        .expect("supplied form finalizes without manual reconstruction");
+        assert_eq!(published["status"], "review_ready");
+        assert!(publish_backend.created);
+        let record = agent_task_lifecycle::reconcile_status(run_id).expect("recovery receipt");
+        assert_eq!(
+            record.metadata["recovery_review_form"]["provenance"]["source"],
+            "operator_supplied_recovery"
+        );
+        assert_eq!(
+            record.metadata["recovery_review_form"]["provenance"]["authoring"]["model"],
+            "openai/gpt-5.6-terra"
+        );
+        assert_eq!(
+            record.metadata["recovery_review_form"]["provenance"]["deterministic_gates"],
+            serde_json::to_value(&record.metadata["latest_promotion"]["deterministic_gates"])
+                .unwrap()
+        );
     });
 }
 

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -535,7 +535,7 @@ pub mod service {
         reconstruct_adoption_options_with_dispatcher,
         reconstruct_options_for_pre_execution_recovery, reconstruct_options_with_dispatcher,
         reconstruct_options_with_local_placement_override, record_replacement_gate_proof,
-        recover_cook_pr, recover_missing_promotion_aggregate,
+        recover_cook_pr, recover_cook_pr_with_review_form, recover_missing_promotion_aggregate,
         recover_terminal_transport_proxy_evidence, register_cook_batch_work_handler,
         register_cook_work_handler, register_promotion_job_driver, resolve_cook_budget,
         resolve_supervision_policy, resume, resume_cook, resume_cook_batch,

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -554,12 +554,12 @@ pub mod service {
         AgentTaskDiscoveryReport, AgentTaskDiscoveryRun, AgentTaskHydratedEvidence,
         AgentTaskLiveness, AgentTaskPromotionJob, AgentTaskPromotionJobDriver,
         AgentTaskPromotionJobPhase, AgentTaskPromotionRequest, AgentTaskRetryServiceResult,
-        AgentTaskRunResult, CookActivityProbe, CookContinuationState, CookMode, CookProgressEvent,
-        CookProviderActivity, CookProviderRouteOverride, CookRecipeStore, CookRequest, CookRuntime,
-        CookService, CookSupervisionTick, CookSupervisor, AGENT_TASK_COOK_BATCH_JOB_TYPE,
-        AGENT_TASK_COOK_BATCH_JOB_VERSION, AGENT_TASK_PROMOTION_JOB_TYPE,
-        AGENT_TASK_PROMOTION_JOB_VERSION, DEFAULT_REVIEW_FORM_TIMEOUT_MS,
-        DETACHED_BATCH_COORDINATOR_ENV, MAX_REVIEW_FORM_TIMEOUT_MS,
+        AgentTaskRunResult, AgentTaskSuppliedReviewForm, CookActivityProbe, CookContinuationState,
+        CookMode, CookProgressEvent, CookProviderActivity, CookProviderRouteOverride,
+        CookRecipeStore, CookRequest, CookRuntime, CookService, CookSupervisionTick,
+        CookSupervisor, AGENT_TASK_COOK_BATCH_JOB_TYPE, AGENT_TASK_COOK_BATCH_JOB_VERSION,
+        AGENT_TASK_PROMOTION_JOB_TYPE, AGENT_TASK_PROMOTION_JOB_VERSION,
+        DEFAULT_REVIEW_FORM_TIMEOUT_MS, DETACHED_BATCH_COORDINATOR_ENV, MAX_REVIEW_FORM_TIMEOUT_MS,
     };
     pub use super::super::agent_task_service::{
         artifacts, logs, persist_initial_recipe, promotion_source,

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -856,6 +856,43 @@ impl AgentTaskLifecycleStore {
         .map(|_| ())
     }
 
+    /// Atomically persist a metadata value only when it is absent or already
+    /// byte-for-byte identical. This prevents concurrent recovery callers from
+    /// publishing against a receipt another caller authored.
+    pub(crate) fn compare_and_set_metadata_value(
+        &self,
+        run_id: &str,
+        key: &str,
+        value: Value,
+    ) -> Result<()> {
+        let run_id = sanitize_run_id(run_id);
+        let mut conflict = false;
+        self.mutate_record(&run_id, |record| {
+            let metadata = record.ensure_metadata_object();
+            match metadata.get(key) {
+                Some(existing) if existing == &value => false,
+                Some(_) => {
+                    conflict = true;
+                    false
+                }
+                None => {
+                    metadata.insert(key.to_string(), value.clone());
+                    record.updated_at = Some(super::now_timestamp());
+                    true
+                }
+            }
+        })?;
+        if conflict {
+            return Err(Error::validation_invalid_argument(
+                key,
+                "durable metadata already contains a different value",
+                Some(run_id),
+                None,
+            ));
+        }
+        Ok(())
+    }
+
     pub fn read_record_bounded(&self, run_id: &str) -> Result<AgentTaskRunRecord> {
         read_record_bounded_in_store(self, run_id)
     }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -794,6 +794,15 @@ pub struct FinalizePrArgs {
     /// Complete typed AI review form to supply for a recovered Cook whose historical provider outcome did not record one: inline JSON, `@FILE`, or `-`.
     #[arg(long, value_name = "JSON|@FILE|-", requires = "recover")]
     pub review_form: Option<String>,
+    /// Tool that authored the supplied review form.
+    #[arg(long, value_name = "TOOL", requires = "review_form")]
+    pub review_form_tool: Option<String>,
+    /// Concrete model that authored the supplied review form.
+    #[arg(long, value_name = "MODEL", requires = "review_form")]
+    pub review_form_model: Option<String>,
+    /// Operator or agent identity submitting the supplied review form.
+    #[arg(long, value_name = "IDENTITY", requires = "review_form")]
+    pub review_form_author: Option<String>,
     /// Validate the complete hydrated dossier and candidate without publishing.
     #[arg(long)]
     pub preflight: bool,

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -788,9 +788,12 @@ pub struct FinalizePrArgs {
     /// Related issue reference: #NUMBER, OWNER/REPO#NUMBER, or a github.com issue URL.
     #[arg(long = "relates-to", value_name = "ISSUE_REF")]
     pub relates_to: Vec<String>,
-    /// Explicit reviewer override in `TARGET=VALUE@PROVENANCE` form.
+    /// Explicit reviewer override in `TARGET=VALUE@PROVENANCE` form. Overrides require a recorded review form; use `--review-form` with `--recover` to supply one when it is absent.
     #[arg(long = "review-override", value_name = "TARGET=VALUE@PROVENANCE")]
     pub review_overrides: Vec<String>,
+    /// Complete typed AI review form to supply for a recovered Cook whose historical provider outcome did not record one: inline JSON, `@FILE`, or `-`.
+    #[arg(long, value_name = "JSON|@FILE|-", requires = "recover")]
+    pub review_form: Option<String>,
     /// Validate the complete hydrated dossier and candidate without publishing.
     #[arg(long)]
     pub preflight: bool,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -971,6 +971,36 @@ pub(crate) fn finalize_pull_request(mut args: FinalizePrArgs) -> CmdResult<Value
                     )
                 })
             })
+            .transpose()?
+            .map(|form| {
+                Ok::<_, Error>(agent_task_service::AgentTaskSuppliedReviewForm {
+                    form,
+                    tool: args.review_form_tool.clone().ok_or_else(|| {
+                        Error::validation_invalid_argument(
+                            "review_form_tool",
+                            "--review-form-tool is required with --review-form",
+                            None,
+                            None,
+                        )
+                    })?,
+                    model: args.review_form_model.clone().ok_or_else(|| {
+                        Error::validation_invalid_argument(
+                            "review_form_model",
+                            "--review-form-model is required with --review-form",
+                            None,
+                            None,
+                        )
+                    })?,
+                    operator: args.review_form_author.clone().ok_or_else(|| {
+                        Error::validation_invalid_argument(
+                            "review_form_author",
+                            "--review-form-author is required with --review-form",
+                            None,
+                            None,
+                        )
+                    })?,
+                })
+            })
             .transpose()?;
         let value = agent_task_service::recover_cook_pr_with_review_form(
             run_or_cook_id,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -31,7 +31,7 @@ use homeboy::agents::agent_tasks::review_dossier::{
     AgentTaskPublicContractEvidence, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
     AgentTaskReviewIssueRelationship, AgentTaskReviewIssueRelationshipKind,
     AgentTaskReviewOverride, AgentTaskReviewOverrideTarget, AgentTaskReviewTestStep,
-    AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
+    AiFilledReviewForm, AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
 };
 use homeboy::agents::agent_tasks::service as agent_task_service;
 use homeboy::agents::agent_tasks::{
@@ -956,7 +956,28 @@ pub(crate) fn finalize_pull_request(mut args: FinalizePrArgs) -> CmdResult<Value
             .iter()
             .map(|raw| parse_override(raw))
             .collect::<homeboy::core::Result<Vec<_>>>()?;
-        let value = agent_task_service::recover_cook_pr(run_or_cook_id, overrides, args.preflight)?;
+        let review_form = args
+            .review_form
+            .as_deref()
+            .map(config::read_json_spec_to_string)
+            .transpose()?
+            .map(|raw| {
+                serde_json::from_str::<AiFilledReviewForm>(&raw).map_err(|error| {
+                    Error::validation_invalid_argument(
+                        "review_form",
+                        format!("review form must be a complete typed JSON object: {error}"),
+                        None,
+                        None,
+                    )
+                })
+            })
+            .transpose()?;
+        let value = agent_task_service::recover_cook_pr_with_review_form(
+            run_or_cook_id,
+            review_form,
+            overrides,
+            args.preflight,
+        )?;
         let success = value
             .get("status")
             .and_then(Value::as_str)

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -2,6 +2,42 @@
 
 use super::support::*;
 
+#[derive(Parser)]
+struct FinalizePrCli {
+    #[command(flatten)]
+    args: FinalizePrArgs,
+}
+
+#[test]
+fn finalize_pr_parses_supplied_review_form_spec_and_authorship() {
+    for spec in ["{}", "@/tmp/review-form.json", "-"] {
+        let cli = FinalizePrCli::try_parse_from([
+            "homeboy",
+            "--recover",
+            "cook-9866-attempt-1",
+            "--review-form",
+            spec,
+            "--review-form-tool",
+            "OpenCode",
+            "--review-form-model",
+            "openai/gpt-5.6-terra",
+            "--review-form-author",
+            "operator@example.test",
+        ])
+        .expect("parse supplied review form");
+        assert_eq!(cli.args.review_form.as_deref(), Some(spec));
+        assert_eq!(cli.args.review_form_tool.as_deref(), Some("OpenCode"));
+        assert_eq!(
+            cli.args.review_form_model.as_deref(),
+            Some("openai/gpt-5.6-terra")
+        );
+        assert_eq!(
+            cli.args.review_form_author.as_deref(),
+            Some("operator@example.test")
+        );
+    }
+}
+
 #[test]
 fn validate_plan_reports_invalid_input_without_creating_a_lifecycle_record() {
     with_isolated_home(|_| {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/support.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/support.rs
@@ -13,7 +13,7 @@ pub(in crate::commands::agent_task) use super::super::args::{
     AgentTaskControllerProofArgs, AgentTaskControllerRunFromSpecArgs,
 };
 pub(in crate::commands::agent_task) use super::super::args::{
-    AgentTaskCookArgs, CompileLoopArgs, DiagnoseArgs, EvidenceArgs, LogsArgs,
+    AgentTaskCookArgs, CompileLoopArgs, DiagnoseArgs, EvidenceArgs, FinalizePrArgs, LogsArgs,
     ReplayProviderBoundaryArgs, ResumeArgs, ReviewArgs, RunArgs, StatusArgs, SubmitArgs,
     ValidatePlanArgs,
 };


### PR DESCRIPTION
Closes #9866

## Summary
- Add finalize-pr --recover --review-form for complete typed review-form recovery without provider redispatch.
- Require authoring tool, concrete model, and submitting operator identity; retain reviewer-visible provenance and a durable receipt alongside authenticated implementation lineage.
- Validate the assembled dossier before persisting supplied-form receipts; serialize receipts and reject conflicting submissions.
- Reuse identical receipts after interrupted publication and reject replacement of valid historical forms.
- Reconcile the original PR history and current main without rewriting commits; restore the public AiFilledReviewForm export required by the CLI.

## Verification
Verified locally on the refreshed branch:
- cargo test -p homeboy-agents recovery_supplies_missing_historical_review_form_without_provider_dispatch --lib: passed
- cargo test -p homeboy-agents concurrent_conflicting_recovery_receipts_admit_only_one_submission --lib: passed
- cargo test -p homeboy-agents finalization --lib: 117 passed, zero failed
- cargo test -p homeboy-cli finalize_pr_parses_supplied_review_form_spec_and_authorship --lib: passed
- cargo check -p homeboy-cli: passed
- cargo fmt --all -- --check: passed
- git diff --check: passed

The recovery regression exercises the lifecycle with a controlled publication backend. Live historical-run publication has not been exercised. Exact-head CI is tracked in the checks below.

## AI Assistance
OpenAI GPT-5.6 Terra through OpenCode assisted with the original implementation and tests. OpenAI GPT-6 Astra (openai/gpt-6-astra) through OpenCode compared the stale PR against current main, reconciled both histories, fixed the CLI contract export, ran the listed verification, and updated this PR under Chris Huber’s direction.