### PR TITLE
Fix Lab fuzz detach handoff

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -665,6 +665,18 @@ pub(super) fn fuzz_run_outcome(
         };
     }
 
+    if results.is_none() {
+        return FuzzRunOutcome {
+            status: "failed",
+            success: false,
+            exit_code: if runner_exit_code == 0 {
+                1
+            } else {
+                runner_exit_code
+            },
+        };
+    }
+
     if let Some(non_proof_status) = results.and_then(fuzz_campaign_non_proof_status) {
         return FuzzRunOutcome {
             status: non_proof_status,

--- a/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
@@ -946,6 +946,22 @@ fn fuzz_run_outcome_fails_when_successful_command_reports_failed_campaign() {
 }
 
 #[test]
+fn fuzz_run_outcome_fails_when_successful_command_omits_campaign() {
+    let outcome = fuzz_run_outcome(
+        0,
+        true,
+        false,
+        None,
+        None,
+        homeboy::fuzz::FuzzGateProfile::Evidence,
+    );
+
+    assert_eq!(outcome.status, "failed");
+    assert!(!outcome.success);
+    assert_eq!(outcome.exit_code, 1);
+}
+
+#[test]
 fn fuzz_run_outcome_fails_when_successful_command_reports_open_finding() {
     let mut campaign = empty_fuzz_campaign();
     campaign.findings = vec![FuzzFinding {

--- a/crates/homeboy-lab-runner/src/lab_args/offload.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/offload.rs
@@ -201,6 +201,9 @@ pub(crate) fn rewrite_lab_offload_args(
         if arg.starts_with("--placement=") {
             continue;
         }
+        if arg == "--detach-after-handoff" || arg.starts_with("--detach-after-handoff=") {
+            continue;
+        }
         if arg == "--output" {
             let _ = iter.next();
             if let Some(path) = remote_output_file {
@@ -381,6 +384,9 @@ pub(crate) fn rewrite_runner_resident_lab_offload_args(
             continue;
         }
         if arg.starts_with("--placement=") {
+            continue;
+        }
+        if arg == "--detach-after-handoff" || arg.starts_with("--detach-after-handoff=") {
             continue;
         }
         if arg == "--output" {

--- a/crates/homeboy-lab-runner/src/lab_args/tests.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/tests.rs
@@ -138,6 +138,26 @@ mod migrated_legacy_lab_arg_tests {
     }
 
     #[test]
+    fn rewrite_strips_controller_detach_policy() {
+        let input = args(&[
+            "homeboy",
+            "--detach-after-handoff",
+            "fuzz",
+            "run",
+            "component-a",
+        ]);
+
+        assert_eq!(
+            rewrite_lab_offload_args(&input, "/runner/project", &[], None),
+            args(&["homeboy", "fuzz", "run", "component-a"])
+        );
+        assert_eq!(
+            rewrite_runner_resident_lab_offload_args(&input, None),
+            args(&["homeboy", "fuzz", "run", "component-a"])
+        );
+    }
+
+    #[test]
     fn rewrite_maps_structured_output_to_runner_path() {
         let input = args(&[
             "homeboy",


### PR DESCRIPTION
Closes #14323

- Keep `--detach-after-handoff` controller-only when remapping Lab runner argv.
- Treat fuzz success without a campaign envelope as failure.

AI assistance disclosure: OpenAI GPT-5.6 Terra via OpenCode implemented the fix.