### PR TITLE
Fix runner wait-timeout handoff and cancellation

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -71,6 +71,14 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         concurrency_limit: Option<usize>,
 
+        /// Seconds the controller waits for an accepted runner job; zero detaches immediately
+        #[arg(long)]
+        runner_exec_wait_timeout_secs: Option<u64>,
+
+        /// Cancel an in-flight remote job when the controller wait expires
+        #[arg(long)]
+        cancel_on_wait_timeout: Option<bool>,
+
         /// Artifact retention/copying policy label for future execution commands
         #[arg(long)]
         artifact_policy: Option<String>,
@@ -95,6 +103,14 @@ pub(super) enum RunnerCommand {
         /// Maximum concurrent workflows this server should accept
         #[arg(long)]
         concurrency_limit: Option<usize>,
+
+        /// Seconds the controller waits for an accepted runner job; zero detaches immediately
+        #[arg(long)]
+        runner_exec_wait_timeout_secs: Option<u64>,
+
+        /// Cancel an in-flight remote job when the controller wait expires
+        #[arg(long)]
+        cancel_on_wait_timeout: Option<bool>,
 
         /// Artifact retention/copying policy label for future execution commands
         #[arg(long)]

--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -30,6 +30,8 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             homeboy_path,
             daemon,
             concurrency_limit,
+            runner_exec_wait_timeout_secs,
+            cancel_on_wait_timeout,
             artifact_policy,
         } => map_registry(add(RunnerAddInput {
             json,
@@ -42,6 +44,8 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
                 homeboy_path,
                 daemon,
                 concurrency_limit,
+                runner_exec_wait_timeout_secs,
+                cancel_on_wait_timeout,
                 artifact_policy,
                 ..RunnerSettings::default()
             },
@@ -52,6 +56,8 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             homeboy_path,
             daemon,
             concurrency_limit,
+            runner_exec_wait_timeout_secs,
+            cancel_on_wait_timeout,
             artifact_policy,
         } => map_registry(enable(
             &server_id,
@@ -60,6 +66,8 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
                 homeboy_path,
                 daemon,
                 concurrency_limit,
+                runner_exec_wait_timeout_secs,
+                cancel_on_wait_timeout,
                 artifact_policy,
                 ..RunnerSettings::default()
             },
@@ -512,6 +520,18 @@ pub(super) fn render_compact_exec_output(output: &RunnerExecOutput) -> String {
     rendered.push_str(&format!("Runner: {}\n", output.runner_id));
     rendered.push_str(&format!("Remote cwd: {}\n", output.remote_cwd));
     rendered.push_str(&format!("Exit status: {}\n", output.exit_code));
+    if output.is_in_flight() {
+        rendered
+            .push_str("Status: remote job still in flight; remote exit status is unavailable\n");
+        if let Some(action) = output.execution_record.as_ref().and_then(|record| {
+            record
+                .next_actions
+                .iter()
+                .find(|action| action.label == "runner_job_follow")
+        }) {
+            rendered.push_str(&format!("Follow: {}\n", action.command.join(" ")));
+        }
+    }
     if let Some(job_id) = output.job_id.as_deref() {
         rendered.push_str(&format!("Job: {job_id}\n"));
     }

--- a/crates/homeboy-cli/src/commands/runner/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/mod.rs
@@ -74,6 +74,7 @@ pub(crate) fn run_plain_text_raw(args: RunnerArgs) -> super::output_runtime::Com
             json: false,
             raw: false,
             command,
+            ..
         } => dispatch::run_exec_command(
             exec::RunnerExecInput {
                 runner_id: id,

--- a/crates/homeboy-cli/src/commands/runner/registry.rs
+++ b/crates/homeboy-cli/src/commands/runner/registry.rs
@@ -373,6 +373,12 @@ pub(super) fn enable(
     if let Some(concurrency_limit) = settings.concurrency_limit {
         spec.insert("concurrency_limit".to_string(), concurrency_limit.into());
     }
+    if let Some(timeout) = settings.runner_exec_wait_timeout_secs {
+        spec.insert("runner_exec_wait_timeout_secs".to_string(), timeout.into());
+    }
+    if let Some(cancel) = settings.cancel_on_wait_timeout {
+        spec.insert("cancel_on_wait_timeout".to_string(), cancel.into());
+    }
     if let Some(artifact_policy) = settings.artifact_policy {
         spec.insert("artifact_policy".to_string(), artifact_policy.into());
     }

--- a/crates/homeboy-cli/src/commands/runner/tests/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/exec.rs
@@ -388,6 +388,39 @@ fn compact_exec_output_shows_metadata_and_streams_once() {
 }
 
 #[test]
+fn compact_exec_output_marks_durable_in_flight_job_without_a_failure() {
+    let output = RunnerExecOutput {
+        execution_record: Some(
+            homeboy::core::runner_execution_envelope::RunnerExecutionRecord::in_flight(
+                "job-123", "lab", "daemon",
+            )
+            .with_job_id("job-123")
+            .with_next_actions([
+                homeboy::core::runner_execution_envelope::RunnerExecutionNextAction {
+                    label: "runner_job_follow".to_string(),
+                    command: vec![
+                        "homeboy".to_string(),
+                        "runner".to_string(),
+                        "job".to_string(),
+                        "logs".to_string(),
+                        "lab".to_string(),
+                        "job-123".to_string(),
+                        "--follow".to_string(),
+                    ],
+                },
+            ]),
+        ),
+        ..runner_exec_output("lab", RunnerExecMode::Daemon, "/workspace")
+    };
+
+    let rendered = render_compact_exec_output(&output);
+
+    assert!(rendered.contains("Status: remote job still in flight"));
+    assert!(rendered.contains("Follow: homeboy runner job logs lab job-123 --follow"));
+    assert!(rendered.contains("Exit status: 0"));
+}
+
+#[test]
 fn compact_exec_command_run_preserves_full_output_file_payload() {
     let output = RunnerExecOutput {
         variant: "exec",

--- a/crates/homeboy-core/src/server/mod.rs
+++ b/crates/homeboy-core/src/server/mod.rs
@@ -73,6 +73,17 @@ pub struct RunnerSettings {
     pub daemon: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub concurrency_limit: Option<usize>,
+    /// Maximum seconds the controller waits for an accepted runner job. Unset
+    /// retains the twenty-minute default; zero detaches immediately. The
+    /// `HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS` env var overrides this for one run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_exec_wait_timeout_secs: Option<u64>,
+    /// Whether an accepted remote runner job is cancelled when the controller
+    /// stops waiting. Unset cancels agent-task workloads and preserves the
+    /// historical no-cancel behavior for other runner commands. The
+    /// `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT` env var can enable this for one run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancel_on_wait_timeout: Option<bool>,
     /// Bounds a child which emits only runner-wrapper heartbeats. Zero disables
     /// this safeguard for workloads whose semantic progress cannot be observed.
     #[serde(default, skip_serializing_if = "HeartbeatOnlyStallPolicy::is_default")]

--- a/crates/homeboy-core/src/server/mod.rs
+++ b/crates/homeboy-core/src/server/mod.rs
@@ -79,8 +79,8 @@ pub struct RunnerSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runner_exec_wait_timeout_secs: Option<u64>,
     /// Whether an accepted remote runner job is cancelled when the controller
-    /// stops waiting. Unset cancels agent-task workloads and preserves the
-    /// historical no-cancel behavior for other runner commands. The
+    /// stops waiting. Unset preserves accepted work for every runner command.
+    /// The
     /// `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT` env var can enable this for one run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cancel_on_wait_timeout: Option<bool>,

--- a/crates/homeboy-core/src/server/mod.rs
+++ b/crates/homeboy-core/src/server/mod.rs
@@ -79,8 +79,8 @@ pub struct RunnerSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runner_exec_wait_timeout_secs: Option<u64>,
     /// Whether an accepted remote runner job is cancelled when the controller
-    /// stops waiting. Unset preserves accepted work for every runner command.
-    /// The
+    /// stops waiting. Unset cancels agent-task workloads and preserves other
+    /// accepted work. The
     /// `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT` env var can enable this for one run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cancel_on_wait_timeout: Option<bool>,

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -587,25 +587,6 @@ fn record_reverse_broker_metadata(
     context.store.update_run_metadata(&run.id, metadata)
 }
 
-pub fn mirror_daemon_job_progress(
-    runner: &Runner,
-    cwd: &str,
-    command: &[String],
-    job: &Job,
-    events: &[JobEvent],
-    run_id: Option<&str>,
-) -> Result<RunRecord> {
-    mirror_daemon_job_progress_with_ownership(
-        runner,
-        cwd,
-        command,
-        job,
-        events,
-        run_id,
-        MirrorRunOwnership::Inferred,
-    )
-}
-
 pub(crate) fn mirror_daemon_job_progress_with_ownership(
     runner: &Runner,
     cwd: &str,

--- a/crates/homeboy-lab-runner/src/evidence/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mod.rs
@@ -21,9 +21,8 @@ pub use download::{
 
 pub use homeboy_core::api_jobs::RunnerJobLogSnapshot;
 pub use mirror::{
-    controller_artifact_metadata, mirror_connected_runner_run, mirror_daemon_job_progress,
-    mirrored_runner_job_identity, refresh_mirrored_daemon_evidence, runner_job_log_snapshot,
-    terminalize_mirrored_daemon_job,
+    controller_artifact_metadata, mirror_connected_runner_run, mirrored_runner_job_identity,
+    refresh_mirrored_daemon_evidence, runner_job_log_snapshot, terminalize_mirrored_daemon_job,
 };
 pub(crate) use mirror::{
     mirror_daemon_evidence, mirror_daemon_job_progress_with_ownership,

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -376,7 +376,8 @@ pub(super) fn exec_via_reverse_broker(
         },
         || Ok(()),
         |_, _| Ok(()),
-    );
+    )
+    .map(RunnerExecCompletion::into_output);
 }
 
 /// Preserve file-backed argv values past controller cleanup. Values are content

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -2332,17 +2332,24 @@ pub(super) fn runner_job_result_fields(
     let capture = result
         .get("capture")
         .and_then(|value| serde_json::from_value(value.clone()).ok());
-    let exit_code = result
-        .get("exit_code")
-        .and_then(Value::as_i64)
-        .and_then(|code| i32::try_from(code).ok())
-        .unwrap_or_else(|| {
-            if job_status == JobStatus::Succeeded {
-                0
-            } else {
-                1
-            }
-        });
+    // The terminal snapshot is authoritative when cancellation races a worker
+    // result. Keep that result intact for evidence and validation, but never
+    // report a cancelled job as a successful command.
+    let exit_code = if job_status == JobStatus::Cancelled {
+        1
+    } else {
+        result
+            .get("exit_code")
+            .and_then(Value::as_i64)
+            .and_then(|code| i32::try_from(code).ok())
+            .unwrap_or_else(|| {
+                if job_status == JobStatus::Succeeded {
+                    0
+                } else {
+                    1
+                }
+            })
+    };
     RunnerJobResultFields {
         result,
         stdout,

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -7,7 +7,7 @@ use reqwest::blocking::Client;
 use serde_json::{json, Value};
 
 use crate::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_workload_result;
-use homeboy_core::api_jobs::{Job, JobEvent, JobStatus, RunnerJobLifecycleMetadata};
+use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStatus, RunnerJobLifecycleMetadata};
 use homeboy_core::daemon::{DirectDaemonExecSubmitRequest, WorkspaceOwnerRegisterRequest};
 use homeboy_core::engine::command::CommandCaptureMetadata;
 use homeboy_core::error::{Error, ErrorCode, Result};
@@ -2187,6 +2187,29 @@ pub(crate) fn result_event_data(events: &[JobEvent]) -> Option<Value> {
         .rev()
         .find(|event| matches!(event.kind, homeboy_core::api_jobs::JobEventKind::Result))
         .and_then(|event| event.data.clone())
+}
+
+/// Cancellation can terminalize queued work before a worker has emitted its
+/// normal result event. Supply the equivalent non-success result locally so the
+/// shared terminal evidence path can project the authoritative job snapshot.
+pub(super) fn append_cancelled_result_if_absent(job: &Job, events: &mut Vec<JobEvent>) {
+    if job.status != JobStatus::Cancelled || result_event_data(events).is_some() {
+        return;
+    }
+    events.push(JobEvent {
+        sequence: events
+            .last()
+            .map(|event| event.sequence.saturating_add(1))
+            .unwrap_or(1),
+        job_id: job.id,
+        kind: JobEventKind::Result,
+        timestamp_ms: job.updated_at_ms,
+        message: Some("runner job cancelled before producing a result".to_string()),
+        data: Some(json!({
+            "exit_code": 1,
+            "stderr": "runner job cancelled",
+        })),
+    });
 }
 
 pub(super) fn append_agent_task_lifecycle_workload_event(

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -25,9 +25,7 @@ use super::super::capabilities::{
 };
 use super::super::daemon_http_get::daemon_get;
 use super::super::evidence::{local_job_run_id, runner_exec_run_label};
-use super::super::evidence::{
-    mirror_daemon_evidence, mirror_daemon_job_progress, terminalize_mirrored_daemon_job,
-};
+use super::super::evidence::{mirror_daemon_evidence, terminalize_mirrored_daemon_job};
 use super::super::resource_metrics::RunnerResourceMetrics;
 use super::super::{Runner, RunnerCapabilityPreflight, RunnerJob, RunnerKind};
 
@@ -383,7 +381,8 @@ pub(super) fn exec_via_daemon(
             }
             Ok(())
         },
-    );
+    )
+    .map(RunnerExecCompletion::into_output);
 }
 
 pub(super) fn record_and_report_promotion_progress_frames(
@@ -2180,106 +2179,6 @@ pub(super) fn lab_terminal_result_transport_error(
             "Inspect the daemon job report with `homeboy runner job logs {} {job_id}`.",
             runner.id
         ))
-}
-
-pub(super) fn daemon_job_wait_timeout(
-    runner: &Runner,
-    cwd: &str,
-    command: &[String],
-    job: &Job,
-    events: &[JobEvent],
-    label: &str,
-    supports_cancellation: bool,
-) -> Error {
-    let job_id = job.id.to_string();
-    let mirrored = mirror_daemon_job_progress(runner, cwd, command, job, events, None);
-    let mirrored_run_id = mirrored.as_ref().ok().map(|run| run.id.clone());
-    let timeout_hint = format!(
-        "Set controller-side `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}` before invoking homeboy to change this wait budget, e.g. `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}=2400 homeboy ...`; workload settings are applied inside the remote job and cannot extend the controller wait."
-    );
-    // Opt-in (#6891): when the operator set `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT`,
-    // best-effort cancel the still-running remote job so it stops holding its rig
-    // lock. Off by default — the historical contract is preserved exactly.
-    let cancel_outcome = attempt_wait_timeout_cancel(&runner.id, &job_id);
-    let message_tail = match &cancel_outcome {
-        WaitTimeoutCancelOutcome::Disabled => {
-            "the remote job is still in flight and was not cancelled".to_string()
-        }
-        WaitTimeoutCancelOutcome::Cancelled => format!(
-            "remote cancellation was requested on the runner job (opt-in `{RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV}`)"
-        ),
-        WaitTimeoutCancelOutcome::Failed(reason) => format!(
-            "remote cancellation was requested (opt-in `{RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV}`) but failed: {reason}; the remote job may still be in flight"
-        ),
-    };
-    let mut error = Error::internal_unexpected(format!(
-        "{label} {job_id} on runner {} did not finish before timeout; {message_tail}",
-        runner.id
-    ));
-    error.details["runner_id"] = Value::String(runner.id.clone());
-    error.details["job_id"] = Value::String(job_id.clone());
-    // The controller stopped waiting, not the daemon job. Preserve this
-    // discriminator so the Lab adapter retains the durable handoff rather than
-    // recording a pre-dispatch failure for an already accepted job.
-    error.details["status"] = Value::String("controller_wait_expired".to_string());
-    error.details["reason"] = Value::String("controller_wait_expired".to_string());
-    error.details["remote_cwd"] = Value::String(cwd.to_string());
-    error.details["command"] = json!(redact_argv(command));
-    error.details["cancel_on_wait_timeout"] = Value::String(
-        match &cancel_outcome {
-            WaitTimeoutCancelOutcome::Disabled => "disabled",
-            WaitTimeoutCancelOutcome::Cancelled => "requested",
-            WaitTimeoutCancelOutcome::Failed(_) => "failed",
-        }
-        .to_string(),
-    );
-    match mirrored {
-        Ok(run) => {
-            error.details["active_run_id"] = Value::String(run.id.clone());
-            error = error
-                .with_hint(format!(
-                    "Mirrored controller timeout state as run `{}`; inspect it with `homeboy runs show {}`.",
-                    run.id, run.id
-                ))
-                .with_hint(format!(
-                    "After the remote job finishes, run `homeboy runs artifacts {}` to refresh and list mirrored Lab artifacts without SSH temp-directory spelunking.",
-                    run.id
-                ));
-        }
-        Err(err) => {
-            error = error.with_hint(format!(
-                "Could not persist a local timeout mirror for remote job `{job_id}`: {}",
-                err.message
-            ));
-        }
-    }
-    for hint in lab_offload_handoff_hints(
-        &runner.id,
-        Some(cwd),
-        &job_id,
-        mirrored_run_id.as_deref(),
-        DaemonJobHandoffState::InFlight,
-        supports_cancellation,
-    ) {
-        error = error.with_hint(hint);
-    }
-    match &cancel_outcome {
-        WaitTimeoutCancelOutcome::Disabled => {}
-        WaitTimeoutCancelOutcome::Cancelled => {
-            error = error.with_hint(format!(
-                "Opt-in `{RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV}` is set: requested remote cancellation of job `{job_id}` to release its rig lock. Confirm with `homeboy runner job logs {} {job_id}`.",
-                runner.id
-            ));
-        }
-        WaitTimeoutCancelOutcome::Failed(reason) => {
-            error = error.with_hint(format!(
-                "Opt-in `{RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV}` is set but remote cancellation failed: {reason}. Cancel manually with `homeboy runner job cancel {} {job_id}`.",
-                runner.id
-            ));
-        }
-    }
-    error.retryable = Some(true);
-    error.with_hint(timeout_hint)
 }
 
 pub(crate) fn result_event_data(events: &[JobEvent]) -> Option<Value> {

--- a/crates/homeboy-lab-runner/src/execution/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/handoff.rs
@@ -103,7 +103,7 @@ pub(super) fn print_lab_offload_handoff(
 #[derive(Debug)]
 pub(super) enum WaitTimeoutCancelOutcome {
     Disabled,
-    Cancelled,
+    Cancelled(Job),
     Failed(String),
 }
 
@@ -132,7 +132,8 @@ pub(super) fn cancel_on_wait_timeout_enabled(
 /// opt-in is off so callers preserve the byte-identical default contract. When
 /// the opt-in is on, the existing `runner_job_cancel` primitive is invoked and
 /// any error is captured rather than propagated (the controller still needs to
-/// surface the timeout).
+/// surface the timeout). A successful cancellation retains the daemon's
+/// authoritative job projection, which may already be terminal.
 pub(super) fn attempt_wait_timeout_cancel(
     runner_id: &str,
     job_id: &str,
@@ -142,13 +143,13 @@ pub(super) fn attempt_wait_timeout_cancel(
         return WaitTimeoutCancelOutcome::Disabled;
     }
     match invoke_runner_job_cancel(runner_id, job_id) {
-        Ok(()) => WaitTimeoutCancelOutcome::Cancelled,
+        Ok(job) => WaitTimeoutCancelOutcome::Cancelled(job),
         Err(err) => WaitTimeoutCancelOutcome::Failed(err.message),
     }
 }
 
-fn invoke_runner_job_cancel(runner_id: &str, job_id: &str) -> Result<()> {
-    runner_job_cancel(runner_id, job_id).map(|_| ())
+fn invoke_runner_job_cancel(runner_id: &str, job_id: &str) -> Result<Job> {
+    runner_job_cancel(runner_id, job_id).map(|(job, _)| job)
 }
 
 pub fn runner_job_cancel(runner_id: &str, job_id: &str) -> Result<(Job, Vec<JobEvent>)> {

--- a/crates/homeboy-lab-runner/src/execution/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/handoff.rs
@@ -108,12 +108,10 @@ pub(super) enum WaitTimeoutCancelOutcome {
 }
 
 /// Resolve wait-timeout cancellation. A truthy environment override takes
-/// precedence; otherwise an explicit runner setting wins. Agent-task workloads
-/// default to cancellation so an expired controller cannot leave their rig lock
-/// held indefinitely, while all other runner commands retain the prior default.
+/// precedence; otherwise an explicit runner setting wins. Accepted work always
+/// remains in flight by default, including agent-task workloads.
 pub(super) fn cancel_on_wait_timeout_enabled(
     settings: &homeboy_core::server::RunnerSettings,
-    is_agent_task: bool,
 ) -> bool {
     if std::env::var(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV)
         .ok()
@@ -127,7 +125,7 @@ pub(super) fn cancel_on_wait_timeout_enabled(
     {
         return true;
     }
-    settings.cancel_on_wait_timeout.unwrap_or(is_agent_task)
+    settings.cancel_on_wait_timeout.unwrap_or(false)
 }
 
 /// Best-effort remote cancellation on wait-timeout. Returns `Disabled` when the

--- a/crates/homeboy-lab-runner/src/execution/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/handoff.rs
@@ -98,10 +98,8 @@ pub(super) fn print_lab_offload_handoff(
     }
 }
 
-/// Outcome of the opt-in best-effort remote cancellation attempted when the
-/// controller's runner-exec wait budget expires. `Disabled` is the default
-/// (opt-in off) and preserves the historical contract: the remote job is left
-/// in flight and uncancelled (#6891).
+/// Outcome of the best-effort remote cancellation attempted when the
+/// controller's runner-exec wait budget expires.
 #[derive(Debug)]
 pub(super) enum WaitTimeoutCancelOutcome {
     Disabled,
@@ -109,11 +107,15 @@ pub(super) enum WaitTimeoutCancelOutcome {
     Failed(String),
 }
 
-/// Whether the operator opted in to cancelling the remote job on wait-timeout
-/// via `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT`. Accepts the usual truthy
-/// spellings; anything else (including unset) keeps the default behavior.
-pub(super) fn cancel_on_wait_timeout_enabled() -> bool {
-    std::env::var(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV)
+/// Resolve wait-timeout cancellation. A truthy environment override takes
+/// precedence; otherwise an explicit runner setting wins. Agent-task workloads
+/// default to cancellation so an expired controller cannot leave their rig lock
+/// held indefinitely, while all other runner commands retain the prior default.
+pub(super) fn cancel_on_wait_timeout_enabled(
+    settings: &homeboy_core::server::RunnerSettings,
+    is_agent_task: bool,
+) -> bool {
+    if std::env::var(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV)
         .ok()
         .map(|value| {
             matches!(
@@ -122,6 +124,10 @@ pub(super) fn cancel_on_wait_timeout_enabled() -> bool {
             )
         })
         .unwrap_or(false)
+    {
+        return true;
+    }
+    settings.cancel_on_wait_timeout.unwrap_or(is_agent_task)
 }
 
 /// Best-effort remote cancellation on wait-timeout. Returns `Disabled` when the
@@ -132,8 +138,9 @@ pub(super) fn cancel_on_wait_timeout_enabled() -> bool {
 pub(super) fn attempt_wait_timeout_cancel(
     runner_id: &str,
     job_id: &str,
+    enabled: bool,
 ) -> WaitTimeoutCancelOutcome {
-    if !cancel_on_wait_timeout_enabled() {
+    if !enabled {
         return WaitTimeoutCancelOutcome::Disabled;
     }
     match invoke_runner_job_cancel(runner_id, job_id) {
@@ -142,51 +149,8 @@ pub(super) fn attempt_wait_timeout_cancel(
     }
 }
 
-/// Invoke the remote-cancel primitive. In production this hits the daemon/broker
-/// `/jobs/{id}/cancel` endpoint via `runner_job_cancel`; tests inject a hook so
-/// the opt-in path can be asserted without a live runner.
 fn invoke_runner_job_cancel(runner_id: &str, job_id: &str) -> Result<()> {
-    #[cfg(test)]
-    {
-        if let Some(result) = test_cancel_hook::take_invoke(runner_id, job_id) {
-            return result;
-        }
-    }
     runner_job_cancel(runner_id, job_id).map(|_| ())
-}
-
-#[cfg(test)]
-pub(super) mod test_cancel_hook {
-    use homeboy_core::error::Result;
-    use std::cell::RefCell;
-
-    type CancelHook = Box<dyn FnMut(&str, &str) -> Result<()>>;
-
-    thread_local! {
-        static HOOK: RefCell<Option<CancelHook>> = const { RefCell::new(None) };
-    }
-
-    /// Install a thread-local cancel hook for the duration of `Guard`'s lifetime.
-    pub(in crate::execution) struct Guard;
-
-    impl Drop for Guard {
-        fn drop(&mut self) {
-            HOOK.with(|cell| *cell.borrow_mut() = None);
-        }
-    }
-
-    pub(in crate::execution) fn install(hook: CancelHook) -> Guard {
-        HOOK.with(|cell| *cell.borrow_mut() = Some(hook));
-        Guard
-    }
-
-    pub(super) fn take_invoke(runner_id: &str, job_id: &str) -> Option<Result<()>> {
-        HOOK.with(|cell| {
-            cell.borrow_mut()
-                .as_mut()
-                .map(|hook| hook(runner_id, job_id))
-        })
-    }
 }
 
 pub fn runner_job_cancel(runner_id: &str, job_id: &str) -> Result<(Job, Vec<JobEvent>)> {
@@ -438,10 +402,17 @@ pub(super) fn persist_lab_offload_handoff_run(
     }
 }
 
-pub(super) fn runner_exec_wait_timeout() -> Duration {
+pub(super) fn runner_exec_wait_timeout(
+    settings: &homeboy_core::server::RunnerSettings,
+) -> Duration {
     std::env::var(RUNNER_EXEC_WAIT_TIMEOUT_ENV)
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
         .map(Duration::from_secs)
+        .or_else(|| {
+            settings
+                .runner_exec_wait_timeout_secs
+                .map(Duration::from_secs)
+        })
         .unwrap_or_else(|| Duration::from_secs(DEFAULT_RUNNER_EXEC_WAIT_TIMEOUT_SECS))
 }

--- a/crates/homeboy-lab-runner/src/execution/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/handoff.rs
@@ -108,10 +108,11 @@ pub(super) enum WaitTimeoutCancelOutcome {
 }
 
 /// Resolve wait-timeout cancellation. A truthy environment override takes
-/// precedence; otherwise an explicit runner setting wins. Accepted work always
-/// remains in flight by default, including agent-task workloads.
+/// precedence; otherwise an explicit runner setting wins. Unset settings cancel
+/// agent-task workloads so their remote rig locks cannot leak past expiry.
 pub(super) fn cancel_on_wait_timeout_enabled(
     settings: &homeboy_core::server::RunnerSettings,
+    workload: Option<&homeboy_core::lab_contract::LabRunnerWorkload>,
 ) -> bool {
     if std::env::var(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV)
         .ok()
@@ -125,7 +126,9 @@ pub(super) fn cancel_on_wait_timeout_enabled(
     {
         return true;
     }
-    settings.cancel_on_wait_timeout.unwrap_or(false)
+    settings
+        .cancel_on_wait_timeout
+        .unwrap_or_else(|| workload.is_some_and(|workload| workload.agent_task.is_some()))
 }
 
 /// Best-effort remote cancellation on wait-timeout. Returns `Disabled` when the

--- a/crates/homeboy-lab-runner/src/execution/job_flow.rs
+++ b/crates/homeboy-lab-runner/src/execution/job_flow.rs
@@ -22,6 +22,23 @@ pub(super) struct MirroredJobEvidence {
     pub(super) artifacts: Vec<JobArtifactMetadata>,
 }
 
+/// The controller either observed a terminal remote command or intentionally
+/// detached after persisting its accepted in-flight job. This boundary prevents
+/// a local wait expiry from being represented as a remote command failure.
+pub(super) enum RunnerExecCompletion {
+    Terminal(RunnerExecOutput, i32),
+    InFlight(RunnerExecOutput),
+}
+
+impl RunnerExecCompletion {
+    pub(super) fn into_output(self) -> (RunnerExecOutput, i32) {
+        match self {
+            Self::Terminal(output, exit_code) => (output, exit_code),
+            Self::InFlight(output) => (output, 0),
+        }
+    }
+}
+
 pub(super) struct SubmittedRunnerJobFlow<'a> {
     pub(super) runner: &'a Runner,
     pub(super) mode: RunnerExecMode,
@@ -66,7 +83,7 @@ pub(super) fn complete_submitted_runner_job<
     mirror: Mirror,
     mut after_events: AfterEvents,
     mut finalize: Finalize,
-) -> Result<(RunnerExecOutput, i32)>
+) -> Result<RunnerExecCompletion>
 where
     Accepted: FnMut(&Job) -> Result<()>,
     AfterHandoff: FnMut(&Job) -> Result<()>,
@@ -145,7 +162,7 @@ where
     )?;
     after_handoff(&job)?;
     if flow.detach_after_handoff {
-        return Ok(detached_handoff_output(
+        let (output, _) = detached_handoff_output(
             flow.runner,
             flow.mode,
             flow.cwd,
@@ -156,10 +173,11 @@ where
             flow.require_paths,
             flow.run_id,
             persisted_run_id,
-        ));
+        );
+        return Ok(RunnerExecCompletion::InFlight(output));
     }
 
-    let deadline = Instant::now() + runner_exec_wait_timeout();
+    let deadline = Instant::now() + runner_exec_wait_timeout(&flow.runner.settings);
     let mut reported_progress_sequence = 0;
     while !job.status.is_terminal() {
         if let Some(status) = flow.run_id.as_deref().and_then(|run_id| {
@@ -184,15 +202,42 @@ where
                 &events,
                 &mut reported_progress_sequence,
             );
-            return Err(daemon_job_wait_timeout(
+            let (mut output, _) = detached_handoff_output(
                 flow.runner,
-                &flow.cwd,
-                &flow.command,
-                &job,
-                &events,
-                flow.timeout_label,
-                true,
-            ));
+                flow.mode,
+                flow.cwd,
+                flow.command,
+                flow.source_snapshot,
+                job,
+                flow.path_materialization_plan,
+                flow.require_paths,
+                flow.run_id,
+                persisted_run_id,
+            );
+            let cancellation = attempt_wait_timeout_cancel(
+                &flow.runner.id,
+                &job_id,
+                cancel_on_wait_timeout_enabled(
+                    &flow.runner.settings,
+                    flow.lab_runner_workload
+                        .as_ref()
+                        .is_some_and(|workload| workload.agent_task.is_some()),
+                ),
+            );
+            let cancellation_message = match cancellation {
+                WaitTimeoutCancelOutcome::Disabled => "remote job remains in flight".to_string(),
+                WaitTimeoutCancelOutcome::Cancelled => {
+                    "remote cancellation was requested".to_string()
+                }
+                WaitTimeoutCancelOutcome::Failed(reason) => {
+                    format!("remote cancellation was requested but failed: {reason}")
+                }
+            };
+            output.stderr = format!(
+                "{} {job_id} on runner {} is still in flight after the controller wait timeout; {cancellation_message}. Remote command outcome is not known.\n",
+                flow.timeout_label, flow.runner.id
+            );
+            return Ok(RunnerExecCompletion::InFlight(output));
         }
         std::thread::sleep(Duration::from_millis(200));
         job = poll(&job)?;
@@ -394,7 +439,7 @@ where
     {
         append_runner_exec_diagnostic_hint(&mut output, Some(hint.to_string()));
     }
-    Ok((output, exit_code))
+    Ok(RunnerExecCompletion::Terminal(output, exit_code))
 }
 
 pub(super) fn terminal_notification_run_id<'a>(

--- a/crates/homeboy-lab-runner/src/execution/job_flow.rs
+++ b/crates/homeboy-lab-runner/src/execution/job_flow.rs
@@ -205,7 +205,10 @@ where
             let cancellation = attempt_wait_timeout_cancel(
                 &flow.runner.id,
                 &job_id,
-                cancel_on_wait_timeout_enabled(&flow.runner.settings),
+                cancel_on_wait_timeout_enabled(
+                    &flow.runner.settings,
+                    flow.lab_runner_workload.as_ref(),
+                ),
             );
             if let WaitTimeoutCancelOutcome::Cancelled(cancelled_job) = &cancellation {
                 if cancelled_job.status.is_terminal() {

--- a/crates/homeboy-lab-runner/src/execution/job_flow.rs
+++ b/crates/homeboy-lab-runner/src/execution/job_flow.rs
@@ -217,12 +217,7 @@ where
             let cancellation = attempt_wait_timeout_cancel(
                 &flow.runner.id,
                 &job_id,
-                cancel_on_wait_timeout_enabled(
-                    &flow.runner.settings,
-                    flow.lab_runner_workload
-                        .as_ref()
-                        .is_some_and(|workload| workload.agent_task.is_some()),
-                ),
+                cancel_on_wait_timeout_enabled(&flow.runner.settings),
             );
             let cancellation_message = match cancellation {
                 WaitTimeoutCancelOutcome::Disabled => "remote job remains in flight".to_string(),

--- a/crates/homeboy-lab-runner/src/execution/job_flow.rs
+++ b/crates/homeboy-lab-runner/src/execution/job_flow.rs
@@ -202,6 +202,20 @@ where
                 &events,
                 &mut reported_progress_sequence,
             );
+            let cancellation = attempt_wait_timeout_cancel(
+                &flow.runner.id,
+                &job_id,
+                cancel_on_wait_timeout_enabled(&flow.runner.settings),
+            );
+            if let WaitTimeoutCancelOutcome::Cancelled(cancelled_job) = &cancellation {
+                if cancelled_job.status.is_terminal() {
+                    // Cancellation returns the daemon's authoritative snapshot.
+                    // Project terminal work through the normal lifecycle instead
+                    // of claiming a cancelled remote command still runs.
+                    job = cancelled_job.clone();
+                    continue;
+                }
+            }
             let (mut output, _) = detached_handoff_output(
                 flow.runner,
                 flow.mode,
@@ -214,14 +228,9 @@ where
                 flow.run_id,
                 persisted_run_id,
             );
-            let cancellation = attempt_wait_timeout_cancel(
-                &flow.runner.id,
-                &job_id,
-                cancel_on_wait_timeout_enabled(&flow.runner.settings),
-            );
             let cancellation_message = match cancellation {
                 WaitTimeoutCancelOutcome::Disabled => "remote job remains in flight".to_string(),
-                WaitTimeoutCancelOutcome::Cancelled => {
+                WaitTimeoutCancelOutcome::Cancelled(_) => {
                     "remote cancellation was requested".to_string()
                 }
                 WaitTimeoutCancelOutcome::Failed(reason) => {
@@ -251,6 +260,7 @@ where
     let mut job_events = events(&job).map(|events| {
         redact_runner_job_events(&events, flow.redaction_env, flow.secret_env_names)
     })?;
+    append_cancelled_result_if_absent(&job, &mut job_events);
     record_and_report_promotion_progress_frames(
         flow.run_id.as_deref(),
         &job_id,

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -34,10 +34,9 @@ use super::{
 
 const DEFAULT_RUNNER_EXEC_WAIT_TIMEOUT_SECS: u64 = 20 * 60;
 pub(crate) const RUNNER_EXEC_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS";
-/// Opt-in: when set to a truthy value, a controller-side wait-timeout best-effort
-/// cancels the still-running remote runner job (freeing its rig lock) instead of
-/// only mirroring it. Off by default — the default contract leaves the remote job
-/// in flight and uncancelled (#6891).
+/// Per-run override: when set to a truthy value, a controller-side wait-timeout
+/// best-effort cancels the still-running remote runner job. Otherwise the runner
+/// setting applies; unset settings cancel agent-task workloads only.
 pub(crate) const RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT";
 // These runner env-var markers now live in the shared runner-contract crate so
 // core can reference them without a core -> runner edge. Re-exported here so the
@@ -411,6 +410,16 @@ pub struct RunnerExecOutput {
     pub handoff: Option<LabRunnerHandoff>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diagnostics: Option<RunnerExecDiagnostics>,
+}
+
+impl RunnerExecOutput {
+    /// An accepted remote job is still authoritative when its controller-side
+    /// execution record remains running; no remote exit status is implied.
+    pub fn is_in_flight(&self) -> bool {
+        self.execution_record
+            .as_ref()
+            .is_some_and(|record| record.status == "running")
+    }
 }
 
 #[expect(

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -47,27 +47,81 @@ fn runner_wait_settings_and_environment_resolve_at_the_controller() {
 }
 
 #[test]
-fn cancellation_requires_explicit_runner_setting_or_truthy_env() {
+fn cancellation_defaults_to_agent_task_workloads_after_overrides() {
     let _env = EnvVarGuard::unset(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV);
     let settings = homeboy_core::server::RunnerSettings::default();
-    assert!(!cancel_on_wait_timeout_enabled(&settings));
+    assert!(!cancel_on_wait_timeout_enabled(&settings, None));
+    assert!(cancel_on_wait_timeout_enabled(
+        &settings,
+        Some(&agent_task_workload())
+    ));
 
     let settings = homeboy_core::server::RunnerSettings {
         cancel_on_wait_timeout: Some(false),
         ..Default::default()
     };
-    assert!(!cancel_on_wait_timeout_enabled(&settings));
+    assert!(!cancel_on_wait_timeout_enabled(
+        &settings,
+        Some(&agent_task_workload())
+    ));
 
     let settings = homeboy_core::server::RunnerSettings {
         cancel_on_wait_timeout: Some(true),
         ..Default::default()
     };
-    assert!(cancel_on_wait_timeout_enabled(&settings));
+    assert!(cancel_on_wait_timeout_enabled(&settings, None));
 
     let _env = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "true");
     assert!(cancel_on_wait_timeout_enabled(
-        &homeboy_core::server::RunnerSettings::default()
+        &homeboy_core::server::RunnerSettings {
+            cancel_on_wait_timeout: Some(false),
+            ..Default::default()
+        },
+        Some(&agent_task_workload()),
     ));
+}
+
+fn agent_task_workload() -> homeboy_core::lab_contract::LabRunnerWorkload {
+    let plan = homeboy_core::plan::HomeboyPlan::builder_for_description(
+        homeboy_core::plan::PlanKind::LabOffload,
+        "wait expiry test",
+    )
+    .build();
+    let command = crate::LabOffloadCommand {
+        command: homeboy_core::lab_contract::LabCommandContract::portable(
+            "agent-task cook",
+            None,
+            false,
+            &[],
+        ),
+        required_extensions: Vec::new(),
+        required_capabilities: Vec::new(),
+        workload: None,
+    };
+    let mut workload =
+        crate::workload::build_lab_runner_workload(crate::workload::LabRunnerWorkloadBuildInput {
+            plan: &plan,
+            command: &command,
+            capture_patch: false,
+            mutation_flag: None,
+            allow_dirty_lab_workspace: false,
+            runner_id: "lab",
+            runner_mode: "daemon",
+            assignment_source: "test",
+            status: "offloaded",
+            remote_workspace: Some("/srv/homeboy/project"),
+            fallback_reason: None,
+            workspace_mapping_ref: None,
+            proof_id: None,
+        });
+    workload.agent_task = crate::workload::lab_runner_workload_agent_task_from_command(
+        &["homeboy", "agent-task", "cook"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>(),
+        Some("agent-task-wait-expiry"),
+    );
+    workload
 }
 
 #[test]
@@ -638,11 +692,11 @@ fn zero_wait_direct_daemon_preserves_accepted_running_handoff() {
 }
 
 #[test]
-fn zero_wait_direct_daemon_projects_terminal_cancellation() {
+fn zero_wait_direct_daemon_cancels_unset_agent_task_workload() {
     homeboy_core::test_support::with_isolated_home(|_| {
         crate::register_runner_daemon_exec_driver();
         let _timeout = EnvVarGuard::set(RUNNER_EXEC_WAIT_TIMEOUT_ENV, "0");
-        let _cancel = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "true");
+        let _cancel = EnvVarGuard::unset(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV);
         let _controller = EnvVarGuard::set("HOMEBOY_CONTROLLER_ID", "handoff-cancel-test");
         let workspace = tempfile::tempdir().expect("workspace");
         let started = workspace.path().join("started");
@@ -669,7 +723,7 @@ fn zero_wait_direct_daemon_projects_terminal_cancellation() {
             None,
             Vec::new(),
             Vec::new(),
-            None,
+            Some(agent_task_workload()),
             None,
             false,
             false,
@@ -853,11 +907,11 @@ fn zero_wait_reverse_broker_preserves_accepted_running_handoff() {
 }
 
 #[test]
-fn zero_wait_reverse_broker_projects_terminal_cancellation() {
+fn zero_wait_reverse_broker_cancels_unset_agent_task_workload() {
     homeboy_core::test_support::with_isolated_home(|_| {
         allow_unauthenticated_loopback_broker();
         let _timeout = EnvVarGuard::set(RUNNER_EXEC_WAIT_TIMEOUT_ENV, "0");
-        let _cancel = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "true");
+        let _cancel = EnvVarGuard::unset(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV);
         let _controller = EnvVarGuard::set("HOMEBOY_CONTROLLER_ID", "handoff-cancel-test");
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
         let broker_url = format!("http://{}", listener.local_addr().expect("address"));
@@ -879,7 +933,7 @@ fn zero_wait_reverse_broker_projects_terminal_cancellation() {
             None,
             Vec::new(),
             Vec::new(),
-            None,
+            Some(agent_task_workload()),
             None,
             false,
             false,
@@ -890,6 +944,7 @@ fn zero_wait_reverse_broker_projects_terminal_cancellation() {
 
         assert_eq!(exit_code, 1);
         assert!(!output.is_in_flight());
+        let job_id = output.job_id.as_deref().expect("accepted job id");
         assert_eq!(
             output.job.as_ref().map(|job| job.status),
             Some(JobStatus::Cancelled)
@@ -902,6 +957,8 @@ fn zero_wait_reverse_broker_projects_terminal_cancellation() {
             Some("failed")
         );
         assert!(!output.stderr.contains("still in flight"));
+        let client = Client::builder().build().expect("broker client");
+        wait_for_cancelled_daemon_job(&client, &broker_url, job_id);
     });
 }
 

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -171,6 +171,60 @@ fn terminal_handoff_hints_reflect_cancelled_job_state() {
 }
 
 #[test]
+fn cancelled_terminal_snapshot_overrides_a_preexisting_success_result() {
+    let mut job = running_job();
+    job.status = JobStatus::Cancelled;
+    job.finished_at_ms = Some(job.updated_at_ms);
+    let result = json!({
+        "exit_code": 0,
+        "stdout": "completed before cancellation won",
+        "stderr": "",
+    });
+    let mut events = vec![JobEvent {
+        sequence: 1,
+        job_id: job.id,
+        kind: JobEventKind::Result,
+        timestamp_ms: job.updated_at_ms,
+        message: Some("worker result".to_string()),
+        data: Some(result.clone()),
+    }];
+
+    append_cancelled_result_if_absent(&job, &mut events);
+    let fields = runner_job_result_fields(&events, job.status, &Default::default(), &[]);
+    let runner_result = runner_result(
+        Some(&job),
+        fields.exit_code,
+        &fields.stdout,
+        &fields.stderr,
+        None,
+        None,
+    );
+    let execution_record = runner_execution_record_for_output(
+        &ssh_runner(),
+        "daemon",
+        fields.exit_code,
+        Some(job.id.to_string()),
+        None,
+        None,
+        None,
+        &[],
+        &[],
+        &[],
+        None,
+    );
+
+    // This shared projection is used by both direct-daemon and reverse-broker
+    // terminal paths. The worker result remains evidence, while cancellation
+    // controls the reported command and lifecycle outcomes.
+    assert_eq!(events.len(), 1);
+    assert_eq!(fields.result, result);
+    assert_eq!(fields.exit_code, 1);
+    assert_eq!(runner_result.exit_code, 1);
+    assert_eq!(runner_result.status, JobStatus::Cancelled);
+    assert_eq!(execution_record.status, "failed");
+}
+
+#[test]
 fn lab_offload_handoff_persists_run_when_job_is_accepted() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let runner = ssh_runner();

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -46,20 +46,27 @@ fn runner_wait_settings_and_environment_resolve_at_the_controller() {
 }
 
 #[test]
-fn cancellation_defaults_to_agent_task_and_honors_runner_setting_or_env() {
+fn cancellation_requires_explicit_runner_setting_or_truthy_env() {
     let _env = EnvVarGuard::unset(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV);
     let settings = homeboy_core::server::RunnerSettings::default();
-    assert!(!cancel_on_wait_timeout_enabled(&settings, false));
-    assert!(cancel_on_wait_timeout_enabled(&settings, true));
+    assert!(!cancel_on_wait_timeout_enabled(&settings));
 
     let settings = homeboy_core::server::RunnerSettings {
         cancel_on_wait_timeout: Some(false),
         ..Default::default()
     };
-    assert!(!cancel_on_wait_timeout_enabled(&settings, true));
+    assert!(!cancel_on_wait_timeout_enabled(&settings));
+
+    let settings = homeboy_core::server::RunnerSettings {
+        cancel_on_wait_timeout: Some(true),
+        ..Default::default()
+    };
+    assert!(cancel_on_wait_timeout_enabled(&settings));
 
     let _env = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "true");
-    assert!(cancel_on_wait_timeout_enabled(&settings, false));
+    assert!(cancel_on_wait_timeout_enabled(
+        &homeboy_core::server::RunnerSettings::default()
+    ));
 }
 
 #[test]
@@ -524,6 +531,139 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
                 && handoff.runner_job_id.as_deref() == Some(job_id)
         }));
     });
+}
+
+#[test]
+fn zero_wait_direct_daemon_preserves_accepted_running_handoff() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        crate::register_runner_daemon_exec_driver();
+        let _timeout = EnvVarGuard::set(RUNNER_EXEC_WAIT_TIMEOUT_ENV, "0");
+        let _cancel = EnvVarGuard::unset(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV);
+        let workspace = tempfile::tempdir().expect("workspace");
+        let started = workspace.path().join("started");
+        let release = workspace.path().join("release");
+        let _release_on_drop = ReleaseBlockedWorkload(release.clone());
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let daemon_url = format!("http://{}", listener.local_addr().expect("address"));
+        std::thread::spawn(move || {
+            let _ = homeboy_core::daemon::serve_listener(listener);
+        });
+
+        let (output, exit_code) = exec_via_daemon(
+            &ssh_runner(),
+            &daemon_url,
+            None,
+            workspace.path().display().to_string(),
+            None,
+            blocked_workload_command(&started, &release),
+            Default::default(),
+            Vec::new(),
+            false,
+            None,
+            None,
+            Vec::new(),
+            Vec::new(),
+            None,
+            None,
+            false,
+            false,
+            true,
+            false,
+            None,
+        )
+        .expect("zero-wait direct daemon handoff");
+
+        assert_zero_wait_handoff(&output, exit_code);
+        wait_for_path(&started, "direct daemon workload start");
+        let job_id = output.job_id.as_deref().expect("accepted job id");
+        let client = Client::builder().no_proxy().build().expect("daemon client");
+        let job = fetch_daemon_job(&client, &daemon_url, job_id).expect("accepted daemon job");
+        assert!(matches!(job.status, JobStatus::Queued | JobStatus::Running));
+    });
+}
+
+#[test]
+fn zero_wait_reverse_broker_preserves_accepted_running_handoff() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        allow_unauthenticated_loopback_broker();
+        let _timeout = EnvVarGuard::set(RUNNER_EXEC_WAIT_TIMEOUT_ENV, "0");
+        let _cancel = EnvVarGuard::unset(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let broker_url = format!("http://{}", listener.local_addr().expect("address"));
+        std::thread::spawn(move || {
+            let _ = homeboy_core::daemon::serve_listener(listener);
+        });
+
+        let (output, exit_code) = exec_via_reverse_broker(
+            &ssh_runner(),
+            &broker_url,
+            "/srv/homeboy/project".to_string(),
+            None,
+            vec!["homeboy".to_string(), "test".to_string()],
+            Default::default(),
+            Vec::new(),
+            false,
+            None,
+            None,
+            Vec::new(),
+            Vec::new(),
+            None,
+            None,
+            false,
+            false,
+            true,
+            false,
+        )
+        .expect("zero-wait reverse broker handoff");
+
+        assert_zero_wait_handoff(&output, exit_code);
+        let job_id = output.job_id.as_deref().expect("accepted job id");
+        let client = Client::builder().build().expect("broker client");
+        let job = fetch_daemon_job(&client, &broker_url, job_id).expect("accepted broker job");
+        assert!(matches!(job.status, JobStatus::Queued | JobStatus::Running));
+    });
+}
+
+fn blocked_workload_command(started: &std::path::Path, release: &std::path::Path) -> Vec<String> {
+    vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        "printf started > \"$1\"; while [ ! -e \"$2\" ]; do sleep 0.01; done".to_string(),
+        "sh".to_string(),
+        started.display().to_string(),
+        release.display().to_string(),
+    ]
+}
+
+fn assert_zero_wait_handoff(output: &RunnerExecOutput, exit_code: i32) {
+    assert_eq!(exit_code, 0);
+    assert!(output.is_in_flight());
+    assert!(output.job_id.is_some());
+    let run_id = output.mirror_run_id.as_deref().expect("durable run id");
+    assert_eq!(
+        output
+            .execution_record
+            .as_ref()
+            .map(|record| record.status.as_str()),
+        Some("running")
+    );
+    let envelope: homeboy_core::lab_contract::LabRunnerHandoffEnvelope =
+        serde_json::from_str(&output.stdout).expect("typed running handoff");
+    assert_eq!(envelope.status, "running");
+    assert_eq!(
+        envelope.identity.runner_job_id,
+        output.job_id.as_deref().expect("accepted job id")
+    );
+    assert_eq!(envelope.mirror_run_id.as_deref(), Some(run_id));
+    let store = ObservationStore::open_initialized().expect("observation store");
+    assert_eq!(
+        store
+            .get_run(run_id)
+            .expect("read durable run")
+            .expect("durable run")
+            .status,
+        "running"
+    );
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -2,6 +2,7 @@ use super::*;
 use base64::Engine;
 use homeboy_core::api_jobs::JobEventKind;
 use homeboy_core::observation::{NewRunRecord, ObservationStore};
+use homeboy_runner_contract::RunnerSessionRole;
 use reqwest::blocking::Client;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -580,6 +581,134 @@ fn zero_wait_direct_daemon_preserves_accepted_running_handoff() {
         let job = fetch_daemon_job(&client, &daemon_url, job_id).expect("accepted daemon job");
         assert!(matches!(job.status, JobStatus::Queued | JobStatus::Running));
     });
+}
+
+#[test]
+fn zero_wait_direct_daemon_explicitly_cancels_accepted_job_after_typed_handoff() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        crate::register_runner_daemon_exec_driver();
+        let _timeout = EnvVarGuard::set(RUNNER_EXEC_WAIT_TIMEOUT_ENV, "0");
+        let _cancel = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "true");
+        let _controller = EnvVarGuard::set("HOMEBOY_CONTROLLER_ID", "handoff-cancel-test");
+        let workspace = tempfile::tempdir().expect("workspace");
+        let started = workspace.path().join("started");
+        let release = workspace.path().join("release");
+        let _release_on_drop = ReleaseBlockedWorkload(release.clone());
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let daemon_url = format!("http://{}", listener.local_addr().expect("address"));
+        std::thread::spawn(move || {
+            let _ = homeboy_core::daemon::serve_listener(listener);
+        });
+        persist_direct_daemon_cancel_session(&daemon_url);
+
+        let (output, exit_code) = exec_via_daemon(
+            &ssh_runner(),
+            &daemon_url,
+            None,
+            workspace.path().display().to_string(),
+            None,
+            blocked_workload_command(&started, &release),
+            Default::default(),
+            Vec::new(),
+            false,
+            None,
+            None,
+            Vec::new(),
+            Vec::new(),
+            None,
+            None,
+            false,
+            false,
+            true,
+            false,
+            None,
+        )
+        .expect("zero-wait direct daemon cancellation handoff");
+
+        assert_eq!(exit_code, 0);
+        assert!(output.is_in_flight());
+        let job_id = output.job_id.as_deref().expect("accepted job id");
+        let run_id = output.mirror_run_id.as_deref().expect("durable run id");
+        let envelope: homeboy_core::lab_contract::LabRunnerHandoffEnvelope =
+            serde_json::from_str(&output.stdout).expect("typed running handoff");
+        assert_eq!(envelope.status, "running");
+        assert_eq!(envelope.identity.runner_job_id, job_id);
+        assert_eq!(envelope.mirror_run_id.as_deref(), Some(run_id));
+        assert!(
+            output.stderr.contains("remote cancellation was requested."),
+            "{}",
+            output.stderr
+        );
+
+        let client = Client::builder().no_proxy().build().expect("daemon client");
+        wait_for_cancelled_daemon_job(&client, &daemon_url, job_id);
+    });
+}
+
+fn persist_direct_daemon_cancel_session(daemon_url: &str) {
+    let local_port = daemon_url
+        .rsplit_once(':')
+        .expect("daemon URL port")
+        .1
+        .parse()
+        .expect("daemon port");
+    let runner_dir = homeboy_core::paths::homeboy()
+        .expect("homeboy directory")
+        .join("runners");
+    std::fs::create_dir_all(&runner_dir).expect("create runner directory");
+    std::fs::write(
+        runner_dir.join("lab.json"),
+        r#"{"id":"lab","kind":"local","workspace_root":"/srv/homeboy"}"#,
+    )
+    .expect("persist runner config");
+    let session = RunnerSession {
+        runner_id: "lab".to_string(),
+        mode: RunnerTunnelMode::DirectSsh,
+        role: RunnerSessionRole::Controller,
+        server_id: Some("srv".to_string()),
+        controller_id: Some("handoff-cancel-test".to_string()),
+        broker_url: None,
+        remote_daemon_address: None,
+        local_port: Some(local_port),
+        local_url: Some(daemon_url.to_string()),
+        tunnel_pid: None,
+        tunnel_process_start_identity: None,
+        proxy_forward: None,
+        remote_daemon_pid: Some(std::process::id()),
+        remote_daemon_lease_id: None,
+        homeboy_version: "test".to_string(),
+        homeboy_build_identity: None,
+        connected_at: chrono::Utc::now().to_rfc3339(),
+        worker_identity: None,
+        worker_pid: None,
+        last_seen_at: None,
+        leaseless_recovery_evidence: None,
+    };
+    let path = homeboy_core::paths::runner_controller_session_file("lab", "handoff-cancel-test")
+        .expect("session path");
+    std::fs::create_dir_all(path.parent().expect("session directory"))
+        .expect("create session directory");
+    std::fs::write(
+        path,
+        serde_json::to_vec(&session).expect("serialize session"),
+    )
+    .expect("persist session");
+}
+
+fn wait_for_cancelled_daemon_job(client: &Client, daemon_url: &str, job_id: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let job = fetch_daemon_job(client, daemon_url, job_id).expect("accepted daemon job");
+        if job.status.is_terminal() {
+            assert_eq!(job.status, JobStatus::Cancelled);
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for cancellation of accepted daemon job"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -584,7 +584,7 @@ fn zero_wait_direct_daemon_preserves_accepted_running_handoff() {
 }
 
 #[test]
-fn zero_wait_direct_daemon_explicitly_cancels_accepted_job_after_typed_handoff() {
+fn zero_wait_direct_daemon_projects_terminal_cancellation() {
     homeboy_core::test_support::with_isolated_home(|_| {
         crate::register_runner_daemon_exec_driver();
         let _timeout = EnvVarGuard::set(RUNNER_EXEC_WAIT_TIMEOUT_ENV, "0");
@@ -623,22 +623,23 @@ fn zero_wait_direct_daemon_explicitly_cancels_accepted_job_after_typed_handoff()
             false,
             None,
         )
-        .expect("zero-wait direct daemon cancellation handoff");
+        .expect("zero-wait direct daemon cancellation result");
 
-        assert_eq!(exit_code, 0);
-        assert!(output.is_in_flight());
+        assert_eq!(exit_code, 1);
+        assert!(!output.is_in_flight());
         let job_id = output.job_id.as_deref().expect("accepted job id");
-        let run_id = output.mirror_run_id.as_deref().expect("durable run id");
-        let envelope: homeboy_core::lab_contract::LabRunnerHandoffEnvelope =
-            serde_json::from_str(&output.stdout).expect("typed running handoff");
-        assert_eq!(envelope.status, "running");
-        assert_eq!(envelope.identity.runner_job_id, job_id);
-        assert_eq!(envelope.mirror_run_id.as_deref(), Some(run_id));
-        assert!(
-            output.stderr.contains("remote cancellation was requested."),
-            "{}",
-            output.stderr
+        assert_eq!(
+            output.job.as_ref().map(|job| job.status),
+            Some(JobStatus::Cancelled)
         );
+        assert_eq!(
+            output
+                .execution_record
+                .as_ref()
+                .map(|record| record.status.as_str()),
+            Some("failed")
+        );
+        assert!(!output.stderr.contains("still in flight"));
 
         let client = Client::builder().no_proxy().build().expect("daemon client");
         wait_for_cancelled_daemon_job(&client, &daemon_url, job_id);
@@ -681,7 +682,51 @@ fn persist_direct_daemon_cancel_session(daemon_url: &str) {
         connected_at: chrono::Utc::now().to_rfc3339(),
         worker_identity: None,
         worker_pid: None,
-        last_seen_at: None,
+        last_seen_at: Some(chrono::Utc::now().to_rfc3339()),
+        leaseless_recovery_evidence: None,
+    };
+    let path = homeboy_core::paths::runner_controller_session_file("lab", "handoff-cancel-test")
+        .expect("session path");
+    std::fs::create_dir_all(path.parent().expect("session directory"))
+        .expect("create session directory");
+    std::fs::write(
+        path,
+        serde_json::to_vec(&session).expect("serialize session"),
+    )
+    .expect("persist session");
+}
+
+fn persist_reverse_broker_cancel_session(broker_url: &str) {
+    let runner_dir = homeboy_core::paths::homeboy()
+        .expect("homeboy directory")
+        .join("runners");
+    std::fs::create_dir_all(&runner_dir).expect("create runner directory");
+    std::fs::write(
+        runner_dir.join("lab.json"),
+        r#"{"id":"lab","kind":"local","workspace_root":"/srv/homeboy"}"#,
+    )
+    .expect("persist runner config");
+    let session = RunnerSession {
+        runner_id: "lab".to_string(),
+        mode: RunnerTunnelMode::Reverse,
+        role: RunnerSessionRole::Controller,
+        server_id: Some("srv".to_string()),
+        controller_id: Some("handoff-cancel-test".to_string()),
+        broker_url: Some(broker_url.to_string()),
+        remote_daemon_address: None,
+        local_port: None,
+        local_url: None,
+        tunnel_pid: None,
+        tunnel_process_start_identity: None,
+        proxy_forward: None,
+        remote_daemon_pid: None,
+        remote_daemon_lease_id: None,
+        homeboy_version: "test".to_string(),
+        homeboy_build_identity: None,
+        connected_at: chrono::Utc::now().to_rfc3339(),
+        worker_identity: None,
+        worker_pid: None,
+        last_seen_at: Some(chrono::Utc::now().to_rfc3339()),
         leaseless_recovery_evidence: None,
     };
     let path = homeboy_core::paths::runner_controller_session_file("lab", "handoff-cancel-test")
@@ -750,6 +795,59 @@ fn zero_wait_reverse_broker_preserves_accepted_running_handoff() {
         let client = Client::builder().build().expect("broker client");
         let job = fetch_daemon_job(&client, &broker_url, job_id).expect("accepted broker job");
         assert!(matches!(job.status, JobStatus::Queued | JobStatus::Running));
+    });
+}
+
+#[test]
+fn zero_wait_reverse_broker_projects_terminal_cancellation() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        allow_unauthenticated_loopback_broker();
+        let _timeout = EnvVarGuard::set(RUNNER_EXEC_WAIT_TIMEOUT_ENV, "0");
+        let _cancel = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "true");
+        let _controller = EnvVarGuard::set("HOMEBOY_CONTROLLER_ID", "handoff-cancel-test");
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let broker_url = format!("http://{}", listener.local_addr().expect("address"));
+        std::thread::spawn(move || {
+            let _ = homeboy_core::daemon::serve_listener(listener);
+        });
+        persist_reverse_broker_cancel_session(&broker_url);
+
+        let (output, exit_code) = exec_via_reverse_broker(
+            &ssh_runner(),
+            &broker_url,
+            "/srv/homeboy/project".to_string(),
+            None,
+            vec!["homeboy".to_string(), "test".to_string()],
+            Default::default(),
+            Vec::new(),
+            false,
+            None,
+            None,
+            Vec::new(),
+            Vec::new(),
+            None,
+            None,
+            false,
+            false,
+            true,
+            false,
+        )
+        .expect("zero-wait reverse broker cancellation result");
+
+        assert_eq!(exit_code, 1);
+        assert!(!output.is_in_flight());
+        assert_eq!(
+            output.job.as_ref().map(|job| job.status),
+            Some(JobStatus::Cancelled)
+        );
+        assert_eq!(
+            output
+                .execution_record
+                .as_ref()
+                .map(|record| record.status.as_str()),
+            Some("failed")
+        );
+        assert!(!output.stderr.contains("still in flight"));
     });
 }
 

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -30,244 +30,36 @@ fn accepted_handoff_persistence_error_carries_an_explicit_remote_boundary() {
 }
 
 #[test]
-fn timeout_mirrors_remote_job_without_cancelling() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let runner = ssh_runner();
-        let job_id = uuid::Uuid::new_v4();
-        let job = Job {
-            id: job_id,
-            operation: "runner.exec".to_string(),
-            status: JobStatus::Running,
-            created_at_ms: 1_700_000_000_000,
-            updated_at_ms: 1_700_000_001_000,
-            started_at_ms: Some(1_700_000_000_000),
-            finished_at_ms: None,
-            event_count: 0,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            stale_reason: None,
-            daemon_lease_id: None,
-            target_runner_id: None,
-            target_project_id: None,
-            claim_id: None,
-            claimed_by_runner_id: None,
-            claimed_at_ms: None,
-            claim_expires_at_ms: None,
-            artifacts: Vec::new(),
-            runner_job_projection: None,
-        };
-        let err = daemon_job_wait_timeout(
-            &runner,
-            "/srv/homeboy/project",
-            &["homeboy".to_string(), "bench".to_string()],
-            &job,
-            &[],
-            "runner daemon job",
-            true,
-        );
-        let run_id = format!("runner-exec-bench-lab-{job_id}");
+fn runner_wait_settings_and_environment_resolve_at_the_controller() {
+    let settings = homeboy_core::server::RunnerSettings {
+        runner_exec_wait_timeout_secs: Some(2400),
+        ..Default::default()
+    };
+    let _env = EnvVarGuard::unset(RUNNER_EXEC_WAIT_TIMEOUT_ENV);
+    assert_eq!(
+        runner_exec_wait_timeout(&settings),
+        Duration::from_secs(2400)
+    );
 
-        assert!(err.message.contains("runner daemon job"));
-        assert!(err.message.contains(job_id.to_string().as_str()));
-        assert!(err.message.contains("lab"));
-        assert!(err.message.contains("was not cancelled"));
-        assert_eq!(err.details["status"], "controller_wait_expired");
-        assert_eq!(err.details["reason"], "controller_wait_expired");
-        assert_eq!(err.retryable, Some(true));
-        assert!(err.hints.iter().any(|hint| hint
-            .message
-            .contains(&format!("homeboy runs show {run_id}"))));
-        assert!(err.hints.iter().any(|hint| hint
-            .message
-            .contains(&format!("homeboy runs artifacts {run_id}"))));
-        assert!(err.hints.iter().any(|hint| hint
-            .message
-            .contains("Lab offload handoff: runner `lab` has daemon job")));
-        assert!(err.hints.iter().any(|hint| hint.message.contains(
-            "homeboy runner exec --cwd /srv/homeboy/project lab -- homeboy runs list --status running --limit 20"
-        )));
-        assert!(err.hints.iter().any(|hint| hint
-            .message
-            .contains(&format!("homeboy runner job cancel lab {job_id}"))));
-        assert!(err.hints.iter().any(|hint| {
-            hint.message.contains(RUNNER_EXEC_WAIT_TIMEOUT_ENV)
-                && hint.message.contains("controller-side")
-                && hint.message.contains("workload settings")
-        }));
-
-        let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
-        let mirrored = store
-            .get_run(&run_id)
-            .expect("get mirrored run")
-            .expect("mirrored run");
-        assert_eq!(mirrored.status, "running");
-        assert_eq!(
-            mirrored.metadata_json["lab"]["remote_job"]["id"].as_str(),
-            Some(job_id.to_string().as_str())
-        );
-    });
+    let _env = EnvVarGuard::set(RUNNER_EXEC_WAIT_TIMEOUT_ENV, "60");
+    assert_eq!(runner_exec_wait_timeout(&settings), Duration::from_secs(60));
 }
 
 #[test]
-fn controller_wait_expiry_is_distinct_from_a_remote_job_failure() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let runner = ssh_runner();
-        let job = running_job_with_id(uuid::Uuid::new_v4());
-        let error = daemon_job_wait_timeout(
-            &runner,
-            "/srv/homeboy/project",
-            &["homeboy".to_string(), "agent-task".to_string()],
-            &job,
-            &[],
-            "runner daemon job",
-            true,
-        );
+fn cancellation_defaults_to_agent_task_and_honors_runner_setting_or_env() {
+    let _env = EnvVarGuard::unset(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV);
+    let settings = homeboy_core::server::RunnerSettings::default();
+    assert!(!cancel_on_wait_timeout_enabled(&settings, false));
+    assert!(cancel_on_wait_timeout_enabled(&settings, true));
 
-        assert_eq!(
-            error.details["job_id"].as_str(),
-            Some(job.id.to_string().as_str())
-        );
-        assert_eq!(error.details["reason"], "controller_wait_expired");
-    });
-}
+    let settings = homeboy_core::server::RunnerSettings {
+        cancel_on_wait_timeout: Some(false),
+        ..Default::default()
+    };
+    assert!(!cancel_on_wait_timeout_enabled(&settings, true));
 
-fn running_job_with_id(id: uuid::Uuid) -> Job {
-    Job {
-        id,
-        operation: "runner.exec".to_string(),
-        status: JobStatus::Running,
-        created_at_ms: 1_700_000_000_000,
-        updated_at_ms: 1_700_000_001_000,
-        started_at_ms: Some(1_700_000_000_000),
-        finished_at_ms: None,
-        event_count: 0,
-        source_snapshot: None,
-        path_materialization_plan: None,
-        stale_reason: None,
-        daemon_lease_id: None,
-        target_runner_id: None,
-        target_project_id: None,
-        claim_id: None,
-        claimed_by_runner_id: None,
-        claimed_at_ms: None,
-        claim_expires_at_ms: None,
-        artifacts: Vec::new(),
-        runner_job_projection: None,
-    }
-}
-
-#[test]
-fn opt_in_cancels_remote_job_on_wait_timeout() {
-    use std::cell::RefCell;
-    use std::rc::Rc;
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let _env = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "1");
-        let calls: Rc<RefCell<Vec<(String, String)>>> = Rc::new(RefCell::new(Vec::new()));
-        let recorder = calls.clone();
-        let _hook = test_cancel_hook::install(Box::new(move |runner_id: &str, job_id: &str| {
-            recorder
-                .borrow_mut()
-                .push((runner_id.to_string(), job_id.to_string()));
-            Ok(())
-        }));
-
-        let runner = ssh_runner();
-        let job_id = uuid::Uuid::new_v4();
-        let job = running_job_with_id(job_id);
-        let err = daemon_job_wait_timeout(
-            &runner,
-            "/srv/homeboy/project",
-            &["homeboy".to_string(), "bench".to_string()],
-            &job,
-            &[],
-            "runner daemon job",
-            true,
-        );
-
-        // The opt-in cancel primitive fired exactly once, targeting this job.
-        assert_eq!(calls.borrow().len(), 1);
-        assert_eq!(calls.borrow()[0], ("lab".to_string(), job_id.to_string()));
-        // The timeout still surfaces, but no longer claims the job was left running.
-        assert!(!err.message.contains("was not cancelled"));
-        assert!(err.message.contains("remote cancellation was requested"));
-        assert_eq!(err.details["cancel_on_wait_timeout"], "requested");
-        assert!(err.hints.iter().any(|hint| hint
-            .message
-            .contains("requested remote cancellation of job")));
-    });
-}
-
-#[test]
-fn opt_in_off_leaves_remote_job_uncancelled() {
-    use std::cell::RefCell;
-    use std::rc::Rc;
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let _env = EnvVarGuard::unset(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV);
-        let calls: Rc<RefCell<usize>> = Rc::new(RefCell::new(0));
-        let recorder = calls.clone();
-        let _hook = test_cancel_hook::install(Box::new(move |_runner_id: &str, _job_id: &str| {
-            *recorder.borrow_mut() += 1;
-            Ok(())
-        }));
-
-        let runner = ssh_runner();
-        let job_id = uuid::Uuid::new_v4();
-        let job = running_job_with_id(job_id);
-        let err = daemon_job_wait_timeout(
-            &runner,
-            "/srv/homeboy/project",
-            &["homeboy".to_string(), "bench".to_string()],
-            &job,
-            &[],
-            "runner daemon job",
-            true,
-        );
-
-        // Default contract: the cancel primitive is never invoked.
-        assert_eq!(*calls.borrow(), 0);
-        assert!(err.message.contains("was not cancelled"));
-        assert_eq!(err.details["cancel_on_wait_timeout"], "disabled");
-    });
-}
-
-#[test]
-fn opt_in_surfaces_remote_cancel_failure_on_wait_timeout() {
-    use std::cell::RefCell;
-    use std::rc::Rc;
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let _env = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "true");
-        let calls: Rc<RefCell<usize>> = Rc::new(RefCell::new(0));
-        let recorder = calls.clone();
-        let _hook = test_cancel_hook::install(Box::new(move |_runner_id: &str, _job_id: &str| {
-            *recorder.borrow_mut() += 1;
-            Err(homeboy_core::error::Error::internal_unexpected(
-                "runner is not connected",
-            ))
-        }));
-
-        let runner = ssh_runner();
-        let job_id = uuid::Uuid::new_v4();
-        let job = running_job_with_id(job_id);
-        let err = daemon_job_wait_timeout(
-            &runner,
-            "/srv/homeboy/project",
-            &["homeboy".to_string(), "bench".to_string()],
-            &job,
-            &[],
-            "runner daemon job",
-            true,
-        );
-
-        assert_eq!(*calls.borrow(), 1);
-        assert!(err.message.contains("remote cancellation was requested"));
-        assert!(err.message.contains("but failed"));
-        assert!(err.message.contains("runner is not connected"));
-        assert_eq!(err.details["cancel_on_wait_timeout"], "failed");
-        assert!(err
-            .hints
-            .iter()
-            .any(|hint| hint.message.contains("remote cancellation failed")));
-    });
+    let _env = EnvVarGuard::set(RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV, "true");
+    assert!(cancel_on_wait_timeout_enabled(&settings, false));
 }
 
 #[test]
@@ -1089,7 +881,7 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
         let job = running_job();
         let job_id = job.id.to_string();
 
-        let (output, exit_code) = detached_handoff_output(
+        let (output, _) = detached_handoff_output(
             &runner,
             RunnerExecMode::Daemon,
             "/srv/homeboy/project".to_string(),
@@ -1109,8 +901,10 @@ fn detached_handoff_output_includes_runner_job_and_agent_task_followups() {
             Some("agent-task-run-6454".to_string()),
             Some("mirrored-run-6454".to_string()),
         );
+        let (output, exit_code) = RunnerExecCompletion::InFlight(output).into_output();
 
         assert_eq!(exit_code, 0);
+        assert!(output.is_in_flight());
         assert_eq!(output.job_id.as_deref(), Some(job_id.as_str()));
         assert_eq!(output.mirror_run_id.as_deref(), Some("mirrored-run-6454"));
         assert_eq!(

--- a/crates/homeboy-lab-runner/src/execution/tests/policy.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/policy.rs
@@ -186,5 +186,8 @@ fn canonical_daemon_body_returns_nested_body() {
 #[test]
 fn runner_exec_wait_timeout_defaults_to_controller_timeout_budget() {
     std::env::remove_var(RUNNER_EXEC_WAIT_TIMEOUT_ENV);
-    assert_eq!(runner_exec_wait_timeout(), Duration::from_secs(20 * 60));
+    assert_eq!(
+        runner_exec_wait_timeout(&homeboy_core::server::RunnerSettings::default()),
+        Duration::from_secs(20 * 60)
+    );
 }

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -835,10 +835,17 @@ pub(crate) fn exec_lab_context(
         }
     };
 
-    context.plan = with_step(
-        context.plan,
-        PlanStep::builder("lab.exec", "lab.exec", PlanStepStatus::Success).build(),
-    );
+    let in_flight = exec_output.is_in_flight();
+    let exec_step = if in_flight {
+        PlanStep::builder("lab.exec", "lab.exec", PlanStepStatus::PartialSuccess)
+            .skip_reason(
+                "controller wait expired after durable runner handoff; remote command outcome remains pending",
+            )
+            .build()
+    } else {
+        PlanStep::builder("lab.exec", "lab.exec", PlanStepStatus::Success).build()
+    };
+    context.plan = with_step(context.plan, exec_step);
     if let Some(run_id) = context.agent_task_run_id.as_deref() {
         // This route's decision is the authoritative one for the execution
         // being verified. Adopt it when the record carries none, or carries
@@ -867,6 +874,39 @@ pub(crate) fn exec_lab_context(
             run_id,
             outcome,
         )?;
+    }
+    if in_flight {
+        if let Some(workspace) = context.materialized_workspace.as_mut() {
+            workspace.preserve();
+        }
+        if let (Some(run_id), Some(job_id)) = (
+            context.agent_task_run_id.as_deref(),
+            exec_output.job_id.as_deref(),
+        ) {
+            agent_task_lifecycle::record_detached_lab_run_in_store(
+                &lab_lifecycle_store,
+                agent_task_lifecycle::DetachedLabRunRecord {
+                    run_id,
+                    runner_id,
+                    runner_job_id: job_id,
+                    remote_workspace: &remote_cwd,
+                    remote_command: &context.remote_command,
+                },
+            )?;
+        }
+        let mut stderr = String::new();
+        for message in context.messages {
+            stderr.push_str(&message);
+            stderr.push('\n');
+        }
+        stderr.push_str(&exec_output.stderr);
+        return Ok(LabOffloadOutcome::InFlight {
+            plan: context.plan,
+            stdout: exec_output.stdout.clone(),
+            stderr,
+            exit_code,
+            output_file_content: Some(exec_output.stdout),
+        });
     }
     let dependency_cache_save_outputs =
         save_dependency_caches(runner_id, &context.dependency_cache_saves)?;

--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -195,9 +195,8 @@ remain authoritative. Homeboy reports an in-flight handoff with
 `homeboy runner job logs <runner> <job> --follow` when cancellation is disabled,
 fails, or returns a nonterminal job. If cancellation returns a terminal job,
 Homeboy projects that terminal non-success result instead of claiming the remote
-command continues. Unset `cancel_on_wait_timeout` does not cancel any workload,
-including agent-task workloads; set it explicitly to request best-effort
-cancellation.
+command continues. Unset `cancel_on_wait_timeout` cancels agent-task workloads
+and leaves other workloads in flight; set it explicitly to override that default.
 
 ## Detached handoff evidence
 

--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -193,8 +193,9 @@ submitted; workload settings inside the remote command cannot change them.
 When the wait expires after acceptance, the runner job and its durable run IDs
 remain authoritative. Homeboy reports an in-flight handoff with
 `homeboy runner job logs <runner> <job> --follow`; it does not report the remote
-command as failed. Unset `cancel_on_wait_timeout` defaults to cancellation for
-agent-task workloads and no cancellation for all other runner commands.
+command as failed. Unset `cancel_on_wait_timeout` does not cancel any workload,
+including agent-task workloads; set it explicitly to request best-effort
+cancellation.
 
 ## Detached handoff evidence
 

--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -192,8 +192,10 @@ submitted; workload settings inside the remote command cannot change them.
 
 When the wait expires after acceptance, the runner job and its durable run IDs
 remain authoritative. Homeboy reports an in-flight handoff with
-`homeboy runner job logs <runner> <job> --follow`; it does not report the remote
-command as failed. Unset `cancel_on_wait_timeout` does not cancel any workload,
+`homeboy runner job logs <runner> <job> --follow` when cancellation is disabled,
+fails, or returns a nonterminal job. If cancellation returns a terminal job,
+Homeboy projects that terminal non-success result instead of claiming the remote
+command continues. Unset `cancel_on_wait_timeout` does not cancel any workload,
 including agent-task workloads; set it explicitly to request best-effort
 cancellation.
 

--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -178,6 +178,24 @@ is parsed from standard Homeboy JSON error envelopes (`error.details.field`,
 `error.field`, or `contract_field`) when present; otherwise it is omitted and the
 raw execution evidence remains under `execution`.
 
+### Controller runner wait
+
+These controller-only variables are resolved before a runner command is
+submitted; workload settings inside the remote command cannot change them.
+
+| Variable | Runner setting | Meaning |
+|----------|----------------|---------|
+| `HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS` | `runner_exec_wait_timeout_secs` | Per-run whole-second wait override. Unset falls back to the runner setting, then 1200 seconds. `0` returns after durable handoff. |
+| `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT` | `cancel_on_wait_timeout` | Truthy values (`1`, `true`, `yes`, `on`) request best-effort cancellation after expiry. Otherwise the runner setting applies. |
+| `HOMEBOY_REQUIRE_EXACT_RUNNER_VERSION` | `require_exact_homeboy_version` | Truthy values require an exact controller and runner Homeboy version. |
+| `HOMEBOY_REQUIRE_FRESH_RUNTIME_OVERLAY` | `require_fresh_runtime_overlay` | Truthy values reject a provably stale runtime overlay. |
+
+When the wait expires after acceptance, the runner job and its durable run IDs
+remain authoritative. Homeboy reports an in-flight handoff with
+`homeboy runner job logs <runner> <job> --follow`; it does not report the remote
+command as failed. Unset `cancel_on_wait_timeout` defaults to cancellation for
+agent-task workloads and no cancellation for all other runner commands.
+
 ## Detached handoff evidence
 
 Detached Lab offload handoffs return a `homeboy/runner-exec-handoff/v1`

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -869,9 +869,9 @@ Arbitrary runner updates must use `--json` or `--base64`; positional `key=value`
 `runner_exec_wait_timeout_secs` controls how long the controller waits after a
 runner accepts a job (`0` returns an in-flight handoff immediately).
 `cancel_on_wait_timeout` controls whether an expired controller wait requests
-remote cancellation. Its unset default is `false` for every runner command,
-including agent-task workloads. If cancellation returns a terminal job, Homeboy
-returns its terminal non-success result rather than an in-flight handoff.
+remote cancellation. Its unset default is `true` for agent-task workloads and
+`false` for other runner commands. If cancellation returns a terminal job,
+Homeboy returns its terminal non-success result rather than an in-flight handoff.
 
 ### `trust`
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -870,7 +870,8 @@ Arbitrary runner updates must use `--json` or `--base64`; positional `key=value`
 runner accepts a job (`0` returns an in-flight handoff immediately).
 `cancel_on_wait_timeout` controls whether an expired controller wait requests
 remote cancellation. Its unset default is `false` for every runner command,
-including agent-task workloads.
+including agent-task workloads. If cancellation returns a terminal job, Homeboy
+returns its terminal non-success result rather than an in-flight handoff.
 
 ### `trust`
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -869,8 +869,8 @@ Arbitrary runner updates must use `--json` or `--base64`; positional `key=value`
 `runner_exec_wait_timeout_secs` controls how long the controller waits after a
 runner accepts a job (`0` returns an in-flight handoff immediately).
 `cancel_on_wait_timeout` controls whether an expired controller wait requests
-remote cancellation. Its unset default is `true` for agent-task workloads and
-`false` for other runner commands.
+remote cancellation. Its unset default is `false` for every runner command,
+including agent-task workloads.
 
 ### `trust`
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -861,10 +861,16 @@ homeboy runner show <id>
 homeboy runner set <id> --json <JSON>
 homeboy runner set <id> --base64 <BASE64_JSON>
 homeboy runner set <id> --json '{"workspace_root":"/srv/homeboy","concurrency_limit":4}'
+homeboy runner set <id> --json '{"runner_exec_wait_timeout_secs":2400,"cancel_on_wait_timeout":true}'
 ```
 
 Updates a runner by merging a JSON object into the runner config. SSH runner settings live under `servers/<id>.json` as the server's `runner` capability; local runners live under `runners/<id>.json`.
 Arbitrary runner updates must use `--json` or `--base64`; positional `key=value` and trailing arbitrary `--key value` updates are not accepted.
+`runner_exec_wait_timeout_secs` controls how long the controller waits after a
+runner accepts a job (`0` returns an in-flight handoff immediately).
+`cancel_on_wait_timeout` controls whether an expired controller wait requests
+remote cancellation. Its unset default is `true` for agent-task workloads and
+`false` for other runner commands.
 
 ### `trust`
 

--- a/docs/reference/schemas/server-schema.md
+++ b/docs/reference/schemas/server-schema.md
@@ -134,7 +134,7 @@ cancellation policy on the runner instead of relying on process environment:
 | Setting | Per-run env override | Unset default |
 | --- | --- | --- |
 | `runner_exec_wait_timeout_secs` | `HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS` | 1200 seconds; `0` detaches immediately |
-| `cancel_on_wait_timeout` | `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT` | `false`; set `true` to request best-effort cancellation after wait expiry |
+| `cancel_on_wait_timeout` | `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT` | `true` for agent-task workloads and `false` otherwise; set explicitly to override |
 
 The timeout environment value overrides the configured number when it parses as
 whole seconds. A truthy cancellation environment value (`1`, `true`, `yes`,

--- a/docs/reference/schemas/server-schema.md
+++ b/docs/reference/schemas/server-schema.md
@@ -24,6 +24,8 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
     "homeboy_path": "string",
     "daemon": boolean,
     "concurrency_limit": number,
+    "runner_exec_wait_timeout_secs": number,
+    "cancel_on_wait_timeout": boolean,
     "artifact_policy": "string",
     "require_exact_homeboy_version": boolean,
     "require_fresh_runtime_overlay": boolean,
@@ -77,6 +79,8 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
     "homeboy_path": "/usr/local/bin/homeboy",
     "daemon": false,
     "concurrency_limit": 4,
+    "runner_exec_wait_timeout_secs": 2400,
+    "cancel_on_wait_timeout": true,
     "artifact_policy": "copy",
     "policy": {
       "snapshot_excludes": ["generated-state", "generated-state/**"]
@@ -121,6 +125,31 @@ Use `runner.secret_env` for values that must be read at execution time instead o
 ```
 
 Homeboy rejects likely credential names in newly persisted `runner.env` entries. Use `secret_env` for those values; it is also the explicit sensitivity declaration for non-obvious names. Existing legacy entries can be inspected without values using `homeboy runner doctor <id> --scope secret-env` and migrated into OS keychain-backed references with `--repair`. Homeboy command output redacts sensitive names in `env` and keeps `secret_env` as references only. Secret file contents and referenced environment variable values are not printed by runner config/status diagnostics.
+
+### Controller Wait Lifecycle
+
+Runner jobs remain durable after controller wait expiry. Configure the wait and
+cancellation policy on the runner instead of relying on process environment:
+
+| Setting | Per-run env override | Unset default |
+| --- | --- | --- |
+| `runner_exec_wait_timeout_secs` | `HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS` | 1200 seconds; `0` detaches immediately |
+| `cancel_on_wait_timeout` | `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT` | `true` for agent-task workloads, `false` otherwise |
+
+The timeout environment value overrides the configured number when it parses as
+whole seconds. A truthy cancellation environment value (`1`, `true`, `yes`,
+`on`) enables cancellation for one run. On expiry Homeboy returns a successful
+in-flight handoff, preserves the runner job and run IDs, and prints the runner
+job follow command; it does not claim that the remote command failed.
+
+```json
+{
+  "runner": {
+    "runner_exec_wait_timeout_secs": 2400,
+    "cancel_on_wait_timeout": true
+  }
+}
+```
 
 ### Lab Offload Safety Gates
 

--- a/docs/reference/schemas/server-schema.md
+++ b/docs/reference/schemas/server-schema.md
@@ -134,7 +134,7 @@ cancellation policy on the runner instead of relying on process environment:
 | Setting | Per-run env override | Unset default |
 | --- | --- | --- |
 | `runner_exec_wait_timeout_secs` | `HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS` | 1200 seconds; `0` detaches immediately |
-| `cancel_on_wait_timeout` | `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT` | `true` for agent-task workloads, `false` otherwise |
+| `cancel_on_wait_timeout` | `HOMEBOY_RUNNER_CANCEL_ON_WAIT_TIMEOUT` | `false`; set `true` to request best-effort cancellation after wait expiry |
 
 The timeout environment value overrides the configured number when it parses as
 whole seconds. A truthy cancellation environment value (`1`, `true`, `yes`,

--- a/docs/reference/schemas/server-schema.md
+++ b/docs/reference/schemas/server-schema.md
@@ -139,8 +139,9 @@ cancellation policy on the runner instead of relying on process environment:
 The timeout environment value overrides the configured number when it parses as
 whole seconds. A truthy cancellation environment value (`1`, `true`, `yes`,
 `on`) enables cancellation for one run. On expiry Homeboy returns a successful
-in-flight handoff, preserves the runner job and run IDs, and prints the runner
-job follow command; it does not claim that the remote command failed.
+in-flight handoff only when cancellation is disabled, fails, or returns a
+nonterminal job. A terminal cancellation result is projected as a terminal
+non-success result; it does not claim that the remote command continues.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- make runner wait timeout configurable through the persisted runner contract and CLI
- detach accepted non-agent work safely when the controller stops waiting
- default expired agent-task waits to remote cancellation while preserving explicit policy overrides
- project authoritative cancelled jobs as terminal failures without discarding worker event evidence

## Verification
- `cargo test -p homeboy-lab-runner execution::tests::handoff --lib` (37 tests; one timing-sensitive unrelated test passed on exact rerun)
- `cargo test -p homeboy-cli commands::runner::tests::exec --lib` (39 passed)
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Closes #11109.

## AI assistance
OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode implemented and independently reviewed the timeout, handoff, and cancellation changes. Chris Huber directed the work and reviewed the resulting evidence.