### PR TITLE
test(deploy): use the shared git fixture helper

### DIFF
--- a/crates/homeboy-deploy/src/execution/mod.rs
+++ b/crates/homeboy-deploy/src/execution/mod.rs
@@ -65,7 +65,6 @@ mod tests {
     };
     use homeboy_core::project::Project;
     use std::io::Write;
-    use std::process::Command;
 
     #[test]
     fn bound_captured_read_retains_full_source_within_limit() {
@@ -533,20 +532,7 @@ mod tests {
         assert!(zip.by_name("demo-plugin/node_modules/junk.js").is_err());
     }
 
-    fn git(dir: &std::path::Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: {}{}",
-            args,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 
     #[test]
     fn cleanup_deploy_build_artifact_preserves_non_empty_build_dir() {

--- a/crates/homeboy-deploy/src/generated_artifacts.rs
+++ b/crates/homeboy-deploy/src/generated_artifacts.rs
@@ -189,20 +189,7 @@ mod tests {
     use homeboy_core::component::{CleanupArtifactDeclaration, Component};
     use homeboy_core::defaults::deploy_generated_build_dir;
 
-    fn run_git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: stdout={} stderr={}",
-            args,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as run_git;
 
     fn git_repo() -> tempfile::TempDir {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -1025,20 +1025,7 @@ mod tests {
             .success());
     }
 
-    fn run_git(path: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("git command");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: stdout={} stderr={}",
-            args,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as run_git;
 
     fn git_stdout(path: &Path, args: &[&str]) -> String {
         let output = std::process::Command::new("git")

--- a/crates/homeboy-deploy/src/orchestration/modes.rs
+++ b/crates/homeboy-deploy/src/orchestration/modes.rs
@@ -1229,18 +1229,7 @@ mod tests {
         );
     }
 
-    fn git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("git command");
-        assert!(
-            output.status.success(),
-            "{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 
     fn local_client() -> SshClient {
         SshClient {

--- a/crates/homeboy-deploy/src/orchestration/preflight.rs
+++ b/crates/homeboy-deploy/src/orchestration/preflight.rs
@@ -761,7 +761,6 @@ pub(super) fn verify_expected_version(components: &[Component], expected: &str) 
 mod tests {
     use std::collections::HashMap;
     use std::path::Path;
-    use std::process::Command;
 
     use super::{
         guard_deployment_provenance, guard_head_matches_invocation_checkout,
@@ -896,18 +895,7 @@ mod tests {
             .expect("projects without a policy retain legacy force semantics");
     }
 
-    fn git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 
     #[test]
     fn stale_local_source_refuses_until_explicitly_allowed() {

--- a/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
+++ b/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
@@ -1295,19 +1295,7 @@ mod tests {
         );
     }
 
-    fn git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("git command");
-        assert!(
-            output.status.success(),
-            "git {:?}: {}",
-            args,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 
     fn git_output(path: &Path, args: &[&str]) -> String {
         let output = Command::new("git")

--- a/crates/homeboy-deploy/src/planning.rs
+++ b/crates/homeboy-deploy/src/planning.rs
@@ -1014,19 +1014,7 @@ mod tests {
     use homeboy_core::server::SshClient;
     use tempfile::TempDir;
 
-    fn run_git(path: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("git command");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: {}",
-            args,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as run_git;
 
     fn init_source_repo(path: &Path) {
         run_git(path, &["init", "-q", "-b", "main"]);

--- a/crates/homeboy-deploy/src/provenance.rs
+++ b/crates/homeboy-deploy/src/provenance.rs
@@ -101,19 +101,7 @@ pub(crate) use homeboy_core::tag_gap::{detect_tag_gap, warn_tag_gap};
 mod provenance_tests {
     use super::*;
 
-    fn run_git(dir: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: {}",
-            args,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as run_git;
 
     fn committed_repo() -> tempfile::TempDir {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/homeboy-deploy/src/provider.rs
+++ b/crates/homeboy-deploy/src/provider.rs
@@ -619,7 +619,6 @@ mod tests {
     use homeboy_core::component::{Component, DeploymentProviderAttachment};
     use homeboy_core::error::Error;
     use homeboy_core::project::{Project, ProjectComponentAttachment};
-    use std::process::Command;
 
     /// Three of these steps used to emit the identical literal
     /// `"Could not prepare deployment provider input"`, so a report named the
@@ -767,14 +766,7 @@ mod tests {
         );
     }
 
-    fn git(path: &std::path::Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("git command");
-        assert!(output.status.success(), "git {:?} failed", args);
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 
     fn provider_repository(id: &str) -> tempfile::TempDir {
         let repository = tempfile::tempdir().expect("repository");

--- a/crates/homeboy-deploy/src/types.rs
+++ b/crates/homeboy-deploy/src/types.rs
@@ -1357,19 +1357,7 @@ mod tests {
         );
     }
 
-    fn run_git(path: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("git command");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: {}",
-            args,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as run_git;
 
     #[test]
     fn release_state_status_uses_needs_release_public_name() {


### PR DESCRIPTION
## Summary
Ten test modules in `homeboy-deploy` each defined their own identical `run_git` / `git` helper wrapping `Command::new("git")` with a success assertion. `homeboy_core::test_support::run_git_fixture_command` already provides this, and the crate already depends on core with the `test-support` feature.

Each local definition becomes an aliased import, so every call site is unchanged:

```rust
use homeboy_core::test_support::run_git_fixture_command as run_git;
```

Net **-119 lines**. Second slice of #13227, after #14322 did `homeboy-release`.

Files: `generated_artifacts`, `types`, `provider`, `orchestration_ref_checkout`, `provenance`, `planning`, `execution/mod`, `orchestration/{mod,modes,preflight}`, plus three `std::process::Command` imports that became unused.

## What was left alone
`preparation.rs` has two helpers that return captured stdout rather than asserting. Those map to `git_fixture_output`, not `run_git_fixture_command`, and are a separate pass. The script only rewrote helpers matching the exact assert-only shape and skipped anything else.

## Verification
`cargo test -p homeboy-deploy`: **325 passed, 5 failed** — and the same 5 fail identically on baseline `main`:

```
orchestration::tests::exact_ref_preparation_preserves_duplicate_source_version_target_artifact_paths
safety_and_artifact::tests::deploy_artifact_persists_transfer_extract_and_verify_phases
safety_and_artifact::tests::test_deploy_artifact_flattens_double_nested_plugin_zip
safety_and_artifact::tests::test_deploy_artifact_leaves_flat_archive_untouched
safety_and_artifact::tests::test_directory_artifact_normalizes_group_write_and_setgid
```

Diffing the two failure sets gives **zero branch-only failures**. `cargo check -p homeboy-deploy --tests` is warning-free.

Those 5 pre-existing failures look worth a separate look — four are artifact packaging/permission tests, which may be environment-dependent on macOS.

## AI Assistance
OpenAI GPT-5.6 Sol through OpenCode applied the established consolidation to this crate, skipped the stdout-returning variants as out of shape, and diffed the failure set against a baseline worktree to confirm none were introduced. Chris Huber directed the work and remains responsible for acceptance.