### PR TITLE
fix(extension): admit local refresh on controller

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -2895,7 +2895,7 @@ fn preflight_hot_command_with_input(
         output_runtime::emit_json_result_for_identity(Err(err), output_file, 2, command_identity);
         return Some(2);
     }
-    if let Some(hot_command) = resource_policy::hot_command(&cli.command) {
+    if let Some(hot_command) = resource_policy::hot_command_for_cli(cli) {
         if let Ok((resources, _)) = preflight() {
             let mut lab_readiness = if hot_command.lab_offload_supported {
                 crate::runner::lab_runner_readiness().ok()
@@ -4189,6 +4189,120 @@ mod tests {
                 ResourceAdmissionDecision::NotRequired
             );
         }
+    }
+
+    #[test]
+    fn local_extension_refresh_completes_without_hot_lab_admission() {
+        use crate::core::parsed_command_preflight::{
+            resolve_parsed_command_preflight, LabReadinessSnapshot, ParsedCommandPolicySnapshot,
+            ResourceAdmissionDecision, ResourceAdmissionEvidence, ResourceHeat,
+        };
+
+        crate::test_support::with_isolated_home(|home| {
+            let source = home.path().join("portable-extension");
+            std::fs::create_dir_all(&source).expect("local extension source");
+            std::fs::write(
+                source.join("fixture.json"),
+                r#"{"name":"fixture extension","version":"1.0.0"}"#,
+            )
+            .expect("extension manifest");
+            let args = vec![
+                "homeboy".to_string(),
+                "extension".to_string(),
+                "refresh".to_string(),
+                source.to_string_lossy().to_string(),
+                "--id".to_string(),
+                "fixture".to_string(),
+            ];
+            let cli = Cli::parse_from(&args);
+            let input = resource_policy::parsed_command_preflight_input(&cli, &args);
+
+            assert_eq!(
+                input.resource_admission,
+                crate::core::parsed_command_preflight::ResourceAdmissionRequirement::Exempt
+            );
+            for routed_args in [
+                vec![
+                    "homeboy".to_string(),
+                    "--placement".to_string(),
+                    "lab".to_string(),
+                    "extension".to_string(),
+                    "refresh".to_string(),
+                    source.to_string_lossy().to_string(),
+                    "--id".to_string(),
+                    "fixture".to_string(),
+                ],
+                vec![
+                    "homeboy".to_string(),
+                    "extension".to_string(),
+                    "refresh".to_string(),
+                    "https://example.test/extensions.git".to_string(),
+                    "--id".to_string(),
+                    "fixture".to_string(),
+                ],
+            ] {
+                let routed_cli = Cli::parse_from(&routed_args);
+                assert!(matches!(
+                    resource_policy::parsed_command_preflight_input(&routed_cli, &routed_args)
+                        .resource_admission,
+                    crate::core::parsed_command_preflight::ResourceAdmissionRequirement::Required { .. }
+                ));
+            }
+            let result = resolve_parsed_command_preflight(
+                args.clone(),
+                input,
+                ParsedCommandPolicySnapshot {
+                    resource_admission_evidence: ResourceAdmissionEvidence::Observed {
+                        pressure: ResourceHeat::Hot,
+                    },
+                    resource_policy: None,
+                    lab_readiness: Some(LabReadinessSnapshot {
+                        state: "stale".to_string(),
+                        selected_runner_id: None,
+                        available_runner_ids: Vec::new(),
+                        reasons: vec!["stale Lab inventory".to_string()],
+                        remediation_commands: Vec::new(),
+                        repair_admitted_runner_ids: Vec::new(),
+                    }),
+                    selected_runner_id: None,
+                    generic_route: generic_route_policy_snapshot(&cli, None),
+                    deferred_pressure_refusal: false,
+                    runner_admitted: false,
+                    runner_incompatible: false,
+                    auto_local_capacity_fallback: false,
+                },
+            )
+            .expect("local refresh remains admitted with stale Lab inventory");
+            assert_eq!(
+                result.resource_admission,
+                ResourceAdmissionDecision::NotRequired
+            );
+            assert_eq!(
+                preflight_hot_command_with(
+                    &cli,
+                    None,
+                    &output::CommandIdentity::with_operation("extension", "refresh"),
+                    || -> crate::commands::CmdResult<crate::commands::resources::DoctorOutput> {
+                        panic!("local refresh must not probe controller resources or Lab")
+                    },
+                ),
+                None
+            );
+
+            let Commands::Extension(extension) = cli.command else {
+                unreachable!("extension refresh parses as an extension command")
+            };
+            let (output, exit_code) = crate::commands::extension::run(extension)
+                .expect("local extension refresh completes after admission");
+            assert_eq!(exit_code, 0);
+            assert!(matches!(
+                output,
+                crate::commands::extension::ExtensionOutput::Refresh {
+                    extension_id,
+                    ..
+                } if extension_id == "fixture"
+            ));
+        });
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -343,6 +343,17 @@ impl ExtensionArgs {
         )
     }
 
+    /// A valid local refresh replaces controller extension state from an
+    /// already-present resource. It is not a portable workload unless the
+    /// operator explicitly selects Lab.
+    pub(crate) fn refreshes_local_source(&self) -> bool {
+        matches!(
+            &self.command,
+            ExtensionCommand::Refresh { source, .. }
+                if homeboy_core::extension::lifecycle::is_local_source(source)
+        )
+    }
+
     pub(crate) fn is_readiness_repair_command(&self) -> bool {
         matches!(self.command, ExtensionCommand::Setup { .. })
     }

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -52,7 +52,7 @@ pub(crate) fn parsed_command_preflight_input(
     let normalized_args = crate::command_capability::homeboy_owned_args(normalized_args);
 
     let resource_admission =
-        hot_command(&cli.command).map_or(ResourceAdmissionRequirement::Exempt, |command| {
+        hot_command_for_cli(cli).map_or(ResourceAdmissionRequirement::Exempt, |command| {
             ResourceAdmissionRequirement::Required {
                 label: command.label.to_string(),
                 engages_at: if command.offload_only_when_hot {
@@ -538,6 +538,21 @@ pub(crate) fn hot_command(command: &Commands) -> Option<HotCommand> {
             Some(HotCommand::local_only(contract.hot_label, Some(reason)))
         }
     }
+}
+
+/// Local extension replacement is bounded controller configuration work. Its
+/// source has already been admitted by existence, so stale Lab inventory must
+/// not block it. An explicit Lab placement or runner remains an operator-owned
+/// portable routing request and retains the ordinary workload policy.
+pub(crate) fn hot_command_for_cli(cli: &Cli) -> Option<HotCommand> {
+    let local_extension_refresh = matches!(
+        &cli.command,
+        Commands::Extension(args) if args.refreshes_local_source()
+    );
+    if local_extension_refresh && cli.runner.is_none() && cli.placement != Placement::Lab {
+        return None;
+    }
+    hot_command(&cli.command)
 }
 
 /// Classify a descriptor-composed route with the exact portable/local-only and

--- a/crates/homeboy-core/src/extension/lifecycle/mod.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/mod.rs
@@ -48,9 +48,9 @@ pub mod source_metadata;
 pub use maintenance::update_all;
 pub use repair::{relink, replace, replace_with_revision, ReplaceResult};
 pub use source::{
-    check_update_available, check_update_available_until, is_git_url, read_source_cleanliness,
-    read_source_revision, read_source_revision_at, read_source_url, ExtensionSourceCleanliness,
-    UpdateAvailable,
+    check_update_available, check_update_available_until, is_git_url, is_local_source,
+    read_source_cleanliness, read_source_revision, read_source_revision_at, read_source_url,
+    ExtensionSourceCleanliness, UpdateAvailable,
 };
 use source::{read_source_metadata_value, source_metadata_dir};
 

--- a/crates/homeboy-core/src/extension/lifecycle/source.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/source.rs
@@ -16,6 +16,15 @@ pub fn is_git_url(source: &str) -> bool {
         || source.ends_with(".git")
 }
 
+/// Whether a refresh source names an extant controller-local resource.
+///
+/// Keep this alongside the source transport classifier so admission and the
+/// lifecycle agree about which inputs are local rather than inferring product
+/// conventions from extension IDs or manifests.
+pub fn is_local_source(source: &str) -> bool {
+    !is_git_url(source) && Path::new(source).exists()
+}
+
 /// Check if a git-cloned extension has updates available.
 /// Runs `git fetch` then checks if HEAD is behind the remote tracking branch.
 /// Returns None for linked extensions or if check fails.


### PR DESCRIPTION
Closes #14294

## Summary
- Treat refreshes from existing controller-local extension sources as bounded controller configuration work.
- Preserve portable admission for remote sources and explicit Lab placement.
- Cover the real refresh workflow under hot pressure and stale Lab inventory.

## Tests
- `cargo test -p homeboy-cli local_extension_refresh_completes_without_hot_lab_admission --lib`
- `cargo test -p homeboy-core extension::lifecycle::source::tests --lib`
- `cargo fmt --check`
- `git diff --check`
- Attempted `cargo test -p homeboy-cli --lib`; unrelated long-running Lab dispatch tests exceeded the 20-minute limit before completion.

AI assistance: OpenAI gpt-5.6-terra via OpenCode was used to investigate, implement, and verify this change.