### PR TITLE
refactor(agent-task): return canonical resume acknowledgement

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -8156,7 +8156,7 @@ pub(super) fn resume(args: ResumeArgs) -> CmdResult<Value> {
 
 pub(super) fn run_resume_with_executor(
     run_id: String,
-    full: bool,
+    _full: bool,
     idempotency_key: Option<String>,
     executor: SharedAgentTaskExecutor,
 ) -> CmdResult<Value> {
@@ -8187,33 +8187,21 @@ pub(super) fn run_resume_with_executor(
             None,
         ));
     }
-    if acknowledgement.result.schema == "homeboy/unmaterialized-cook-resume/v1" {
-        let exit_code = if acknowledgement.result.data["terminal"] == true {
+    let exit_code = if acknowledgement.result.schema == "homeboy/unmaterialized-cook-resume/v1" {
+        if acknowledgement.result.data["terminal"] == true {
             2
         } else {
             0
-        };
-        return Ok((acknowledgement.result.data, exit_code));
-    }
-    let aggregate: AgentTaskAggregate = serde_json::from_value(
-        acknowledgement.result.data["aggregate"].clone(),
-    )
-    .map_err(|error| {
-        Error::internal_json(
-            error.to_string(),
-            Some("decode resume action result".to_string()),
-        )
-    })?;
-    let exit_code = acknowledgement.result.data["exit_code"]
-        .as_i64()
-        .and_then(|code| i32::try_from(code).ok())
-        .unwrap_or(0);
+        }
+    } else {
+        acknowledgement.result.data["exit_code"]
+            .as_i64()
+            .and_then(|code| i32::try_from(code).ok())
+            .unwrap_or(0)
+    };
     Ok((
-        if full {
-            aggregate_value_with_failure_reasons(&aggregate)
-        } else {
-            super::status::compact_aggregate_summary(&aggregate, Some(&run_id))
-        },
+        serde_json::to_value(acknowledgement)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?,
         exit_code,
     ))
 }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -2237,8 +2237,17 @@ fn unmaterialized_cook_resume_replays_the_canonical_action_result() {
         let replay = resume(args()).expect("replay admission resume");
 
         assert_eq!(replay, first);
-        assert_eq!(first.0["schema"], "homeboy/unmaterialized-cook-resume/v1");
-        assert_eq!(first.0["run_id"], run_id);
+        assert_eq!(
+            first.0["schema"],
+            homeboy_control_plane_contract::CONTROL_PLANE_ACTION_ACKNOWLEDGEMENT_SCHEMA
+        );
+        assert_eq!(first.0["action"], "resume");
+        assert_eq!(first.0["idempotency_key"], "resume-unmaterialized-1");
+        assert_eq!(
+            first.0["result"]["schema"],
+            "homeboy/unmaterialized-cook-resume/v1"
+        );
+        assert_eq!(first.0["result"]["data"]["run_id"], run_id);
     });
 }
 
@@ -4815,15 +4824,15 @@ fn verify_replacement_file_gates_are_snapshotted_before_execution() {
 }
 
 #[test]
-fn resume_command_executes_existing_run() {
+fn resume_command_executes_existing_run_and_returns_the_replayable_acknowledgement() {
     with_temp_home(|| {
         agent_task_lifecycle::submit_plan(&test_plan(), Some("run-resume-cli")).expect("submitted");
         let observed_status = Arc::new(Mutex::new(None));
 
-        let (_value, exit_code) = run_resume_with_executor(
+        let (value, exit_code) = run_resume_with_executor(
             "run-resume-cli".to_string(),
             false,
-            None,
+            Some("resume-cli-1".to_string()),
             Arc::new(InspectingExecutor {
                 run_id: "run-resume-cli".to_string(),
                 observed_status: Arc::clone(&observed_status),
@@ -4839,8 +4848,39 @@ fn resume_command_executes_existing_run() {
         let completed = lifecycle_status("run-resume-cli").expect("completed status");
 
         assert_eq!(exit_code, 0);
+        let acknowledgement: homeboy_control_plane_contract::ControlPlaneActionAcknowledgement =
+            serde_json::from_value(value.clone()).expect("canonical action acknowledgement");
+        assert_eq!(
+            acknowledgement.schema,
+            homeboy_control_plane_contract::CONTROL_PLANE_ACTION_ACKNOWLEDGEMENT_SCHEMA
+        );
+        assert_eq!(
+            acknowledgement.action,
+            homeboy_control_plane_contract::ControlPlaneAction::Resume
+        );
+        assert_eq!(acknowledgement.idempotency_key, "resume-cli-1");
+        assert_eq!(
+            acknowledgement.resource.state,
+            homeboy_control_plane_contract::ControlPlaneRunState::Succeeded
+        );
         assert!(observed.metadata["resume_requested_at"].is_string());
         assert_eq!(completed.state, AgentTaskRunState::Succeeded);
+
+        let replay_executor = Arc::new(CapturingExecutor::default());
+        let replay = run_resume_with_executor(
+            "run-resume-cli".to_string(),
+            false,
+            Some("resume-cli-1".to_string()),
+            replay_executor.clone(),
+        )
+        .expect("replayed resume")
+        .0;
+        assert_eq!(replay, value);
+        assert!(replay_executor
+            .observed_request
+            .lock()
+            .expect("executor lock")
+            .is_none());
     });
 }
 


### PR DESCRIPTION
## Summary

- return the canonical control-plane action acknowledgement unchanged from `agent-task resume`
- preserve existing normal and unmaterialized-Cook exit-code semantics
- remove CLI-owned aggregate and special-case response projections
- prove idempotent replay returns the same acknowledgement without executing provider work twice

Part of #13697.

## Verification

- `cargo test -p homeboy-cli unmaterialized_cook_resume_replays_the_canonical_action_result --lib -- --test-threads=1`
- `cargo test -p homeboy-cli resume_command_executes_existing_run_and_returns_the_replayable_acknowledgement --lib -- --test-threads=1`
- `cargo check -p homeboy-cli`
- `cargo fmt --all --check`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the remaining resume response projections, replaced them with the canonical action acknowledgement, and verified execution, exit-code, and idempotent replay behavior under Chris Huber's direction.