### PR TITLE
fix(runner): reap process groups on cancellation

### DIFF
--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -1884,7 +1884,7 @@ impl JobStore {
             ));
         }
 
-        self.durable_transaction(|inner| {
+        let (job, child) = self.durable_transaction(|inner| {
             let stored = inner
                 .jobs
                 .get_mut(&job_id)
@@ -1935,7 +1935,15 @@ impl JobStore {
                 ));
             }
             if stored.job.status.is_terminal() {
-                return Ok(stored.job.clone());
+                let child = (stored.job.status == JobStatus::Cancelled)
+                    .then(|| {
+                        stored
+                            .local_child
+                            .as_ref()
+                            .and_then(|child| child.process.clone())
+                    })
+                    .flatten();
+                return Ok((stored.job.clone(), child));
             }
             validate_transition(stored.job.status, JobStatus::Cancelled)?;
             let now = timestamp_ms();
@@ -1953,8 +1961,16 @@ impl JobStore {
             stored.events.push(event);
             apply_event_retention(&mut stored.events, self.event_retention_limit());
             stored.job.event_count = stored.events.len();
-            Ok(stored.job.clone())
-        })
+            Ok((
+                stored.job.clone(),
+                stored
+                    .local_child
+                    .as_ref()
+                    .and_then(|child| child.process.clone()),
+            ))
+        })?;
+        super::store::reap_cancelled_local_child(child.as_ref())?;
+        Ok(job)
     }
 
     pub fn reconcile_expired_remote_runner_claims(&self, now_ms: u64) -> Result<Vec<Job>> {

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use fs4::fs_std::FileExt;
 use homeboy_lab_contract::lab::execution_envelope::lab_runner_workload_from_execution_envelope;
@@ -38,6 +39,7 @@ const LOCAL_CHILD_RESERVATION_LEASE_MS: u64 = 60_000;
 /// Admissions protect the controller-to-daemon handoff window. A stopped
 /// controller must eventually stop consuming daemon replacement capacity.
 pub(crate) const ADMISSION_RESERVATION_LEASE_MS: u64 = 30_000;
+const LOCAL_CHILD_CANCELLATION_GRACE: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone)]
 pub(crate) struct AdmissionReservation {
@@ -217,7 +219,7 @@ pub(super) struct LocalChildExecution {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     reservation_expires_at_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    process: Option<LocalChildProcessIdentity>,
+    pub(super) process: Option<LocalChildProcessIdentity>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1573,7 +1575,10 @@ impl JobStore {
                 Some(vec![format!("POST /controller/jobs/{job_id}/cancel")]),
             ));
         }
-        self.transition(job_id, JobStatus::Cancelled, reason.into())
+        let child = self.local_child_process(job_id)?;
+        let job = self.transition(job_id, JobStatus::Cancelled, reason.into())?;
+        reap_cancelled_local_child(child.as_ref())?;
+        Ok(job)
     }
 
     #[cfg(test)]
@@ -2831,6 +2836,59 @@ impl JobStore {
             .map(|persistence| persistence.event_retention_limit)
             .unwrap_or(usize::MAX)
     }
+
+    fn local_child_process(&self, job_id: Uuid) -> Result<Option<LocalChildProcessIdentity>> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        Ok(stored
+            .local_child
+            .as_ref()
+            .and_then(|child| child.process.clone()))
+    }
+}
+
+/// Stop the isolated group recorded before the job became visible as running.
+/// The executor owns reaping its direct child; waiting for the group here also
+/// prevents a cancelled job from leaving its descendants available to later work.
+pub(super) fn reap_cancelled_local_child(child: Option<&LocalChildProcessIdentity>) -> Result<()> {
+    let Some(child) = child else {
+        return Ok(());
+    };
+    let Some(process_group_id) = child.process_group_id else {
+        return Ok(());
+    };
+    if process_group_id != child.pid {
+        return Err(Error::internal_unexpected(format!(
+            "refuse to reap recorded process group {process_group_id}: expected isolated leader {}",
+            child.pid
+        )));
+    }
+    if let LocalChildStartDiscriminator::LinuxProcStatStarttimeTicks { ticks } =
+        &child.discriminator
+    {
+        match crate::process::linux_process_starttime_ticks(child.pid) {
+            Ok(Some(actual)) if actual != *ticks => {
+                return Err(Error::internal_unexpected(format!(
+                    "refuse to reap reused local child process group {process_group_id}"
+                )));
+            }
+            Ok(_) => {}
+            Err(evidence) => {
+                return Err(Error::internal_unexpected(format!(
+                    "inspect local child {}/process group {process_group_id} before cancellation: {evidence}",
+                    child.pid
+                )));
+            }
+        }
+    }
+    crate::process::terminate_isolated_process_group_with_grace(
+        process_group_id,
+        LOCAL_CHILD_CANCELLATION_GRACE,
+    )?;
+    Ok(())
 }
 
 impl JobStore {

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2812,7 +2812,9 @@ fn cancelling_daemon_exec_job_terminates_process_tree() {
             "cwd": cwd.display().to_string(),
             "command": [
                 "__homeboy_test_process_tree__",
-                format!("sleep 30 & echo $! > {child_pid_path}; wait; touch {marker_path}"),
+                format!(
+                    "trap '' TERM; sleep 30 & echo $! > {child_pid_path}; while :; do :; done; touch {marker_path}"
+                ),
             ],
         })),
         &store,
@@ -2844,6 +2846,27 @@ fn cancelling_daemon_exec_job_terminates_process_tree() {
         !marker.exists(),
         "cancelled daemon runner exec left a child process running"
     );
+
+    let follow_up = route_with_job_store_and_body(
+        "POST",
+        "/exec",
+        Some(serde_json::json!({
+            "runner_id": "lab-local",
+            "cwd": cwd.display().to_string(),
+            "command": ["__homeboy_test_process_tree__", "sleep 0.1"],
+        })),
+        &store,
+    );
+    assert_eq!(follow_up.status_code, 200);
+    let follow_up_id = uuid::Uuid::parse_str(
+        follow_up.body["body"]["job"]["id"]
+            .as_str()
+            .expect("follow-up job id"),
+    )
+    .expect("parse follow-up job id");
+    wait_for("follow-up daemon exec job to complete", || {
+        store.get(follow_up_id).expect("follow-up job").status == JobStatus::Succeeded
+    });
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- reap recorded daemon-local runner process groups when jobs are cancelled
- escalate from SIGTERM to SIGKILL after a bounded grace period
- cover a TERM-resistant sleep-and-spawn fixture and verify a follow-up job completes

Closes #14326

## Testing
- `cargo test -p homeboy-core --lib daemon::daemon_test::cancelling_daemon_exec_job_terminates_process_tree -- --nocapture`
- `cargo test -p homeboy-core --lib api_jobs::tests -- --nocapture`

## AI Disclosure
OpenAI GPT-5.6 Terra via OpenCode.