### PR TITLE
fix(fuzz): discover package script workloads

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/fuzz_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/fuzz_config.rs
@@ -15,6 +15,12 @@ pub struct FuzzConfig {
     pub runtime_helpers: Vec<RuntimeHelperRequirement>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub workloads: Vec<FuzzWorkloadConfig>,
+    /// Extension-owned JSON values that declare a workload when present.
+    ///
+    /// This keeps ecosystem-specific manifest paths and JSON pointers in the
+    /// extension contract while core performs only generic JSON lookup.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workload_json_probes: Vec<FuzzWorkloadJsonProbe>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub case_artifact: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -40,4 +46,18 @@ pub struct FuzzWorkloadConfig {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lifecycle: Option<LifecycleContract>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FuzzWorkloadJsonProbe {
+    /// JSON file relative to the component root.
+    pub path: String,
+    /// RFC 6901 JSON Pointer whose non-empty string value declares the workload.
+    pub pointer: String,
+    /// Stable workload identifier emitted when the pointer resolves.
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }

--- a/crates/homeboy-cli/src/commands/fuzz/tests/report_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/report_tests.rs
@@ -97,6 +97,7 @@ fn fuzz_campaign_contract_surfaces_extension_metadata() {
         env: Vec::new(),
         runtime_helpers: Vec::new(),
         workloads: Vec::new(),
+        workload_json_probes: Vec::new(),
         case_artifact: Some("failing-case".to_string()),
         corpus_artifacts: vec!["corpus".to_string()],
         seed: Some("manifest-seed".to_string()),

--- a/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
@@ -152,6 +152,62 @@ fn fuzz_workloads_include_rig_declared_paths() {
 }
 
 #[test]
+fn node_package_fuzz_script_is_listed_and_selected_for_run() {
+    with_isolated_home(|home| {
+        let extension_dir = home.path().join(".config/homeboy/extensions/nodejs");
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join("nodejs.json"),
+            serde_json::json!({
+                "name": "Node.js",
+                "version": "0.0.0",
+                "fuzz": {
+                    "extension_script": "fuzz.sh",
+                    "workload_json_probes": [{
+                        "path": "package.json",
+                        "pointer": "/scripts/fuzz",
+                        "id": "package-script-fuzz",
+                        "label": "package.json scripts.fuzz"
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .expect("extension manifest");
+        let component_dir = tempfile::tempdir().expect("component dir");
+        fs::write(
+            component_dir.path().join("package.json"),
+            serde_json::json!({ "scripts": { "fuzz": "node scripts/fuzz.mjs" } }).to_string(),
+        )
+        .expect("package manifest");
+        let args = FuzzListArgs {
+            comp: PositionalComponentArgs {
+                component: Some("node-package".to_string()),
+                path: Some(component_dir.path().to_string_lossy().to_string()),
+            },
+            rig: None,
+            remote_discovery: false,
+            extension_override: ExtensionOverrideArgs {
+                extensions: vec!["nodejs".to_string()],
+            },
+            setting_args: SettingArgs::default(),
+        };
+
+        let listed = run_list(args).expect("list package fuzz script");
+
+        assert_eq!(listed.count, 1);
+        assert_eq!(listed.workloads[0].id, "package-script-fuzz");
+        assert_eq!(
+            select_workload(&listed.workloads, None)
+                .expect("select sole package workload")
+                .expect("package workload")
+                .id,
+            "package-script-fuzz"
+        );
+    });
+}
+
+#[test]
 fn fuzz_workload_parses_artifact_postprocess_metadata() {
     let spec: RigSpec = serde_json::from_value(serde_json::json!({
         "id": "package-fuzz",

--- a/crates/homeboy-cli/src/commands/fuzz/workloads.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/workloads.rs
@@ -393,6 +393,14 @@ pub(super) fn fuzz_workloads(
                 .into_iter()
                 .map(|path| fuzz_workload_from_path(extension_id, &path)),
         );
+
+        if let Ok(manifest) = homeboy_core::extension::catalog::load_extension(extension_id) {
+            workloads.extend(manifest.fuzz.as_ref().into_iter().flat_map(|fuzz| {
+                fuzz.workload_json_probes
+                    .iter()
+                    .filter_map(|probe| json_probe_workload(component, extension_id, probe))
+            }));
+        }
     }
 
     if let Some(extensions) = component.extensions.as_ref() {
@@ -412,6 +420,27 @@ pub(super) fn fuzz_workloads(
     }
 
     workloads
+}
+
+fn json_probe_workload(
+    component: &homeboy::core::component::Component,
+    extension_id: &str,
+    probe: &homeboy_extension_contract::fuzz_config::FuzzWorkloadJsonProbe,
+) -> Option<FuzzWorkloadOutput> {
+    let path = Path::new(&component.local_path).join(&probe.path);
+    let contents = std::fs::read_to_string(&path).ok()?;
+    let value = serde_json::from_str::<serde_json::Value>(&contents).ok()?;
+    (!value.pointer(&probe.pointer)?.as_str()?.trim().is_empty()).then_some(())?;
+    Some(FuzzWorkloadOutput {
+        id: probe.id.clone(),
+        label: probe.label.clone(),
+        description: probe.description.clone(),
+        source: format!(
+            "extension:{extension_id}:json:{}#{}",
+            probe.path, probe.pointer
+        ),
+        manifest_path: None,
+    })
 }
 
 pub(super) fn fuzz_execution_inputs(
@@ -497,6 +526,10 @@ pub(super) fn select_workload<'a>(
     let first = path_workloads.next();
     if first.is_some() && path_workloads.next().is_none() {
         return Ok(first);
+    }
+
+    if workloads.len() == 1 {
+        return Ok(workloads.first());
     }
 
     if workloads.len() > 1 {

--- a/docs/reference/schemas/extension-manifest-schema.md
+++ b/docs/reference/schemas/extension-manifest-schema.md
@@ -561,6 +561,12 @@ Extensions declare fuzz workload metadata with a top-level `fuzz` capability blo
 - **`fuzz.workloads[].id`** (string): Stable workload identifier.
 - **`fuzz.workloads[].label`** (string): Optional human-readable workload label.
 - **`fuzz.workloads[].description`** (string): Optional workload description.
+- **`fuzz.workload_json_probes`** (array): Extension-owned JSON declarations that
+  surface a workload when a pointer resolves to a non-empty string. Each probe
+  declares `path` relative to the component root, an RFC 6901 `pointer`, and a
+  stable workload `id`. For example, the Node.js extension declares
+  `package.json` with `/scripts/fuzz`; projects do not duplicate that command in
+  `homeboy.json`.
 - **`fuzz.case_artifact`** (string): Optional generic artifact id or semantic key for the primary replayable case artifact.
 - **`fuzz.corpus_artifacts`** (array): Optional generic artifact ids or semantic keys for persisted corpus artifacts.
 - **`fuzz.seed`** (string): Optional default seed surfaced in `fuzz run` output when the caller did not pass `--seed`.


### PR DESCRIPTION
## Summary
- add a generic extension manifest JSON workload probe contract
- resolve declared probes through the same fuzz discovery path used by list and run
- list and select the sole package-script workload in the Node.js regression test

The Node.js declaration is supplied by Extra-Chill/homeboy-extensions#2795.

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::fuzz::tests::workload_tests`

Closes #14328.

## AI disclosure
OpenAI GPT-5.6 Terra via OpenCode.