### PR TITLE
refactor(agent-task): return canonical retry acknowledgement

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -8310,18 +8310,20 @@ where
             None,
         ));
     }
-    let record: AgentTaskRunRecord =
-        serde_json::from_value(acknowledgement.result.data["record"].clone()).map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("decode retry action result".to_string()),
-            )
-        })?;
     let execute = args.run
         && acknowledgement.result.data["runnable"]
             .as_bool()
             .unwrap_or(false);
     if execute {
+        let record: AgentTaskRunRecord = serde_json::from_value(
+            acknowledgement.result.data["record"].clone(),
+        )
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("decode retry action result".to_string()),
+            )
+        })?;
         if record.metadata["cook_id"].is_string() {
             return continue_cook_with_queued_execution(
                 CookContinueArgs {
@@ -8345,10 +8347,11 @@ where
         }
         return run_submitted_with_executor(record.run_id, None, executor);
     }
-    let mut value = serde_json::to_value(record).unwrap_or(Value::Null);
-    value["action_acknowledgement"] = json!(acknowledgement.acknowledgement);
-    value["idempotency_key"] = json!(acknowledgement.idempotency_key);
-    Ok((value, 0))
+    Ok((
+        serde_json::to_value(acknowledgement)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?,
+        0,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -4434,7 +4434,7 @@ fn cancel_command_reports_a_deferred_cancellation_without_claiming_the_run_is_ca
 }
 
 #[test]
-fn retry_command_submits_new_queued_run() {
+fn retry_command_returns_the_replayable_control_plane_acknowledgement() {
     with_temp_home(|| {
         agent_task_lifecycle::submit_plan(&test_plan(), Some("run-retry-source"))
             .expect("submitted");
@@ -4452,13 +4452,32 @@ fn retry_command_submits_new_queued_run() {
             provider_rotations: None,
         })
         .expect("retry queued");
-        let action_acknowledgement = value["action_acknowledgement"].clone();
-        let record: AgentTaskRunRecord = serde_json::from_value(value).expect("record");
+        let acknowledgement: homeboy_control_plane_contract::ControlPlaneActionAcknowledgement =
+            serde_json::from_value(value.clone()).expect("canonical action acknowledgement");
 
         assert_eq!(exit_code, 0);
-        assert_eq!(record.run_id, "run-retry-cli");
-        assert_eq!(record.state, AgentTaskRunState::Queued);
-        assert_eq!(record.metadata["retry_of"], json!("run-retry-source"));
+        assert_eq!(
+            acknowledgement.schema,
+            homeboy_control_plane_contract::CONTROL_PLANE_ACTION_ACKNOWLEDGEMENT_SCHEMA
+        );
+        assert_eq!(
+            acknowledgement.action,
+            homeboy_control_plane_contract::ControlPlaneAction::Retry
+        );
+        assert_eq!(acknowledgement.idempotency_key, "retry-cli-1");
+        assert_eq!(
+            acknowledgement.result.data["record"]["run_id"],
+            "run-retry-cli"
+        );
+        assert_eq!(acknowledgement.result.data["record"]["state"], "queued");
+        assert_eq!(
+            acknowledgement.result.data["record"]["metadata"]["retry_of"],
+            json!("run-retry-source")
+        );
+        assert_eq!(
+            value,
+            serde_json::to_value(&acknowledgement).expect("serialize canonical acknowledgement")
+        );
         let replay = retry(RetryArgs {
             run_id: "run-retry-source".to_string(),
             new_run_id: Some("run-retry-cli".to_string()),
@@ -4473,7 +4492,7 @@ fn retry_command_submits_new_queued_run() {
         })
         .expect("replayed retry")
         .0;
-        assert_eq!(replay["action_acknowledgement"], action_acknowledgement);
+        assert_eq!(replay, value);
         assert_eq!(
             agent_task_lifecycle::list_records().expect("records").len(),
             2,


### PR DESCRIPTION
## Summary

- return the canonical control-plane action acknowledgement unchanged from queue-only `agent-task retry`
- remove the legacy CLI projection that decoded a run record and appended selected acknowledgement fields
- preserve `retry --run` decoding and execution behavior
- prove idempotent replay returns the same acknowledgement without creating another successor

Part of #13697.

## Verification

- `cargo test -p homeboy-cli retry_command_returns_the_replayable_control_plane_acknowledgement --lib -- --test-threads=1`
- `cargo test -p homeboy-cli cook_retry_run_executes_the_replacement_through_its_cook_lifecycle --lib -- --test-threads=1`
- `cargo check -p homeboy-cli`
- `cargo fmt --all --check`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the remaining retry response duplication, replaced it with the canonical acknowledgement, and verified replay and execution behavior under Chris Huber's direction.