### PR TITLE
fix(cook): admit fetched base when origin is unreachable

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1817,6 +1817,30 @@ mod declared_base_tests {
         assert_eq!(error.details["git_base_preflight"]["timeout_ms"], 100);
     }
 
+    /// An SSH credential failure is transport evidence in its own right. It
+    /// used to be classified only because the remote host string contained
+    /// `proxy`, so the same failure to any other host was misreported as an
+    /// invalid base ref.
+    #[test]
+    fn ssh_credential_failure_is_transport_without_a_proxy_hostname() {
+        assert!(is_git_transport_failure(
+            "git@github.example: Permission denied (publickey).\nfatal: Could not read from remote repository."
+        ));
+        assert!(is_git_transport_failure(
+            "sign_and_send_pubkey: signing failed for ECDSA from agent: agent refused operation"
+        ));
+        assert!(is_git_transport_failure("Host key verification failed."));
+    }
+
+    /// A hostname is not evidence. A genuinely invalid ref must stay a
+    /// validation failure even when the remote is named `proxy.example.test`.
+    #[test]
+    fn a_proxy_hostname_alone_is_not_transport_evidence() {
+        assert!(!is_git_transport_failure(
+            "fatal: couldn't find remote ref refs/heads/nope on proxy.example.test"
+        ));
+    }
+
     #[test]
     fn materialized_workspace_is_the_lab_execution_checkout() {
         assert!(materialized_promotion_workspace_in_context(None)
@@ -3050,6 +3074,12 @@ fn declared_base_transport_error(
     error
 }
 
+/// Classify a base-preflight failure as transport rather than a bad ref.
+///
+/// Every needle names diagnostic evidence emitted by Git, SSH, or the TLS
+/// stack. A bare `proxy` needle used to match here, which classified any
+/// failure whose remote host merely contained that word — including a local
+/// credential failure that is transport-related for unrelated reasons.
 fn is_git_transport_failure(stderr: &str) -> bool {
     let stderr = stderr.to_ascii_lowercase();
     [
@@ -3058,10 +3088,24 @@ fn is_git_transport_failure(stderr: &str) -> bool {
         "could not resolve host",
         "connection timed out",
         "connection refused",
+        "connection closed",
+        "connection reset",
         "network is unreachable",
-        "proxy",
-        "tls",
-        "ssl",
+        "no route to host",
+        "broken pipe",
+        "proxy connect",
+        "proxy error",
+        "proxy authentication",
+        "proxycommand",
+        "tls handshake",
+        "ssl certificate",
+        "ssl connect error",
+        "permission denied (publickey",
+        "could not read from remote repository",
+        "authentication failed",
+        "host key verification failed",
+        "agent refused operation",
+        "sign_and_send_pubkey",
     ]
     .iter()
     .any(|needle| stderr.contains(needle))

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -7832,20 +7832,65 @@ fn pin_cook_workspace_base_at(options: &mut CookRequest, workspace: &Path) -> Re
     {
         counter.count.fetch_add(1, Ordering::SeqCst);
     }
-    let Some(base) = crate::agent_task_promotion::capture_declared_base(
-        workspace,
-        Some(&options.finalization.base),
-    )?
-    else {
-        return Ok(());
+    let declared = &options.finalization.base;
+    let pinned = match crate::agent_task_promotion::capture_declared_base(workspace, Some(declared))
+    {
+        Ok(Some(base)) => CookWorkspaceBasePin {
+            base: base.base,
+            sha: base.sha,
+            provenance: "origin_ls_remote",
+            remote_freshness: "checked",
+        },
+        Ok(None) => return Ok(()),
+        // The controller's authenticated transport is not the only authority
+        // for a base that is already present locally. A previously fetched
+        // remote-tracking ref names the exact commit this run would have
+        // pinned, so admit it rather than terminalizing with zero provider
+        // executions. Its unverified freshness is recorded, not hidden.
+        Err(error) if error.retryable == Some(true) => {
+            match local_tracking_cook_base(workspace, declared) {
+                Some(pin) => pin,
+                None => return Err(error),
+            }
+        }
+        Err(error) => return Err(error),
     };
-    options.workspace.task_base_sha = Some(base.sha.clone());
+    options.workspace.task_base_sha = Some(pinned.sha.clone());
     options.identity.initial_plan.metadata["cook_workspace_base"] = serde_json::json!({
         "schema": "homeboy/cook-workspace-base/v1",
-        "base": base.base,
-        "sha": base.sha,
+        "base": pinned.base,
+        "sha": pinned.sha,
+        "provenance": pinned.provenance,
+        "remote_freshness": pinned.remote_freshness,
     });
     Ok(())
+}
+
+struct CookWorkspaceBasePin {
+    base: String,
+    sha: String,
+    provenance: &'static str,
+    remote_freshness: &'static str,
+}
+
+/// Resolve a declared base from the checkout's existing remote-tracking ref.
+/// This reads only local objects, so it stays available when the controller
+/// cannot authenticate to the remote.
+fn local_tracking_cook_base(workspace: &Path, base: &str) -> Option<CookWorkspaceBasePin> {
+    let reference = format!("refs/remotes/origin/{base}");
+    let sha = homeboy_core::git::output_optional(
+        workspace,
+        &["rev-parse", "--verify", &format!("{reference}^{{commit}}")],
+    )?;
+    let sha = sha.trim();
+    (sha.len() == 40 && sha.bytes().all(|byte| byte.is_ascii_hexdigit())).then(|| {
+        CookWorkspaceBasePin {
+            base: base.to_string(),
+            sha: sha.to_string(),
+            provenance: "local_remote_tracking_ref",
+            remote_freshness: "unverified",
+        }
+    })
 }
 
 fn preflight_cook_workspace_base_ancestry_with_provider(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -9666,6 +9666,110 @@ fn workspace_base_capture_lock_times_out_while_another_controller_holds_it() {
     });
 }
 
+/// Build a checkout whose `origin` is unreachable, optionally retaining the
+/// remote-tracking ref a previous fetch would have left behind.
+#[cfg(test)]
+fn unreachable_origin_repository(temp: &Path, with_tracking_ref: bool) -> (PathBuf, String) {
+    let repository = temp.join("repository");
+    std::fs::create_dir(&repository).expect("create repository");
+    let git = |args: &[&str]| {
+        assert!(Command::new("git")
+            .args(args)
+            .current_dir(&repository)
+            .status()
+            .expect("run git")
+            .success());
+    };
+    git(&["init", "-b", "main"]);
+    std::fs::write(repository.join("fixture.txt"), "base\n").expect("write base");
+    git(&["add", "fixture.txt"]);
+    git(&[
+        "-c",
+        "user.name=Homeboy Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-m",
+        "base",
+    ]);
+    let head = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&repository)
+            .output()
+            .expect("resolve HEAD")
+            .stdout,
+    )
+    .expect("HEAD is UTF-8")
+    .trim()
+    .to_string();
+    if with_tracking_ref {
+        git(&["update-ref", "refs/remotes/origin/main", &head]);
+    }
+    // Port 1 refuses immediately, so the preflight fails as transport without
+    // depending on any external network.
+    git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://127.0.0.1:1/repository.git",
+    ]);
+    (repository, head)
+}
+
+/// The controller's authenticated transport is not the only authority for a
+/// base that was already fetched. Terminalizing here consumed zero provider
+/// executions and produced no worktree, purely because one network call failed.
+#[test]
+fn cook_base_pin_falls_back_to_the_fetched_tracking_ref_when_origin_is_unreachable() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("temporary repository");
+        let (repository, head) = unreachable_origin_repository(temp.path(), true);
+
+        let mut options = batch_cook_options(
+            "cook-base-transport-fallback",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.workspace.source_worktree_path = Some(repository.clone());
+        pin_cook_workspace_base_at(&mut options, &repository)
+            .expect("an already-fetched base admits the cook");
+
+        assert_eq!(
+            options.workspace.task_base_sha.as_deref(),
+            Some(head.as_str())
+        );
+        let recorded = &options.identity.initial_plan.metadata["cook_workspace_base"];
+        assert_eq!(recorded["sha"], head);
+        assert_eq!(recorded["base"], "main");
+        assert_eq!(
+            recorded["provenance"], "local_remote_tracking_ref",
+            "evidence must show the base was not verified against the remote"
+        );
+        assert_eq!(recorded["remote_freshness"], "unverified");
+    });
+}
+
+/// Without a local base the run has nothing immutable to pin, so it must still
+/// fail before provider execution rather than invent a base.
+#[test]
+fn cook_base_pin_still_fails_when_origin_is_unreachable_and_nothing_was_fetched() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("temporary repository");
+        let (repository, _) = unreachable_origin_repository(temp.path(), false);
+
+        let mut options = batch_cook_options(
+            "cook-base-transport-no-fallback",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.workspace.source_worktree_path = Some(repository.clone());
+        let error = pin_cook_workspace_base_at(&mut options, &repository)
+            .expect_err("no local base is available to pin");
+
+        assert_eq!(error.retryable, Some(true));
+        assert!(options.workspace.task_base_sha.is_none());
+    });
+}
+
 #[test]
 fn workspace_base_capture_repairs_controller_plan_after_recipe_write_interruption() {
     homeboy_core::test_support::with_isolated_home(|_| {


### PR DESCRIPTION
## Summary
- fall back to `refs/remotes/origin/<base>` when the controller cannot reach the remote, pinning that exact immutable SHA instead of terminalizing before provider execution
- record base `provenance` and `remote_freshness` so a remote-verified base is distinguishable from a locally-tracked one
- keep failing closed when neither the remote nor a tracking ref yields a base commit
- classify base-preflight transport failures on their own evidence instead of the bare `proxy` needle

Closes #14307

## Why

A Lab-placed Cook died in `worktree_provider_lookup` with zero provider executions and no worktree created, because one `git ls-remote --heads origin` call in the *controller's* checkout failed on credentials. The exact base object it needed was already present locally:

```text
$ git rev-parse origin/trunk
29b15de192089e627ec5ac1a1f96b38b1ca65444
```

Preview for the same inputs succeeded, because preview records an unreachable remote as `deferred`. Execution then failed hard on that same condition, so a successful preview did not predict admission.

The fallback stays deterministic: it pins one exact 40-character commit that is already in the local object database, and it never invents or guesses a base. Unverified freshness is recorded in `cook_workspace_base` rather than hidden, and finalization still resolves the base with live transport.

## Secondary defect

`is_git_transport_failure` matched the bare substring `proxy`. The observed failure was classified as transport only because the remote host string contained that word; neither `permission denied (publickey)` nor `could not read from remote repository` was matched. Classification now rests on Git/SSH/TLS diagnostic evidence, and a `proxy` hostname alone is no longer treated as transport evidence.

## Verification
- `cargo test -p homeboy-agents --lib cook_base_pin` (2 passed — fallback admits the fetched base; absent tracking ref still fails closed)
- `cargo test -p homeboy-agents --lib -- ssh_credential_failure_is_transport_without_a_proxy_hostname a_proxy_hostname_alone_is_not_transport_evidence` (2 passed)
- `cargo test -p homeboy-agents --lib transport` (33 passed)
- `cargo test -p homeboy-agents --lib declared_base` (10 passed)
- `cargo fmt --check`
- `git diff --check`

The new fixtures point `origin` at `https://127.0.0.1:1/repository.git`, which refuses immediately, so the transport failure is reproduced without any external network.

## AI Assistance
OpenAI GPT-5.6 Terra through OpenCode reproduced the failure from a real durable Cook run, located the base-resolution ownership in `cook.rs` and `promote.rs`, implemented the fallback and classification changes, and added the regression coverage. Chris Huber directed the work and remains responsible for acceptance.