### PR TITLE
fix(agent-task): fence cancelled Cook retries

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -461,6 +461,7 @@ mod tests {
                     cook_id: cook_id.to_string(),
                     latest_run_id: attempt.clone(),
                     latest_substantive_candidate: None,
+                    cancellation_fence: None,
                     attempts: vec![crate::agent_task_lifecycle::AgentTaskCookIndexAttempt {
                         attempt: 1,
                         run_id: attempt.clone(),
@@ -499,6 +500,7 @@ mod tests {
                     cook_id: direct.clone(),
                     latest_run_id: other,
                     latest_substantive_candidate: None,
+                    cancellation_fence: None,
                     attempts: Vec::new(),
                 },
             )

--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -41,6 +41,23 @@ pub fn cancel_run_in_store(
     reason: Option<&str>,
 ) -> Result<AgentTaskRunRecord> {
     let requested_run_id = sanitize_run_id(run_id);
+    // The Cook index is the authority every later attempt registration shares.
+    // Fence it before resolving the current alias so a retry cannot become the
+    // new mission outcome between cancellation passes.
+    lifecycle_store.with_config_lock(|| {
+        lifecycle_store.update_cook_index(&requested_run_id, |index| {
+            if index.cancellation_fence.is_some() {
+                return false;
+            }
+            index.cancellation_fence = Some(json!({
+                "state": "cancelled",
+                "cancelled_at": now_timestamp(),
+                "reason": reason.unwrap_or("cancel requested"),
+            }));
+            true
+        })?;
+        Ok(())
+    })?;
     let mut resolved_run_id = resolve_run_id_in_store(lifecycle_store, &requested_run_id)?;
     // Index publication is independent from parent cancellation. Re-resolve
     // after each mutation until the Cook alias is stable, so every attempt that
@@ -1101,6 +1118,60 @@ mod tests {
                 homeboy_core::ErrorCode::ValidationInvalidArgument
             );
             assert!(!cook_index_exists(cook_id).expect("inspect absent Cook index"));
+        });
+    }
+
+    #[test]
+    fn cancellation_fence_preserves_candidate_evidence_and_rejects_retry_materialization() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-cancellation-fence";
+            let first_run_id = "cook-cancellation-fence-attempt-1";
+            let second_run_id = "cook-cancellation-fence-attempt-2";
+            let plan = AgentTaskPlan::new("cancellation-fence", Vec::new());
+            submit_plan(&plan, Some(first_run_id)).expect("submit first attempt");
+            record_cook_attempt_in_store(&test_lifecycle_store(), cook_id, 1, first_run_id)
+                .expect("index first attempt");
+            test_lifecycle_store()
+                .update_cook_index(cook_id, |index| {
+                    index.latest_substantive_candidate =
+                        Some(AgentTaskCookLatestSubstantiveCandidate {
+                            schema: "test".to_string(),
+                            run_id: first_run_id.to_string(),
+                            attempt: 1,
+                            task_id: "task".to_string(),
+                            artifact_id: "patch".to_string(),
+                            artifact_kind: "patch".to_string(),
+                            artifact_sha256: None,
+                            artifact_size_bytes: None,
+                            integrity: json!({}),
+                            promotion_provenance: None,
+                            destination_provenance: None,
+                            recorded_at: now_timestamp(),
+                        });
+                    true
+                })
+                .expect("persist retained candidate");
+
+            cancel_run(cook_id, Some("operator cancellation")).expect("cancel Cook mission");
+            submit_plan(&plan, Some(second_run_id)).expect("submit raced retry");
+            let error =
+                record_cook_attempt_in_store(&test_lifecycle_store(), cook_id, 2, second_run_id)
+                    .expect_err("cancelled mission rejects retry materialization");
+
+            assert_eq!(
+                error.code,
+                homeboy_core::ErrorCode::ValidationInvalidArgument
+            );
+            let index = cook_index_in_store(&test_lifecycle_store(), cook_id).expect("Cook index");
+            assert_eq!(
+                index.cancellation_fence.as_ref().unwrap()["state"],
+                "cancelled"
+            );
+            assert_eq!(
+                index.latest_substantive_candidate.as_ref().unwrap().run_id,
+                first_run_id,
+                "cancellation retains earlier candidate evidence"
+            );
         });
     }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -2859,7 +2859,21 @@ pub(crate) fn apply_aggregate_to_record(
     aggregate_path: String,
 ) {
     record.updated_at = Some(now_timestamp());
-    set_run_state(record, run_state_for_aggregate(aggregate));
+    let terminal_state = run_state_for_aggregate(aggregate);
+    if record.state != AgentTaskRunState::Cancelled {
+        // A controller failure is durable terminal evidence. Never project an
+        // aggregate as successful while that evidence remains attached.
+        set_run_state(
+            record,
+            if terminal_state == AgentTaskRunState::Succeeded
+                && record.metadata.get("cook_controller_failure").is_some()
+            {
+                AgentTaskRunState::Failed
+            } else {
+                terminal_state
+            },
+        );
+    }
     record.aggregate_path = Some(aggregate_path);
     record.totals = Some(aggregate.totals.clone());
     record.tasks = tasks_for_aggregate(plan, aggregate);

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -6726,6 +6726,18 @@ pub(crate) fn record_cook_attempt_locked_in_store(
         ));
     }
     let recorded_at = now_timestamp();
+    if lifecycle_store
+        .read_cook_index(&cook_id)
+        .ok()
+        .is_some_and(|index| index.cancellation_fence.is_some())
+    {
+        return Err(Error::validation_invalid_argument(
+            "cook_id",
+            "Cook mission was cancelled before this attempt could materialize",
+            Some(cook_id),
+            None,
+        ));
+    }
     let metadata = record.ensure_metadata_object();
     metadata.insert("cook_id".to_string(), json!(&cook_id));
     metadata.insert("cook_attempt".to_string(), json!(attempt));
@@ -7034,6 +7046,7 @@ pub fn select_cook_candidate_from_attempts(
             cook_id: cook_id.to_string(),
             latest_run_id,
             latest_substantive_candidate: None,
+            cancellation_fence: None,
             attempts,
         },
         None,
@@ -7160,7 +7173,7 @@ pub(crate) fn update_cook_candidate_after_completion_in_store(
         return Ok(());
     };
     lifecycle_store.update_cook_index(cook_id, |index| {
-        replace_latest_substantive_candidate(index, candidate)
+        index.cancellation_fence.is_none() && replace_latest_substantive_candidate(index, candidate)
     })?;
     Ok(())
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -418,6 +418,10 @@ pub struct AgentTaskCookIndex {
     /// bytes. Unlike `latest_run_id`, empty retries never replace this.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub latest_substantive_candidate: Option<AgentTaskCookLatestSubstantiveCandidate>,
+    /// Mission-level cancellation is durable authority over later Cook attempt
+    /// admission and completion projection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancellation_fence: Option<Value>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub attempts: Vec<AgentTaskCookIndexAttempt>,
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -4281,6 +4281,38 @@ fn cancellation_wins_the_retry_pre_execution_failure_race() {
 }
 
 #[test]
+fn controller_failure_cannot_terminalize_a_successful_aggregate() {
+    with_isolated_home(|_| {
+        let run_id = "controller-failure-terminalization";
+        let plan = test_plan();
+        let lifecycle_store = test_lifecycle_store();
+        submit_plan(&plan, Some(run_id)).expect("submit");
+        record_cook_controller_failure_in_store(
+            &lifecycle_store,
+            run_id,
+            &json!({ "code": "controller_failure", "message": "artifact mirror missing" }),
+        )
+        .expect("persist controller failure");
+        let mut record = lifecycle_store.read_record(run_id).expect("read record");
+
+        let terminal = record_aggregate_in_store(
+            &lifecycle_store,
+            &mut record,
+            &plan,
+            &succeeded_aggregate(&plan),
+        )
+        .expect("retain aggregate evidence");
+
+        assert_eq!(terminal.state, AgentTaskRunState::Failed);
+        assert!(terminal.aggregate_path.is_some());
+        assert_eq!(
+            terminal.metadata["cook_controller_failure"]["code"],
+            "controller_failure"
+        );
+    });
+}
+
+#[test]
 fn snapshot_fence_transition_preserves_cancelled_terminal_winner() {
     with_isolated_home(|_| {
         let run_id = "snapshot-fence-cancelled";

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3830,6 +3830,7 @@ pub(crate) fn dispatch_cook_follow_up(
         // Refresh the durable execution attestation before this plan can be
         // persisted or handed to a local or detached provider.
         bind_dispatch_workspace_attestations(&mut follow_up_plan)?;
+        ensure_cook_attempt_admitted(lifecycle_store, cook_id)?;
         lifecycle_store.submit_plan_with_current_runtime(&follow_up_plan, &next_run_id)?;
         lifecycle_store.record_cook_attempt(cook_id, next_attempt, &next_run_id)?;
         if budget_scope == CookFollowUpBudgetScope::CandidateAdoptionReview {
@@ -3848,6 +3849,7 @@ pub(crate) fn dispatch_cook_follow_up(
             // this baseline-bound workspace contract, and so the run record the
             // claim is written onto exists.
             let operation_key = retry_dispatch_operation_key(&next_run_id);
+            ensure_cook_attempt_admitted(lifecycle_store, cook_id)?;
             match lifecycle_store.claim_cook_operation(
                 &next_run_id,
                 &operation_key,
@@ -3873,6 +3875,7 @@ pub(crate) fn dispatch_cook_follow_up(
                 | agent_task_lifecycle::ClaimOutcome::LeaseHeld => {}
             }
         } else {
+            ensure_cook_attempt_admitted(lifecycle_store, cook_id)?;
             run_loaded_plan_with_derived_cook_baseline_in_store(
                 lifecycle_store,
                 follow_up_plan,
@@ -3908,6 +3911,27 @@ pub(crate) fn dispatch_cook_follow_up(
     remediation_category_usage.add(reservation);
     Ok(CookFollowUpDispatch::Dispatched {
         run_id: next_run_id,
+    })
+}
+
+pub(crate) fn ensure_cook_attempt_admitted(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    cook_id: &str,
+) -> Result<()> {
+    lifecycle_store.with_config_lock(|| {
+        if lifecycle_store
+            .read_cook_index(cook_id)
+            .ok()
+            .is_some_and(|index| index.cancellation_fence.is_some())
+        {
+            return Err(Error::validation_invalid_argument(
+                "cook_id",
+                "Cook mission was cancelled; retries and follow-ups are not admitted",
+                Some(cook_id.to_string()),
+                None,
+            ));
+        }
+        Ok(())
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -13710,6 +13710,7 @@ fn legacy_substantive_candidate_selection_is_explicitly_incomplete_after_64_newe
                 cook_id: cook_id.to_string(),
                 latest_run_id: format!("{cook_id}-65"),
                 latest_substantive_candidate: None,
+                cancellation_fence: None,
                 attempts,
             },
         )
@@ -14180,6 +14181,7 @@ fn large_cook_index_selects_the_deterministic_top_64_window() {
                 cook_id: cook_id.to_string(),
                 latest_run_id: format!("{cook_id}-10000"),
                 latest_substantive_candidate: None,
+                cancellation_fence: None,
                 attempts,
             },
         )

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -2119,6 +2119,7 @@ fn reserve_cook_retry_lifecycle(
     force: bool,
     preflight: &dyn Fn(&AgentTaskPlan) -> Result<()>,
 ) -> Result<CookRetryReservation> {
+    super::cook::ensure_cook_attempt_admitted(lifecycle_store, &retry.cook_id)?;
     let operation_key = format!("retry:{}:{}", retry.cook_id, retry.attempt);
     match agent_task_lifecycle::claim_cook_operation_in_store(
         lifecycle_store,
@@ -2240,6 +2241,7 @@ fn retryable_cook_attempt(
     let Some(cook_id) = source.metadata["cook_id"].as_str() else {
         return Ok(None);
     };
+    super::cook::ensure_cook_attempt_admitted(lifecycle_store, cook_id)?;
     let Some(source_attempt) = source.metadata["cook_attempt"].as_u64() else {
         return Ok(None);
     };

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -3891,6 +3891,7 @@ fn index_cook_attempts(cook_id: &str, first_run_id: &str, latest_run_id: &str) {
         cook_id: cook_id.to_string(),
         latest_run_id: latest_run_id.to_string(),
         latest_substantive_candidate: None,
+        cancellation_fence: None,
         attempts: [first_run_id, latest_run_id]
             .into_iter()
             .enumerate()

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -1532,6 +1532,7 @@ pub(super) fn write_cook_index_attempt_locked_in_store(
             cook_id: cook_id.clone(),
             latest_run_id: run_id.clone(),
             latest_substantive_candidate: None,
+            cancellation_fence: None,
             attempts: Vec::new(),
         }
     };


### PR DESCRIPTION
## Summary
- persist Cook mission cancellation on the indexed attempt authority
- reject retry and follow-up admission after the fence, while retaining completion artifacts and existing candidate evidence
- prevent successful terminal projection while durable controller failure evidence remains

Closes #14292

## Verification
- cargo test -p homeboy-agents cancellation_fence_preserves_candidate_evidence_and_rejects_retry_materialization --lib
- cargo test -p homeboy-agents provider_terminalization_observes_cancellation_that_won_the_race --lib
- cargo test -p homeboy-agents cancellation_wins_the_retry_pre_execution_failure_race --lib
- cargo test -p homeboy-agents controller_failure_cannot_terminalize_a_successful_aggregate --lib
- cargo fmt --check
- git diff --check

AI assistance: OpenCode with openai/gpt-5.6-terra was used to inspect lifecycle authority, implement the cancellation fence, and run verification.