### PR TITLE
fix(upgrade): converge stale local daemon

### DIFF
--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -252,18 +252,7 @@ impl LocalControllerJobClient {
     /// rather than terminating an unobserved owner, and the final connection
     /// re-runs exact-build validation before any controller job is submitted.
     pub fn connect_current_build_recovering_idle() -> Result<Self> {
-        let status = read_status()?;
-        if recovery_actions::authorizes_automatic_idle_restart(&status) {
-            match status.freshness.lease_id.as_deref() {
-                Some(lease_id) => {
-                    stop_for_lease(lease_id)?;
-                }
-                None => {
-                    stop()?;
-                }
-            }
-            start_background(DEFAULT_ADDR)?;
-        }
+        let _ = converge_current_build_idle_daemon()?;
         Self::connect_current_build()
     }
 
@@ -491,6 +480,63 @@ impl LocalControllerJobClient {
             )
         })
     }
+}
+
+/// Rotate a stale resident daemon only when its authoritative status permits
+/// the canonical idle restart, then prove the replacement runs this build.
+///
+/// Unlike [`LocalControllerJobClient::connect_current_build_recovering_idle`],
+/// this does not start a daemon when none is resident. Controller upgrades use
+/// it to converge an existing daemon before reporting success.
+pub fn converge_current_build_idle_daemon() -> Result<bool> {
+    let status = read_status()?;
+    if !status.running || status.fresh {
+        return Ok(false);
+    }
+
+    if !recovery_actions::authorizes_automatic_idle_restart(&status) {
+        let plan = recovery_actions::plan_recovery(&status);
+        let recovery_command = if plan.executable && plan.required_confirmations.is_empty() {
+            "homeboy daemon recover --yes".to_string()
+        } else {
+            plan.steps
+                .first()
+                .map(|step| step.command.clone())
+                .unwrap_or_else(|| "homeboy daemon status".to_string())
+        };
+        let mut error = Error::validation_invalid_argument(
+            "daemon_build_identity",
+            "controller upgrade left a resident daemon that cannot be automatically converged",
+            status.freshness.daemon_build_identity,
+            Some(vec![format!("Run: {recovery_command}")]),
+        );
+        error.details["restart_required"] = serde_json::Value::Bool(true);
+        error.details["recovery_command"] = serde_json::Value::String(recovery_command);
+        return Err(error);
+    }
+
+    match status.freshness.lease_id.as_deref() {
+        Some(lease_id) => {
+            stop_for_lease(lease_id)?;
+        }
+        None => {
+            stop()?;
+        }
+    }
+    start_background(DEFAULT_ADDR)?;
+
+    let converged = read_status()?;
+    if converged.fresh {
+        return Ok(true);
+    }
+
+    Err(Error::internal_unexpected(format!(
+        "controller upgrade restarted the resident daemon but it did not converge to the invoking build: {}",
+        converged
+            .stale_reason
+            .as_deref()
+            .unwrap_or("daemon status remains stale")
+    )))
 }
 
 static DAEMON_JOB_STORE: OnceLock<JobStore> = OnceLock::new();

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -633,6 +633,7 @@ fn run_controller_upgrade_with_operation(
                 services_pending_restart: Vec::new(),
                 operation_id: None,
             };
+            converge_resident_daemon_after_controller_reconciliation(&completion)?;
             if completion.superseded {
                 invalidate_superseded_evidence(&mut result);
             }
@@ -918,6 +919,7 @@ fn run_controller_upgrade_with_operation(
             &final_selection_guard,
             || restart_resident_services_after_swap(success, skip_services),
         );
+    converge_resident_daemon_after_controller_reconciliation(&completion)?;
 
     let runner_disposition = runner_convergence_disposition(
         runner_completion_is_skipped(skip_runners, upgrade_completed, completion_superseded),
@@ -2015,6 +2017,19 @@ fn restart_resident_services_after_reconciliation(
     } else {
         restart()
     }
+}
+
+/// A local daemon is controller-owned runtime state even though it is not a
+/// configured resident service. Do this after reconciliation so a contender
+/// cannot cause this invocation to rotate a daemon for a controller it did not
+/// promote.
+fn converge_resident_daemon_after_controller_reconciliation(
+    completion: &ControllerCompletionIdentity,
+) -> Result<bool> {
+    if !completion.superseded {
+        return homeboy_core::daemon::converge_current_build_idle_daemon();
+    }
+    Ok(false)
 }
 
 /// Surface declared resident services that still hold the old binary, with the


### PR DESCRIPTION
## Summary
- converge an idle stale local daemon after controller upgrade reconciliation
- verify the replacement daemon runs the invoking build before upgrade succeeds
- preserve the existing lease-bound restart policy for local job admission

Closes #14275

AI assistance: OpenCode with openai/gpt-5.6-terra was used to inspect the control flow, implement the fix, and run verification.