### PR TITLE
test(lab-runner): use the shared git fixture helper

### DIFF
--- a/crates/homeboy-lab-runner/src/apply.rs
+++ b/crates/homeboy-lab-runner/src/apply.rs
@@ -571,17 +571,5 @@ mod tests {
         repo
     }
 
-    fn git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 }

--- a/crates/homeboy-lab-runner/src/execution/extension_parity.rs
+++ b/crates/homeboy-lab-runner/src/execution/extension_parity.rs
@@ -2020,19 +2020,7 @@ mod tests {
         });
     }
 
-    fn git(path: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: {}",
-            args,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 
     /// Commit an extension checkout and return its HEAD SHA, which is what both
     /// sides report as `source_revision`.

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -3271,14 +3271,7 @@ mod tests {
         });
     }
 
-    fn git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(output.status.success(), "git {} failed", args.join(" "));
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 
     fn git_output(path: &Path, args: &[&str]) -> String {
         let output = Command::new("git")

--- a/crates/homeboy-lab-runner/src/lab_apply.rs
+++ b/crates/homeboy-lab-runner/src/lab_apply.rs
@@ -127,7 +127,6 @@ fn read_lab_patch_artifact(path: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
 
     use super::*;
 
@@ -401,17 +400,5 @@ mod tests {
         }
     }
 
-    fn git(path: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 }

--- a/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
@@ -20,19 +20,7 @@ use crate::{
 };
 use homeboy_core::worktree;
 
-fn git(path: &Path, args: &[&str]) {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .output()
-        .expect("run git");
-    assert!(
-        output.status.success(),
-        "git {:?} failed: {}",
-        args,
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
+use homeboy_core::test_support::run_git_fixture_command as git;
 
 fn init_task_worktree(source: &Path, worktree: &Path, branch: &str) {
     std::fs::create_dir_all(source).expect("source dir");

--- a/crates/homeboy-lab-runner/src/offload_changed_since.rs
+++ b/crates/homeboy-lab-runner/src/offload_changed_since.rs
@@ -446,19 +446,7 @@ mod tests {
         );
     }
 
-    fn git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 
     fn git_stdout(path: &Path, args: &[&str]) -> String {
         let output = Command::new("git")

--- a/crates/homeboy-lab-runner/src/runtime_overlay_freshness.rs
+++ b/crates/homeboy-lab-runner/src/runtime_overlay_freshness.rs
@@ -391,19 +391,7 @@ mod tests {
         REQUIRE_FRESH_RUNTIME_OVERLAY_ENV, REQUIRE_FRESH_RUNTIME_OVERLAY_SETTING,
     };
 
-    fn git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 
     fn git_out(path: &Path, args: &[&str]) -> String {
         let output = Command::new("git")

--- a/crates/homeboy-lab-runner/src/validation_dependencies.rs
+++ b/crates/homeboy-lab-runner/src/validation_dependencies.rs
@@ -355,19 +355,7 @@ mod tests {
         parent_remote_path, sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
     };
 
-    fn git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: {}",
-            args,
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 
     fn init_checkout_with_upstream(path: &Path) -> tempfile::TempDir {
         let remote = tempfile::tempdir().expect("remote");

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -813,7 +813,6 @@ pub(super) fn is_excluded(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::process::Command;
 
     #[test]
     fn snapshot_identity_ignores_declared_context_excludes() {
@@ -856,14 +855,7 @@ mod tests {
         );
     }
 
-    fn git(cwd: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(cwd)
-            .output()
-            .expect("run git");
-        assert!(output.status.success(), "git {args:?} failed");
-    }
+    use homeboy_core::test_support::run_git_fixture_command as git;
 }
 
 pub(crate) fn materialize_snapshot(

--- a/crates/homeboy-lab-runner/src/workspace/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/mod.rs
@@ -7,23 +7,8 @@ mod snapshot;
 mod snapshots;
 mod update;
 
-use std::path::Path;
-use std::process::Command;
-
 /// Run a git command in `path`, asserting success. Shared test helper.
-fn git(path: &Path, args: &[&str]) {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .output()
-        .expect("run git");
-    assert!(
-        output.status.success(),
-        "git {} failed: {}",
-        args.join(" "),
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
+use homeboy_core::test_support::run_git_fixture_command as git;
 
 /// Create a git repo with a single committed file then dirty the working tree.
 fn dirty_git_repo() -> tempfile::TempDir {


### PR DESCRIPTION
## Summary
Ten test modules in `homeboy-lab-runner` each defined an identical `git` / `run_git` helper wrapping `Command::new("git")` with a success assertion. Each becomes an aliased import of the existing shared primitive, leaving every call site unchanged:

```rust
use homeboy_core::test_support::run_git_fixture_command as git;
```

Net **-115 lines**. Third slice of #13227, after #14322 (release) and #14329 (deploy).

Files: `offload_changed_since`, `runtime_overlay_freshness`, `lab_apply`, `apply`, `validation_dependencies`, `lab_workspaces/tests/provider_config`, `workspace/snapshot`, `workspace/tests/mod`, `lab/offload/workspace_stage`, `execution/extension_parity`, plus four imports that became unused.

## Left alone
`git_dependency_materialization.rs` has a helper that does not match the assert-only shape, so the script skipped it rather than assuming equivalence.

## Verification, and its limit
The full `homeboy-lab-runner` lib suite **does not complete locally** — it was still running when killed at 55 minutes. I could not produce a whole-crate result, so I am not claiming one.

Instead I ran the ten touched modules against a baseline worktree with an identical filter:

| | passed | failed |
|---|---|---|
| this branch | 339 | 4 |
| baseline `main` | 339 | 4 |

Same counts, same four failing test names (`provider_config` ×2, `workspace::tests::snapshot`, `workspace::tests::snapshots`). Zero branch-only failures. `cargo check -p homeboy-lab-runner --tests` is warning-free.

That a crate suite cannot finish in under an hour is worth knowing independently of this change.

## AI Assistance
OpenAI GPT-5.6 Sol through OpenCode applied the established consolidation, skipped one helper whose shape differed, and — after the full suite proved unrunnable locally — verified the touched modules against a baseline worktree under a matched filter. Chris Huber directed the work and remains responsible for acceptance.