### PR TITLE
fix(bench): expose actionable comparison result refs

### DIFF
--- a/crates/homeboy-cli/src/commands/bench.rs
+++ b/crates/homeboy-cli/src/commands/bench.rs
@@ -558,17 +558,19 @@ fn comparison_actionable_metadata<'a>(
                 semantic_key: Some(semantic_key.clone()),
             });
             let action = match artifact.artifact_type.as_deref() {
-                Some("file") => Some(CommandNextAction::new(
-                    format!("get artifact {semantic_key}"),
-                    format!(
-                        "homeboy runs artifact get {} {} -o <path>",
-                        persisted_run.run_id, artifact_id
-                    ),
-                )),
                 Some("directory") => Some(CommandNextAction::new(
                     format!("preview artifact {semantic_key}"),
                     format!(
                         "homeboy runs artifact preview {} {}",
+                        persisted_run.run_id, artifact_id
+                    ),
+                )),
+                // Persisted artifact records default an omitted type to file;
+                // URL records use the same retrieval command.
+                None | Some("file" | "url") => Some(CommandNextAction::new(
+                    format!("get artifact {semantic_key}"),
+                    format!(
+                        "homeboy runs artifact get {} {} -o <path>",
                         persisted_run.run_id, artifact_id
                     ),
                 )),

--- a/crates/homeboy-cli/src/commands/bench.rs
+++ b/crates/homeboy-cli/src/commands/bench.rs
@@ -557,16 +557,28 @@ fn comparison_actionable_metadata<'a>(
                 ),
                 semantic_key: Some(semantic_key.clone()),
             });
-            actionable.next_actions.push(
-                CommandNextAction::new(
+            let action = match artifact.artifact_type.as_deref() {
+                Some("file") => Some(CommandNextAction::new(
                     format!("get artifact {semantic_key}"),
                     format!(
                         "homeboy runs artifact get {} {} -o <path>",
                         persisted_run.run_id, artifact_id
                     ),
-                )
-                .with_kind(CommandNextActionKind::Artifacts),
-            );
+                )),
+                Some("directory") => Some(CommandNextAction::new(
+                    format!("preview artifact {semantic_key}"),
+                    format!(
+                        "homeboy runs artifact preview {} {}",
+                        persisted_run.run_id, artifact_id
+                    ),
+                )),
+                _ => None,
+            };
+            if let Some(action) = action {
+                actionable
+                    .next_actions
+                    .push(action.with_kind(CommandNextActionKind::Artifacts));
+            }
         }
     }
 

--- a/crates/homeboy-cli/src/commands/bench.rs
+++ b/crates/homeboy-cli/src/commands/bench.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::thread;
 
@@ -19,7 +19,10 @@ use super::utils::args::{
     filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, PassthroughCommand,
     PositionalComponentArgs, PresentationArgs, SettingArgs,
 };
-use super::utils::response::actionable_metadata_value_for_run_ref;
+use super::utils::response::{
+    actionable_metadata_for_run_ref, actionable_metadata_value_for_run_ref,
+    CommandActionableMetadata, CommandArtifactRef, CommandNextAction, CommandNextActionKind,
+};
 use super::CmdResult;
 use crate::command_contract::{
     CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, CommandPortabilityContract,
@@ -484,15 +487,90 @@ pub(crate) fn run_rig_profile(options: RigRunBenchOptions) -> CmdResult<BenchOut
 }
 
 fn attach_bench_actionable(output: &mut BenchOutput) {
-    if let BenchOutput::Single(output) = output {
-        if let Some(persisted_run) = &output.persisted_run {
-            output.actionable = Some(actionable_metadata_value_for_run_ref(
-                persisted_run.run_id.clone(),
-                "bench",
-                "homeboy-bench",
-            ));
+    match output {
+        BenchOutput::Single(output) => {
+            if let Some(persisted_run) = &output.persisted_run {
+                output.actionable = Some(actionable_metadata_value_for_run_ref(
+                    persisted_run.run_id.clone(),
+                    "bench",
+                    "homeboy-bench",
+                ));
+            }
+        }
+        BenchOutput::Comparison(output) => {
+            output.actionable = Some(comparison_actionable_metadata(output.rigs.iter().map(
+                |rig| {
+                    (
+                        rig.rig_id.as_str(),
+                        rig.persisted_run.as_ref(),
+                        rig.artifacts.as_slice(),
+                    )
+                },
+            )));
+        }
+        _ => {}
+    }
+}
+
+fn comparison_actionable_metadata<'a>(
+    rigs: impl IntoIterator<
+        Item = (
+            &'a str,
+            Option<&'a homeboy_core::extension::bench::BenchPersistedRun>,
+            &'a [homeboy_core::extension::bench::BenchArtifactRef],
+        ),
+    >,
+) -> serde_json::Value {
+    let mut actionable = CommandActionableMetadata::default();
+    let mut artifact_ids = BTreeSet::new();
+
+    for (rig_id, persisted_run, artifacts) in rigs {
+        let Some(persisted_run) = persisted_run else {
+            continue;
+        };
+        let run_metadata =
+            actionable_metadata_for_run_ref(persisted_run.run_id.clone(), "bench", "homeboy-bench");
+        if actionable.run.is_none() {
+            actionable.run = run_metadata.run;
+            actionable.next_actions = run_metadata.next_actions;
+        }
+        actionable.refs.runs.extend(run_metadata.refs.runs);
+
+        for artifact in artifacts {
+            let Some(artifact_id) = artifact.observation_artifact_id.as_deref() else {
+                continue;
+            };
+            if !artifact_ids.insert((persisted_run.run_id.clone(), artifact_id.to_string())) {
+                continue;
+            }
+            let semantic_key = format!("{rig_id}/{}/{}", artifact.scenario_id, artifact.name);
+            actionable.artifacts.push(CommandArtifactRef {
+                id: artifact_id.to_string(),
+                kind: artifact
+                    .kind
+                    .clone()
+                    .or_else(|| artifact.artifact_type.clone())
+                    .unwrap_or_else(|| "bench_artifact".to_string()),
+                uri: format!(
+                    "homeboy://run/{}/artifact/{artifact_id}",
+                    persisted_run.run_id
+                ),
+                semantic_key: Some(semantic_key.clone()),
+            });
+            actionable.next_actions.push(
+                CommandNextAction::new(
+                    format!("get artifact {semantic_key}"),
+                    format!(
+                        "homeboy runs artifact get {} {} -o <path>",
+                        persisted_run.run_id, artifact_id
+                    ),
+                )
+                .with_kind(CommandNextActionKind::Artifacts),
+            );
         }
     }
+
+    serde_json::to_value(actionable).unwrap_or(serde_json::Value::Null)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -724,6 +802,7 @@ pub fn run(mut args: BenchArgs) -> CmdResult<BenchOutput> {
             rig_state: single_output.rig_state,
             failure: single_output.failure,
             diagnostics: single_output.diagnostics,
+            persisted_run: single_output.persisted_run,
         });
     }
 
@@ -738,9 +817,16 @@ pub fn run(mut args: BenchArgs) -> CmdResult<BenchOutput> {
         output.default_baseline_expansion = Some(metadata);
     }
     if run_args.json_summary {
+        let mut output = BenchOutput::Comparison(output);
+        attach_bench_actionable(&mut output);
+        let BenchOutput::Comparison(output) = output else {
+            unreachable!("comparison output remains a comparison after metadata attachment");
+        };
         return Ok((BenchOutput::ComparisonSummary(output.into()), exit));
     }
-    Ok((BenchOutput::Comparison(output), exit))
+    let mut output = BenchOutput::Comparison(output);
+    attach_bench_actionable(&mut output);
+    Ok((output, exit))
 }
 
 struct CrossRigBenchOutput {

--- a/crates/homeboy-cli/src/commands/bench/tests/cross_rig_tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/cross_rig_tests.rs
@@ -32,6 +32,69 @@ fn cross_rig_run_passes_selector_to_each_rig() {
 }
 
 #[test]
+fn cross_rig_output_lifts_run_and_artifact_refs() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_a = tempfile::TempDir::new().expect("component a");
+        let component_b = tempfile::TempDir::new().expect("component b");
+        write_rig(home, "rig-a", "studio", component_a.path());
+        write_rig(home, "rig-b", "studio", component_b.path());
+        for rig_id in ["rig-a", "rig-b"] {
+            let path = home
+                .path()
+                .join(".config/homeboy/rigs")
+                .join(format!("{rig_id}.json"));
+            let mut rig: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&path).expect("read rig"))
+                    .expect("parse rig");
+            rig["bench_workloads"] = serde_json::json!({});
+            std::fs::write(&path, serde_json::to_string(&rig).expect("serialize rig"))
+                .expect("write rig");
+        }
+        let mut args = run_args(
+            None,
+            vec!["rig-a".to_string(), "rig-b".to_string()],
+            vec!["visual".to_string()],
+        );
+        args.run.runs = 2;
+
+        let (output, exit_code) = run(args).expect("cross-rig visual bench should run");
+        let payload = serde_json::to_value(output).expect("serialize bench output");
+        let envelope = crate::commands::utils::response::cli_response_for_json_result_for_command(
+            &Ok(payload.clone()),
+            exit_code,
+            "bench",
+            None,
+        );
+        let value = serde_json::to_value(envelope).expect("serialize command result");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["run"]["kind"], "bench");
+        assert_eq!(value["refs"]["runs"].as_array().map(Vec::len), Some(2));
+        assert!(
+            value["artifacts"]
+                .as_array()
+                .is_some_and(|artifacts| artifacts.len() >= 2),
+            "expected promoted visual artifact references: {value}"
+        );
+        for artifact in value["artifacts"].as_array().expect("artifact refs") {
+            assert!(artifact["id"].as_str().is_some_and(|id| !id.is_empty()));
+            assert!(
+                artifact["uri"].as_str().is_some_and(
+                    |uri| uri.starts_with("homeboy://run/") && uri.contains("/artifact/")
+                )
+            );
+        }
+
+        let summary = crate::commands::bench_summary::render_bench_summary(&payload)
+            .expect("compact comparison summary");
+        assert!(summary.contains("Comparison means:\n"), "{summary}");
+        assert!(summary.contains("Runs:\n"), "{summary}");
+        assert!(summary.contains("homeboy runs artifact get "), "{summary}");
+    });
+}
+
+#[test]
 fn cross_rig_json_summary_omits_full_results_payload() {
     with_isolated_home(|home| {
         write_bench_extension(home);
@@ -62,6 +125,13 @@ fn cross_rig_json_summary_omits_full_results_payload() {
                 assert!(value["rigs"][0].get("results").is_none());
                 assert!(value["rigs"][0].get("artifacts").is_none());
                 assert!(value["rigs"][0].get("rig_state").is_none());
+                assert!(value["rigs"][0]["persisted_run"]["run_id"].is_string());
+                assert_eq!(
+                    value["_homeboy_actionable"]["refs"]["runs"]
+                        .as_array()
+                        .map(Vec::len),
+                    Some(2)
+                );
             }
             _ => panic!("expected comparison summary output"),
         }

--- a/crates/homeboy-cli/src/commands/bench/tests/cross_rig_tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/cross_rig_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::cli_surface::Cli;
+use clap::Parser;
 
 #[test]
 fn cross_rig_run_passes_selector_to_each_rig() {
@@ -86,11 +88,39 @@ fn cross_rig_output_lifts_run_and_artifact_refs() {
             );
         }
 
+        let artifact_actions = value["next_actions"]
+            .as_array()
+            .expect("next actions")
+            .iter()
+            .filter(|action| action["kind"] == "artifacts")
+            .collect::<Vec<_>>();
+        assert!(
+            !artifact_actions.is_empty(),
+            "expected artifact actions: {value}"
+        );
+        for action in artifact_actions {
+            let command = action["command"].as_str().expect("artifact command");
+            assert!(command.contains(" runs artifact preview "), "{command}");
+            Cli::try_parse_from(shlex::split(command).expect("shell-safe command"))
+                .expect("advertised artifact command must parse");
+        }
+
         let summary = crate::commands::bench_summary::render_bench_summary(&payload)
             .expect("compact comparison summary");
         assert!(summary.contains("Comparison means:\n"), "{summary}");
         assert!(summary.contains("Runs:\n"), "{summary}");
-        assert!(summary.contains("homeboy runs artifact get "), "{summary}");
+        let artifact_commands = summary
+            .lines()
+            .filter_map(|line| line.split_once(": homeboy ").map(|(_, command)| command))
+            .filter(|command| command.starts_with("runs artifact "));
+        for command in artifact_commands {
+            let command = format!("homeboy {command}");
+            assert!(command.contains(" runs artifact preview "), "{command}");
+            Cli::try_parse_from(shlex::split(&command).expect("shell-safe command"))
+                .expect("advertised summary command must parse");
+        }
+        assert!(summary.contains("runs artifact preview"), "{summary}");
+        assert!(!summary.contains("runs artifact get"), "{summary}");
     });
 }
 

--- a/crates/homeboy-cli/src/commands/bench/tests/cross_rig_tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/cross_rig_tests.rs
@@ -87,6 +87,25 @@ fn cross_rig_output_lifts_run_and_artifact_refs() {
                 )
             );
         }
+        for rig in payload["payload"]["rigs"]
+            .as_array()
+            .expect("comparison rigs")
+        {
+            let artifacts = rig["artifacts"].as_array().expect("rig artifacts");
+            assert!(
+                artifacts
+                    .iter()
+                    .any(|artifact| artifact["name"] == "visual_result"
+                        && artifact["type"] == "file"),
+                "expected persisted untyped file type: {rig}"
+            );
+            assert!(
+                artifacts
+                    .iter()
+                    .any(|artifact| artifact["name"] == "visual_url" && artifact["type"] == "url"),
+                "expected persisted URL type: {rig}"
+            );
+        }
 
         let artifact_actions = value["next_actions"]
             .as_array()
@@ -98,12 +117,27 @@ fn cross_rig_output_lifts_run_and_artifact_refs() {
             !artifact_actions.is_empty(),
             "expected artifact actions: {value}"
         );
-        for action in artifact_actions {
+        for action in &artifact_actions {
             let command = action["command"].as_str().expect("artifact command");
-            assert!(command.contains(" runs artifact preview "), "{command}");
             Cli::try_parse_from(shlex::split(command).expect("shell-safe command"))
                 .expect("advertised artifact command must parse");
         }
+        assert!(
+            artifact_actions.iter().any(|action| action["command"]
+                .as_str()
+                .is_some_and(|command| command.contains(" runs artifact preview "))),
+            "expected directory preview action: {value}"
+        );
+        assert!(
+            artifact_actions
+                .iter()
+                .filter(|action| action["command"]
+                    .as_str()
+                    .is_some_and(|command| command.contains(" runs artifact get ")))
+                .count()
+                >= 4,
+            "expected file and URL get actions for both rigs: {value}"
+        );
 
         let summary = crate::commands::bench_summary::render_bench_summary(&payload)
             .expect("compact comparison summary");
@@ -115,12 +149,14 @@ fn cross_rig_output_lifts_run_and_artifact_refs() {
             .filter(|command| command.starts_with("runs artifact "));
         for command in artifact_commands {
             let command = format!("homeboy {command}");
-            assert!(command.contains(" runs artifact preview "), "{command}");
             Cli::try_parse_from(shlex::split(&command).expect("shell-safe command"))
                 .expect("advertised summary command must parse");
         }
         assert!(summary.contains("runs artifact preview"), "{summary}");
-        assert!(!summary.contains("runs artifact get"), "{summary}");
+        assert!(
+            summary.matches("runs artifact get").count() >= 4,
+            "{summary}"
+        );
     });
 }
 

--- a/crates/homeboy-cli/src/commands/bench/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/mod.rs
@@ -80,7 +80,9 @@ for scenario in $selected; do
   if [ "$scenario" = "visual" ]; then
     visual_comparison_dir="$HOMEBOY_BENCH_RESULTS_FILE.visual-comparisons/$scenario"
     mkdir -p "$visual_comparison_dir"
-    artifacts=", \"artifacts\": { \"visual_comparison_dir\": { \"path\": \"$visual_comparison_dir\", \"type\": \"directory\" } }"
+    visual_result="$visual_comparison_dir/result.txt"
+    printf 'visual result\n' > "$visual_result"
+    artifacts=", \"artifacts\": { \"visual_comparison_dir\": { \"path\": \"$visual_comparison_dir\", \"type\": \"directory\" }, \"visual_result\": { \"path\": \"$visual_result\" }, \"visual_url\": { \"url\": \"https://artifacts.example.test/visual.txt\" } }"
   fi
   cat >> "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
     $comma{ "id": "$scenario", "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0}, "metrics": { "p95_ms": 1.0, "warmup_iterations": ${HOMEBOY_BENCH_WARMUP_ITERATIONS:--1}, "bench_env_projected": $(if [ "$BENCH_ENV_PROJECTION" = "present" ]; then printf 1; else printf 0; fi) }$artifacts }

--- a/crates/homeboy-cli/src/commands/bench_summary.rs
+++ b/crates/homeboy-cli/src/commands/bench_summary.rs
@@ -483,10 +483,19 @@ fn comparison_artifact_lines(output: &Value) -> Vec<String> {
             if let (Some(run_id), Some(artifact_id)) =
                 (run_id, string_value(artifact, &["observation_artifact_id"]))
             {
-                lines.push(format!(
-                    "  {rig_id}/{name}: homeboy runs artifact get {run_id} {artifact_id} -o <path>"
-                ));
-                continue;
+                let command = match string_value(artifact, &["type"]) {
+                    Some("file") => Some(format!(
+                        "  {rig_id}/{name}: homeboy runs artifact get {run_id} {artifact_id} -o <path>"
+                    )),
+                    Some("directory") => Some(format!(
+                        "  {rig_id}/{name}: homeboy runs artifact preview {run_id} {artifact_id}"
+                    )),
+                    _ => None,
+                };
+                if let Some(command) = command {
+                    lines.push(command);
+                    continue;
+                }
             }
             if let Some(locator) = artifact_locator(artifact) {
                 lines.push(format!("  {rig_id}/{name}: {locator}"));

--- a/crates/homeboy-cli/src/commands/bench_summary.rs
+++ b/crates/homeboy-cli/src/commands/bench_summary.rs
@@ -115,6 +115,8 @@ fn render_comparison_summary(output: &Value) -> String {
     if !rig_lines.is_empty() {
         lines.extend(rig_lines);
     }
+    lines.extend(comparison_metric_lines(output));
+    lines.extend(comparison_run_lines(output));
 
     let regressions = usize_value(output, &["regressions"])
         .or_else(|| array_len(output, &["failures"]))
@@ -472,11 +474,20 @@ fn comparison_artifact_lines(output: &Value) -> Vec<String> {
     let mut lines = Vec::new();
     for rig in rigs {
         let rig_id = string_value(rig, &["rig_id"]).unwrap_or("<rig>");
+        let run_id = string_value(rig, &["persisted_run", "run_id"]);
         let Some(artifacts) = value_at(rig, &["artifacts"]).and_then(Value::as_array) else {
             continue;
         };
         for artifact in artifacts {
             let name = string_value(artifact, &["name"]).unwrap_or("artifact");
+            if let (Some(run_id), Some(artifact_id)) =
+                (run_id, string_value(artifact, &["observation_artifact_id"]))
+            {
+                lines.push(format!(
+                    "  {rig_id}/{name}: homeboy runs artifact get {run_id} {artifact_id} -o <path>"
+                ));
+                continue;
+            }
             if let Some(locator) = artifact_locator(artifact) {
                 lines.push(format!("  {rig_id}/{name}: {locator}"));
             }
@@ -484,6 +495,51 @@ fn comparison_artifact_lines(output: &Value) -> Vec<String> {
     }
     if !lines.is_empty() {
         lines.insert(0, "Artifacts:".to_string());
+    }
+    lines
+}
+
+fn comparison_metric_lines(output: &Value) -> Vec<String> {
+    let Some(summaries) = value_at(output, &["summary"]).and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut lines = Vec::new();
+    for summary in summaries.iter().take(3) {
+        let scenario = string_value(summary, &["scenario"]).unwrap_or("<scenario>");
+        let Some(rows) = value_at(summary, &["rows"]).and_then(Value::as_array) else {
+            continue;
+        };
+        for row in rows.iter().take(4) {
+            let rig_id = string_value(row, &["rig_id"]).unwrap_or("<rig>");
+            let Some(mean) = row.get("mean_ms").and_then(Value::as_f64) else {
+                continue;
+            };
+            lines.push(format!(
+                "  {scenario}/{rig_id}: mean_ms={}",
+                format_metric(mean)
+            ));
+        }
+    }
+    if !lines.is_empty() {
+        lines.insert(0, "Comparison means:".to_string());
+    }
+    lines
+}
+
+fn comparison_run_lines(output: &Value) -> Vec<String> {
+    let Some(rigs) = value_at(output, &["rigs"]).and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut lines = rigs
+        .iter()
+        .filter_map(|rig| {
+            let rig_id = string_value(rig, &["rig_id"])?;
+            let run_id = string_value(rig, &["persisted_run", "run_id"])?;
+            Some(format!("  {rig_id}: {run_id}"))
+        })
+        .collect::<Vec<_>>();
+    if !lines.is_empty() {
+        lines.insert(0, "Runs:".to_string());
     }
     lines
 }

--- a/crates/homeboy-cli/src/commands/bench_summary.rs
+++ b/crates/homeboy-cli/src/commands/bench_summary.rs
@@ -484,11 +484,13 @@ fn comparison_artifact_lines(output: &Value) -> Vec<String> {
                 (run_id, string_value(artifact, &["observation_artifact_id"]))
             {
                 let command = match string_value(artifact, &["type"]) {
-                    Some("file") => Some(format!(
-                        "  {rig_id}/{name}: homeboy runs artifact get {run_id} {artifact_id} -o <path>"
-                    )),
                     Some("directory") => Some(format!(
                         "  {rig_id}/{name}: homeboy runs artifact preview {run_id} {artifact_id}"
+                    )),
+                    // Persisted artifact records default an omitted type to file;
+                    // URL records use the same retrieval command.
+                    None | Some("file" | "url") => Some(format!(
+                        "  {rig_id}/{name}: homeboy runs artifact get {run_id} {artifact_id} -o <path>"
                     )),
                     _ => None,
                 };

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -227,9 +227,7 @@ pub(crate) fn run_command_output(
             |payload, _| super::activity::render_activity_summary(payload),
         ),
         Commands::Bench(args) => {
-            let summarize = args.is_run_invocation()
-                && !args.wants_full_json()
-                && !homeboy::core::lab_routing::is_lab_offload_subprocess();
+            let summarize = args.is_run_invocation() && !args.wants_full_json();
             command_run_with_summary(
                 dispatch(Commands::Bench(args), spec, placement),
                 |payload, _| {

--- a/crates/homeboy-core/src/extension/bench/artifact_persistence.rs
+++ b/crates/homeboy-core/src/extension/bench/artifact_persistence.rs
@@ -352,6 +352,10 @@ pub fn apply_recorded_bench_artifact_links(
     record: &ArtifactRecord,
 ) -> Option<BenchDiagnostic> {
     artifact.observation_artifact_id = Some(record.id.clone());
+    // The observation record owns the durable storage type. Source artifacts
+    // may omit or use a domain-specific type, neither of which is a retrieval
+    // contract after promotion.
+    artifact.artifact_type = Some(record.artifact_type.clone());
     let public_url = artifact_links::public_artifact_url(record)?;
     if artifact_links::public_artifact_url_is_reachable_or_legacy(record) {
         artifact.public_url = Some(public_url.clone());

--- a/crates/homeboy-core/src/extension/bench/report/comparison.rs
+++ b/crates/homeboy-core/src/extension/bench/report/comparison.rs
@@ -389,6 +389,7 @@ pub fn aggregate_comparison_with_axes(
             hints: Some(hints),
             reports: BenchComparisonReports { side_by_side },
             default_baseline_expansion: None,
+            actionable: None,
         },
         exit_code,
     )

--- a/crates/homeboy-core/src/extension/bench/report/comparison/types.rs
+++ b/crates/homeboy-core/src/extension/bench/report/comparison/types.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 use serde_json::Value;
 
-use super::super::BenchArtifactRef;
+use super::super::{BenchArtifactRef, BenchPersistedRun};
 use crate::extension::bench::diagnostic::BenchDiagnostic;
 use crate::extension::bench::parsing::{BenchMetricPhase, BenchMetricPolicy, BenchResults};
 use crate::extension::bench::run::BenchRunFailure;
@@ -76,6 +76,11 @@ pub struct BenchComparisonOutput {
     pub reports: BenchComparisonReports,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_baseline_expansion: Option<BenchDefaultBaselineExpansion>,
+    #[serde(
+        rename = "_homeboy_actionable",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub actionable: Option<Value>,
 }
 
 #[derive(Serialize)]
@@ -109,6 +114,11 @@ pub struct BenchComparisonSummaryOutput {
     pub hints: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_baseline_expansion: Option<BenchDefaultBaselineExpansion>,
+    #[serde(
+        rename = "_homeboy_actionable",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub actionable: Option<Value>,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
@@ -127,6 +137,8 @@ pub struct BenchComparisonRigSummary {
     pub exit_code: i32,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<BenchDiagnostic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persisted_run: Option<BenchPersistedRun>,
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
@@ -171,6 +183,8 @@ pub struct RigBenchEntry {
     pub failure: Option<BenchRunFailure>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<BenchDiagnostic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persisted_run: Option<BenchPersistedRun>,
 }
 
 impl From<BenchComparisonOutput> for BenchComparisonSummaryOutput {
@@ -191,6 +205,7 @@ impl From<BenchComparisonOutput> for BenchComparisonSummaryOutput {
                     status: rig.status,
                     exit_code: rig.exit_code,
                     diagnostics: rig.diagnostics,
+                    persisted_run: rig.persisted_run,
                 })
                 .collect(),
             summary: output.summary,
@@ -203,6 +218,7 @@ impl From<BenchComparisonOutput> for BenchComparisonSummaryOutput {
             diagnostic_classes: output.diagnostic_classes,
             hints: output.hints,
             default_baseline_expansion: output.default_baseline_expansion,
+            actionable: output.actionable,
         }
     }
 }

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -489,16 +489,88 @@ pub fn compact_command_result_output(stream: &str) -> Option<String> {
     {
         lines.push(format!("Job: {job_id}"));
     }
-    if let Some(summary) = value.get("summary").and_then(serde_json::Value::as_str) {
-        lines.push(format!("Summary: {}", compact_line(summary)));
-    }
+    append_result_summary_lines(&value, &mut lines);
     append_result_outcome_lines(&value, &mut lines);
+    append_result_reference_lines(&value, &mut lines);
     if value.get("success").and_then(serde_json::Value::as_bool) == Some(false) {
         if let Some(cause) = command_result_root_cause(&value) {
             lines.push(format!("Root cause: {}", compact_line(&cause)));
         }
     }
     Some(bound_terminal_output(lines.join("\n")))
+}
+
+fn append_result_summary_lines(value: &serde_json::Value, lines: &mut Vec<String>) {
+    const MAX_SUMMARY_LINES: usize = 12;
+    let Some(summary) = value.get("summary").and_then(serde_json::Value::as_str) else {
+        return;
+    };
+    let mut summary_lines = summary.lines().filter(|line| !line.trim().is_empty());
+    let lines_to_render = summary_lines
+        .by_ref()
+        .take(MAX_SUMMARY_LINES)
+        .collect::<Vec<_>>();
+    let summary_truncated = summary_lines.next().is_some();
+    match lines_to_render.as_slice() {
+        [] => {}
+        [line] => lines.push(format!("Summary: {}", compact_line(line))),
+        lines_to_render => {
+            lines.push("Summary:".to_string());
+            lines.extend(
+                lines_to_render
+                    .iter()
+                    .map(|line| format!("  {}", line.trim())),
+            );
+            if summary_truncated {
+                lines.push("  [summary truncated]".to_string());
+            }
+        }
+    }
+}
+
+fn append_result_reference_lines(value: &serde_json::Value, lines: &mut Vec<String>) {
+    const MAX_REFERENCES: usize = 8;
+    let primary_run_id = value
+        .get("run")
+        .and_then(|run| run.get("id"))
+        .and_then(serde_json::Value::as_str);
+    let mut run_count = 0;
+    if let Some(runs) = value
+        .get("refs")
+        .and_then(|refs| refs.get("runs"))
+        .and_then(serde_json::Value::as_array)
+    {
+        for run in runs {
+            let Some(run_id) = run.get("id").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            if Some(run_id) == primary_run_id {
+                continue;
+            }
+            lines.push(format!("Run ref: {run_id}"));
+            run_count += 1;
+            if run_count == MAX_REFERENCES {
+                break;
+            }
+        }
+    }
+    let mut artifact_count = 0;
+    if let Some(artifacts) = value.get("artifacts").and_then(serde_json::Value::as_array) {
+        for artifact in artifacts {
+            let Some(id) = artifact.get("id").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            let label = artifact
+                .get("semantic_key")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("artifact");
+            lines.push(format!("Artifact ref: {label} ({id})"));
+            artifact_count += 1;
+            if artifact_count == MAX_REFERENCES {
+                break;
+            }
+        }
+    }
 }
 
 fn append_result_outcome_lines(value: &serde_json::Value, lines: &mut Vec<String>) {
@@ -1480,6 +1552,33 @@ mod tests {
         assert!(stdout.contains("Evidence: homeboy runs show fuzz-1"));
         assert!(stdout.len() <= COMPACT_COMMAND_RESULT_LIMIT_BYTES);
         assert!(!stdout.contains("\"campaign\""));
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn terminal_projection_keeps_structured_summary_and_references_bounded() {
+        let nested = r#"{
+            "schema":"homeboy/command-result/v3",
+            "command":"bench",
+            "success":true,
+            "status":"succeeded",
+            "run":{"id":"bench-baseline"},
+            "refs":{"runs":[{"id":"bench-baseline"},{"id":"bench-candidate"}]},
+            "summary":"Bench comparison\nResult: PASS\nComparison means:\n  visual/baseline: mean_ms=12\n  visual/candidate: mean_ms=14\nRuns:\n  baseline: bench-baseline\n  candidate: bench-candidate",
+            "artifacts":[{"id":"baseline-diff","semantic_key":"baseline/visual/diff"},{"id":"candidate-diff","semantic_key":"candidate/visual/diff"}],
+            "data":{"large":"this remains in the output artifact"}
+        }"#;
+
+        let (stdout, stderr) =
+            compact_lab_terminal_output(nested, "", Some("homeboy-lab"), 0, None, false);
+
+        assert!(stdout.contains("Comparison means:"));
+        assert!(stdout.contains("visual/baseline: mean_ms=12"));
+        assert!(stdout.contains("Run: bench-baseline"));
+        assert!(stdout.contains("Run ref: bench-candidate"));
+        assert!(stdout.contains("Artifact ref: baseline/visual/diff (baseline-diff)"));
+        assert!(stdout.len() <= COMPACT_COMMAND_RESULT_LIMIT_BYTES);
+        assert!(!stdout.contains("this remains in the output artifact"));
         assert!(stderr.is_empty());
     }
 

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -210,6 +210,7 @@ mod fixtures {
             rig_state: None,
             failure: None,
             diagnostics: Vec::new(),
+            persisted_run: None,
         }
     }
 
@@ -234,6 +235,7 @@ mod fixtures {
                 diagnostics: Vec::new(),
             }),
             diagnostics: Vec::new(),
+            persisted_run: None,
         }
     }
 

--- a/tests/core/rig/bench_default_baseline_output_test.rs
+++ b/tests/core/rig/bench_default_baseline_output_test.rs
@@ -177,6 +177,7 @@ fn default_baseline_failure_summary_marks_implicit_baseline() {
                 diagnostics: Vec::new(),
             }),
             diagnostics: Vec::new(),
+            persisted_run: None,
         },
         RigBenchEntry {
             rig_id: "studio-bfb".to_string(),
@@ -188,6 +189,7 @@ fn default_baseline_failure_summary_marks_implicit_baseline() {
             rig_state: None,
             failure: None,
             diagnostics: Vec::new(),
+            persisted_run: None,
         },
     ];
     let (mut output, _) = aggregate_comparison("studio".to_string(), 10, entries);


### PR DESCRIPTION
## Summary

- Preserve persisted run references in cross-rig benchmark comparison output.
- Add bounded terminal summaries with metrics, run IDs, and artifact references.
- Emit truthful retrieval actions: `get` for persisted file/URL artifacts and `preview` for directories.
- Keep full payloads in durable results while returning compact structured output through Lab routing.

Closes #9875.

## Verification

- `cargo test -p homeboy-cli cross_rig_output_lifts_run_and_artifact_refs --lib`
- `cargo test -p homeboy-cli cross_rig_json_summary_omits_full_results_payload --lib`
- `cargo test -p homeboy-core terminal_projection_keeps_structured_summary_and_references_bounded --lib`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## AI Assistance

OpenCode with `openai/gpt-5.6-terra` implemented the candidate and follow-up fixes. OpenCode with `openai/gpt-5.6-sol` orchestrated independent code-review passes, verification, and promotion.