### PR TITLE
test(agent-task): use the shared git fixture helper

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -762,7 +762,6 @@ mod tests {
     use crate::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskExecutorAdapter};
     use homeboy_core::test_support::with_isolated_home;
     use std::collections::HashMap;
-    use std::process::Command;
     use std::sync::Arc;
 
     #[test]
@@ -1994,14 +1993,7 @@ mod tests {
         run_git(path, &["commit", "-m", "init"]);
     }
 
-    fn run_git(path: &std::path::Path, args: &[&str]) {
-        let status = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .status()
-            .expect("git command runs");
-        assert!(status.success(), "git {:?} failed", args);
-    }
+    use homeboy_core::test_support::run_git_command as run_git;
 
     #[test]
     fn resolves_workspace_path_without_specialized_coupling() {
@@ -2246,17 +2238,5 @@ mod tests {
         }
     }
 
-    fn git(path: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_command as git;
 }

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -1012,14 +1012,7 @@ mod remote_base_tests {
     use super::*;
     use std::process::Command;
 
-    fn git(path: &std::path::Path, args: &[&str]) {
-        assert!(Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .status()
-            .expect("git runs")
-            .success());
-    }
+    use homeboy_core::test_support::run_git_command as git;
 
     fn repo() -> tempfile::TempDir {
         let repo = tempfile::tempdir().expect("temp repo");

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -3556,19 +3556,7 @@ fn prepare_dirty_scheduler_workspace(scratch: &std::path::Path) {
     std::fs::write(fixture.join("untracked.txt"), "generated\n").expect("fixture state");
 }
 
-fn run_git(cwd: &std::path::Path, args: &[&str]) {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .expect("run git");
-    assert!(
-        output.status.success(),
-        "git {:?} failed: {}",
-        args,
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
+use homeboy_core::test_support::run_git_command as run_git;
 
 /// Rooted in an explicit store rather than a mutated process environment
 /// (#7505). The reservation is made through the sibling that was handed

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1682,14 +1682,7 @@ mod declared_base_tests {
         std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
     }
 
-    fn git(path: &Path, args: &[&str]) {
-        assert!(Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .status()
-            .expect("git runs")
-            .success());
-    }
+    use homeboy_core::test_support::run_git_command as git;
 
     fn git_output(path: &Path, args: &[&str]) -> String {
         let output = Command::new("git")

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -9,19 +9,7 @@ use std::sync::{Arc, Mutex};
 
 static DEFAULT_TIMEOUT_ENV_LOCK: Mutex<()> = Mutex::new(());
 
-fn git(cwd: &std::path::Path, args: &[&str]) {
-    let output = std::process::Command::new("git")
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .expect("run git");
-    assert!(
-        output.status.success(),
-        "git {:?} failed: {}",
-        args,
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
+use homeboy_core::test_support::run_git_command as git;
 
 fn linked_cook_source(temp: &tempfile::TempDir) -> std::path::PathBuf {
     let repository = temp.path().join("repository");

--- a/crates/homeboy-agents/src/agent_task_runtime_dependency_graph.rs
+++ b/crates/homeboy-agents/src/agent_task_runtime_dependency_graph.rs
@@ -391,19 +391,7 @@ mod tests {
         }
     }
 
-    fn run_git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    use homeboy_core::test_support::run_git_command as run_git;
 
     fn init_repo(path: &Path) {
         run_git(path, &["init", "-b", "main"]);

--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -1285,12 +1285,5 @@ mod tests {
         );
     }
 
-    fn git(cwd: &Path, args: &[&str]) {
-        let status = Command::new("git")
-            .args(args)
-            .current_dir(cwd)
-            .status()
-            .expect("run git");
-        assert!(status.success(), "git {:?} failed with {status}", args);
-    }
+    use homeboy_core::test_support::run_git_command as git;
 }

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -3681,14 +3681,7 @@ mod tests {
         scratch
     }
 
-    fn run_git(cwd: &Path, args: &[&str]) {
-        let status = Command::new("git")
-            .args(args)
-            .current_dir(cwd)
-            .status()
-            .expect("run git");
-        assert!(status.success(), "git {args:?}");
-    }
+    use homeboy_core::test_support::run_git_command as run_git;
 
     /// Build a source repository with one pushed commit on `main` plus a
     /// linked attempt worktree detached at that commit, exactly the shape


### PR DESCRIPTION
## Summary
Eight test modules in `homeboy-agents` each defined an identical `git` / `run_git` helper wrapping `Command::new("git")` with a success assertion. Each becomes an aliased import of the identity-neutral shared helper, leaving call sites unchanged:

```rust
use homeboy_core::test_support::run_git_command as git;
```

Net **-84 lines**. Fifth and final crate slice of #13227.

Files: `controller_scratch`, `agent_task_runtime_dependency_graph`, `agent_task_finalization/backend`, `agent_task_provider/tests/scheduler_tests`, `agent_task_promotion/promote`, `agent_task_scheduler/attempt_workspace`, `agent_task_lifecycle/tests/terminal_and_reconcile`, `agent_task_dispatch_plan/mod`, plus one unused import.

This uses `run_git_command` from the start, so unlike the first three crates there is no authorship change to correct later.

## Verification
This crate contains the known bimodal `scheduler_tests` cluster, so a single run proves nothing. Matched filter, both sides, repeated:

| run | branch | baseline `main` |
|---|---|---|
| 1 | 252 passed / 1 failed | 252 passed / 1 failed |
| 2 | 252 passed / 1 failed | 252 passed / 2 failed |
| 3 | 252 passed / 1 failed | — |

Identical pass counts. The *identity* of the failing test rotates between runs on both sides — baseline alternated between `terminal_and_reconcile::aggregate_source_loads_completed_run_without_path_spelunking` and `scheduler_tests::structured_runtime_progress_keeps_provider_alive_until_completion`.

One run flagged `dispatch_plan::no_configured_rotation_still_resolves_to_a_single_execution` as branch-only, in a file this PR touches. It passes **3/3 in isolation** and did not recur across the two later filtered runs, so it belongs to the same rotating set rather than to this change.

`cargo check -p homeboy-agents --tests` clean.

## #13227 status after this
Five crates consolidated — release, deploy, lab-runner, core, agents — all on one identity-neutral helper. Remaining: the 11 stdout-returning variants that map to `git_fixture_output`, and a handful of non-canonical shapes deliberately skipped in each crate.

## AI Assistance
OpenAI GPT-5.6 Sol through OpenCode applied the consolidation on the settled contract and distinguished a rotating flaky failure from a regression by repeating matched-filter runs on both sides. Chris Huber directed the work and remains responsible for acceptance.