### PR TITLE
fix(agent-task): normalize readiness diagnostics

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
@@ -250,13 +250,6 @@ fn evaluate_provider_dispatchability_with_config_credentials_and_deadline(
         .filter(|provider| provider.backend == backend)
         .collect::<Vec<_>>();
     let unresolved = |state: &'static str, reason: &'static str, route_reason: String| {
-        // A selector can fail while the backend's declared providers are otherwise
-        // usable. Preserve that component evidence while route precedence keeps
-        // the aggregate verdict unavailable.
-        let credentials_ready = !candidate_providers.is_empty()
-            && candidate_providers
-                .iter()
-                .all(|provider| provider_credential_readiness(provider).dispatchable);
         let configuration_ready = !candidate_providers.is_empty()
             && candidate_providers
                 .iter()
@@ -271,12 +264,8 @@ fn evaluate_provider_dispatchability_with_config_credentials_and_deadline(
                 reason: None,
             },
             credentials: AgentTaskProviderDispatchabilityCredentialCheck {
-                status: if credentials_ready {
-                    AgentTaskProviderCredentialStatus::Unverified
-                } else {
-                    AgentTaskProviderCredentialStatus::Missing
-                },
-                ready: credentials_ready,
+                status: AgentTaskProviderCredentialStatus::Unverified,
+                ready: false,
                 missing: Vec::new(),
                 // A route that never resolved to one provider was never
                 // probed, so nothing here was live-verified.
@@ -380,19 +369,21 @@ fn evaluate_provider_dispatchability_with_config_credentials_and_deadline(
                     if let Some(remediation) = remediation.as_ref() {
                         runtime_remediation.push(remediation.clone());
                     }
-                    let classification = if verdict.classification.trim().is_empty() {
-                        "unknown"
-                    } else {
-                        verdict.classification.trim()
+                    let classification = match verdict.classification.trim() {
+                        "" => "unknown".to_string(),
+                        "provider_account_blocked" => "account".to_string(),
+                        classification => classification.to_string(),
                     };
                     let reason = (!verdict.ready).then(|| {
                         if verdict.reason.trim().is_empty() {
-                            classification.to_string()
+                            classification.clone()
                         } else {
-                            format!(
-                                "{classification}: {}",
-                                homeboy_core::redaction::redact_string(&verdict.reason)
-                            )
+                            let mut cause = homeboy_core::redaction::redact_string(&verdict.reason);
+                            let prefix = format!("{}:", verdict.classification.trim());
+                            while let Some(next) = cause.strip_prefix(&prefix) {
+                                cause = next.trim_start().to_string();
+                            }
+                            format!("{classification}: {cause}")
                         }
                     });
                     let evidence = AgentTaskProviderRuntimeEvidence {
@@ -723,6 +714,7 @@ fn missing_readiness_invocation_diagnosis(
 
 fn sanitize_classification(classification: &str) -> String {
     match classification {
+        "provider_account_blocked" => "account".to_string(),
         "ready"
         | "deterministic_incompatibility"
         | "auth_failure"
@@ -1736,6 +1728,70 @@ mod tests {
             evaluate_provider_dispatchability(&ambiguous_catalog, "shared", None, None, false);
         assert_eq!(ambiguous.state, "route_ambiguous");
         assert!(!ambiguous.checks.route.ready);
+    }
+
+    #[test]
+    fn unresolved_route_never_claims_credentials_are_missing() {
+        let provider: super::super::AgentTaskExecutorProvider = serde_json::from_value(json!({
+            "id": "credential.provider",
+            "backend": "credential",
+            "provider_defaults": {
+                "credential": {
+                    "required_secret_env": ["HOMEBOY_TEST_UNRESOLVED_ROUTE_CREDENTIAL"]
+                }
+            }
+        }))
+        .expect("provider fixture");
+        let verdict = evaluate_provider_dispatchability(
+            &catalog(provider),
+            "credential",
+            Some("missing.provider"),
+            None,
+            false,
+        );
+
+        assert_eq!(verdict.state, "route_unavailable");
+        assert_eq!(
+            verdict.checks.credentials.status,
+            AgentTaskProviderCredentialStatus::Unverified
+        );
+        assert!(!verdict.checks.credentials.ready);
+        assert!(verdict.checks.credentials.missing.is_empty());
+    }
+
+    #[test]
+    fn repeated_provider_classification_is_normalized_in_readiness_output() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let count = root.path().join("count");
+        let script = root.path().join("readiness.js");
+        std::fs::write(
+            &script,
+            "process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:false,classification:'provider_account_blocked',retryable:false,remediation:'switch account',reason:'provider_account_blocked: provider_account_blocked: account access rejected',cache_key:'blocked',identity:{}}));",
+        )
+        .expect("readiness script");
+
+        let verdict = evaluate_provider_dispatchability(
+            &catalog(provider(&script, &count)),
+            "test",
+            None,
+            None,
+            true,
+        );
+
+        assert_eq!(verdict.state, "account_unavailable");
+        assert_eq!(
+            verdict.checks.runtime.reason.as_deref(),
+            Some("account: account access rejected")
+        );
+        assert_eq!(
+            verdict
+                .readiness
+                .live_inference
+                .evidence
+                .as_ref()
+                .map(|evidence| evidence.classification.as_str()),
+            Some("account")
+        );
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -2339,7 +2339,12 @@ fn provider_readiness_exhausted_outcome(
         .readiness_skips
         .iter()
         .filter_map(|skip| skip.classification.as_deref())
-        .collect::<Vec<_>>();
+        .fold(Vec::new(), |mut classifications, classification| {
+            if !classifications.contains(&classification) {
+                classifications.push(classification);
+            }
+            classifications
+        });
     let retryable = scheduled.readiness_skips.iter().any(|skip| skip.retryable);
     let failure_classification = if classifications.contains(&"timeout") {
         AgentTaskFailureClassification::Timeout
@@ -2347,11 +2352,10 @@ fn provider_readiness_exhausted_outcome(
         AgentTaskFailureClassification::RateLimited
     } else if classifications.contains(&"transient_failure") {
         AgentTaskFailureClassification::Transient
-    } else if classifications
-        .iter()
-        .any(|classification| matches!(*classification, "account" | "auth_failure"))
-    {
+    } else if classifications.contains(&"account") {
         AgentTaskFailureClassification::ProviderAccountBlocked
+    } else if classifications.contains(&"auth_failure") {
+        AgentTaskFailureClassification::ProviderCredentialsExhausted
     } else if classifications.contains(&"capability") {
         AgentTaskFailureClassification::CapabilityMissing
     } else {

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -1226,6 +1226,60 @@ mod provider_rotation_tests {
     }
 
     #[test]
+    fn readiness_exhaustion_normalizes_auth_failures_as_credential_rejections() {
+        struct RejectedCredentials;
+
+        impl AgentTaskExecutorAdapter for RejectedCredentials {
+            fn provider_route_readiness(
+                &self,
+                _request: &AgentTaskRequest,
+            ) -> ProviderRouteReadiness {
+                ProviderRouteReadiness {
+                    ready: false,
+                    state: "credentials_unusable".to_string(),
+                    reason: "configured credentials were rejected".to_string(),
+                    reset_at: None,
+                    classification: Some("auth_failure".to_string()),
+                    retryable: false,
+                    remediation: Some("repair provider credentials".to_string()),
+                    cache_identity: None,
+                    provider_identity: None,
+                    capacity_key: None,
+                    diagnostic_data: None,
+                }
+            }
+
+            fn execute(
+                &self,
+                _request: AgentTaskRequest,
+                _context: AgentTaskExecutionContext,
+            ) -> AgentTaskOutcome {
+                panic!("rejected credentials must not dispatch")
+            }
+        }
+
+        let mut plan = plan_with_tasks(1);
+        plan.options.rotation = Some(rotation_policy(vec![entry("fallback")]));
+        enable_rotation(&mut plan);
+
+        let aggregate = AgentTaskScheduler::new(Arc::new(RejectedCredentials)).run(plan);
+        let outcome = &aggregate.outcomes[0];
+
+        assert_eq!(
+            outcome.failure_classification,
+            Some(AgentTaskFailureClassification::ProviderCredentialsExhausted)
+        );
+        assert_eq!(
+            outcome.metadata["provider_readiness_exhaustion"]["classifications"],
+            json!(["auth_failure"])
+        );
+        assert_eq!(
+            outcome.metadata["provider_readiness_routing"]["skipped"][0]["state"],
+            "credentials_unusable"
+        );
+    }
+
+    #[test]
     fn readiness_diagnostic_class_message_and_data_use_one_route() {
         struct MixedDiagnosticRoutes;
 


### PR DESCRIPTION
Closes #14293

## Summary
- normalize repeated provider-account classification prefixes into one canonical readiness result
- keep unresolved routes credential-unverified instead of reporting an empty missing-credential list
- distinguish rejected configured credentials from account blocks in readiness exhaustion evidence

## Tests
- `cargo fmt --check`
- `cargo test -p homeboy-agents --lib repeated_provider_classification_is_normalized_in_readiness_output`
- `cargo test -p homeboy-agents --lib unresolved_route_never_claims_credentials_are_missing`
- `cargo test -p homeboy-agents --lib readiness_exhaustion_normalizes_auth_failures_as_credential_rejections`
- `cargo test -p homeboy-agents --lib shared_evaluator_uses_effective_config_redacts_runtime_reason_and_deduplicates`

`cargo test -p homeboy-agents --lib` was attempted and completed with 2,228 passing and 41 failing tests. The failures included readiness timeouts, provider-evidence lock poisoning, process-containment timing, and temporary-artifact errors under the full parallel suite; the focused affected tests above pass.

AI assistance: OpenAI gpt-5.6-terra via OpenCode was used to investigate, implement, and verify this change.