### PR TITLE
Prevent large Cook requests from exceeding SSH capability-probe argument limits.

### DIFF
--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -576,6 +576,52 @@ impl SshClient {
         self.execute_ssh_with_timeout(&effective, None, timeout)
     }
 
+    /// Execute with this client's environment delivered over stdin instead of
+    /// interpolated into the remote command argv.
+    ///
+    /// This preserves the configured environment while keeping request-sized
+    /// values out of the controller and remote shell command lines.
+    pub fn execute_with_materialized_env(&self, command: &str) -> CommandOutput {
+        let env = self
+            .env
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        let command = wrap_command_with_secret_env_read_loop(&format!(
+            "{} && {}",
+            remote_shell_path_preamble(),
+            command
+        ));
+        let input = build_secret_env_stdin_block(&env);
+        if self.is_local {
+            return execute_local_command_with_stdin(&command, &input);
+        }
+        self.execute_with_stdin(&command, SshStdin::Inline(&input))
+    }
+
+    /// Execute with a materialized environment and a hard wall-clock deadline.
+    pub fn execute_with_materialized_env_and_timeout(
+        &self,
+        command: &str,
+        timeout: Duration,
+    ) -> CommandOutput {
+        let env = self
+            .env
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        let command = wrap_command_with_secret_env_read_loop(&format!(
+            "{} && {}",
+            remote_shell_path_preamble(),
+            command
+        ));
+        let input = build_secret_env_stdin_block(&env);
+        if self.is_local {
+            return execute_local_command_with_stdin_and_timeout(&command, &input, timeout);
+        }
+        self.execute_ssh_with_timeout(&command, Some(&input), timeout)
+    }
+
     /// Execute a command with replayable bytes delivered over stdin and a hard
     /// wall-clock deadline.
     pub fn execute_with_input_and_timeout(

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -1348,3 +1348,34 @@ fn owned_remote_wrapper_executes_a_large_payload() {
         output.stderr
     );
 }
+
+#[test]
+fn materialized_env_keeps_large_cook_payloads_off_the_probe_command() {
+    let prompt = "prompt-14304-".repeat(16 * 1024);
+    let plan = "plan-14304-".repeat(16 * 1024);
+    let mut client = SshClient {
+        host: "localhost".to_string(),
+        user: "tester".to_string(),
+        port: 22,
+        identity_file: None,
+        auth: None,
+        is_local: true,
+        env: HashMap::new(),
+    };
+    client.env.insert("COOK_PROMPT".to_string(), prompt.clone());
+    client.env.insert("COOK_PLAN".to_string(), plan.clone());
+    client
+        .env
+        .insert("HOMEBOY_COMMAND".to_string(), "sh".to_string());
+
+    let output = client.execute_with_materialized_env(
+        "[ ${#COOK_PROMPT} -gt 128000 ] && [ ${#COOK_PLAN} -gt 128000 ] && \"$HOMEBOY_COMMAND\" -c 'exit 0' && git --version >/dev/null && printf 'homeboy-git-probe-ok'",
+    );
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(output.stdout, "homeboy-git-probe-ok");
+    assert!(
+        prompt.len() + plan.len() > 128 * 1024,
+        "test payload must exceed argv safety margin"
+    );
+}

--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -512,8 +512,8 @@ impl RunnerCapabilitySnapshot {
         let probe = move || {
             let output = preflight
                 .timeout
-                .map(|timeout| client.execute_with_timeout(&script, timeout))
-                .unwrap_or_else(|| client.execute(&script));
+                .map(|timeout| client.execute_with_materialized_env_and_timeout(&script, timeout))
+                .unwrap_or_else(|| client.execute_with_materialized_env(&script));
             if output.timed_out {
                 return Err(Error::new(
                     ErrorCode::RemoteCommandTimeout,


### PR DESCRIPTION
## Summary
Materialize remote capability-probe environment over SSH stdin so large Cook prompt/plan values cannot exhaust argv before Homeboy and Git probes run.

## What changed
- Added generic SshClient materialized-environment execution paths, including timeout support, using the existing safe stdin environment importer.
- Switched Lab runner capability batches to materialized environment transport.
- Added an oversized Cook prompt/plan regression test that validates configured Homeboy and Git probe commands remain usable.
- Committed locally as 6d32e1dcef02921ee169db6424682df1ba1731a2; publication is intentionally deferred to the controller.

## How to test
1. Run `cargo fmt --check`; expect passes as recorded by Cook's deterministic gate.
2. Run `cargo test -p homeboy-core materialized_env_keeps_large_cook_payloads_off_the_probe_command`; expect passes as recorded by Cook's deterministic gate.
3. Run `cargo test -p homeboy-lab-runner capabilities::tests::capability_preflight_accepts_configured_homeboy_and_git_version_evidence`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Preserves probe environment values, timeout behavior, output/error handling, and non-evaluating stdin export semantics. Only capability-probe transport changes from inline exports to stdin materialization.

## Evidence
- Verified command `cargo fmt --check`: status=succeeded; candidate commit `e6150ebb0861b46bfc2fe6a190c7b851b3159e58`, tree `aa23aeaf5d5c9f1ef3e8a0bcdb8f0bc51884a322`, fingerprint `7894a2ee1c45ee17b20132cedd806bdee2d747d4e61a98be4bd19c7017e2ad98`; durable gate `replacement-fmt`
- Verified command `cargo test -p homeboy-core materialized_env_keeps_large_cook_payloads_off_the_probe_command`: status=succeeded; candidate commit `e6150ebb0861b46bfc2fe6a190c7b851b3159e58`, tree `aa23aeaf5d5c9f1ef3e8a0bcdb8f0bc51884a322`, fingerprint `7894a2ee1c45ee17b20132cedd806bdee2d747d4e61a98be4bd19c7017e2ad98`; durable gate `replacement-large-payload`; total=61, passed=61, failed=0, ignored=0
- Verified command `cargo test -p homeboy-lab-runner capabilities::tests::capability_preflight_accepts_configured_homeboy_and_git_version_evidence`: status=succeeded; candidate commit `e6150ebb0861b46bfc2fe6a190c7b851b3159e58`, tree `aa23aeaf5d5c9f1ef3e8a0bcdb8f0bc51884a322`, fingerprint `7894a2ee1c45ee17b20132cedd806bdee2d747d4e61a98be4bd19c7017e2ad98`; durable gate `replacement-capability-preflight`; total=61, passed=61, failed=0, ignored=0
- Base advanced after verification: verified main at 85b211a9b989323d5c0d9e029e752f9fe8193992; publication observed d2abeaca9bfe8a8b6aeba62a6d4630e27c79f369. Candidate ancestry was validated against the verified snapshot.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 3 gate(s) completed green.
- Durable run execution: CandidateRecoverable
- Explicit operator authorization for external replacement proof was recorded.
- Original infrastructure-invalid verification retained: 2 failed gate record(s); inspect durable gate details.
- Replacement candidate-bound verification: 3 gate(s) completed green with matching command evidence.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/14304
- Task objective: Fix the regression recorded in Extra-Chill/homeboy#14304 using a fresh isolated worktree. The current Build \`0.367.8+1923c412a59f\` fails a Lab Cook before provider execution: its capability probe emits \`/bin/bash: Argument list too long\` and falsely reports \`homeboy\` and \`git\` missing. The durable affected run is \`agent-task-6773a8ef-e4bc-4e55-b97f-d9fb6fa78802-attempt-1-dcc6e6c4-transport-retry\`.
- Verified candidate scope: 3 changed file(s): crates/homeboy-core/src/server/client/ssh\_client.rs, crates/homeboy-core/src/server/client/tests.rs, crates/homeboy-lab-runner/src/capabilities.rs.
- Verified finalization base: main at 85b211a9b989323d5c0d9e029e752f9fe8193992
- deterministic gate passed: sh -lc cargo fmt --check (Passed)
- deterministic gate passed: sh -lc cargo test -p homeboy-core materialized\_env\_keeps\_large\_cook\_payloads\_off\_the\_probe\_command (Passed)
- deterministic gate passed: sh -lc cargo test -p homeboy-lab-runner capabilities::tests::capability\_preflight\_accepts\_configured\_homeboy\_and\_git\_version\_evidence (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Inspected merged #14306 and traced the remaining payload path: daemon capability admission overlays request environment, then inline SSH exports embed large Cook prompt/plan bytes. This is a follow-up repair for #14304 that closes the remaining indirect argv expansion after #14306 removed duplicate script embedding. OpenCode orchestrator and Homeboy OpenCode executor both used OpenAI openai/gpt-5.6-terra to diagnose, implement, and verify the repair.
