### PR TITLE
refactor(agent-task): centralize aggregate transitions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/aggregate_transition.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/aggregate_transition.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+/// The authoritative transition from a controller aggregate to its durable run
+/// record. Callers retain ownership of source-specific validation and metadata;
+/// this layer owns the shared record, aggregate, workspace, and artifact
+/// projections.
+pub(crate) struct AgentTaskAggregateTransition<'a> {
+    pub record: &'a mut AgentTaskRunRecord,
+    pub plan: &'a AgentTaskPlan,
+    pub aggregate: &'a AgentTaskAggregate,
+}
+
+pub(crate) fn apply_aggregate_transition_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    transition: AgentTaskAggregateTransition<'_>,
+) -> Result<AgentTaskRunRecord> {
+    let AgentTaskAggregateTransition {
+        record,
+        plan,
+        aggregate,
+    } = transition;
+    let aggregate_path = lifecycle_store
+        .aggregate_path(&record.run_id)
+        .display()
+        .to_string();
+    apply_aggregate_to_record(record, plan, aggregate, aggregate_path);
+    lifecycle_store.write_aggregate_and_record(record, aggregate)?;
+    record_terminal_artifact_projection_in_store(lifecycle_store, record, aggregate)?;
+    Ok(record.clone())
+}

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -1358,13 +1358,6 @@ pub(crate) fn record_aggregate_in_store(
     plan: &AgentTaskPlan,
     aggregate: &AgentTaskAggregate,
 ) -> Result<AgentTaskRunRecord> {
-    let aggregate_path = lifecycle_store.aggregate_path(&record.run_id);
-    apply_aggregate_to_record(
-        record,
-        plan,
-        aggregate,
-        aggregate_path.display().to_string(),
-    );
     let mut retained_roots = Vec::new();
     let roots: Vec<PathBuf> = plan
         .tasks
@@ -1407,8 +1400,14 @@ pub(crate) fn record_aggregate_in_store(
         &aggregate.outcomes,
     )?;
     crate::controller_scratch::finalize_run_at(&lifecycle_store.data_root(), &record.run_id)?;
-    lifecycle_store.write_aggregate_and_record(record, aggregate)?;
-    record_terminal_artifact_projection_in_store(lifecycle_store, record, aggregate)?;
+    apply_aggregate_transition_in_store(
+        lifecycle_store,
+        AgentTaskAggregateTransition {
+            record,
+            plan,
+            aggregate,
+        },
+    )?;
     // The Cook index this completion updates belongs to the same store the
     // aggregate was just committed into. Resolving it ambiently made this
     // rooted function write its substantive-candidate pointer into whatever

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -387,21 +387,19 @@ fn project_terminal_runner_lifecycle_event_in_store(
     validate_terminal_child_identity(record, snapshot, event)?;
     let aggregate = projected_runner_aggregate(record, &event.aggregate);
     let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);
-    let aggregate_path = lifecycle_store
-        .aggregate_path(&record.run_id)
-        .display()
-        .to_string();
-    apply_aggregate_to_record(record, &projection_plan, &aggregate, aggregate_path);
     record_verified_lab_placement_outcome(record)?;
     // The aggregate is the task result. A successful enclosing daemon job only
     // proves transport completion, not task success.
     record_runner_job_terminal_metadata(record, snapshot.job.status, &snapshot.events);
-    lifecycle_store.write_aggregate_and_record(record, &aggregate)?;
-    crate::agent_task_lifecycle::record_terminal_artifact_projection_in_store(
+    apply_aggregate_transition_in_store(
         lifecycle_store,
-        record,
-        &aggregate,
-    )
+        AgentTaskAggregateTransition {
+            record,
+            plan: &projection_plan,
+            aggregate: &aggregate,
+        },
+    )?;
+    Ok(())
 }
 
 pub(crate) fn project_persisted_terminal_runner_events(
@@ -459,21 +457,18 @@ pub(crate) fn project_persisted_terminal_runner_events_in_store(
             return Ok(false);
         }
         let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);
-        let aggregate_path = lifecycle_store
-            .aggregate_path(&record.run_id)
-            .display()
-            .to_string();
-        apply_aggregate_to_record(record, &projection_plan, &aggregate, aggregate_path);
         record_verified_lab_placement_outcome(record)?;
         record.ensure_metadata_object().insert(
             "terminal_transport_recovery".to_string(),
             json!("persisted_runner_job_events"),
         );
-        lifecycle_store.write_aggregate_and_record(record, &aggregate)?;
-        crate::agent_task_lifecycle::record_terminal_artifact_projection_in_store(
+        apply_aggregate_transition_in_store(
             lifecycle_store,
-            record,
-            &aggregate,
+            AgentTaskAggregateTransition {
+                record,
+                plan: &projection_plan,
+                aggregate: &aggregate,
+            },
         )?;
         return Ok(true);
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -34,6 +34,7 @@ mod action_eligibility;
 pub mod activity_provider;
 pub mod agent_task_handoff_event;
 pub mod agent_task_lifecycle_event;
+mod aggregate_transition;
 mod artifact_materialization;
 mod cancellation;
 mod control_plane_identities;
@@ -67,6 +68,7 @@ pub use acceptance_verifier::{
     AgentTaskAcceptanceVerifier, AgentTaskAcceptanceVerifierProvenance,
 };
 pub use action_eligibility::*;
+pub(crate) use aggregate_transition::*;
 pub use artifact_materialization::*;
 pub use cancellation::*;
 pub use control_plane_identities::{

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -296,6 +296,37 @@ impl RunnerContinuationProvider for ServiceRunnerFixture {
 }
 
 #[test]
+fn aggregate_transition_commits_record_aggregate_and_terminal_artifact_projection() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    let mut record = stub_lab_offload_submission(&lifecycle_store, &plan, "aggregate-transition")
+        .expect("submit aggregate transition run");
+    let aggregate = succeeded_aggregate(&plan);
+
+    let completed = record_aggregate_in_store(&lifecycle_store, &mut record, &plan, &aggregate)
+        .expect("apply aggregate transition");
+    let persisted = lifecycle_store
+        .read_record("aggregate-transition")
+        .expect("persisted transitioned record");
+    let persisted_aggregate = lifecycle_store
+        .read_aggregate("aggregate-transition")
+        .expect("persisted transitioned aggregate");
+
+    assert_eq!(completed.state, AgentTaskRunState::Succeeded);
+    assert_eq!(persisted.state, AgentTaskRunState::Succeeded);
+    assert_eq!(
+        persisted.lifecycle.execution.state,
+        homeboy_core::run_lifecycle_record::RunExecutionState::Succeeded
+    );
+    assert_eq!(persisted_aggregate, aggregate);
+    assert_eq!(
+        persisted.metadata["artifact_projection"]["status"],
+        "complete"
+    );
+}
+
+#[test]
 fn cancellation_routes_managed_service_cleanup_to_its_lab_owner() {
     with_isolated_home(|_| {
         ensure_runner_continuation_provider_reset_hook();


### PR DESCRIPTION
Closes #14286

## Summary
- add one store-rooted aggregate transition that updates record state, paired aggregate persistence, terminal workspace authority, and artifact projection
- route normal aggregate completion and both terminal runner reconciliation paths through the shared transition
- add a direct lifecycle test covering durable record, aggregate, lifecycle, and artifact projection updates

## Tests
- `cargo fmt --check`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::terminal_and_reconcile::aggregate_transition_commits_record_aggregate_and_terminal_artifact_projection`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::submit_and_persist::terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retry_is_idempotent`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::submit_and_persist::terminal_proxy_reconciliation_hydrates_persisted_dispatch_terminal_states`
- `cargo test -p homeboy-agents runner_terminal_reconciliation_is_idempotent`
- `cargo test -p homeboy-agents agent_task_service::cook::tests::compiled_cook_binds_and_executes_the_first_ready_production_provider_route -- --exact`
- `cargo test -p homeboy-agents` was started but exceeded the 10-minute verification limit; its one observed parallel Cook failure passed when rerun in isolation.

AI assistance: OpenAI gpt-5.6-terra via OpenCode was used to investigate, implement, and verify this change.