### PR TITLE
fix(status): avoid stale current version claims

### DIFF
--- a/crates/homeboy-upgrade/src/controller_staleness.rs
+++ b/crates/homeboy-upgrade/src/controller_staleness.rs
@@ -17,10 +17,10 @@
 //! whole surface costs one small file read per command and at most one network
 //! call per day — the call the startup check was already making.
 //!
-//! Every failure mode degrades to [`ControllerCurrency::Unknown`]: no cache, an
-//! unparseable version, an operator-disabled update check, or an offline host
-//! all report "not established" rather than guessing "current" or failing a
-//! command.
+//! Every failure mode degrades to [`ControllerCurrency::Unknown`]: no cache, a
+//! stale cache, an unparseable version, an operator-disabled update check, or
+//! an offline host all report "not established" rather than guessing "current"
+//! or failing a command.
 //!
 //! # What this deliberately does not compute
 //!
@@ -102,7 +102,9 @@ pub struct ControllerStaleness {
     /// Embedded git commit of the running build, when the build recorded one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_commit: Option<String>,
-    /// Latest published release, as of the cached check.
+    /// Latest published release, as of the cached check. When `status` is
+    /// `unknown` and this is present, `detail` identifies it as an expired
+    /// cached observation and gives the command that verifies it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub latest_version: Option<String>,
     /// Minor releases between the running build and the latest published
@@ -120,7 +122,7 @@ pub struct ControllerStaleness {
     pub cache_age_secs: Option<u64>,
     /// One-line human summary.
     pub detail: String,
-    /// Command that resolves the drift, present only when there is drift.
+    /// Command that resolves the drift or verifies an expired cached release.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remediation: Option<String>,
 }
@@ -148,13 +150,47 @@ pub fn current() -> ControllerStaleness {
         );
     }
 
+    let now = update_check_cache::now_unix();
     let cached = update_check::cached_latest_release();
+    if let Some(cached) = cached.as_ref() {
+        if !update_check::cached_latest_release_is_fresh(cached.checked_at) {
+            return expired_cache(&identity, cached, now);
+        }
+    }
     assess(
         &identity,
         cached.as_ref().map(|entry| entry.latest_version.as_str()),
         cached.as_ref().map(|entry| entry.checked_at),
-        update_check_cache::now_unix(),
+        now,
     )
+}
+
+/// An expired update-check cache is not authoritative enough to say that a
+/// matching patch version is current. Keep the observation and its age visible,
+/// but direct the operator to the live check that owns this answer.
+fn expired_cache(
+    identity: &BuildIdentity,
+    cached: &update_check::CachedLatestRelease,
+    now: u64,
+) -> ControllerStaleness {
+    let latest_version = normalize_version(&cached.latest_version);
+    let cache_age_secs = age_secs(cached.checked_at, now);
+    ControllerStaleness {
+        status: ControllerCurrency::Unknown,
+        stale: false,
+        escalated: false,
+        running_version: identity.version.clone(),
+        build_identity: identity.display.clone(),
+        git_commit: identity.git_commit.clone(),
+        latest_version: Some(latest_version.clone()),
+        minor_releases_behind: None,
+        checked_at: Some(cached.checked_at),
+        cache_age_secs: Some(cache_age_secs),
+        detail: format!(
+            "controller freshness not established: v{latest_version} is a cached release observation from {cache_age_secs}s ago; run `homeboy upgrade --check` to verify the current release"
+        ),
+        remediation: Some("homeboy upgrade --check".to_string()),
+    }
 }
 
 /// Pure staleness comparison. Separated from cache and clock access so the
@@ -496,6 +532,25 @@ mod tests {
     }
 
     #[test]
+    fn expired_cache_never_reports_a_matching_patch_as_current() {
+        let cached = update_check::CachedLatestRelease {
+            latest_version: "0.367.11".to_string(),
+            checked_at: 100,
+        };
+        let staleness = expired_cache(&identity("0.367.11", None), &cached, 100 + 86_401);
+
+        assert_eq!(staleness.status, ControllerCurrency::Unknown);
+        assert!(!staleness.stale);
+        assert_eq!(staleness.latest_version.as_deref(), Some("0.367.11"));
+        assert_eq!(staleness.cache_age_secs, Some(86_401));
+        assert_eq!(
+            staleness.remediation.as_deref(),
+            Some("homeboy upgrade --check")
+        );
+        assert!(staleness.detail.contains("cached release observation"));
+    }
+
+    #[test]
     fn serialized_shape_is_stable() {
         let staleness = assess(
             &identity("0.327.0", Some("ed33954781a9")),
@@ -557,7 +612,11 @@ mod tests {
 
         assert_eq!(staleness.running_version, build_identity::current().version);
         assert_eq!(staleness.stale, staleness.status.is_behind());
-        assert_eq!(staleness.stale, staleness.remediation.is_some());
+        assert!(
+            staleness.stale
+                || staleness.remediation.is_none()
+                || staleness.status == ControllerCurrency::Unknown
+        );
         assert!(!staleness.detail.is_empty());
     }
 }

--- a/crates/homeboy-upgrade/src/upgrade/update_check.rs
+++ b/crates/homeboy-upgrade/src/upgrade/update_check.rs
@@ -153,6 +153,13 @@ pub fn cached_latest_release() -> Option<CachedLatestRelease> {
     })
 }
 
+/// Whether a cached release observation is still recent enough to establish a
+/// current-version verdict. Stale observations remain useful evidence, but must
+/// not make a status surface claim that a matching binary is current.
+pub fn cached_latest_release_is_fresh(checked_at: u64) -> bool {
+    update_check_cache::is_cache_fresh(checked_at, CHECK_INTERVAL_SECS)
+}
+
 /// Whether the operator has turned the update check off, by environment or by
 /// config. Callers that report freshness must treat this as "not established"
 /// rather than "current".

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -144,8 +144,10 @@ Both the summary and the project dashboard now carry a `controller` object:
 **Cost.** No network call is made by `status`. The latest published release is
 read from the same daily cache the startup update check already maintains, so
 the whole surface is one small file read per command and at most one network
-call per day. A failure to check degrades to `unknown`; it never fails a
-command.
+call per day. A cache older than one day is reported as an aged cached
+observation, not a current-version verdict; it includes its age and directs you
+to `homeboy upgrade --check` for a live answer. A failure to check degrades to
+`unknown`; it never fails a command.
 
 **What is not reported.** The commit delta (`215 commits behind`) needs a source
 checkout with a fresh `origin/main`, which a packaged install does not have. The


### PR DESCRIPTION
Closes #14330

## Summary
- treat an expired update-check cache as an unverified controller freshness observation
- retain the cached release and its age while directing operators to `homeboy upgrade --check`
- document the compact status cache behavior

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-upgrade`

AI disclosure: OpenAI GPT-5.6 Terra via OpenCode.