### PR TITLE
fix(ssh): embed owned remote payload once

### DIFF
--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -1427,11 +1427,16 @@ const PROCESS_TERMINATION_GRACE: Duration = Duration::from_millis(100);
 /// backgrounding and then explicitly redirect the child's fd 0 from fd 3,
 /// restoring the original stdin stream.
 pub(super) fn wrap_owned_remote_command(command: &str) -> String {
+    // Bind the payload once. Embedding it separately in the setsid and Perl
+    // branches doubled every remote command inside a single `exec` argv, and
+    // large payloads (capability probes composed from runner env plus required
+    // tool, command, and capability entries) reached the exec limit and failed
+    // with `Argument list too long` before any branch ran. See #14304, and
+    // #8855, #8951, #9009, #10492 for the same limit at other sites.
     format!(
-        "exec 3<&0 || {{ printf '%s\\n' 'Homeboy SSH execution could not preserve remote stdin.' >&2; exit 1; }}; if command -v setsid >/dev/null 2>&1; then setsid sh -c {} <&3 & elif command -v perl >/dev/null 2>&1; then perl -MPOSIX -e {} sh -c {} <&3 & else printf '%s\\n' 'Homeboy SSH execution requires remote session authority (setsid or Perl POSIX).' >&2; exec 3<&-; exit 127; fi; __homeboy_remote_pid=$!; exec 3<&-; __homeboy_remote_cleanup() {{ kill -TERM -\"$__homeboy_remote_pid\" 2>/dev/null || true; __homeboy_remote_attempt=0; while kill -0 -\"$__homeboy_remote_pid\" 2>/dev/null && [ \"$__homeboy_remote_attempt\" -lt 10 ]; do sleep 0.01; __homeboy_remote_attempt=$((__homeboy_remote_attempt + 1)); done; kill -KILL -\"$__homeboy_remote_pid\" 2>/dev/null || true; }}; trap '__homeboy_remote_cleanup; exit 143' HUP INT TERM; wait \"$__homeboy_remote_pid\"; __homeboy_remote_status=$?; __homeboy_remote_cleanup; exit \"$__homeboy_remote_status\"",
+        "exec 3<&0 || {{ printf '%s\\n' 'Homeboy SSH execution could not preserve remote stdin.' >&2; exit 1; }}; __homeboy_remote_command={}; if command -v setsid >/dev/null 2>&1; then setsid sh -c \"$__homeboy_remote_command\" <&3 & elif command -v perl >/dev/null 2>&1; then perl -MPOSIX -e {} sh -c \"$__homeboy_remote_command\" <&3 & else printf '%s\\n' 'Homeboy SSH execution requires remote session authority (setsid or Perl POSIX).' >&2; exec 3<&-; exit 127; fi; __homeboy_remote_pid=$!; exec 3<&-; __homeboy_remote_cleanup() {{ kill -TERM -\"$__homeboy_remote_pid\" 2>/dev/null || true; __homeboy_remote_attempt=0; while kill -0 -\"$__homeboy_remote_pid\" 2>/dev/null && [ \"$__homeboy_remote_attempt\" -lt 10 ]; do sleep 0.01; __homeboy_remote_attempt=$((__homeboy_remote_attempt + 1)); done; kill -KILL -\"$__homeboy_remote_pid\" 2>/dev/null || true; }}; trap '__homeboy_remote_cleanup; exit 143' HUP INT TERM; wait \"$__homeboy_remote_pid\"; __homeboy_remote_status=$?; __homeboy_remote_cleanup; exit \"$__homeboy_remote_status\"",
         shell::quote_arg(command),
         shell::quote_arg("POSIX::setsid() >= 0 or die \"setsid: $!\\n\"; exec @ARGV or die \"exec: $!\\n\";"),
-        shell::quote_arg(command),
     )
 }
 

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -1288,3 +1288,63 @@ fn an_interactive_session_carrying_a_command_requests_a_terminal() {
         "ssh already allocates a tty when no command is given: {bare:?}"
     );
 }
+
+/// A remote command is embedded once in the owned-execution wrapper.
+///
+/// The wrapper previously inlined the payload separately in its `setsid` and
+/// Perl branches, so every remote command was doubled inside one `exec` argv.
+/// Large payloads (capability probes composed from runner env plus required
+/// tool, command, and capability entries) then failed with `Argument list too
+/// long` before either branch ran, which stalled Lab handoff for every Cook.
+/// See #14304, and #8855, #8951, #9009, #10492 for the same limit elsewhere.
+#[test]
+fn owned_remote_wrapper_embeds_its_payload_once() {
+    let payload_body = "x".repeat(64 * 1024);
+    let command = format!(
+        "printf '%s' {}",
+        crate::engine::shell::quote_arg(&payload_body)
+    );
+    let wrapped = wrap_owned_remote_command(&command);
+
+    let occurrences = wrapped.matches(&payload_body).count();
+    assert_eq!(
+        occurrences, 1,
+        "wrapper must embed the remote payload once, found {occurrences} copies"
+    );
+
+    // The exec footprint is what actually hit the limit, so bound it against
+    // the payload rather than trusting the copy count alone.
+    let overhead = wrapped.len().saturating_sub(command.len());
+    assert!(
+        overhead < command.len(),
+        "wrapper overhead {overhead} must stay below the payload size {}",
+        command.len()
+    );
+}
+
+/// The de-duplicated wrapper still executes the payload it was given.
+#[test]
+fn owned_remote_wrapper_executes_a_large_payload() {
+    let filler = "#".repeat(64 * 1024);
+    let command = format!("{filler}\nprintf '%s' homeboy-14304-marker");
+    let mut process = Command::new("sh");
+    process
+        .args(["-c", &wrap_owned_remote_command(&command)])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::server::process_cleanup::configure_process_group_cleanup(&mut process);
+
+    let output = execute_command_with_stdin_source_timeout(
+        process,
+        StdinSource::Reader(Box::new(Cursor::new(Vec::new()))),
+        Duration::from_secs(30),
+    );
+
+    assert!(output.success, "{}", output.stderr);
+    assert!(
+        output.stdout.contains("homeboy-14304-marker"),
+        "expected the large payload to execute, got stdout={:?} stderr={:?}",
+        output.stdout,
+        output.stderr
+    );
+}


### PR DESCRIPTION
## Summary

`wrap_owned_remote_command` embedded the full remote payload twice in a single `exec` argv — once for the `setsid` branch and once for the Perl branch. Combined with the environment exported by `prepend_env`, large payloads crossed the remote exec argument limit and failed with `Argument list too long` before either branch ran.

This bound the payload to a shell variable once and reference it from both branches, halving the exec footprint while preserving the existing session-authority, stdin-preservation, and process-group cleanup semantics.

Refs #14304

## Impact

The Lab runner capability probe is composed from runner env plus required tool, command, and capability entries, so it is one of the largest remote payloads Homeboy sends. On this controller it exceeded the limit, which meant:

```
root_cause.class: runner.lab_transport_failure
probe.stderr: "/bin/bash: Argument list too long"
```

Every Lab-placed Cook terminalized in `lab_handoff` before reaching a provider. Observed on Cook run `agent-task-0714bafd-71c7-4b12-9279-8a830ab99bb4`.

This is the same exec limit previously fixed at other sites in #8855, #8951, #9009, and #10492. The owned-remote wrapper was not covered by those fixes.

## Scope

This PR fixes the exec-limit cause only. Two items in #14304 are explicitly **not** addressed here:

- The claim that a failed probe reports tools as missing was withdrawn. `parse_batch_probe_output` already fails closed with `RunnerLabTransportFailure`, and `missing_tool_records` is diagnostic payload inside that error rather than a capability verdict. See the correction comment on #14304.
- `runner doctor` still reports the runner as `warn` with only an unrelated `playwright.browser_ready` check while Lab handoff is blocked. That diagnostic gap remains open on #14304.

## Tests

- `owned_remote_wrapper_embeds_its_payload_once` — asserts the payload appears exactly once and bounds wrapper overhead below the payload size. Fails against the previous wrapper, which embedded it twice.
- `owned_remote_wrapper_executes_a_large_payload` — executes a 64 KiB payload through the wrapper and asserts its output, proving the de-duplicated form still runs.

Commands run:

- `cargo fmt --check`
- `cargo test -p homeboy-core --lib server::client::tests` — 48 passed, 0 failed
- `cargo test -p homeboy-lab-runner --lib capabilities` — 37 passed, 0 failed

Two runs of the broader `homeboy-core --lib server::client` and `homeboy-lab-runner --lib` suites hit the 1500s hermetic suite deadline under local parallel load and terminated their process groups. Every test involved passed when rerun in isolation, consistent with #14175.

## AI assistance

Claude Opus 4.5 via Claude Code reproduced the Lab handoff failure while preparing a tracked Cook, traced the exec-limit amplification to the owned-remote wrapper, implemented this change, wrote the regression tests, and verified them. Chris Huber directed the work and remains responsible for it.