### PR TITLE
test: normalize git fixture helpers onto the identity-neutral contract

### DIFF
--- a/crates/homeboy-deploy/src/execution/mod.rs
+++ b/crates/homeboy-deploy/src/execution/mod.rs
@@ -532,7 +532,7 @@ mod tests {
         assert!(zip.by_name("demo-plugin/node_modules/junk.js").is_err());
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     #[test]
     fn cleanup_deploy_build_artifact_preserves_non_empty_build_dir() {

--- a/crates/homeboy-deploy/src/generated_artifacts.rs
+++ b/crates/homeboy-deploy/src/generated_artifacts.rs
@@ -189,7 +189,7 @@ mod tests {
     use homeboy_core::component::{CleanupArtifactDeclaration, Component};
     use homeboy_core::defaults::deploy_generated_build_dir;
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn git_repo() -> tempfile::TempDir {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -1025,7 +1025,7 @@ mod tests {
             .success());
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn git_stdout(path: &Path, args: &[&str]) -> String {
         let output = std::process::Command::new("git")

--- a/crates/homeboy-deploy/src/orchestration/modes.rs
+++ b/crates/homeboy-deploy/src/orchestration/modes.rs
@@ -1229,7 +1229,7 @@ mod tests {
         );
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     fn local_client() -> SshClient {
         SshClient {

--- a/crates/homeboy-deploy/src/orchestration/preflight.rs
+++ b/crates/homeboy-deploy/src/orchestration/preflight.rs
@@ -895,7 +895,7 @@ mod tests {
             .expect("projects without a policy retain legacy force semantics");
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     #[test]
     fn stale_local_source_refuses_until_explicitly_allowed() {

--- a/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
+++ b/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
@@ -1295,7 +1295,7 @@ mod tests {
         );
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     fn git_output(path: &Path, args: &[&str]) -> String {
         let output = Command::new("git")

--- a/crates/homeboy-deploy/src/planning.rs
+++ b/crates/homeboy-deploy/src/planning.rs
@@ -1014,7 +1014,7 @@ mod tests {
     use homeboy_core::server::SshClient;
     use tempfile::TempDir;
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn init_source_repo(path: &Path) {
         run_git(path, &["init", "-q", "-b", "main"]);

--- a/crates/homeboy-deploy/src/provenance.rs
+++ b/crates/homeboy-deploy/src/provenance.rs
@@ -101,7 +101,7 @@ pub(crate) use homeboy_core::tag_gap::{detect_tag_gap, warn_tag_gap};
 mod provenance_tests {
     use super::*;
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn committed_repo() -> tempfile::TempDir {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/homeboy-deploy/src/provider.rs
+++ b/crates/homeboy-deploy/src/provider.rs
@@ -766,7 +766,7 @@ mod tests {
         );
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     fn provider_repository(id: &str) -> tempfile::TempDir {
         let repository = tempfile::tempdir().expect("repository");

--- a/crates/homeboy-deploy/src/types.rs
+++ b/crates/homeboy-deploy/src/types.rs
@@ -1357,7 +1357,7 @@ mod tests {
         );
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     #[test]
     fn release_state_status_uses_needs_release_public_name() {

--- a/crates/homeboy-lab-runner/src/apply.rs
+++ b/crates/homeboy-lab-runner/src/apply.rs
@@ -571,5 +571,5 @@ mod tests {
         repo
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 }

--- a/crates/homeboy-lab-runner/src/execution/extension_parity.rs
+++ b/crates/homeboy-lab-runner/src/execution/extension_parity.rs
@@ -2020,7 +2020,7 @@ mod tests {
         });
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     /// Commit an extension checkout and return its HEAD SHA, which is what both
     /// sides report as `source_revision`.

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -3271,7 +3271,7 @@ mod tests {
         });
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     fn git_output(path: &Path, args: &[&str]) -> String {
         let output = Command::new("git")

--- a/crates/homeboy-lab-runner/src/lab_apply.rs
+++ b/crates/homeboy-lab-runner/src/lab_apply.rs
@@ -400,5 +400,5 @@ mod tests {
         }
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 }

--- a/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use homeboy_core::worktree;
 
-use homeboy_core::test_support::run_git_fixture_command as git;
+use homeboy_core::test_support::run_git_command as git;
 
 fn init_task_worktree(source: &Path, worktree: &Path, branch: &str) {
     std::fs::create_dir_all(source).expect("source dir");

--- a/crates/homeboy-lab-runner/src/offload_changed_since.rs
+++ b/crates/homeboy-lab-runner/src/offload_changed_since.rs
@@ -446,7 +446,7 @@ mod tests {
         );
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     fn git_stdout(path: &Path, args: &[&str]) -> String {
         let output = Command::new("git")

--- a/crates/homeboy-lab-runner/src/runtime_overlay_freshness.rs
+++ b/crates/homeboy-lab-runner/src/runtime_overlay_freshness.rs
@@ -391,7 +391,7 @@ mod tests {
         REQUIRE_FRESH_RUNTIME_OVERLAY_ENV, REQUIRE_FRESH_RUNTIME_OVERLAY_SETTING,
     };
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     fn git_out(path: &Path, args: &[&str]) -> String {
         let output = Command::new("git")

--- a/crates/homeboy-lab-runner/src/validation_dependencies.rs
+++ b/crates/homeboy-lab-runner/src/validation_dependencies.rs
@@ -355,7 +355,7 @@ mod tests {
         parent_remote_path, sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
     };
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     fn init_checkout_with_upstream(path: &Path) -> tempfile::TempDir {
         let remote = tempfile::tempdir().expect("remote");

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -855,7 +855,7 @@ mod tests {
         );
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 }
 
 pub(crate) fn materialize_snapshot(

--- a/crates/homeboy-lab-runner/src/workspace/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/mod.rs
@@ -8,7 +8,7 @@ mod snapshots;
 mod update;
 
 /// Run a git command in `path`, asserting success. Shared test helper.
-use homeboy_core::test_support::run_git_fixture_command as git;
+use homeboy_core::test_support::run_git_command as git;
 
 /// Create a git repo with a single committed file then dirty the working tree.
 fn dirty_git_repo() -> tempfile::TempDir {

--- a/crates/homeboy-release/src/release/checkout_guard.rs
+++ b/crates/homeboy-release/src/release/checkout_guard.rs
@@ -223,7 +223,7 @@ mod tests {
     use super::ReleaseCheckoutGuard;
     use homeboy_core::component::Component;
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn run_git_allow_failure(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
         std::process::Command::new("git")

--- a/crates/homeboy-release/src/release/executor/git_push.rs
+++ b/crates/homeboy-release/src/release/executor/git_push.rs
@@ -258,7 +258,7 @@ mod tests {
     use homeboy_core::component::Component;
     use std::process::Command;
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     #[test]
     fn git_push_step_fails_when_git_push_fails() {

--- a/crates/homeboy-release/src/release/executor/lockfile_guard.rs
+++ b/crates/homeboy-release/src/release/executor/lockfile_guard.rs
@@ -484,7 +484,7 @@ fn local_file_dependency_error(offenders: &[LocalFileDependency]) -> Error {
 mod tests {
     use super::*;
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn init_repo(dir: &Path) {
         run_git(dir, &["init", "--quiet"]);

--- a/crates/homeboy-release/src/release/executor/package_preflight.rs
+++ b/crates/homeboy-release/src/release/executor/package_preflight.rs
@@ -866,7 +866,7 @@ mod tests {
         }]
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn write_zip(path: &Path, entries: &[(&str, &str)]) {
         let file = std::fs::File::create(path).expect("zip file");

--- a/crates/homeboy-release/src/release/planner.rs
+++ b/crates/homeboy-release/src/release/planner.rs
@@ -687,7 +687,7 @@ mod tests {
 
     use std::path::Path;
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     /// Build a local clone whose HEAD is at `v1.0.0` and an "origin" that is
     /// `extra_upstream_commits` ahead, then update tracking refs without

--- a/crates/homeboy-release/src/release/planning_changelog.rs
+++ b/crates/homeboy-release/src/release/planning_changelog.rs
@@ -334,7 +334,7 @@ mod tests {
         }
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn commit_file(dir: &std::path::Path, name: &str, content: &str, message: &str) {
         if let Some(parent) = dir.join(name).parent() {

--- a/crates/homeboy-release/src/release/planning_git.rs
+++ b/crates/homeboy-release/src/release/planning_git.rs
@@ -315,7 +315,7 @@ mod tests {
     };
     use homeboy_core::component::Component;
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn git_component(dir: &std::path::Path) -> Component {
         Component {

--- a/crates/homeboy-release/src/release/planning_semver.rs
+++ b/crates/homeboy-release/src/release/planning_semver.rs
@@ -453,7 +453,7 @@ mod tests {
     use homeboy_core::git;
     use homeboy_core::git::SemverBump;
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn commit_file(dir: &std::path::Path, name: &str, content: &str, message: &str) {
         if let Some(parent) = dir.join(name).parent() {

--- a/crates/homeboy-release/src/release/planning_worktree.rs
+++ b/crates/homeboy-release/src/release/planning_worktree.rs
@@ -483,7 +483,7 @@ mod tests {
     use homeboy_core::component::Component;
     use homeboy_core::git::UncommittedChanges;
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn git_repo() -> tempfile::TempDir {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/homeboy-release/src/release/preflight_identity.rs
+++ b/crates/homeboy-release/src/release/preflight_identity.rs
@@ -63,5 +63,5 @@ mod tests {
         assert!(error.message.contains("Release preflight source drift"));
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as run_git;
+    use homeboy_core::test_support::run_git_command as run_git;
 }

--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -645,7 +645,7 @@ mod tests {
         OperationRecordStore::in_roots(&test_roots())
     }
 
-    use homeboy_core::test_support::run_git_fixture_command as git;
+    use homeboy_core::test_support::run_git_command as git;
 
     fn fixture_component(home: &tempfile::TempDir) -> Component {
         let remote = home.path().join("origin.git");


### PR DESCRIPTION
## Summary
Repoints 31 test modules in `homeboy-release`, `homeboy-deploy`, and `homeboy-lab-runner` from `run_git_fixture_command` to `run_git_command`, so all four consolidated crates share one contract.

One-line change per file; no call sites move.

## Why this is a correctness fix, not tidying
The earlier slices (#14322, #14329, #14347) aliased the local helpers to `run_git_fixture_command`, which pins a fixed identity through `GitFixture::with_identity`. The helpers it replaced injected nothing and let each test's own `git config` stand.

Those suites passed, so nothing in those three crates depended on authorship — but I claimed the swap was behavior-preserving without having established that. #14351 disproved it: a core test asserts on configured authorship and failed with `homeboy-test <homeboy-test@example.invalid>` in place of its own identity. Same latent hazard existed in these three; it simply had no assertion to trip.

`run_git_command` (added in #14351) is assert-only and identity-neutral, matching the original helpers exactly. This removes the divergence rather than leaving it resting on the absence of a test.

## Verification
| crate | result | matches baseline |
|---|---|---|
| `homeboy-release` | 572 passed, 0 failed | yes, clean |
| `homeboy-deploy` | 325 passed, 5 failed | yes, same 5 as `main` |
| `homeboy-lab-runner` (touched modules) | 339 passed, 4 failed | yes, same 4 as `main` |

No new failures in any of the three. `cargo check --tests` clean across all three crates.

## AI Assistance
OpenAI GPT-5.6 Sol through OpenCode identified that its own earlier slices had changed fixture authorship semantics, and normalized all three onto the identity-neutral helper. Chris Huber directed the work and remains responsible for acceptance.