### PR TITLE
fix(runner): surface offloaded job stdio in logs

### DIFF
--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -1643,6 +1643,16 @@ impl JobStore {
         };
         self.ensure_transition(job_id, status)?;
 
+        // Runner output is bounded and redacted before it becomes a remote
+        // result. Project it into the event stream as well so job logs do not
+        // have to wait for or decode the terminal result to show child stdio.
+        if let Some(stdout) = result.stdout.as_deref().filter(|stdout| !stdout.is_empty()) {
+            self.append_event(job_id, JobEventKind::Stdout, Some(stdout.to_string()), None)?;
+        }
+        if let Some(stderr) = result.stderr.as_deref().filter(|stderr| !stderr.is_empty()) {
+            self.append_event(job_id, JobEventKind::Stderr, Some(stderr.to_string()), None)?;
+        }
+
         let result_data = serde_json::to_value(&result).map_err(|err| {
             Error::internal_json(
                 err.to_string(),

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -742,7 +742,7 @@ fn reverse_worker_streams_redacted_child_progress_without_trusting_stdout_lifecy
         .expect("configure named runner secret");
         let store = JobStore::default();
         let mut request = run_id_echo_request();
-        request.command[2] = "printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"import\",\"current_item\":\"%s\",\"completed\":1,\"total\":2,\"metadata\":{\"api_key\":\"%s\"}}\\n' \"$TOKEN\" \"$TOKEN\"; printf 'HOMEBOY_RUNNER_PROGRESS {not-json}\\n'; printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"done\",\"status\":\"succeeded\"}\\n'; sleep 0.1; dd if=/dev/zero bs=1024 count=4097 2>/dev/null; printf tail".to_string();
+        request.command[2] = "printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"import\",\"current_item\":\"%s\",\"completed\":1,\"total\":2,\"metadata\":{\"api_key\":\"%s\"}}\\n' \"$TOKEN\" \"$TOKEN\"; printf 'HOMEBOY_RUNNER_PROGRESS {not-json}\\n'; printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"done\",\"status\":\"succeeded\"}\\n'; printf 'worker stderr' >&2; sleep 0.1; dd if=/dev/zero bs=1024 count=4097 2>/dev/null; printf tail".to_string();
         request.secret_env_names = vec!["TOKEN".to_string()];
         store
             .submit_runner_api_fixture(request)
@@ -782,6 +782,9 @@ fn reverse_worker_streams_redacted_child_progress_without_trusting_stdout_lifecy
         assert_eq!(progress["metadata"]["api_key"], "[REDACTED]");
         assert!(events.iter().all(|event| event.kind != JobEventKind::Status
             || event.message.as_deref() != Some("succeeded")));
+        assert!(events.iter().any(|event| {
+            event.kind == JobEventKind::Stderr && event.message.as_deref() == Some("worker stderr")
+        }));
         let result = result_event_data(&store, job.id);
         assert!(result["stdout"].as_str().expect("stdout").ends_with("tail"));
         assert_eq!(result["capture"]["stdout"]["truncated"], true);


### PR DESCRIPTION
## Summary
- project bounded, runner-redacted remote stdout and stderr into job events before the terminal result
- cover a Lab reverse runner command writing to stderr

Closes #14324

AI disclosure: OpenAI GPT-5.6 Terra via OpenCode.