### PR TITLE
fix(release): restore generated changelog history

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,6 @@ All notable changes to Homeboy CLI are documented in this file.
 ## [0.367.13] - 2026-09-06
 
 ### Changed
-- return the canonical control-plane action acknowledgement from applied agent-task reconciliation
 - use the shared git fixture helper
 - narrow the agent-tasks facade to its consumers
 - use canonical status resources
@@ -23,7 +22,6 @@ All notable changes to Homeboy CLI are documented in this file.
 ## [0.367.12] - 2026-09-06
 
 ### Changed
-- delete superseded agent-task status-scope and status-summary projections
 - stop publishing internal-only modules
 
 ## [0.367.11] - 2026-09-05


### PR DESCRIPTION
## Summary

- remove the two entries manually added to already finalized release sections by #14320 and #14340
- restore `0.367.12` and `0.367.13` to release-generated history
- leave the underlying changes to be generated once from their conventional commits by Homeboy

Fixes the observed repository state in #14342. Prevention remains tracked by #4876; deterministic release recovery remains tracked by #14342.

## Verification

- compared the two removed lines to the corresponding merged PR diffs
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the unauthorized entries to #14320 and #14340 and prepared this exact two-line restoration under Chris Huber's direction.