### PR TITLE
Canonicalize durable agent-task review

### DIFF
--- a/crates/contracts/homeboy-control-plane-contract/src/capabilities.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/capabilities.rs
@@ -22,6 +22,7 @@ pub struct ControlPlaneCapabilities {
 pub enum ControlPlaneOperation {
     GetCapabilities,
     GetRun,
+    GetRunReview,
     GetRunEvents,
     ExecuteRunAction,
 }
@@ -32,6 +33,7 @@ pub enum ControlPlaneOperation {
 pub enum ControlPlaneResource {
     Mission,
     Run,
+    Review,
     Task,
     Attempt,
     Execution,
@@ -82,6 +84,7 @@ mod tests {
                 operation,
                 ControlPlaneOperation::GetCapabilities
                     | ControlPlaneOperation::GetRun
+                    | ControlPlaneOperation::GetRunReview
                     | ControlPlaneOperation::GetRunEvents
                     | ControlPlaneOperation::ExecuteRunAction
             )),

--- a/crates/contracts/homeboy-control-plane-contract/src/lib.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/lib.rs
@@ -14,6 +14,7 @@ pub mod event;
 pub mod identity;
 pub mod resolve;
 pub mod resource;
+pub mod review;
 
 pub use action::{
     ControlPlaneActionAcknowledgement, ControlPlaneActionOutcome, ControlPlaneActionPayload,
@@ -46,4 +47,7 @@ pub use resource::{
     ControlPlaneLocation, ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneResult,
     ControlPlaneRun, ControlPlaneRunState, ControlPlaneRuntime, ControlPlaneStateSummary,
     CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA, CONTROL_PLANE_RESULT_SCHEMA, CONTROL_PLANE_RUN_SCHEMA,
+};
+pub use review::{
+    ControlPlaneRunReview, ControlPlaneRunReviewRequest, CONTROL_PLANE_RUN_REVIEW_SCHEMA,
 };

--- a/crates/contracts/homeboy-control-plane-contract/src/resource.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/resource.rs
@@ -244,14 +244,13 @@ pub enum ControlPlaneAction {
     Cancel,
     Resume,
     Retry,
-    Review,
     Promote,
     Reconcile,
 }
 
 impl ControlPlaneAction {
     pub const fn is_mutating(self) -> bool {
-        !matches!(self, Self::Review)
+        true
     }
 }
 
@@ -414,14 +413,14 @@ mod tests {
             schema: CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA.to_string(),
             run: run.clone(),
             actions: vec![ControlPlaneActionEligibility {
-                action: ControlPlaneAction::Review,
+                action: ControlPlaneAction::Cancel,
                 availability: ControlPlaneActionAvailability::Available,
-                reason: "review is a non-mutating read available for every durable run".to_string(),
+                reason: "cancellation is available".to_string(),
                 confirmation: ControlPlaneActionConfirmation::None,
                 required_inputs: Vec::new(),
                 idempotent: true,
                 requires_revalidation: true,
-                result_resource_type: "review".to_string(),
+                result_resource_type: "run".to_string(),
             }],
         });
         resource.created_at = "2026-01-01T00:00:00Z".to_string();

--- a/crates/contracts/homeboy-control-plane-contract/src/review.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/review.rs
@@ -1,0 +1,55 @@
+//! Versioned, non-mutating durable-run review resource.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{ControlPlaneRun, RunId};
+
+pub const CONTROL_PLANE_RUN_REVIEW_SCHEMA: &str = "homeboy/control-plane-run-review/v1";
+
+/// Optional read context used to describe a promotion handoff without changing
+/// the durable run or materializing a candidate.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControlPlaneRunReviewRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_worktree: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provider_argv: Vec<String>,
+}
+
+/// Canonical durable review. `evidence` retains the complete bounded durable
+/// read so transports can render summaries without inventing a parallel schema.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControlPlaneRunReview {
+    pub schema: String,
+    pub run: RunId,
+    pub resource: ControlPlaneRun,
+    pub evidence: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_resource_is_versioned_and_round_trips() {
+        let run = RunId::new("run-1").expect("run");
+        let review = ControlPlaneRunReview {
+            schema: CONTROL_PLANE_RUN_REVIEW_SCHEMA.to_string(),
+            run: run.clone(),
+            resource: ControlPlaneRun::new(run),
+            evidence: serde_json::json!({"aggregate": null}),
+        };
+        assert_eq!(
+            serde_json::from_value::<ControlPlaneRunReview>(
+                serde_json::to_value(&review).expect("serialize"),
+            )
+            .expect("deserialize"),
+            review
+        );
+    }
+}

--- a/crates/contracts/homeboy-control-plane-contract/src/review.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/review.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{ControlPlaneRun, RunId};
+use crate::{ControlPlaneError, ControlPlaneRun, RunId};
 
 pub const CONTROL_PLANE_RUN_REVIEW_SCHEMA: &str = "homeboy/control-plane-run-review/v1";
 
@@ -18,6 +18,17 @@ pub struct ControlPlaneRunReviewRequest {
     pub provider_command: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub provider_argv: Vec<String>,
+}
+
+impl ControlPlaneRunReviewRequest {
+    pub fn validate(&self) -> Result<(), ControlPlaneError> {
+        if self.provider_command.is_some() && !self.provider_argv.is_empty() {
+            return Err(ControlPlaneError::invalid_argument(
+                "provider_command and provider_argv are mutually exclusive",
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Canonical durable review. `evidence` retains the complete bounded durable
@@ -51,5 +62,16 @@ mod tests {
             .expect("deserialize"),
             review
         );
+    }
+
+    #[test]
+    fn review_request_rejects_conflicting_provider_inputs() {
+        let request = ControlPlaneRunReviewRequest {
+            to_worktree: None,
+            provider_command: Some("provider".to_string()),
+            provider_argv: vec!["provider".to_string()],
+        };
+
+        assert!(request.validate().is_err());
     }
 }

--- a/crates/homeboy-agents/src/agent_task_action_result.rs
+++ b/crates/homeboy-agents/src/agent_task_action_result.rs
@@ -165,7 +165,6 @@ fn action_name(action: ControlPlaneAction) -> &'static str {
         ControlPlaneAction::Cancel => "cancel",
         ControlPlaneAction::Promote => "promote",
         ControlPlaneAction::Reconcile => "reconcile",
-        ControlPlaneAction::Review => "review",
         ControlPlaneAction::Resume => "resume",
         ControlPlaneAction::Retry => "retry",
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/action_eligibility.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/action_eligibility.rs
@@ -66,14 +66,6 @@ pub fn lifecycle_action_eligibility(
                 "agent_task_run",
             ),
             action(
-                ControlPlaneAction::Review,
-                available("review is a non-mutating read available for every durable run"),
-                ControlPlaneActionConfirmation::None,
-                Vec::new(),
-                true,
-                "agent_task_review",
-            ),
-            action(
                 ControlPlaneAction::Promote,
                 promotion,
                 ControlPlaneActionConfirmation::Required,
@@ -232,11 +224,7 @@ mod tests {
         ] {
             let report = lifecycle_action_eligibility(&record(state, false), None);
             assert_eq!(report.schema, CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA);
-            assert_eq!(report.actions.len(), 6);
-            assert_eq!(
-                decision(&report, ControlPlaneAction::Review),
-                ControlPlaneActionAvailability::Available
-            );
+            assert_eq!(report.actions.len(), 5);
             if state.is_terminal() {
                 assert_eq!(
                     decision(&report, ControlPlaneAction::Cancel),

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -329,6 +329,39 @@ fn append_resume_gates(command: &mut Vec<String>, gates: &Value) {
     if gates.get("rerun_completed_gates").and_then(Value::as_bool) == Some(true) {
         command.push("--rerun-completed-gates".to_string());
     }
+    if let Some(environment) = gates.get("gate_environment") {
+        if let Some(mode) = environment.get("mode").and_then(Value::as_str) {
+            command.extend([
+                "--gate-environment-mode".to_string(),
+                mode.replace('_', "-"),
+            ]);
+        }
+        if let Some(variables) = environment.get("variables").and_then(Value::as_object) {
+            for (name, value) in variables {
+                if let Some(value) = value.as_str() {
+                    command.extend(["--gate-env".to_string(), format!("{name}={value}")]);
+                }
+            }
+        }
+        for (key, flag) in [
+            ("isolate_home", "--isolate-gate-home"),
+            ("isolate_xdg", "--isolate-gate-xdg"),
+        ] {
+            if let Some(value) = environment.get(key).and_then(Value::as_bool) {
+                command.push(format!("{flag}={value}"));
+            }
+        }
+        if let Some(inputs) = environment
+            .get("extension_inputs")
+            .and_then(Value::as_array)
+        {
+            for input in inputs {
+                if let Ok(input) = serde_json::to_string(input) {
+                    command.extend(["--gate-extension-input".to_string(), input]);
+                }
+            }
+        }
+    }
 }
 
 fn review_retry_context(run_id: &str) -> Value {
@@ -874,8 +907,8 @@ fn review_failure_reasons(aggregate: &crate::agent_tasks::AgentTaskAggregate) ->
         for diagnostic in &outcome.diagnostics {
             diagnostics.push(serde_json::json!({
                 "task_id": outcome.task_id,
-                "class": diagnostic.class,
-                "message": diagnostic.message,
+                "class": redacted_bounded(&diagnostic.class, STATE_BOUND),
+                "message": redacted_bounded(&diagnostic.message, MESSAGE_BOUND),
                 "source": "diagnostics",
             }));
         }
@@ -927,8 +960,8 @@ fn collect_nested_diagnostics(value: &Value, task_id: &str, diagnostics: &mut Ve
                     ) {
                         diagnostics.push(serde_json::json!({
                             "task_id": task_id,
-                            "class": class,
-                            "message": message,
+                            "class": redacted_bounded(class, STATE_BOUND),
+                            "message": redacted_bounded(message, MESSAGE_BOUND),
                             "source": "nested_diagnostics",
                         }));
                     }
@@ -2260,8 +2293,9 @@ pub fn register() {
 #[cfg(test)]
 mod tests {
     use super::{
-        event_page, live_provider_liveness, observed_file_timestamp, phase, project_record,
-        LifecycleStoreLookup, OrchestrationService, RunLookup, RunSnapshot,
+        append_resume_gates, event_page, live_provider_liveness, observed_file_timestamp, phase,
+        project_record, review_failure_reasons, LifecycleStoreLookup, OrchestrationService,
+        RunLookup, RunSnapshot,
     };
     use crate::agent_task_lifecycle::{
         AgentTaskLifecycleStore, AgentTaskRunRecord, AgentTaskRunState,
@@ -2586,6 +2620,78 @@ mod tests {
                 "durable_read.authoritative_aggregate_absent"
             );
         });
+    }
+
+    #[test]
+    fn review_resume_gate_contract_preserves_environment_policy() {
+        let mut command = Vec::new();
+        append_resume_gates(
+            &mut command,
+            &json!({
+                "gate_environment": {
+                    "mode": "replace",
+                    "variables": { "MODE": "test" },
+                    "isolate_home": true,
+                    "isolate_xdg": false,
+                    "extension_inputs": [{ "id": "wordpress", "source": "/opt/wordpress" }]
+                }
+            }),
+        );
+
+        assert_eq!(
+            command,
+            vec![
+                "--gate-environment-mode",
+                "replace",
+                "--gate-env",
+                "MODE=test",
+                "--isolate-gate-home=true",
+                "--isolate-gate-xdg=false",
+                "--gate-extension-input",
+                "{\"id\":\"wordpress\",\"source\":\"/opt/wordpress\"}",
+            ]
+        );
+    }
+
+    #[test]
+    fn review_failure_diagnostics_are_redacted_bounded_and_failure_only() {
+        let mut aggregate: crate::agent_tasks::AgentTaskAggregate = serde_json::from_value(json!({
+            "schema": "homeboy/agent-task-aggregate/v1",
+            "plan_id": "plan",
+            "status": "failed",
+            "totals": { "skipped": 0 }
+        }))
+        .expect("aggregate");
+        aggregate.outcomes = vec![
+            crate::agent_tasks::AgentTaskOutcome {
+                task_id: "failed".to_string(),
+                status: crate::agent_tasks::AgentTaskOutcomeStatus::Failed,
+                outputs: json!({ "diagnostics": [{
+                    "class": "provider.error",
+                    "message": format!("token=secret {}", "x".repeat(1_000))
+                }] }),
+                ..Default::default()
+            },
+            crate::agent_tasks::AgentTaskOutcome {
+                task_id: "success".to_string(),
+                status: crate::agent_tasks::AgentTaskOutcomeStatus::Succeeded,
+                diagnostics: vec![serde_json::from_value(json!({
+                    "class": "provider.success",
+                    "message": "successful wrapper diagnostic"
+                }))
+                .expect("diagnostic")],
+                ..Default::default()
+            },
+        ];
+
+        let reasons = review_failure_reasons(&aggregate);
+
+        assert_eq!(reasons.len(), 1);
+        assert!(
+            reasons[0]["message"].as_str().is_some_and(|message| message
+                .starts_with("token=[REDACTED]")
+                && message.len() <= 259)
+        );
     }
 
     #[test]

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -13,8 +13,9 @@ use homeboy_control_plane_contract::{
     ControlPlaneCancelDisposition, ControlPlaneCancelParameters, ControlPlaneCancelResult,
     ControlPlaneCapabilities, ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEvidenceRef,
     ControlPlaneLiveness, ControlPlaneLocation, ControlPlaneOperation, ControlPlaneOwner,
-    ControlPlaneProviderSummary, ControlPlaneResource, ControlPlaneRun, ControlPlaneRunState,
-    ControlPlaneRuntime, ControlPlaneStateSummary, ExecutionId, ProviderSessionId, RunId,
+    ControlPlaneProviderSummary, ControlPlaneResource, ControlPlaneRun, ControlPlaneRunReview,
+    ControlPlaneRunReviewRequest, ControlPlaneRunState, ControlPlaneRuntime,
+    ControlPlaneStateSummary, ExecutionId, ProviderSessionId, RunId,
     CONTROL_PLANE_ACTION_ACKNOWLEDGEMENT_SCHEMA, CONTROL_PLANE_ACTION_REQUEST_SCHEMA,
     CONTROL_PLANE_CANCEL_PARAMETERS_SCHEMA, CONTROL_PLANE_CANCEL_RESULT_SCHEMA,
     CONTROL_PLANE_EMPTY_ACTION_PAYLOAD_SCHEMA, CONTROL_PLANE_PROMOTE_PARAMETERS_SCHEMA,
@@ -152,14 +153,277 @@ impl<L: RunLookup> OrchestrationService<L> {
     }
 }
 
+fn review_promotion_candidates(
+    run_id: &str,
+    request: &ControlPlaneRunReviewRequest,
+    aggregate: &crate::agent_tasks::AgentTaskAggregate,
+    review: &crate::agent_tasks::AgentTaskAggregateReport,
+    record: &AgentTaskRunRecord,
+    cook_contract: Option<&(String, Value)>,
+    observation_store: &homeboy_core::observation::ObservationStore,
+) -> Vec<Value> {
+    review
+        .apply_candidates
+        .iter()
+        .chain(review.review_candidates.iter().filter(|candidate| {
+            aggregate
+                .outcomes
+                .iter()
+                .find(|outcome| outcome.task_id == candidate.task_id)
+                .is_some_and(|outcome| {
+                    outcome.status
+                        == crate::agent_tasks::AgentTaskOutcomeStatus::CandidateRecoverable
+                })
+        }))
+        .flat_map(|candidate| {
+            let artifact_ids = aggregate
+                .outcomes
+                .iter()
+                .find(|outcome| outcome.task_id == candidate.task_id)
+                .filter(|outcome| {
+                    outcome.status
+                        == crate::agent_tasks::AgentTaskOutcomeStatus::CandidateRecoverable
+                })
+                .and_then(|outcome| {
+                    crate::agent_task_promotion::canonical_recoverable_patch_artifacts_in_observation_store(
+                        outcome,
+                        &crate::agent_task_promotion::AgentTaskPromotionOptions {
+                            source: "{}".to_string(),
+                            source_run_id: Some(run_id.to_string()),
+                            source_path: None,
+                            source_worktree_path: None,
+                            base_ref: None,
+                            task_base_sha: None,
+                            candidate_ref: None,
+                            to_worktree: "<managed-worktree>".to_string(),
+                            task_id: Some(candidate.task_id.clone()),
+                            artifact_id: None,
+                            dry_run: true,
+                            gates: Default::default(),
+                            provider_command: None,
+                            provider_invocation: None,
+                        },
+                        observation_store,
+                    )
+                    .ok()
+                    .map(|canonical| {
+                        canonical
+                            .artifacts
+                            .into_iter()
+                            .map(|artifact| artifact.id)
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .unwrap_or_else(|| candidate.artifact_ids.clone());
+            let selection_required = artifact_ids.len() > 1;
+            artifact_ids.into_iter().map(move |artifact_id| {
+                let mut command = vec![
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    "promote".to_string(),
+                    run_id.to_string(),
+                    "--task-id".to_string(),
+                    candidate.task_id.clone(),
+                    "--artifact-id".to_string(),
+                    artifact_id.clone(),
+                ];
+                let continuation = record.metadata.get("latest_promotion").filter(|promotion| {
+                    crate::agent_task_service::promotion_is_resumable(promotion, false)
+                        && promotion.pointer("/source/task_id").and_then(Value::as_str)
+                            == Some(candidate.task_id.as_str())
+                        && promotion
+                            .pointer("/patch_artifact/id")
+                            .and_then(Value::as_str)
+                            == Some(artifact_id.as_str())
+                });
+                let destination = continuation
+                    .and_then(|promotion| promotion.pointer("/target/worktree"))
+                    .and_then(Value::as_str)
+                    .or(request.to_worktree.as_deref());
+                let command = destination.map(|destination| {
+                    command.extend(["--to-worktree".to_string(), destination.to_string()]);
+                    if let Some(contract) = continuation
+                        .and_then(|promotion| promotion.pointer("/provenance/resume_contract"))
+                    {
+                        append_resume_base(&mut command, contract);
+                        if cook_contract.is_none() {
+                            append_resume_gates(
+                                &mut command,
+                                contract.get("gates").unwrap_or(&Value::Null),
+                            );
+                        }
+                    } else if let Some((base, _)) = cook_contract {
+                        command.extend(["--base".to_string(), base.clone()]);
+                    }
+                    if cook_contract.is_some() {
+                        command.push("--gates-from-cook-recipe".to_string());
+                    }
+                    if let Some(provider_command) = &request.provider_command {
+                        command
+                            .extend(["--provider-command".to_string(), provider_command.clone()]);
+                    }
+                    command.extend(
+                        request
+                            .provider_argv
+                            .iter()
+                            .map(|argument| format!("--provider-argv={argument}")),
+                    );
+                    command
+                });
+                serde_json::json!({
+                    "task_id": candidate.task_id,
+                    "artifact_id": artifact_id,
+                    "reason": candidate.reason,
+                    "command": command,
+                    "ready": destination.is_some(),
+                    "destination_required": destination.is_none(),
+                    "selection_required": selection_required,
+                })
+            })
+        })
+        .collect()
+}
+
+fn append_resume_base(command: &mut Vec<String>, contract: &Value) {
+    if let Some(base) = contract.pointer("/inputs/base_ref").and_then(Value::as_str) {
+        command.extend(["--base".to_string(), base.to_string()]);
+    }
+}
+
+fn append_resume_gates(command: &mut Vec<String>, gates: &Value) {
+    for (key, flag) in [
+        ("verify", "--verify"),
+        ("private_verify", "--private-verify"),
+    ] {
+        for value in gates
+            .get(key)
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+        {
+            command.extend([flag.to_string(), value.to_string()]);
+        }
+    }
+    for (key, flag) in [
+        ("private_gate_reveal", "--private-gate-reveal"),
+        ("gate_timeout_seconds", "--gate-timeout-seconds"),
+        (
+            "gate_heartbeat_interval_seconds",
+            "--gate-heartbeat-interval-seconds",
+        ),
+        (
+            "gate_no_progress_timeout_seconds",
+            "--gate-no-progress-timeout-seconds",
+        ),
+    ] {
+        if let Some(value) = gates.get(key).and_then(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .or_else(|| value.as_u64().map(|value| value.to_string()))
+        }) {
+            command.extend([flag.to_string(), value.replace('_', "-")]);
+        }
+    }
+    if gates.get("rerun_completed_gates").and_then(Value::as_bool) == Some(true) {
+        command.push("--rerun-completed-gates".to_string());
+    }
+}
+
+fn review_retry_context(run_id: &str) -> Value {
+    serde_json::json!({
+        "run_id": run_id,
+        "retry_action": ControlPlaneAction::Retry,
+        "resume_action": ControlPlaneAction::Resume,
+    })
+}
+
 impl OrchestrationService<LifecycleStoreLookup> {
     /// Operations wired by the durable lifecycle-backed provider.
     pub fn capabilities() -> ControlPlaneCapabilities {
         let mut capabilities = Self::read_capabilities();
+        capabilities.resources.push(ControlPlaneResource::Review);
+        capabilities
+            .operations
+            .push(ControlPlaneOperation::GetRunReview);
         capabilities
             .operations
             .push(ControlPlaneOperation::ExecuteRunAction);
         capabilities
+    }
+
+    /// Read review evidence exclusively from this service's injected store.
+    pub fn review(
+        &self,
+        requested_id: &RunId,
+        request: &ControlPlaneRunReviewRequest,
+    ) -> Result<ControlPlaneRunReview, ControlPlaneError> {
+        let snapshot = self.lookup.get(requested_id)?.ok_or_else(|| {
+            ControlPlaneError::not_found(format!("agent-task run not found: {requested_id}"))
+        })?;
+        let durable_read = crate::agent_task_lifecycle::durable_local_read_in_store(
+            &self.lookup.store,
+            requested_id.as_str(),
+        )
+        .map_err(map_lifecycle_error)?;
+        let resource = project_record(&durable_read.record, snapshot.plan.as_ref())?;
+        let aggregate = durable_read.aggregate;
+        let aggregate_review = aggregate.as_ref().map(|aggregate| {
+            crate::agent_tasks::AgentTaskAggregateReport::from(aggregate.outcomes.clone())
+        });
+        let cook_contract = review_cook_contract(&self.lookup.store, requested_id.as_str())?;
+        let observation_store =
+            homeboy_core::observation::ObservationStore::open_initialized_for_lifecycle_in_roots(
+                self.lookup.store.roots(),
+            )
+            .map_err(map_lifecycle_error)?;
+        let promotion_candidates = aggregate
+            .as_ref()
+            .zip(aggregate_review.as_ref())
+            .map(|(aggregate, review)| {
+                review_promotion_candidates(
+                    requested_id.as_str(),
+                    request,
+                    aggregate,
+                    review,
+                    &durable_read.record,
+                    cook_contract.as_ref(),
+                    &observation_store,
+                )
+            })
+            .unwrap_or_default();
+        let failure_reasons = aggregate
+            .as_ref()
+            .map(review_failure_reasons)
+            .filter(|reasons| !reasons.is_empty());
+        let canonical_candidate =
+            review_canonical_candidate(&durable_read.record, aggregate_review.as_ref(), &resource);
+        let (record, cleanup_evidence) = review_record_projection(&durable_read.record);
+        let evidence = serde_json::json!({
+            "record": record,
+            "logs": crate::agent_task_lifecycle::logs_in_store(&self.lookup.store, requested_id.as_str()).map_err(map_lifecycle_error)?,
+            "artifacts": crate::agent_task_lifecycle::artifacts_in_store(&self.lookup.store, requested_id.as_str()).map_err(map_lifecycle_error)?,
+            "aggregate": aggregate,
+            "aggregate_review": aggregate_review,
+            "promotion_candidates": promotion_candidates,
+            "diagnostic_summary": failure_reasons.as_ref().and_then(|reasons| reasons.first()).cloned(),
+            "failure_reasons": failure_reasons,
+            "execution_states": review_execution_states(aggregate.as_ref(), &durable_read.record, &resource),
+            "canonical_candidate": canonical_candidate,
+            "next_actions": review_next_actions(&durable_read.record, aggregate_review.as_ref(), request.to_worktree.is_some()),
+            "cleanup_evidence": cleanup_evidence,
+            "transport": { "authoritative": "homeboy-agent-task-lifecycle", "chat_state_required": false },
+            "action_eligibility": resource.action_eligibility,
+            "retry_context": review_retry_context(requested_id.as_str()),
+            "read": { "phase": "controller_local", "mutated": false, "unavailable_sources": durable_read.unavailable_sources },
+        });
+        Ok(ControlPlaneRunReview {
+            schema: homeboy_control_plane_contract::CONTROL_PLANE_RUN_REVIEW_SCHEMA.to_string(),
+            run: requested_id.clone(),
+            resource,
+            evidence,
+        })
     }
 
     /// Execute the canonical run mutation against the same durable lifecycle
@@ -538,12 +802,6 @@ impl OrchestrationService<LifecycleStoreLookup> {
                                 ),
                             }
                         }
-                        _ => {
-                            return Err(ControlPlaneError::invalid_argument(format!(
-                                "{} is not wired through the canonical action executor",
-                                action_name(request.action)
-                            )))
-                        }
                     }
                 };
                 let result = ControlPlaneActionAcknowledgement {
@@ -574,6 +832,405 @@ impl OrchestrationService<LifecycleStoreLookup> {
             }
         }
     }
+}
+
+fn review_cook_contract(
+    store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Option<(String, Value)>, ControlPlaneError> {
+    let recipe_store = crate::agent_task_service::CookRecipeStore::new(store.roots().clone());
+    let Some(recipe) = recipe_store
+        .load_recipe_for_attempt(run_id)
+        .map_err(map_lifecycle_error)?
+    else {
+        return Ok(None);
+    };
+    let base = recipe
+        .finalization
+        .get("base")
+        .and_then(Value::as_str)
+        .filter(|base| !base.trim().is_empty())
+        .ok_or_else(|| {
+            ControlPlaneError::invalid_argument(
+                "durable Cook recipe is missing its declared promotion base",
+            )
+        })?
+        .to_string();
+    Ok(Some((base, recipe.gate_policy)))
+}
+
+fn review_failure_reasons(aggregate: &crate::agent_tasks::AgentTaskAggregate) -> Vec<Value> {
+    let mut diagnostics = Vec::new();
+    for outcome in aggregate.outcomes.iter().filter(|outcome| {
+        matches!(
+            outcome.status,
+            crate::agent_tasks::AgentTaskOutcomeStatus::Failed
+                | crate::agent_tasks::AgentTaskOutcomeStatus::ProviderError
+                | crate::agent_tasks::AgentTaskOutcomeStatus::Timeout
+                | crate::agent_tasks::AgentTaskOutcomeStatus::UnableToRemediate
+                | crate::agent_tasks::AgentTaskOutcomeStatus::Cancelled
+        )
+    }) {
+        for diagnostic in &outcome.diagnostics {
+            diagnostics.push(serde_json::json!({
+                "task_id": outcome.task_id,
+                "class": diagnostic.class,
+                "message": diagnostic.message,
+                "source": "diagnostics",
+            }));
+        }
+        collect_nested_diagnostics(&outcome.outputs, &outcome.task_id, &mut diagnostics);
+        collect_nested_diagnostics(&outcome.metadata, &outcome.task_id, &mut diagnostics);
+    }
+    diagnostics.sort_by_key(|diagnostic| {
+        let class = diagnostic["class"].as_str().unwrap_or_default();
+        let priority = if class.contains("validation") || class.contains("fatal") {
+            0
+        } else if class.contains("registration") || class.contains("missing") {
+            1
+        } else {
+            2
+        };
+        (
+            priority,
+            class.to_string(),
+            diagnostic["message"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+        )
+    });
+    let mut seen = std::collections::BTreeSet::new();
+    diagnostics
+        .into_iter()
+        .filter(|diagnostic| {
+            seen.insert((
+                diagnostic["class"].as_str().unwrap_or_default().to_string(),
+                diagnostic["message"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+            ))
+        })
+        .take(8)
+        .collect()
+}
+
+fn collect_nested_diagnostics(value: &Value, task_id: &str, diagnostics: &mut Vec<Value>) {
+    match value {
+        Value::Object(object) => {
+            if let Some(items) = object.get("diagnostics").and_then(Value::as_array) {
+                for item in items {
+                    if let (Some(class), Some(message)) = (
+                        item.get("class").and_then(Value::as_str),
+                        item.get("message").and_then(Value::as_str),
+                    ) {
+                        diagnostics.push(serde_json::json!({
+                            "task_id": task_id,
+                            "class": class,
+                            "message": message,
+                            "source": "nested_diagnostics",
+                        }));
+                    }
+                }
+            }
+            for nested in object.values() {
+                collect_nested_diagnostics(nested, task_id, diagnostics);
+            }
+        }
+        Value::Array(values) => {
+            for nested in values {
+                collect_nested_diagnostics(nested, task_id, diagnostics);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn review_execution_states(
+    aggregate: Option<&crate::agent_tasks::AgentTaskAggregate>,
+    record: &AgentTaskRunRecord,
+    resource: &ControlPlaneRun,
+) -> Value {
+    let review = aggregate.map(|aggregate| {
+        crate::agent_tasks::AgentTaskAggregateReport::from(aggregate.outcomes.clone())
+    });
+    let canonical_candidate = review_canonical_candidate(record, review.as_ref(), resource);
+    let candidate_state = canonical_candidate["state"]
+        .as_str()
+        .unwrap_or("not_available");
+    let candidate_tasks = review
+        .as_ref()
+        .map(|review| {
+            review
+                .tasks
+                .iter()
+                .map(|task| {
+                    let reason_code = if task.status
+                        == crate::agent_tasks::AgentTaskOutcomeStatus::NoOp
+                    {
+                        "no_changes_produced"
+                    } else {
+                        match task.decision {
+                            crate::agent_tasks::AgentTaskReconciliationDecision::NoOp => {
+                                "no_changes_produced"
+                            }
+                            crate::agent_tasks::AgentTaskReconciliationDecision::ApplyCandidate => {
+                                candidate_state
+                            }
+                            crate::agent_tasks::AgentTaskReconciliationDecision::RetryCandidate => {
+                                "provider_retry_required"
+                            }
+                            crate::agent_tasks::AgentTaskReconciliationDecision::IssueReportCandidate => {
+                                "issue_report_required"
+                            }
+                            crate::agent_tasks::AgentTaskReconciliationDecision::ReviewCandidate => {
+                                "review_required"
+                            }
+                        }
+                    };
+                    serde_json::json!({ "task_id": task.task_id, "state": task.decision, "reason_code": reason_code })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let promotion = record.metadata.get("latest_promotion");
+    let promotion_state = promotion
+        .and_then(|promotion| promotion.get("status"))
+        .and_then(Value::as_str)
+        .unwrap_or("not_attempted");
+    let target_applied = promotion.is_some_and(review_promotion_target_applied);
+    let accepted_inherited_failure = promotion
+        .and_then(|promotion| promotion.get("deterministic_gates"))
+        .and_then(Value::as_array)
+        .is_some_and(|gates| {
+            gates.iter().any(|gate| {
+                gate.get("status").and_then(Value::as_str) == Some("accepted_inherited_failure")
+            })
+        });
+    let finalization_state = record
+        .metadata
+        .pointer("/cook_finalization/status")
+        .and_then(Value::as_str)
+        .map(|status| match status {
+            "review_ready" | "draft_published" => "completed",
+            "failed" | "finalization_failed" => "finalization_failed",
+            "pending" | "finalization_pending" => "finalization_pending",
+            other => other,
+        })
+        .unwrap_or("not_attempted");
+    serde_json::json!({
+        "schema": "homeboy/agent-task-execution-states/v1",
+        "provider": aggregate.map(|aggregate| aggregate.outcomes.iter().map(|outcome| {
+            let failed = matches!(outcome.status, crate::agent_tasks::AgentTaskOutcomeStatus::Failed | crate::agent_tasks::AgentTaskOutcomeStatus::ProviderError | crate::agent_tasks::AgentTaskOutcomeStatus::Timeout | crate::agent_tasks::AgentTaskOutcomeStatus::UnableToRemediate | crate::agent_tasks::AgentTaskOutcomeStatus::Cancelled);
+            serde_json::json!({ "task_id": outcome.task_id, "state": if failed { "failed" } else { "succeeded" }, "outcome_status": outcome.status, "failure_classification": outcome.failure_classification })
+        }).collect::<Vec<_>>()).unwrap_or_default(),
+        "candidate": { "state": candidate_state, "tasks": candidate_tasks },
+        "gate": { "state": if accepted_inherited_failure { "accepted_inherited_failure" } else if !target_applied { "not_run" } else if matches!(promotion_state, "gate_failed" | "no_changes_gate_failed") { "failed" } else if promotion_state == "verification_pending" { "pending" } else if matches!(promotion_state, "applied" | "verified_no_changes") { "passed" } else { "not_run" } },
+        "promotion": { "state": promotion_state, "patch_promoted": target_applied, "verified": target_applied && promotion_state == "applied", "verification_phase": if promotion_state == "verification_pending" && target_applied { "post_apply" } else if promotion_state == "verification_pending" { "pre_apply" } else { "not_pending" }, "target": { "state": if target_applied { "applied" } else if promotion.is_some() { "not_applied" } else { "not_declared" }, "worktree": promotion.and_then(|promotion| promotion.pointer("/target/worktree").or_else(|| promotion.get("to_worktree"))), "candidate_fingerprint_matches": target_applied && promotion.is_some_and(|promotion| promotion.pointer("/provenance/candidate").is_some_and(|candidate| !candidate.is_null())) } },
+        "finalization": { "state": finalization_state, "finalized": finalization_state == "completed" },
+        "publication": resource.publication,
+    })
+}
+
+fn review_canonical_candidate(
+    record: &AgentTaskRunRecord,
+    review: Option<&crate::agent_tasks::AgentTaskAggregateReport>,
+    resource: &ControlPlaneRun,
+) -> Value {
+    let promotion = record.metadata.get("latest_promotion");
+    let promotion_status = promotion
+        .and_then(|promotion| promotion.get("status"))
+        .and_then(Value::as_str);
+    let target_applied = promotion.is_some_and(review_promotion_target_applied);
+    let finalized = record
+        .metadata
+        .get("cook_finalization")
+        .is_some_and(|finalization| {
+            matches!(
+                finalization.get("status").and_then(Value::as_str),
+                Some("review_ready" | "draft_published")
+            ) && finalization
+                .get("pr_url")
+                .or_else(|| finalization.get("pull_request_url"))
+                .and_then(Value::as_str)
+                .is_some_and(|url| !url.trim().is_empty())
+        });
+    let retained = promotion.is_some_and(|promotion| {
+        promotion_status.is_some_and(|status| {
+            matches!(status, "applied" | "gate_failed" | "verification_pending")
+        }) && promotion
+            .get("patch_artifact")
+            .or_else(|| promotion.get("patch"))
+            .and_then(|artifact| artifact.get("id").or_else(|| artifact.get("artifact_id")))
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.trim().is_empty())
+    });
+    let state = if finalized {
+        "finalized"
+    } else if retained {
+        "apply_ready"
+    } else if review.is_some_and(|review| review.summary.apply_candidates > 0) {
+        "patch_available"
+    } else if review.is_some_and(|review| {
+        !review.tasks.is_empty()
+            && review
+                .tasks
+                .iter()
+                .all(|task| task.status == crate::agent_tasks::AgentTaskOutcomeStatus::NoOp)
+    }) {
+        "no_changes_produced"
+    } else {
+        resource
+            .candidate
+            .as_ref()
+            .map(|candidate| candidate.state.as_str())
+            .unwrap_or("not_available")
+    };
+    serde_json::json!({
+        "schema": "homeboy/agent-task-candidate/v1",
+        "state": state,
+        "id": resource.candidate.as_ref().and_then(|candidate| candidate.id.as_deref()),
+        "target_applied": target_applied,
+        "verified": target_applied && promotion_status == Some("applied"),
+        "finalized": finalized,
+        "fingerprint": promotion.and_then(|promotion| promotion.pointer("/provenance/candidate")),
+    })
+}
+
+fn review_promotion_target_applied(promotion: &Value) -> bool {
+    matches!(
+        promotion.get("status").and_then(Value::as_str),
+        Some("verification_pending" | "applied" | "gate_failed")
+    ) && promotion
+        .pointer("/provenance/post_apply")
+        .and_then(Value::as_bool)
+        == Some(true)
+        && promotion
+            .pointer("/patch_artifact/id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.trim().is_empty())
+        && promotion
+            .pointer("/target/worktree")
+            .or_else(|| promotion.get("to_worktree"))
+            .and_then(Value::as_str)
+            .is_some_and(|target| !target.trim().is_empty())
+        && promotion
+            .pointer("/provenance/candidate")
+            .is_some_and(|candidate| !candidate.is_null())
+}
+
+fn review_next_actions(
+    record: &AgentTaskRunRecord,
+    review: Option<&crate::agent_tasks::AgentTaskAggregateReport>,
+    has_target: bool,
+) -> Vec<String> {
+    if record.state == AgentTaskRunState::Queued {
+        return vec!["run this queued durable task with `homeboy agent-task run <run-id>` or let a daemon claim it with `homeboy agent-task run-next`".to_string()];
+    }
+    if record.state == AgentTaskRunState::Running {
+        return vec!["inspect progress with `homeboy agent-task status <run-id>` and `homeboy agent-task logs <run-id>`".to_string()];
+    }
+    let Some(review) = review else {
+        return vec!["terminal run has no aggregate artifact; inspect lifecycle status for finalization errors".to_string()];
+    };
+    let mut actions = Vec::new();
+    if review.summary.apply_candidates > 0 {
+        actions.push(if has_target {
+            "review `promotion_candidates` and run the generated promotion command".to_string()
+        } else {
+            format!(
+                "rerun review with `homeboy agent-task review {} --to-worktree <managed-worktree>`",
+                record.run_id
+            )
+        });
+    }
+    if review.summary.retry_candidates > 0 {
+        actions.push(format!("retry provider-error or timeout candidates after fixing executor/preflight issues with `homeboy agent-task retry {} --run`", record.run_id));
+        actions.push(format!("rerun the persisted plan through Lab with `homeboy --runner <runner-id> agent-task run-plan --plan @{} --record-run-id <new-run-id>`", record.plan_path));
+    }
+    if review.summary.issue_report_candidates > 0 {
+        actions.push(
+            "open or update the tracker with `issue_report_candidates` diagnostics and evidence"
+                .to_string(),
+        );
+    }
+    if review.summary.review_candidates > 0 {
+        actions.push(
+            "inspect `review_candidates` before deciding whether to retry, report, or ignore"
+                .to_string(),
+        );
+    }
+    if actions.is_empty() {
+        actions.push("no promotion, retry, or issue-report candidates were produced; inspect task summaries for no-op completion".to_string());
+    }
+    actions
+}
+
+fn review_record_projection(record: &AgentTaskRunRecord) -> (Value, Vec<Value>) {
+    let mut value = serde_json::to_value(record).unwrap_or(Value::Null);
+    let Some(metadata) = value.get_mut("metadata").and_then(Value::as_object_mut) else {
+        return (value, Vec::new());
+    };
+    let evidence = [
+        "automatic_artifact_retention",
+        "automatic_artifact_retention_inaccessible_roots",
+    ]
+    .into_iter()
+    .filter_map(|key| {
+        let details = metadata.remove(key)?;
+        let count = details
+            .get("worktree_count")
+            .and_then(Value::as_u64)
+            .or_else(|| details.as_array().map(|items| items.len() as u64))
+            .or_else(|| details.get("worktrees").and_then(Value::as_array).map(|items| items.len() as u64))
+            .unwrap_or(0);
+        Some(serde_json::json!({
+            "kind": key,
+            "count": count,
+            "details_omitted": true,
+            "ref": format!("homeboy://agent-task/run/{}/status#metadata.{key}", record.run_id),
+            "command": format!("homeboy agent-task status {}", record.run_id),
+            "export_command": format!("homeboy agent-task status {} --output <path>", record.run_id),
+        }))
+    })
+    .collect();
+    (value, evidence)
+}
+
+fn promotion_handoff(report: &crate::agent_task_promotion::AgentTaskPromotionReport) -> Value {
+    let target_applied = report.status.patch_promoted();
+    let verified = matches!(
+        report.status,
+        crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
+    );
+    let next_action = if report.status.gate_failed() {
+        "patch promoted but deterministic gates failed; use gate feedback before finalizing"
+    } else if target_applied && verified {
+        "patch promoted and deterministic gates verified; finalize a PR"
+    } else if target_applied {
+        "patch promoted into the target worktree; verify, then finalize a PR"
+    } else {
+        "dry run only; rerun promote without `--dry-run` before finalizing"
+    };
+
+    serde_json::json!({
+        "schema": "homeboy/agent-task-promotion-handoff/v1",
+        "states": {
+            "patch_artifact_produced": true,
+            "candidate_retained": true,
+            "target_applied": target_applied,
+            "patch_promoted": target_applied,
+            "verified": verified,
+            "finalized": false,
+            "pr_opened": false,
+        },
+        "boundary": report.status.handoff_boundary(),
+        "finalize_command": report.source.run_id.as_ref().map(|run_id| format!(
+            "homeboy agent-task finalize-pr --recover {run_id}"
+        )),
+        "next_actions": [next_action],
+    })
 }
 
 impl OrchestrationService<LifecycleStoreLookup> {
@@ -728,12 +1385,6 @@ fn validate_action_request(request: &ControlPlaneActionRequest) -> Result<(), Co
         ControlPlaneAction::Reconcile => CONTROL_PLANE_EMPTY_ACTION_PAYLOAD_SCHEMA,
         ControlPlaneAction::Resume => CONTROL_PLANE_EMPTY_ACTION_PAYLOAD_SCHEMA,
         ControlPlaneAction::Retry => CONTROL_PLANE_RETRY_PARAMETERS_SCHEMA,
-        _ => {
-            return Err(ControlPlaneError::invalid_argument(format!(
-                "{} is not wired through the canonical action executor",
-                action_name(request.action)
-            )))
-        }
     };
     if request.parameters.schema != expected_parameters_schema {
         return Err(ControlPlaneError::invalid_argument(format!(
@@ -788,7 +1439,6 @@ const fn action_name(action: ControlPlaneAction) -> &'static str {
         ControlPlaneAction::Cancel => "cancel",
         ControlPlaneAction::Resume => "resume",
         ControlPlaneAction::Retry => "retry",
-        ControlPlaneAction::Review => "review",
         ControlPlaneAction::Promote => "promote",
         ControlPlaneAction::Reconcile => "reconcile",
     }
@@ -832,6 +1482,36 @@ pub fn run_from_current_environment(run_id: &str) -> homeboy_core::Result<Contro
     let store = AgentTaskLifecycleStore::from_current_environment()?;
     OrchestrationService::new(LifecycleStoreLookup::new(store))
         .run(&requested_id)
+        .map_err(|error| match error.class {
+            ControlPlaneErrorClass::NotFound | ControlPlaneErrorClass::InvalidArgument => {
+                homeboy_core::Error::validation_invalid_argument(
+                    "run_id",
+                    error.message,
+                    Some(run_id.to_string()),
+                    None,
+                )
+            }
+            ControlPlaneErrorClass::Unavailable => {
+                homeboy_core::Error::internal_unexpected(error.message)
+            }
+        })
+}
+
+pub fn review_from_current_environment(
+    run_id: &str,
+    request: &ControlPlaneRunReviewRequest,
+) -> homeboy_core::Result<ControlPlaneRunReview> {
+    let requested_id = RunId::new(run_id).map_err(|error| {
+        homeboy_core::Error::validation_invalid_argument(
+            "run_id",
+            error.to_string(),
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    let store = AgentTaskLifecycleStore::from_current_environment()?;
+    OrchestrationService::new(LifecycleStoreLookup::new(store))
+        .review(&requested_id, request)
         .map_err(|error| match error.class {
             ControlPlaneErrorClass::NotFound | ControlPlaneErrorClass::InvalidArgument => {
                 homeboy_core::Error::validation_invalid_argument(
@@ -1575,6 +2255,16 @@ impl ControlPlaneProvider for RegisteredProvider {
         OrchestrationService::new(LifecycleStoreLookup::new(store)).run(requested_id)
     }
 
+    fn review(
+        &self,
+        requested_id: &RunId,
+        request: &ControlPlaneRunReviewRequest,
+    ) -> Result<ControlPlaneRunReview, ControlPlaneError> {
+        let store = AgentTaskLifecycleStore::from_environment()
+            .map_err(|error| ControlPlaneError::unavailable(error.message))?;
+        OrchestrationService::new(LifecycleStoreLookup::new(store)).review(requested_id, request)
+    }
+
     fn events(
         &self,
         requested_id: &RunId,
@@ -1616,11 +2306,12 @@ mod tests {
         ControlPlaneAction, ControlPlaneActionAvailability, ControlPlaneActionOutcome,
         ControlPlaneActionPayload, ControlPlaneActionRequest, ControlPlaneCancelDisposition,
         ControlPlaneCancelResult, ControlPlaneErrorClass, ControlPlaneEvent,
-        ControlPlaneEventSource, ControlPlaneOperation, ControlPlaneRunState, EventCursor, EventId,
-        RunId, CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA, CONTROL_PLANE_ACTION_REQUEST_SCHEMA,
-        CONTROL_PLANE_CANCEL_PARAMETERS_SCHEMA, CONTROL_PLANE_EVENT_SCHEMA,
-        CONTROL_PLANE_PROMOTE_PARAMETERS_SCHEMA, CONTROL_PLANE_PROMOTE_RESULT_SCHEMA,
-        CONTROL_PLANE_RESUME_RESULT_SCHEMA, CONTROL_PLANE_RUN_SCHEMA,
+        ControlPlaneEventSource, ControlPlaneOperation, ControlPlaneRunReviewRequest,
+        ControlPlaneRunState, EventCursor, EventId, RunId, CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA,
+        CONTROL_PLANE_ACTION_REQUEST_SCHEMA, CONTROL_PLANE_CANCEL_PARAMETERS_SCHEMA,
+        CONTROL_PLANE_EVENT_SCHEMA, CONTROL_PLANE_PROMOTE_PARAMETERS_SCHEMA,
+        CONTROL_PLANE_PROMOTE_RESULT_SCHEMA, CONTROL_PLANE_RESUME_RESULT_SCHEMA,
+        CONTROL_PLANE_RUN_SCHEMA,
     };
     use homeboy_core::run_lifecycle_record::RunHeartbeat;
     use homeboy_core::test_support::with_isolated_home;
@@ -1899,10 +2590,73 @@ mod tests {
                 ControlPlaneOperation::GetCapabilities,
                 ControlPlaneOperation::GetRun,
                 ControlPlaneOperation::GetRunEvents,
+                ControlPlaneOperation::GetRunReview,
                 ControlPlaneOperation::ExecuteRunAction,
             ]
         );
         assert!(!capabilities.operations.is_empty());
+    }
+
+    #[test]
+    fn review_preserves_authoritative_aggregate_absence() {
+        with_isolated_home(|_| {
+            let store = AgentTaskLifecycleStore::from_current_environment().expect("store");
+            store.write_record(&record(AGENT_TASK_RUN)).expect("record");
+            let service = OrchestrationService::new(LifecycleStoreLookup::new(store));
+
+            let review = service
+                .review(
+                    &RunId::new(AGENT_TASK_RUN).expect("run"),
+                    &ControlPlaneRunReviewRequest::default(),
+                )
+                .expect("review");
+
+            assert!(review.evidence["aggregate"].is_null());
+            assert_eq!(
+                review.evidence["read"]["unavailable_sources"][0]["source"],
+                "aggregate"
+            );
+            assert_eq!(
+                review.evidence["read"]["unavailable_sources"][0]["reason_code"],
+                "durable_read.authoritative_aggregate_absent"
+            );
+        });
+    }
+
+    #[test]
+    fn review_redacts_automatic_retention_inventory() {
+        with_isolated_home(|_| {
+            let store = AgentTaskLifecycleStore::from_current_environment().expect("store");
+            let mut run = record(AGENT_TASK_RUN);
+            run.metadata["automatic_artifact_retention"] = json!({
+                "worktree_count": 2,
+                "worktrees": ["/private/unrelated-one", "/private/unrelated-two"],
+            });
+            run.metadata["automatic_artifact_retention_inaccessible_roots"] = json!({
+                "worktrees": ["/private/inaccessible"],
+            });
+            store.write_record(&run).expect("record");
+            let service = OrchestrationService::new(LifecycleStoreLookup::new(store));
+
+            let review = service
+                .review(
+                    &RunId::new(AGENT_TASK_RUN).expect("run"),
+                    &ControlPlaneRunReviewRequest::default(),
+                )
+                .expect("review");
+
+            assert!(review.evidence["record"]["metadata"]
+                .get("automatic_artifact_retention")
+                .is_none());
+            assert!(review.evidence["record"]["metadata"]
+                .get("automatic_artifact_retention_inaccessible_roots")
+                .is_none());
+            assert_eq!(review.evidence["cleanup_evidence"][0]["count"], 2);
+            assert_eq!(review.evidence["cleanup_evidence"][1]["count"], 1);
+            let serialized = serde_json::to_string(&review).expect("review JSON");
+            assert!(!serialized.contains("/private/unrelated-one"));
+            assert!(!serialized.contains("/private/inaccessible"));
+        });
     }
 
     #[test]
@@ -2348,10 +3102,6 @@ mod tests {
                 .expect("action eligibility")
                 .schema,
             CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA
-        );
-        assert_eq!(
-            eligibility(&resource, ControlPlaneAction::Review),
-            ControlPlaneActionAvailability::Available
         );
         assert_eq!(
             resource.execution.as_ref().map(|id| id.as_str()),

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -44,6 +44,8 @@ const URI_BOUND: usize = 512;
 const EVENT_PAGE_BOUND: usize = 100;
 const ACTION_INPUT_BOUND: usize = 128;
 const ACTION_REASON_BOUND: usize = 1_024;
+const REVIEW_EVIDENCE_BOUND: usize = 1024 * 1024;
+const REVIEW_EVIDENCE_FIELD_BOUND: usize = 256 * 1024;
 const ACTION_LEASE: std::time::Duration = std::time::Duration::from_secs(30);
 const CANCEL_TERMINAL_WAIT: Duration = Duration::from_secs(15);
 const CANCEL_TERMINAL_POLL_INTERVAL: Duration = Duration::from_secs(1);
@@ -240,17 +242,30 @@ fn review_promotion_candidates(
                     .and_then(|promotion| promotion.pointer("/target/worktree"))
                     .and_then(Value::as_str)
                     .or(request.to_worktree.as_deref());
-                let command = destination.map(|destination| {
+                let command = destination.and_then(|destination| {
                     command.extend(["--to-worktree".to_string(), destination.to_string()]);
+                    let resume_contract = continuation
+                        .and_then(|promotion| promotion.pointer("/provenance/resume_contract"))
+                        .filter(|_| cook_contract.is_none());
+                    let resume_gate_error = resume_contract.and_then(|contract| {
+                        contract
+                            .get("gates")
+                            .ok_or("resume contract has no gate policy")
+                            .and_then(|gates| {
+                                serde_json::from_value::<crate::agent_task_gate::VerifyGateOptions>(
+                                    gates.clone(),
+                                )
+                                .map(|_| ())
+                                .map_err(|_| "resume contract has an invalid gate policy")
+                            })
+                            .err()
+                    });
                     if let Some(contract) = continuation
                         .and_then(|promotion| promotion.pointer("/provenance/resume_contract"))
                     {
                         append_resume_base(&mut command, contract);
-                        if cook_contract.is_none() {
-                            append_resume_gates(
-                                &mut command,
-                                contract.get("gates").unwrap_or(&Value::Null),
-                            );
+                        if resume_contract.is_some() && resume_gate_error.is_none() {
+                            command.push("--gates-from-resume-contract".to_string());
                         }
                     } else if let Some((base, _)) = cook_contract {
                         command.extend(["--base".to_string(), base.clone()]);
@@ -268,16 +283,17 @@ fn review_promotion_candidates(
                             .iter()
                             .map(|argument| format!("--provider-argv={argument}")),
                     );
-                    command
+                    resume_gate_error.is_none().then_some(command)
                 });
                 serde_json::json!({
                     "task_id": candidate.task_id,
                     "artifact_id": artifact_id,
                     "reason": candidate.reason,
                     "command": command,
-                    "ready": destination.is_some(),
+                    "ready": command.is_some(),
                     "destination_required": destination.is_none(),
                     "selection_required": selection_required,
+                    "unavailable_reason": (destination.is_some() && command.is_none()).then_some("durable resume contract has an invalid gate policy"),
                 })
             })
         })
@@ -287,80 +303,6 @@ fn review_promotion_candidates(
 fn append_resume_base(command: &mut Vec<String>, contract: &Value) {
     if let Some(base) = contract.pointer("/inputs/base_ref").and_then(Value::as_str) {
         command.extend(["--base".to_string(), base.to_string()]);
-    }
-}
-
-fn append_resume_gates(command: &mut Vec<String>, gates: &Value) {
-    for (key, flag) in [
-        ("verify", "--verify"),
-        ("private_verify", "--private-verify"),
-    ] {
-        for value in gates
-            .get(key)
-            .and_then(Value::as_array)
-            .into_iter()
-            .flatten()
-            .filter_map(Value::as_str)
-        {
-            command.extend([flag.to_string(), value.to_string()]);
-        }
-    }
-    for (key, flag) in [
-        ("private_gate_reveal", "--private-gate-reveal"),
-        ("gate_timeout_seconds", "--gate-timeout-seconds"),
-        (
-            "gate_heartbeat_interval_seconds",
-            "--gate-heartbeat-interval-seconds",
-        ),
-        (
-            "gate_no_progress_timeout_seconds",
-            "--gate-no-progress-timeout-seconds",
-        ),
-    ] {
-        if let Some(value) = gates.get(key).and_then(|value| {
-            value
-                .as_str()
-                .map(str::to_string)
-                .or_else(|| value.as_u64().map(|value| value.to_string()))
-        }) {
-            command.extend([flag.to_string(), value.replace('_', "-")]);
-        }
-    }
-    if gates.get("rerun_completed_gates").and_then(Value::as_bool) == Some(true) {
-        command.push("--rerun-completed-gates".to_string());
-    }
-    if let Some(environment) = gates.get("gate_environment") {
-        if let Some(mode) = environment.get("mode").and_then(Value::as_str) {
-            command.extend([
-                "--gate-environment-mode".to_string(),
-                mode.replace('_', "-"),
-            ]);
-        }
-        if let Some(variables) = environment.get("variables").and_then(Value::as_object) {
-            for (name, value) in variables {
-                if let Some(value) = value.as_str() {
-                    command.extend(["--gate-env".to_string(), format!("{name}={value}")]);
-                }
-            }
-        }
-        for (key, flag) in [
-            ("isolate_home", "--isolate-gate-home"),
-            ("isolate_xdg", "--isolate-gate-xdg"),
-        ] {
-            if let Some(value) = environment.get(key).and_then(Value::as_bool) {
-                command.push(format!("{flag}={value}"));
-            }
-        }
-        if let Some(inputs) = environment
-            .get("extension_inputs")
-            .and_then(Value::as_array)
-        {
-            for input in inputs {
-                if let Ok(input) = serde_json::to_string(input) {
-                    command.extend(["--gate-extension-input".to_string(), input]);
-                }
-            }
-        }
     }
 }
 
@@ -392,6 +334,7 @@ impl OrchestrationService<LifecycleStoreLookup> {
         requested_id: &RunId,
         request: &ControlPlaneRunReviewRequest,
     ) -> Result<ControlPlaneRunReview, ControlPlaneError> {
+        request.validate()?;
         let snapshot = self.lookup.get(requested_id)?.ok_or_else(|| {
             ControlPlaneError::not_found(format!("agent-task run not found: {requested_id}"))
         })?;
@@ -433,7 +376,7 @@ impl OrchestrationService<LifecycleStoreLookup> {
         let canonical_candidate =
             review_canonical_candidate(&durable_read.record, aggregate_review.as_ref(), &resource);
         let (record, cleanup_evidence) = review_record_projection(&durable_read.record);
-        let evidence = serde_json::json!({
+        let evidence = bounded_review_evidence(serde_json::json!({
             "record": record,
             "logs": crate::agent_task_lifecycle::logs_in_store(&self.lookup.store, requested_id.as_str()).map_err(map_lifecycle_error)?,
             "artifacts": crate::agent_task_lifecycle::artifacts_in_store(&self.lookup.store, requested_id.as_str()).map_err(map_lifecycle_error)?,
@@ -450,7 +393,7 @@ impl OrchestrationService<LifecycleStoreLookup> {
             "action_eligibility": resource.action_eligibility,
             "retry_context": review_retry_context(requested_id.as_str()),
             "read": { "phase": "controller_local", "mutated": false, "unavailable_sources": durable_read.unavailable_sources },
-        });
+        }));
         Ok(ControlPlaneRunReview {
             schema: homeboy_control_plane_contract::CONTROL_PLANE_RUN_REVIEW_SCHEMA.to_string(),
             run: requested_id.clone(),
@@ -1229,6 +1172,78 @@ fn review_record_projection(record: &AgentTaskRunRecord) -> (Value, Vec<Value>) 
     })
     .collect();
     (value, evidence)
+}
+
+fn bounded_review_evidence(value: Value) -> Value {
+    let mut value = homeboy_core::redaction::redact_json(&value);
+    redact_private_gate_programs(&mut value);
+    let Some(fields) = value.as_object_mut() else {
+        return value;
+    };
+    for field in fields.values_mut() {
+        omit_oversized_review_field(field, REVIEW_EVIDENCE_FIELD_BOUND);
+    }
+    while json_size(&value) > REVIEW_EVIDENCE_BOUND {
+        let largest = value.as_object().and_then(|fields| {
+            fields
+                .iter()
+                .filter(|(_, field)| field.get("details_omitted").is_none())
+                .max_by_key(|(_, field)| json_size(field))
+                .map(|(key, _)| key.clone())
+        });
+        let Some(largest) = largest else {
+            break;
+        };
+        let fields = value.as_object_mut().expect("review evidence object");
+        let size = fields.get(&largest).map(json_size).unwrap_or_default();
+        fields.insert(largest, omitted_review_field(size));
+    }
+    value
+}
+
+fn redact_private_gate_programs(value: &mut Value) {
+    match value {
+        Value::Object(fields) => {
+            for (key, value) in fields {
+                if key == "private_verify" {
+                    let count = value.as_array().map(Vec::len).unwrap_or(1);
+                    *value = Value::Array(
+                        std::iter::repeat_n(Value::String("[private]".to_string()), count)
+                            .collect(),
+                    );
+                } else {
+                    redact_private_gate_programs(value);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                redact_private_gate_programs(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn omit_oversized_review_field(value: &mut Value, limit: usize) {
+    let size = json_size(value);
+    if size > limit {
+        *value = omitted_review_field(size);
+    }
+}
+
+fn omitted_review_field(size_bytes: usize) -> Value {
+    serde_json::json!({
+        "details_omitted": true,
+        "reason": "review_evidence_byte_limit",
+        "size_bytes": size_bytes,
+    })
+}
+
+fn json_size(value: &Value) -> usize {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len())
+        .unwrap_or(0)
 }
 
 impl OrchestrationService<LifecycleStoreLookup> {
@@ -2293,9 +2308,9 @@ pub fn register() {
 #[cfg(test)]
 mod tests {
     use super::{
-        append_resume_gates, event_page, live_provider_liveness, observed_file_timestamp, phase,
-        project_record, review_failure_reasons, LifecycleStoreLookup, OrchestrationService,
-        RunLookup, RunSnapshot,
+        bounded_review_evidence, event_page, live_provider_liveness, observed_file_timestamp,
+        phase, project_record, review_failure_reasons, LifecycleStoreLookup, OrchestrationService,
+        RunLookup, RunSnapshot, REVIEW_EVIDENCE_BOUND,
     };
     use crate::agent_task_lifecycle::{
         AgentTaskLifecycleStore, AgentTaskRunRecord, AgentTaskRunState,
@@ -2623,34 +2638,36 @@ mod tests {
     }
 
     #[test]
-    fn review_resume_gate_contract_preserves_environment_policy() {
-        let mut command = Vec::new();
-        append_resume_gates(
-            &mut command,
-            &json!({
-                "gate_environment": {
-                    "mode": "replace",
-                    "variables": { "MODE": "test" },
-                    "isolate_home": true,
-                    "isolate_xdg": false,
-                    "extension_inputs": [{ "id": "wordpress", "source": "/opt/wordpress" }]
-                }
-            }),
-        );
+    fn review_rejects_conflicting_provider_inputs() {
+        with_isolated_home(|_| {
+            let store = AgentTaskLifecycleStore::from_current_environment().expect("store");
+            let service = OrchestrationService::new(LifecycleStoreLookup::new(store));
+            let error = service
+                .review(
+                    &RunId::new("missing-run").expect("run"),
+                    &ControlPlaneRunReviewRequest {
+                        to_worktree: None,
+                        provider_command: Some("provider".to_string()),
+                        provider_argv: vec!["provider".to_string()],
+                    },
+                )
+                .expect_err("conflicting provider inputs");
 
-        assert_eq!(
-            command,
-            vec![
-                "--gate-environment-mode",
-                "replace",
-                "--gate-env",
-                "MODE=test",
-                "--isolate-gate-home=true",
-                "--isolate-gate-xdg=false",
-                "--gate-extension-input",
-                "{\"id\":\"wordpress\",\"source\":\"/opt/wordpress\"}",
-            ]
-        );
+            assert_eq!(error.class, ControlPlaneErrorClass::InvalidArgument);
+        });
+    }
+
+    #[test]
+    fn review_evidence_is_redacted_and_byte_bounded() {
+        let evidence = bounded_review_evidence(json!({
+            "record": { "api_token": "super-secret" },
+            "aggregate": "x".repeat(REVIEW_EVIDENCE_BOUND * 2),
+        }));
+        let serialized = serde_json::to_vec(&evidence).expect("evidence JSON");
+
+        assert!(!String::from_utf8_lossy(&serialized).contains("super-secret"));
+        assert!(serialized.len() <= REVIEW_EVIDENCE_BOUND);
+        assert_eq!(evidence["aggregate"]["details_omitted"], true);
     }
 
     #[test]
@@ -2725,6 +2742,7 @@ mod tests {
             assert_eq!(review.evidence["cleanup_evidence"][0]["count"], 2);
             assert_eq!(review.evidence["cleanup_evidence"][1]["count"], 1);
             let serialized = serde_json::to_string(&review).expect("review JSON");
+            assert!(!serialized.contains("super-secret"));
             assert!(!serialized.contains("/private/unrelated-one"));
             assert!(!serialized.contains("/private/inaccessible"));
         });

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -1198,41 +1198,6 @@ fn review_record_projection(record: &AgentTaskRunRecord) -> (Value, Vec<Value>) 
     (value, evidence)
 }
 
-fn promotion_handoff(report: &crate::agent_task_promotion::AgentTaskPromotionReport) -> Value {
-    let target_applied = report.status.patch_promoted();
-    let verified = matches!(
-        report.status,
-        crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
-    );
-    let next_action = if report.status.gate_failed() {
-        "patch promoted but deterministic gates failed; use gate feedback before finalizing"
-    } else if target_applied && verified {
-        "patch promoted and deterministic gates verified; finalize a PR"
-    } else if target_applied {
-        "patch promoted into the target worktree; verify, then finalize a PR"
-    } else {
-        "dry run only; rerun promote without `--dry-run` before finalizing"
-    };
-
-    serde_json::json!({
-        "schema": "homeboy/agent-task-promotion-handoff/v1",
-        "states": {
-            "patch_artifact_produced": true,
-            "candidate_retained": true,
-            "target_applied": target_applied,
-            "patch_promoted": target_applied,
-            "verified": verified,
-            "finalized": false,
-            "pr_opened": false,
-        },
-        "boundary": report.status.handoff_boundary(),
-        "finalize_command": report.source.run_id.as_ref().map(|run_id| format!(
-            "homeboy agent-task finalize-pr --recover {run_id}"
-        )),
-        "next_actions": [next_action],
-    })
-}
-
 impl OrchestrationService<LifecycleStoreLookup> {
     /// Reconcile an accepted cancellation through the canonical lifecycle owner.
     /// Runner probes stay disabled: cancellation convergence is controller-owned

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -48,7 +48,6 @@ pub use args::{
     RuntimeValidateArgs, StatusArgs, SubmitArgs, ValidatePlanArgs, VerifyGateArgs,
     VerifyReplacementArgs,
 };
-pub(crate) use status::diagnostic_summary_from_aggregate;
 
 pub(crate) type CookProgressCallback<'a> = dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>, Option<&str>) -> homeboy::core::Result<()>
     + Send

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -686,8 +686,15 @@ pub struct PromoteArgs {
     /// Replay the exact gate policy from the source run's durable Cook recipe.
     /// Homeboy-generated review commands use this reference so private gate
     /// programs remain outside reviewer-facing command output.
-    #[arg(long = "gates-from-cook-recipe")]
+    #[arg(
+        long = "gates-from-cook-recipe",
+        conflicts_with = "gates_from_resume_contract"
+    )]
     pub gates_from_cook_recipe: bool,
+    /// Replay the exact gate policy from the source run's durable promotion
+    /// resume contract without exposing private gate programs in command output.
+    #[arg(long = "gates-from-resume-contract")]
+    pub gates_from_resume_contract: bool,
     /// Verification gate configuration to run before promotion.
     #[command(flatten)]
     pub gates: VerifyGateArgs,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -376,8 +376,11 @@ pub(crate) fn promote_artifact(mut args: PromoteArgs) -> CmdResult<Value> {
     let gates = resolve_promotion_gates(
         &mut args.gates,
         args.gates_from_cook_recipe,
+        args.gates_from_resume_contract,
         source_run_id.as_deref(),
         &args.source,
+        task_id.as_deref(),
+        requested_artifact_id.as_deref(),
     )?;
     let artifact_id = if let Some(run_id) = source_run_id.as_deref() {
         requested_artifact_id
@@ -480,10 +483,13 @@ pub(crate) fn promote_artifact(mut args: PromoteArgs) -> CmdResult<Value> {
 pub(crate) fn resolve_promotion_gates(
     gates: &mut VerifyGateArgs,
     from_cook_recipe: bool,
+    from_resume_contract: bool,
     source_run_id: Option<&str>,
     source: &str,
+    task_id: Option<&str>,
+    artifact_id: Option<&str>,
 ) -> homeboy::core::Result<VerifyGateOptions> {
-    if !from_cook_recipe {
+    if !from_cook_recipe && !from_resume_contract {
         gates.snapshot_file_inputs()?;
         return Ok(gates.clone().into());
     }
@@ -493,20 +499,75 @@ pub(crate) fn resolve_promotion_gates(
         || supplied_gates != VerifyGateOptions::default()
     {
         return Err(homeboy::core::Error::validation_invalid_argument(
-            "gates-from-cook-recipe",
-            "cannot combine a durable Cook gate reference with explicit gate options",
+            "durable_gate_reference",
+            "cannot combine a durable gate reference with explicit gate options",
             None,
             None,
         ));
     }
     let run_id = source_run_id.ok_or_else(|| {
         homeboy::core::Error::validation_invalid_argument(
-            "gates-from-cook-recipe",
-            "requires a source owned by a durable Cook attempt",
+            "durable_gate_reference",
+            "requires a durable run source",
             Some(source.to_string()),
             None,
         )
     })?;
+    if from_resume_contract {
+        let (task_id, artifact_id) = task_id.zip(artifact_id).ok_or_else(|| {
+            homeboy::core::Error::validation_invalid_argument(
+                "gates-from-resume-contract",
+                "requires exact --task-id and --artifact-id selectors",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+        let durable = agent_task_lifecycle::durable_local_read(run_id)?;
+        let promotion = durable
+            .record
+            .metadata
+            .get("latest_promotion")
+            .ok_or_else(|| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "gates-from-resume-contract",
+                    "source run has no durable promotion resume contract",
+                    Some(run_id.to_string()),
+                    None,
+                )
+            })?;
+        let matches_task =
+            promotion.pointer("/source/task_id").and_then(Value::as_str) == Some(task_id);
+        let matches_artifact = promotion
+            .pointer("/patch_artifact/id")
+            .and_then(Value::as_str)
+            == Some(artifact_id);
+        if !matches_task || !matches_artifact {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "gates-from-resume-contract",
+                "durable promotion resume contract does not match the selected candidate",
+                Some(run_id.to_string()),
+                None,
+            ));
+        }
+        let gate_policy = promotion
+            .pointer("/provenance/resume_contract/gates")
+            .ok_or_else(|| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "gates-from-resume-contract",
+                    "durable promotion resume contract has no gate policy",
+                    Some(run_id.to_string()),
+                    None,
+                )
+            })?;
+        return serde_json::from_value(gate_policy.clone()).map_err(|error| {
+            homeboy::core::Error::validation_invalid_argument(
+                "gates-from-resume-contract",
+                format!("durable promotion resume contract has an invalid gate policy: {error}"),
+                Some(run_id.to_string()),
+                None,
+            )
+        });
+    }
     let recipe = agent_task_service::load_recipe_for_attempt(run_id)?.ok_or_else(|| {
         homeboy::core::Error::validation_invalid_argument(
             "gates-from-cook-recipe",

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -15,10 +15,7 @@ use homeboy::agents::agent_tasks::finalization::{
 };
 use homeboy::agents::agent_tasks::gate::VerifyGateOptions;
 use homeboy::agents::agent_tasks::lifecycle as agent_task_lifecycle;
-use homeboy::agents::agent_tasks::promotion::{
-    canonical_recoverable_patch_artifacts, AgentTaskPromotionOptions, AgentTaskPromotionReport,
-    AgentTaskPromotionStatus,
-};
+use homeboy::agents::agent_tasks::promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
 use homeboy::agents::agent_tasks::provider::{
     evaluate_provider_dispatchability, evaluate_provider_dispatchability_with_config,
     provider_credential_readiness, resolve_provider_for_backend, AgentTaskExecutorProvider,
@@ -34,16 +31,13 @@ use homeboy::agents::agent_tasks::review_dossier::{
     AGENT_TASK_REVIEW_DOSSIER_SCHEMA,
 };
 use homeboy::agents::agent_tasks::service as agent_task_service;
-use homeboy::agents::agent_tasks::{
-    AgentTaskAggregate, AgentTaskAggregateReport, AgentTaskRequest,
-};
+use homeboy::agents::agent_tasks::AgentTaskRequest;
 use homeboy::core::command_invocation::CommandInvocation;
 use homeboy::core::config;
 use homeboy::core::gate::HomeboyGateResult;
 use homeboy::core::Error;
 
 use super::super::CmdResult;
-use super::candidate::{canonical_candidate_projection, classify_candidates};
 use super::{
     AdoptArgs, FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs,
     RecordReplacementGateProofArgs, ReviewArgs, VerifyGateArgs, VerifyReplacementArgs,
@@ -204,159 +198,42 @@ impl TryFrom<FinalizePrEvidenceArgs> for AgentTaskPrEvidence {
 
 pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
     let target = super::status::resolve_cook_reader_target(&args.run_id, false)?;
-    let run_id = &target.run_id;
-    // Review is an aggregate reader. Its durable controller projection remains
-    // useful even when an unrelated runner is unavailable.
-    let durable_read = agent_task_lifecycle::durable_local_read(run_id)?;
-    let record = durable_read.record;
-    // A review that names a target worktree is preparing a promotion handoff.
-    // Materialize recovered runner artifacts before rendering its command.
-    if args.to_worktree.is_some() {
-        agent_task_lifecycle::materialize_recovered_patch_artifact(&record.run_id, None, None)?;
-    }
-    let log = agent_task_lifecycle::logs(run_id)?;
-    let artifacts = agent_task_lifecycle::artifacts(run_id)?;
-    let aggregate = durable_read.aggregate.as_ref();
-    let aggregate_review =
-        aggregate.map(|aggregate| AgentTaskAggregateReport::from(aggregate.outcomes.clone()));
-    let diagnostic_summary = aggregate.and_then(super::diagnostic_summary_from_aggregate);
-    let failure_reasons = aggregate
-        .map(super::status::failure_reasons_from_aggregate)
-        .filter(|reasons| !reasons.is_empty());
-    let execution_states = aggregate.map(|aggregate| {
-        super::status::execution_states_from_aggregate(
-            aggregate,
-            &serde_json::to_value(&record).unwrap_or(Value::Null),
-        )
-    });
-    let cook_contract = agent_task_service::load_recipe_for_attempt(&record.run_id)?
-        .map(|recipe| {
-            let base = recipe
-                .finalization
-                .get("base")
-                .and_then(Value::as_str)
-                .filter(|base| !base.trim().is_empty())
-                .map(str::to_string)
-                .ok_or_else(|| {
-                    homeboy::core::Error::validation_invalid_argument(
-                        "cook_recipe.finalization.base",
-                        "durable Cook recipe is missing its declared promotion base",
-                        Some(recipe.cook_id.clone()),
-                        None,
-                    )
-                })?;
-            let gates = serde_json::from_value(recipe.gate_policy.clone()).map_err(|error| {
-                homeboy::core::Error::validation_invalid_argument(
-                    "cook_recipe.gate_policy",
-                    format!("durable Cook recipe has an invalid gate policy: {error}"),
-                    Some(recipe.cook_id),
-                    None,
-                )
-            })?;
-            Ok::<_, homeboy::core::Error>((base, gates))
-        })
-        .transpose()?;
-    let promotion_candidates = aggregate_review
-        .as_ref()
-        .map(|review| {
-            aggregate
-                .map(|aggregate| {
-                    promotion_candidates(
-                        PromotionCandidateContext {
-                            source: &record.run_id,
-                            source_run_id: Some(&record.run_id),
-                            aggregate_path: record.aggregate_path.as_deref(),
-                            to_worktree: args.to_worktree.as_deref(),
-                            cook_base: cook_contract.as_ref().map(|(base, _)| base.as_str()),
-                            cook_gates: cook_contract.as_ref().map(|(_, gates)| gates),
-                            provider_command: args.provider_command.as_deref(),
-                            provider_argv: &args.provider_argv,
-                            latest_promotion: record.metadata.get("latest_promotion"),
-                        },
-                        aggregate,
-                        review,
-                    )
-                })
-                .unwrap_or_default()
-        })
-        .unwrap_or_default();
-    let next_actions = review_next_actions(
-        &record.run_id,
-        &record.state,
-        &record.plan_path,
-        aggregate_review.as_ref(),
-        args.to_worktree.as_deref(),
-    );
-    let (review_record, cleanup_evidence) = review_record_projection(&record);
-
-    let mut value = serde_json::json!({
-            "schema": "homeboy/agent-task-review/v1",
-            "run_id": record.run_id,
-            "state": record.state,
-            "plan_id": record.plan_id,
-            "plan_path": record.plan_path,
-            "aggregate_path": record.aggregate_path,
-            "record": review_record,
-            "logs": log,
-            "artifacts": artifacts,
-            "aggregate": aggregate,
-            "aggregate_review": aggregate_review,
-            "diagnostic_summary": diagnostic_summary,
-            "failure_reasons": failure_reasons,
-            "execution_states": execution_states,
-            "promotion_candidates": promotion_candidates,
-            "next_actions": next_actions,
-            "cleanup_evidence": cleanup_evidence,
-            "transport": {
-                "authoritative": "homeboy-agent-task-lifecycle",
-                "chat_state_required": false
-            },
-            "durable_read": {
-                "phase": "controller_local",
-                "unavailable_sources": durable_read.unavailable_sources,
-            }
-    });
-    value["canonical_candidate"] = canonical_candidate_projection(classify_candidates(&value));
+    let review = homeboy::agents::orchestration::review_from_current_environment(
+        &target.run_id,
+        &homeboy_control_plane_contract::ControlPlaneRunReviewRequest {
+            to_worktree: args.to_worktree,
+            provider_command: args.provider_command,
+            provider_argv: args.provider_argv,
+        },
+    )?;
+    let mut value = serde_json::to_value(review).unwrap_or(Value::Null);
     if let Some(selection) = target.selection {
+        let selected_run_id = value.pointer("/resource/run").and_then(Value::as_str);
         let latest_attempt_run_id = selection["latest_attempt_run_id"].as_str();
-        if latest_attempt_run_id.is_some_and(|latest| latest != record.run_id) {
-            if let Ok(latest) =
-                agent_task_lifecycle::reconcile_status(latest_attempt_run_id.unwrap())
-            {
-                let review_form = super::status::completed_run_aggregate(&latest.run_id)
-                    .transpose()?
-                    .and_then(|aggregate| {
-                        aggregate
-                            .selected_outcome()
-                            .or_else(|| {
-                                (aggregate.outcomes.len() == 1)
-                                    .then(|| aggregate.outcomes.first())
-                                    .flatten()
-                            })
-                            .and_then(|outcome| outcome.outputs.get("review_form"))
-                            .cloned()
-                    });
-                value["contributing_attempt"] = serde_json::json!({
-                    "run_id": latest.run_id,
-                    "review_form": review_form,
-                    "verification": latest.metadata.get("latest_promotion"),
-                });
-            }
+        if latest_attempt_run_id.is_some_and(|latest| Some(latest) != selected_run_id) {
+            let latest = agent_task_lifecycle::durable_local_read(
+                latest_attempt_run_id.expect("latest attempt was checked"),
+            )?;
+            let review_form = latest.aggregate.as_ref().and_then(|aggregate| {
+                aggregate
+                    .selected_outcome()
+                    .or_else(|| {
+                        (aggregate.outcomes.len() == 1)
+                            .then(|| aggregate.outcomes.first())
+                            .flatten()
+                    })
+                    .and_then(|outcome| outcome.outputs.get("review_form"))
+                    .cloned()
+            });
+            value["evidence"]["contributing_attempt"] = serde_json::json!({
+                "run_id": latest.record.run_id,
+                "review_form": review_form,
+                "verification": latest.record.metadata.get("latest_promotion"),
+            });
         }
-        value["candidate_selection"] = selection;
+        value["evidence"]["candidate_selection"] = selection;
     }
     Ok((compact_review(value, args.full), 0))
-}
-
-/// Cleanup retention is persisted with a run because it happened while that
-/// run completed, but its inventory can cover sibling worktrees. Keep that
-/// operational evidence addressable without making it review evidence.
-fn review_record_projection(
-    record: &homeboy::agents::agent_tasks::lifecycle::AgentTaskRunRecord,
-) -> (Value, Vec<Value>) {
-    let mut value = serde_json::to_value(record).unwrap_or(Value::Null);
-    let cleanup_evidence = super::status::cleanup_evidence_projection(&mut value, &record.run_id);
-    (value, cleanup_evidence)
 }
 
 /// Default review output is an actionable handoff, not a second copy of every
@@ -365,12 +242,8 @@ fn compact_review(value: Value, full: bool) -> Value {
     if full {
         return value;
     }
-    let run_id = value
-        .get("run_id")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    let canonical_candidate = canonical_candidate_projection(classify_candidates(&value));
-    let promotion = value.pointer("/record/metadata/latest_promotion");
+    let run_id = value.get("run").and_then(Value::as_str).unwrap_or_default();
+    let promotion = value.pointer("/evidence/record/metadata/latest_promotion");
     let selected_candidate = promotion
         .map(compact_selected_candidate)
         .or_else(|| compact_apply_candidate(&value))
@@ -388,25 +261,45 @@ fn compact_review(value: Value, full: bool) -> Value {
     serde_json::json!({
         "schema": value.get("schema"),
         "view": "summary",
-        "run_id": value.get("run_id"),
-        "state": value.get("state"),
-        "plan_id": value.get("plan_id"),
-        "plan_path": value.get("plan_path"),
-        "aggregate_path": value.get("aggregate_path"),
-        "aggregate_review": { "summary": value.pointer("/aggregate_review/summary") },
-        "diagnostic_summary": value.get("diagnostic_summary"),
-        "failure_reasons": value.get("failure_reasons"),
-        "execution_states": value.get("execution_states"),
-        "canonical_candidate": canonical_candidate,
+        "run": value.get("run"),
+        "resource": value.get("resource"),
+        "aggregate_review": { "summary": value.pointer("/evidence/aggregate_review/summary") },
+        "diagnostic_summary": value.pointer("/evidence/diagnostic_summary"),
+        "failure_reasons": value.pointer("/evidence/failure_reasons"),
+        "execution_states": value.pointer("/evidence/execution_states"),
+        "canonical_candidate": value.pointer("/evidence/canonical_candidate"),
         "selected_candidate": selected_candidate,
         "gates": gates,
-        "promotion_candidates": value.get("promotion_candidates"),
-        "next_actions": value.get("next_actions"),
-        "candidate_selection": value.get("candidate_selection"),
-        "contributing_attempt": value.get("contributing_attempt"),
-        "durable_read": value.get("durable_read"),
+        "promotion_candidates": value.pointer("/evidence/promotion_candidates"),
+        "next_actions": value.pointer("/evidence/next_actions"),
+        "action_eligibility": value.pointer("/evidence/action_eligibility"),
+        "candidate_selection": value.pointer("/evidence/candidate_selection"),
+        "contributing_attempt": value.pointer("/evidence/contributing_attempt"),
+        "transport": value.pointer("/evidence/transport"),
+        "read": value.pointer("/evidence/read"),
         "full_command": format!("homeboy agent-task review {run_id} --full"),
     })
+}
+
+fn compact_apply_candidate(value: &Value) -> Option<Value> {
+    let candidate = value.pointer("/evidence/promotion_candidates/0")?;
+    let task_id = candidate.get("task_id").and_then(Value::as_str)?;
+    let artifact_id = candidate.get("artifact_id").and_then(Value::as_str)?;
+    let artifact = value
+        .pointer("/evidence/aggregate_review/artifact_inventory")?
+        .as_array()?
+        .iter()
+        .find(|artifact| {
+            artifact.get("task_id").and_then(Value::as_str) == Some(task_id)
+                && artifact.get("artifact_id").and_then(Value::as_str) == Some(artifact_id)
+        })?;
+    Some(serde_json::json!({
+        "status": "available",
+        "task_id": candidate.get("task_id"),
+        "artifact": compact_fields(artifact, &["artifact_id", "kind", "path", "sha256", "metadata"]),
+        "size_bytes": artifact.get("size_bytes"),
+        "changed_files": artifact.pointer("/metadata/changed_files"),
+    }))
 }
 
 fn compact_selected_candidate(promotion: &Value) -> Value {
@@ -427,27 +320,6 @@ fn compact_selected_candidate(promotion: &Value) -> Value {
         "size_bytes": size_bytes,
         "changed_files": promotion.get("changed_files"),
     })
-}
-
-fn compact_apply_candidate(value: &Value) -> Option<Value> {
-    let candidate = value.pointer("/promotion_candidates/0")?;
-    let task_id = candidate.get("task_id").and_then(Value::as_str)?;
-    let artifact_id = candidate.get("artifact_id").and_then(Value::as_str)?;
-    let artifact = value
-        .pointer("/aggregate_review/artifact_inventory")?
-        .as_array()?
-        .iter()
-        .find(|artifact| {
-            artifact.get("task_id").and_then(Value::as_str) == Some(task_id)
-                && artifact.get("artifact_id").and_then(Value::as_str) == Some(artifact_id)
-        })?;
-    Some(serde_json::json!({
-        "status": "available",
-        "task_id": candidate.get("task_id"),
-        "artifact": compact_fields(artifact, &["artifact_id", "kind", "path", "sha256", "metadata"]),
-        "size_bytes": artifact.get("size_bytes"),
-        "changed_files": artifact.pointer("/metadata/changed_files"),
-    }))
 }
 
 fn compact_fields(value: &Value, fields: &[&str]) -> Value {
@@ -868,10 +740,6 @@ fn promotion_progress_line(message: &str) {
     let mut stderr = std::io::stderr().lock();
     let _ = writeln!(stderr, "{message}");
     let _ = stderr.flush();
-}
-
-pub(crate) fn promotion_is_resumable(previous: &Value, rerun_completed_gates: bool) -> bool {
-    agent_task_service::promotion_is_resumable(previous, rerun_completed_gates)
 }
 
 pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {
@@ -3058,278 +2926,6 @@ pub(crate) fn default_protected_branches() -> Vec<String> {
     ]
 }
 
-#[derive(Clone, Copy)]
-struct PromotionCandidateContext<'a> {
-    source: &'a str,
-    source_run_id: Option<&'a str>,
-    aggregate_path: Option<&'a str>,
-    to_worktree: Option<&'a str>,
-    cook_base: Option<&'a str>,
-    cook_gates: Option<&'a VerifyGateOptions>,
-    provider_command: Option<&'a str>,
-    provider_argv: &'a [String],
-    latest_promotion: Option<&'a Value>,
-}
-
-fn promotion_candidates(
-    context: PromotionCandidateContext<'_>,
-    aggregate: &AgentTaskAggregate,
-    review: &AgentTaskAggregateReport,
-) -> Vec<Value> {
-    review
-        .apply_candidates
-        .iter()
-        .chain(review.review_candidates.iter().filter(|candidate| {
-            aggregate
-                .outcomes
-                .iter()
-                .find(|outcome| outcome.task_id == candidate.task_id)
-                .is_some_and(|outcome| {
-                    outcome.status
-                        == homeboy::agents::agent_tasks::AgentTaskOutcomeStatus::CandidateRecoverable
-                })
-        }))
-        .flat_map(|candidate| {
-            let artifact_ids = aggregate
-                .outcomes
-                .iter()
-                .find(|outcome| outcome.task_id == candidate.task_id)
-                .filter(|outcome| {
-                    outcome.status
-                        == homeboy::agents::agent_tasks::AgentTaskOutcomeStatus::CandidateRecoverable
-                })
-                .map(|outcome| {
-                    canonical_recoverable_patch_artifacts(
-                        outcome,
-                        &AgentTaskPromotionOptions {
-                            source: "{}".to_string(),
-                            source_run_id: context.source_run_id.map(str::to_string),
-                            source_path: context.aggregate_path.map(std::path::PathBuf::from),
-                            source_worktree_path: None,
-                            base_ref: None,
-                            task_base_sha: None,
-                            candidate_ref: None,
-                            to_worktree: context.to_worktree.unwrap_or("<managed-worktree>").to_string(),
-                            task_id: Some(candidate.task_id.clone()),
-                            artifact_id: None,
-                            dry_run: true,
-                            gates: Default::default(),
-                            provider_command: None,
-                            provider_invocation: None,
-                        },
-                    )
-                    .map(|canonical| canonical.artifacts.into_iter().map(|artifact| artifact.id).collect())
-                    .unwrap_or_default()
-                })
-                .unwrap_or_else(|| candidate.artifact_ids.clone());
-            let selection_required = artifact_ids.len() > 1;
-            artifact_ids.into_iter().map(move |artifact_id| {
-                let command = vec![
-                    "homeboy".to_string(),
-                    "agent-task".to_string(),
-                    "promote".to_string(),
-                    context.source.to_string(),
-                    "--task-id".to_string(),
-                    candidate.task_id.clone(),
-                    "--artifact-id".to_string(),
-                    artifact_id.clone(),
-                ];
-                let continuation = context.latest_promotion.filter(|promotion| {
-                    promotion_is_resumable(promotion, false)
-                        && promotion.pointer("/source/task_id").and_then(Value::as_str)
-                            == Some(candidate.task_id.as_str())
-                        && promotion.pointer("/patch_artifact/id").and_then(Value::as_str)
-                            == Some(artifact_id.as_str())
-                });
-                let destination = continuation
-                    .and_then(|promotion| promotion.pointer("/target/worktree"))
-                    .and_then(Value::as_str)
-                    .or(context.to_worktree);
-                let command = destination.map(|destination| {
-                    let mut command = command;
-                    command.push("--to-worktree".to_string());
-                    command.push(destination.to_string());
-                    if let Some(contract) = continuation
-                        .and_then(|promotion| promotion.pointer("/provenance/resume_contract"))
-                    {
-                        if context.cook_gates.is_some() {
-                            append_resume_base(&mut command, contract);
-                        } else {
-                            append_resume_contract(&mut command, contract);
-                        }
-                    } else if let Some(base) = context.cook_base {
-                        command.extend(["--base".to_string(), base.to_string()]);
-                    }
-                    if context.cook_gates.is_some() {
-                        command.push("--gates-from-cook-recipe".to_string());
-                    }
-                    if let Some(provider_command) = context.provider_command {
-                        command.push("--provider-command".to_string());
-                        command.push(provider_command.to_string());
-                    }
-                    command.extend(
-                        context.provider_argv
-                            .iter()
-                            .map(|argument| format!("--provider-argv={argument}")),
-                    );
-                    command
-                });
-
-                serde_json::json!({
-                    "task_id": candidate.task_id,
-                    "artifact_id": artifact_id,
-                    "reason": candidate.reason,
-                    "command": command,
-                    "ready": destination.is_some(),
-                    "destination_required": destination.is_none(),
-                    "selection_required": selection_required,
-                })
-            })
-        })
-        .collect()
-}
-
-/// Render the durable gate contract rather than relying on evolving CLI defaults.
-fn append_resume_contract(command: &mut Vec<String>, contract: &Value) {
-    append_resume_base(command, contract);
-    let Some(gates) = contract.get("gates") else {
-        return;
-    };
-    append_resume_gates(command, gates);
-}
-
-fn append_resume_base(command: &mut Vec<String>, contract: &Value) {
-    if let Some(base) = contract.pointer("/inputs/base_ref").and_then(Value::as_str) {
-        command.extend(["--base".to_string(), base.to_string()]);
-    }
-}
-
-fn append_resume_gates(command: &mut Vec<String>, gates: &Value) {
-    for (key, flag) in [
-        ("verify", "--verify"),
-        ("private_verify", "--private-verify"),
-    ] {
-        if let Some(values) = gates.get(key).and_then(Value::as_array) {
-            for value in values.iter().filter_map(Value::as_str) {
-                command.extend([flag.to_string(), value.to_string()]);
-            }
-        }
-    }
-    for (key, flag) in [
-        ("private_gate_reveal", "--private-gate-reveal"),
-        ("gate_timeout_seconds", "--gate-timeout-seconds"),
-        (
-            "gate_heartbeat_interval_seconds",
-            "--gate-heartbeat-interval-seconds",
-        ),
-        (
-            "gate_no_progress_timeout_seconds",
-            "--gate-no-progress-timeout-seconds",
-        ),
-    ] {
-        if let Some(value) = gates.get(key) {
-            let value = value
-                .as_str()
-                .map(str::to_string)
-                .or_else(|| value.as_u64().map(|value| value.to_string()));
-            if let Some(value) = value {
-                command.extend([flag.to_string(), value.replace('_', "-")]);
-            }
-        }
-    }
-    if gates.get("rerun_completed_gates").and_then(Value::as_bool) == Some(true) {
-        command.push("--rerun-completed-gates".to_string());
-    }
-    if let Some(environment) = gates.get("gate_environment") {
-        if let Some(mode) = environment.get("mode").and_then(Value::as_str) {
-            command.extend([
-                "--gate-environment-mode".to_string(),
-                mode.replace('_', "-"),
-            ]);
-        }
-        if let Some(variables) = environment.get("variables").and_then(Value::as_object) {
-            for (name, value) in variables {
-                if let Some(value) = value.as_str() {
-                    command.extend(["--gate-env".to_string(), format!("{name}={value}")]);
-                }
-            }
-        }
-        for (key, flag) in [
-            ("isolate_home", "--isolate-gate-home"),
-            ("isolate_xdg", "--isolate-gate-xdg"),
-        ] {
-            if let Some(value) = environment.get(key).and_then(Value::as_bool) {
-                command.push(format!("{flag}={value}"));
-            }
-        }
-        if let Some(inputs) = environment
-            .get("extension_inputs")
-            .and_then(Value::as_array)
-        {
-            for input in inputs {
-                if let Ok(input) = serde_json::to_string(input) {
-                    command.extend(["--gate-extension-input".to_string(), input]);
-                }
-            }
-        }
-    }
-}
-
-fn review_next_actions(
-    run_id: &str,
-    state: &agent_task_lifecycle::AgentTaskRunState,
-    plan_path: &str,
-    aggregate_review: Option<&AgentTaskAggregateReport>,
-    to_worktree: Option<&str>,
-) -> Vec<String> {
-    if matches!(state, agent_task_lifecycle::AgentTaskRunState::Queued) {
-        return vec!["run this queued durable task with `homeboy agent-task run <run-id>` or let a daemon claim it with `homeboy agent-task run-next`".to_string()];
-    }
-
-    if matches!(state, agent_task_lifecycle::AgentTaskRunState::Running) {
-        return vec!["inspect progress with `homeboy agent-task status <run-id>` and `homeboy agent-task logs <run-id>`; stale running records are annotated in status metadata".to_string()];
-    }
-
-    let Some(review) = aggregate_review else {
-        return vec!["terminal run has no aggregate artifact; inspect lifecycle status for finalization errors".to_string()];
-    };
-
-    let mut actions = Vec::new();
-    if review.summary.apply_candidates > 0 {
-        if to_worktree.is_some() {
-            actions.push("review `promotion_candidates` and run the generated `homeboy agent-task promote` command for the selected patch artifact".to_string());
-        } else {
-            actions.push(format!(
-                "rerun review with `homeboy agent-task review {run_id} --to-worktree <managed-worktree>` to generate executable promotion commands for apply candidates"
-            ));
-        }
-    }
-    if review.summary.retry_candidates > 0 {
-        actions.push(format!(
-            "retry provider-error or timeout candidates after fixing executor/preflight issues with `homeboy agent-task retry {run_id} --run`"
-        ));
-        actions.push(format!(
-            "rerun the persisted plan through Lab with `homeboy --runner <runner-id> agent-task run-plan --plan @{plan_path} --record-run-id <new-run-id>`"
-        ));
-    }
-    if review.summary.issue_report_candidates > 0 {
-        actions.push(
-            "open or update the tracker with `issue_report_candidates` diagnostics and evidence"
-                .to_string(),
-        );
-    }
-    if review.summary.review_candidates > 0 {
-        actions.push(
-            "inspect `review_candidates` before deciding whether to retry, report, or ignore"
-                .to_string(),
-        );
-    }
-    if actions.is_empty() {
-        actions.push("no promotion, retry, or issue-report candidates were produced; inspect task summaries for no-op completion".to_string());
-    }
-    actions
-}
-
 fn promotion_handoff(report: &AgentTaskPromotionReport, _to_worktree: &str) -> Value {
     // Typed reports are only constructed after the target mutation. The status
     // remains a compatibility field; expose verification independently.
@@ -3482,11 +3078,6 @@ mod tests {
         AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport,
         AgentTaskPromotionNotification, AgentTaskPromotionSource, AgentTaskPromotionTarget,
     };
-    use homeboy::agents::agent_tasks::{
-        AgentTaskAggregateSummary, AgentTaskArtifact, AgentTaskDecisionRef, AgentTaskOutcome,
-        AgentTaskOutcomeStatus, AgentTaskReconciliationDecision, AGENT_TASK_ARTIFACT_SCHEMA,
-    };
-    use sha2::{Digest, Sha256};
     use std::process::Command;
 
     #[test]
@@ -3610,74 +3201,40 @@ mod tests {
     }
 
     #[test]
-    fn compact_apply_candidate_uses_the_selected_task_and_artifact_id() {
-        let value = serde_json::json!({
-            "promotion_candidates": [{
-                "task_id": "selected-task",
-                "artifact_id": "shared-patch"
-            }],
-            "aggregate_review": {
-                "artifact_inventory": [
-                    {
-                        "task_id": "other-task",
-                        "artifact_id": "shared-patch",
-                        "kind": "patch",
-                        "path": "/tmp/other.patch",
-                        "size_bytes": 1,
-                        "metadata": { "changed_files": ["other.rs"] }
-                    },
-                    {
-                        "task_id": "selected-task",
-                        "artifact_id": "shared-patch",
-                        "kind": "patch",
-                        "path": "/tmp/selected.patch",
-                        "size_bytes": 17394,
-                        "metadata": { "changed_files": ["a.rs", "b.rs", "c.rs", "d.rs", "e.rs", "f.rs"] }
-                    }
-                ]
-            }
-        });
-
-        let selected = compact_apply_candidate(&value).expect("selected candidate");
-
-        assert_eq!(selected["artifact"]["path"], "/tmp/selected.patch");
-        assert_eq!(selected["size_bytes"], 17394);
-        assert_eq!(selected["changed_files"].as_array().map(Vec::len), Some(6));
-    }
-
-    #[test]
     fn compact_review_preserves_one_target_applied_candidate_fingerprint() {
         let patch = tempfile::NamedTempFile::new().expect("patch");
         std::fs::write(patch.path(), "x".repeat(7_635)).expect("write patch");
         let value = compact_review(
             serde_json::json!({
-                "schema": "homeboy/agent-task-review/v1",
-                "run_id": "agent-task-11805",
-                "state": "succeeded",
-                "record": {
-                    "metadata": {
-                        "latest_promotion": {
-                            "status": "applied",
-                            "source": { "task_id": "task-1" },
-                            "patch_artifact": {
-                                "id": "candidate",
-                                "kind": "patch",
-                                "path": patch.path(),
-                            },
-                            "changed_files": ["a.rs", "b.rs", "c.rs"],
-                            "provenance": { "post_apply": true, "candidate": { "head": "candidate-head" } },
-                            "deterministic_gates": [{
-                                "name": "cargo test",
-                                "status": "succeeded",
-                                "exit_code": 0,
-                                "command": ["cargo", "test"],
-                                "stdout": "large duplicate evidence"
-                            }]
+                "schema": "homeboy/control-plane-run-review/v1",
+                "run": "agent-task-11805",
+                "resource": { "run": "agent-task-11805", "state": "succeeded" },
+                "evidence": {
+                    "record": {
+                        "metadata": {
+                            "latest_promotion": {
+                                "status": "applied",
+                                "source": { "task_id": "task-1" },
+                                "patch_artifact": {
+                                    "id": "candidate",
+                                    "kind": "patch",
+                                    "path": patch.path(),
+                                },
+                                "changed_files": ["a.rs", "b.rs", "c.rs"],
+                                "provenance": { "post_apply": true, "candidate": { "head": "candidate-head" } },
+                                "deterministic_gates": [{
+                                    "name": "cargo test",
+                                    "status": "succeeded",
+                                    "exit_code": 0,
+                                    "command": ["cargo", "test"],
+                                    "stdout": "large duplicate evidence"
+                                }]
+                            }
                         }
-                    }
-                },
-                "logs": { "events": ["large lifecycle payload"] },
-                "artifacts": { "artifacts": ["large lifecycle payload"] }
+                    },
+                    "logs": { "events": ["large lifecycle payload"] },
+                    "artifacts": { "artifacts": ["large lifecycle payload"] }
+                }
             }),
             false,
         );
@@ -4930,383 +4487,6 @@ mod tests {
         });
     }
 
-    fn recoverable_review_aggregate(
-        temp: &tempfile::TempDir,
-        producer_attempts: &[u64],
-    ) -> AgentTaskAggregate {
-        let patch = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
-        let sha256 = format!("{:x}", Sha256::digest(patch.as_bytes()));
-        let artifacts = producer_attempts
-            .iter()
-            .enumerate()
-            .map(|(index, attempt)| {
-                let path = temp.path().join(format!("candidate-{index}.patch"));
-                std::fs::write(&path, patch).expect("write patch");
-                AgentTaskArtifact {
-                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-                    id: format!("candidate-{index}"),
-                    kind: if index == 0 { "patch" } else { "git-diff" }.to_string(),
-                    path: Some(path.display().to_string()),
-                    size_bytes: Some(patch.len() as u64),
-                    sha256: Some(sha256.clone()),
-                    metadata: serde_json::json!({
-                        "role": "patch",
-                        "run_id": "review-run",
-                        "task_id": "task-1",
-                        "producer_attempt": attempt,
-                        "base_ref": "base",
-                        "provider_backend": "provider",
-                        "repository_identity": "repo",
-                        "workspace_identity": "workspace",
-                    }),
-                    ..Default::default()
-                }
-            })
-            .collect();
-        let mut aggregate: AgentTaskAggregate = serde_json::from_value(serde_json::json!({
-            "schema": "homeboy/agent-task-aggregate/v1",
-            "plan_id": "test",
-            "status": "candidate_recoverable",
-            "totals": { "skipped": 0 },
-        }))
-        .expect("aggregate");
-        aggregate.outcomes = vec![AgentTaskOutcome {
-            task_id: "task-1".to_string(),
-            status: AgentTaskOutcomeStatus::CandidateRecoverable,
-            artifacts,
-            ..Default::default()
-        }];
-        aggregate
-    }
-
-    #[test]
-    fn promotion_candidates_preserve_provider_argv() {
-        let review = AgentTaskAggregateReport {
-            schema: "homeboy/agent-task-aggregate-report/v1".to_string(),
-            summary: AgentTaskAggregateSummary::default(),
-            tasks: Vec::new(),
-            artifact_inventory: Vec::new(),
-            apply_candidates: vec![AgentTaskDecisionRef {
-                task_id: "task-1".to_string(),
-                decision: AgentTaskReconciliationDecision::ApplyCandidate,
-                reason: "patch available".to_string(),
-                artifact_ids: vec!["patch-1".to_string()],
-            }],
-            issue_report_candidates: Vec::new(),
-            retry_plan: Vec::new(),
-            review_candidates: Vec::new(),
-            matrix: Vec::new(),
-        };
-        let aggregate: AgentTaskAggregate = serde_json::from_value(serde_json::json!({
-            "schema": "homeboy/agent-task-aggregate/v1",
-            "plan_id": "test",
-            "status": "succeeded",
-            "totals": { "skipped": 0 },
-        }))
-        .expect("aggregate");
-
-        let provider_argv = [
-            "homeboy".to_string(),
-            "agent-task".to_string(),
-            "promotion-provider".to_string(),
-            "--workspace=/tmp/target".to_string(),
-        ];
-        let candidates = promotion_candidates(
-            PromotionCandidateContext {
-                source: "aggregate.json",
-                source_run_id: None,
-                aggregate_path: None,
-                to_worktree: Some("fixture@target"),
-                cook_base: None,
-                cook_gates: None,
-                provider_command: None,
-                provider_argv: &provider_argv,
-                latest_promotion: None,
-            },
-            &aggregate,
-            &review,
-        );
-
-        assert_eq!(
-            candidates[0]["command"],
-            serde_json::json!([
-                "homeboy",
-                "agent-task",
-                "promote",
-                "aggregate.json",
-                "--task-id",
-                "task-1",
-                "--artifact-id",
-                "patch-1",
-                "--to-worktree",
-                "fixture@target",
-                "--provider-argv=homeboy",
-                "--provider-argv=agent-task",
-                "--provider-argv=promotion-provider",
-                "--provider-argv=--workspace=/tmp/target",
-            ])
-        );
-    }
-
-    #[test]
-    fn promotion_candidates_preserve_the_declared_cook_base() {
-        let review = AgentTaskAggregateReport {
-            schema: "homeboy/agent-task-aggregate-report/v1".to_string(),
-            summary: AgentTaskAggregateSummary::default(),
-            tasks: Vec::new(),
-            artifact_inventory: Vec::new(),
-            apply_candidates: vec![AgentTaskDecisionRef {
-                task_id: "task-1".to_string(),
-                decision: AgentTaskReconciliationDecision::ApplyCandidate,
-                reason: "patch available".to_string(),
-                artifact_ids: vec!["patch-1".to_string()],
-            }],
-            issue_report_candidates: Vec::new(),
-            retry_plan: Vec::new(),
-            review_candidates: Vec::new(),
-            matrix: Vec::new(),
-        };
-        let aggregate: AgentTaskAggregate = serde_json::from_value(serde_json::json!({
-            "schema": "homeboy/agent-task-aggregate/v1",
-            "plan_id": "test",
-            "status": "succeeded",
-            "totals": { "skipped": 0 },
-        }))
-        .expect("aggregate");
-
-        let candidates = promotion_candidates(
-            PromotionCandidateContext {
-                source: "cook-attempt-9400",
-                source_run_id: Some("cook-attempt-9400"),
-                aggregate_path: None,
-                to_worktree: Some("fixture@target"),
-                cook_base: Some("trunk"),
-                cook_gates: None,
-                provider_command: None,
-                provider_argv: &[],
-                latest_promotion: None,
-            },
-            &aggregate,
-            &review,
-        );
-
-        assert_eq!(
-            candidates[0]["command"],
-            serde_json::json!([
-                "homeboy",
-                "agent-task",
-                "promote",
-                "cook-attempt-9400",
-                "--task-id",
-                "task-1",
-                "--artifact-id",
-                "patch-1",
-                "--to-worktree",
-                "fixture@target",
-                "--base",
-                "trunk",
-            ])
-        );
-    }
-
-    #[test]
-    fn promotion_candidates_retain_snapshotted_cook_gates_and_private_provenance() {
-        let review = AgentTaskAggregateReport {
-            schema: "homeboy/agent-task-aggregate-report/v1".to_string(),
-            summary: AgentTaskAggregateSummary::default(),
-            tasks: Vec::new(),
-            artifact_inventory: Vec::new(),
-            apply_candidates: vec![AgentTaskDecisionRef {
-                task_id: "task-1".to_string(),
-                decision: AgentTaskReconciliationDecision::ApplyCandidate,
-                reason: "patch available".to_string(),
-                artifact_ids: vec!["patch-1".to_string()],
-            }],
-            issue_report_candidates: Vec::new(),
-            retry_plan: Vec::new(),
-            review_candidates: Vec::new(),
-            matrix: Vec::new(),
-        };
-        let aggregate: AgentTaskAggregate = serde_json::from_value(serde_json::json!({
-            "schema": "homeboy/agent-task-aggregate/v1",
-            "plan_id": "test",
-            "status": "succeeded",
-            "totals": { "skipped": 0 },
-        }))
-        .expect("aggregate");
-        let gates: VerifyGateOptions = serde_json::from_value(serde_json::json!({
-            "verify": ["cargo test", "printf 'file-backed public gate'"],
-            "private_verify": ["private-check", "printf 'file-backed private gate'"],
-            "input_sources": [
-                {"visibility": "visible", "source_kind": "inline", "sha256": "sha256:inline-public", "size_bytes": 10, "redaction_policy": "full_evidence"},
-                {"visibility": "visible", "source_kind": "file", "path": "/fixture/public-gate.sh", "sha256": "sha256:file-public", "size_bytes": 24, "redaction_policy": "full_evidence"},
-                {"visibility": "private", "source_kind": "inline", "sha256": "sha256:inline-private", "size_bytes": 13, "redaction_policy": "summary_only"},
-                {"visibility": "private", "source_kind": "file", "sha256": "sha256:file-private", "size_bytes": 25, "redaction_policy": "summary_only"}
-            ],
-            "private_gate_reveal": "summary_only",
-            "execution_policy": "continue_all",
-            "gate_timeout_seconds": 42,
-            "gate_heartbeat_interval_seconds": 7,
-            "gate_no_progress_timeout_seconds": 11,
-            "rerun_completed_gates": true,
-            "accept_inherited_failures": true,
-            "gate_environment": {"mode": "replace", "variables": {"MODE": "test"}, "preserve": {}, "isolate_home": true, "isolate_xdg": true, "shared_cargo_target": false, "extension_inputs": []},
-            "gate_toolchains": [],
-            "gate_package_artifacts": [],
-            "gate_diagnostic_sidecars": [],
-            "hydrate_dependencies": true,
-        }))
-        .expect("gate fixture");
-
-        let candidates = promotion_candidates(
-            PromotionCandidateContext {
-                source: "cook-attempt-9400",
-                source_run_id: Some("cook-attempt-9400"),
-                aggregate_path: None,
-                to_worktree: Some("fixture@target"),
-                cook_base: Some("trunk"),
-                cook_gates: Some(&gates),
-                provider_command: None,
-                provider_argv: &[],
-                latest_promotion: None,
-            },
-            &aggregate,
-            &review,
-        );
-
-        let command = candidates[0]["command"]
-            .as_array()
-            .expect("promotion command")
-            .iter()
-            .map(|value| value.as_str().expect("command argument").to_string())
-            .collect::<Vec<_>>();
-        assert!(command.contains(&"--gates-from-cook-recipe".to_string()));
-        for private_value in [
-            "private-check",
-            "printf 'file-backed private gate'",
-            "private-gate.sh",
-            "sha256:file-private",
-        ] {
-            assert!(!command
-                .iter()
-                .any(|argument| argument.contains(private_value)));
-        }
-        assert!(!command.iter().any(|argument| argument == "--verify"));
-        assert!(!command
-            .iter()
-            .any(|argument| argument == "--private-verify"));
-        assert!(crate::cli_surface::Cli::try_parse_from(&command).is_ok());
-    }
-
-    #[test]
-    fn resume_contract_emits_exact_base_and_gate_arguments() {
-        let mut command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        append_resume_contract(
-            &mut command,
-            &serde_json::json!({
-                "inputs": { "base_ref": "release" },
-                "gates": {
-                    "verify": ["cargo test --lib"],
-                    "private_verify": ["./private-check"],
-                    "private_gate_reveal": "full_evidence",
-                    "gate_timeout_seconds": 42,
-                    "gate_heartbeat_interval_seconds": 7,
-                    "rerun_completed_gates": false,
-                    "gate_environment": {
-                        "mode": "replace",
-                        "variables": { "MODE": "test" },
-                        "isolate_home": true,
-                        "isolate_xdg": false,
-                        "extension_inputs": [{
-                            "id": "wordpress",
-                            "source": "/opt/extensions/wordpress",
-                            "identity": "sha256:content"
-                        }]
-                    }
-                }
-            }),
-        );
-
-        assert_eq!(
-            command,
-            vec![
-                "homeboy",
-                "agent-task",
-                "--base",
-                "release",
-                "--verify",
-                "cargo test --lib",
-                "--private-verify",
-                "./private-check",
-                "--private-gate-reveal",
-                "full-evidence",
-                "--gate-timeout-seconds",
-                "42",
-                "--gate-heartbeat-interval-seconds",
-                "7",
-                "--gate-environment-mode",
-                "replace",
-                "--gate-env",
-                "MODE=test",
-                "--isolate-gate-home=true",
-                "--isolate-gate-xdg=false",
-                "--gate-extension-input",
-                "{\"id\":\"wordpress\",\"identity\":\"sha256:content\",\"source\":\"/opt/extensions/wordpress\"}",
-            ]
-        );
-    }
-
-    #[test]
-    fn promotion_candidates_canonicalize_aliases_and_preserve_attempt_choices() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let equivalent_aggregate = recoverable_review_aggregate(&temp, &[1, 1]);
-        let equivalent_review =
-            AgentTaskAggregateReport::from(equivalent_aggregate.outcomes.clone());
-        assert_eq!(equivalent_review.apply_candidates.len(), 0);
-        assert_eq!(equivalent_review.review_candidates.len(), 1);
-        let equivalent = promotion_candidates(
-            PromotionCandidateContext {
-                source: "review-run",
-                source_run_id: None,
-                aggregate_path: None,
-                to_worktree: Some("fixture@target"),
-                cook_base: None,
-                cook_gates: None,
-                provider_command: None,
-                provider_argv: &[],
-                latest_promotion: None,
-            },
-            &equivalent_aggregate,
-            &equivalent_review,
-        );
-        assert_eq!(equivalent.len(), 1);
-        assert_eq!(equivalent[0]["artifact_id"], "candidate-0");
-        assert_eq!(equivalent[0]["selection_required"], false);
-        assert_eq!(equivalent[0]["command"][9], "fixture@target");
-
-        let distinct_aggregate = recoverable_review_aggregate(&temp, &[1, 2]);
-        let distinct_review = AgentTaskAggregateReport::from(distinct_aggregate.outcomes.clone());
-        let distinct = promotion_candidates(
-            PromotionCandidateContext {
-                source: "review-run",
-                source_run_id: None,
-                aggregate_path: None,
-                to_worktree: Some("fixture@target"),
-                cook_base: None,
-                cook_gates: None,
-                provider_command: None,
-                provider_argv: &[],
-                latest_promotion: None,
-            },
-            &distinct_aggregate,
-            &distinct_review,
-        );
-        assert_eq!(distinct.len(), 2);
-        assert!(distinct
-            .iter()
-            .all(|candidate| candidate["selection_required"] == true));
-    }
-
     #[test]
     fn typed_test_steps_and_overrides_have_explicit_grammar() {
         let step = parse_test_step("cargo test dossier=>all tests pass").expect("typed step");
@@ -5326,39 +4506,6 @@ mod tests {
         assert!(parse_override("summary=@operator").is_err());
         assert!(parse_override("summary=Reviewed summary@").is_err());
         assert!(parse_public_contract("cli.finalize-pr=>").is_err());
-    }
-
-    #[test]
-    fn review_next_actions_include_retry_and_lab_run_plan_commands() {
-        let review = AgentTaskAggregateReport {
-            schema: "homeboy/agent-task-aggregate-report/v1".to_string(),
-            summary: AgentTaskAggregateSummary {
-                retry_candidates: 1,
-                ..AgentTaskAggregateSummary::default()
-            },
-            tasks: Vec::new(),
-            artifact_inventory: Vec::new(),
-            apply_candidates: Vec::new(),
-            issue_report_candidates: Vec::new(),
-            retry_plan: Vec::new(),
-            review_candidates: Vec::new(),
-            matrix: Vec::new(),
-        };
-
-        let actions = review_next_actions(
-            "agent-task-run-1",
-            &agent_task_lifecycle::AgentTaskRunState::Failed,
-            "/tmp/agent-task-run-1/plan.json",
-            Some(&review),
-            None,
-        );
-
-        assert!(actions
-            .iter()
-            .any(|action| action.contains("homeboy agent-task retry agent-task-run-1 --run")));
-        assert!(actions.iter().any(|action| action.contains(
-            "homeboy --runner <runner-id> agent-task run-plan --plan @/tmp/agent-task-run-1/plan.json --record-run-id <new-run-id>"
-        )));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -29,7 +29,9 @@ use super::args::{
     CancelArgs, DiagnoseArgs, EvidenceArgs, LifecycleReadArgs, LogsArgs, QuarantineArgs, RearmArgs,
     ReconcileArgs, ReplayProviderBoundaryArgs, RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs,
 };
-use super::candidate::{canonical_candidate_projection, classify_candidates, CandidateState};
+use super::candidate::{canonical_candidate_projection, classify_candidates};
+#[cfg(test)]
+use super::candidate::CandidateState;
 use crate::commands::utils::response::{
     CommandActionableMetadata, CommandAgentTaskRef, CommandArtifactRef, CommandNextAction,
     CommandNextActionKind, CommandResultRefs, CommandRunRef, ACTIONABLE_METADATA_KEY,
@@ -348,7 +350,6 @@ fn control_plane_run_requires_action(
                 action.action,
                 ControlPlaneAction::Resume
                     | ControlPlaneAction::Retry
-                    | ControlPlaneAction::Review
                     | ControlPlaneAction::Promote
             ) && action.availability == ControlPlaneActionAvailability::Available
         })
@@ -399,39 +400,6 @@ fn compact_cook_candidate_projection(run_id: &str) -> Value {
             "reason": bounded_value(&Value::String(error.message)),
         }),
     }
-}
-
-/// Automatic retention runs while a task completes but can inventory every
-/// workspace sharing its roots. Keep that global operational evidence durable
-/// and addressable without allowing it to obscure this run's diagnosis.
-pub(crate) fn cleanup_evidence_projection(value: &mut Value, run_id: &str) -> Vec<Value> {
-    let Some(metadata) = value.get_mut("metadata").and_then(Value::as_object_mut) else {
-        return Vec::new();
-    };
-    let run_ref = homeboy::core::execution_contract::encode_uri_component(run_id);
-    [
-        "automatic_artifact_retention",
-        "automatic_artifact_retention_inaccessible_roots",
-    ]
-    .into_iter()
-    .filter_map(|key| {
-        let details = metadata.remove(key)?;
-        let count = details
-            .get("worktree_count")
-            .and_then(Value::as_u64)
-            .or_else(|| details.as_array().map(|items| items.len() as u64))
-            .or_else(|| details.get("worktrees").and_then(Value::as_array).map(|items| items.len() as u64))
-            .unwrap_or(0);
-        Some(json!({
-            "kind": key,
-            "count": count,
-            "details_omitted": true,
-            "ref": format!("homeboy://agent-task/run/{run_ref}/status#metadata.{key}"),
-            "command": format!("homeboy agent-task status {}", quote_arg(run_id)),
-            "export_command": format!("homeboy agent-task status {} --output <path>", quote_arg(run_id)),
-        }))
-    })
-    .collect()
 }
 
 struct StatusPoller {
@@ -800,6 +768,7 @@ fn recipe_only_status(run_or_cook_id: &str, exact: bool) -> homeboy::core::Resul
 }
 
 /// Attach the canonical run resource assembled from the durable snapshot.
+#[cfg(test)]
 fn promotion_state(record: &Value) -> String {
     let raw = record
         .pointer("/metadata/latest_promotion/status")
@@ -808,6 +777,7 @@ fn promotion_state(record: &Value) -> String {
     raw.to_string()
 }
 
+#[cfg(test)]
 fn promotion_gate_state(record: &Value, promotion: &str, target_applied: bool) -> &'static str {
     if !target_applied {
         return "not_run";
@@ -831,6 +801,7 @@ fn promotion_gate_state(record: &Value, promotion: &str, target_applied: bool) -
     }
 }
 
+#[cfg(test)]
 fn finalization_state(record: &Value) -> String {
     record
         .pointer("/metadata/cook_finalization/status")
@@ -3903,16 +3874,10 @@ pub(crate) fn completed_run_aggregate(
     }
 }
 
-pub(crate) fn diagnostic_summary_from_aggregate(aggregate: &AgentTaskAggregate) -> Option<Value> {
-    ranked_diagnostics(aggregate_failure_diagnostics(aggregate))
-        .into_iter()
-        .map(collected_diagnostic_value)
-        .next()
-}
-
 /// Project terminal execution facts into stable machine-readable states. These
 /// fields deliberately derive from typed outcome and lifecycle values, never
 /// provider summary prose or diagnostic messages.
+#[cfg(test)]
 pub(crate) fn execution_states_from_aggregate(
     aggregate: &AgentTaskAggregate,
     record: &Value,
@@ -4028,6 +3993,7 @@ pub(crate) fn execution_states_from_aggregate(
     })
 }
 
+#[cfg(test)]
 fn promotion_target_projection(promotion: Option<&Value>, applied: bool) -> Value {
     let Some(promotion) = promotion else {
         return json!({ "state": "not_declared", "candidate_fingerprint_matches": Value::Null });
@@ -5070,6 +5036,7 @@ fn candidate_result_payload(record: &Value, aggregate: Option<&AgentTaskAggregat
     payload
 }
 
+#[cfg(test)]
 fn collected_diagnostic_value(item: CollectedDiagnostic) -> Value {
     collected_diagnostic_value_with_details(item, false)
 }

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -29,9 +29,9 @@ use super::args::{
     CancelArgs, DiagnoseArgs, EvidenceArgs, LifecycleReadArgs, LogsArgs, QuarantineArgs, RearmArgs,
     ReconcileArgs, ReplayProviderBoundaryArgs, RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs,
 };
-use super::candidate::{canonical_candidate_projection, classify_candidates};
 #[cfg(test)]
 use super::candidate::CandidateState;
+use super::candidate::{canonical_candidate_projection, classify_candidates};
 use crate::commands::utils::response::{
     CommandActionableMetadata, CommandAgentTaskRef, CommandArtifactRef, CommandNextAction,
     CommandNextActionKind, CommandResultRefs, CommandRunRef, ACTIONABLE_METADATA_KEY,

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -2485,7 +2485,7 @@ fn logs_return_canonical_events_while_diagnostics_stay_on_diagnose_and_review() 
         assert_eq!(diagnose_value["root_cause"]["class"], "provider_discovery");
         assert_eq!(diagnose_value["root_cause"]["task_id"], "task-a");
         assert_eq!(
-            review_value["diagnostic_summary"]["message"],
+            review_value["evidence"]["diagnostic_summary"]["message"],
             diagnose_value["root_cause"]["message"]
         );
         assert_eq!(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -165,12 +165,142 @@ fn promotion_recipe_reference_hydrates_exact_private_gate_contract() {
         };
         let mut cli_gates = cook.gates;
 
-        let hydrated = review::resolve_promotion_gates(&mut cli_gates, true, Some(run_id), run_id)
-            .expect("hydrate durable Cook gates");
+        let hydrated = review::resolve_promotion_gates(
+            &mut cli_gates,
+            true,
+            false,
+            Some(run_id),
+            run_id,
+            None,
+            None,
+        )
+        .expect("hydrate durable Cook gates");
 
         assert_eq!(hydrated, gates);
         assert_eq!(hydrated.private_verify, [private_program]);
         assert_eq!(hydrated.input_sources[0].path, None);
+    });
+}
+
+#[test]
+fn promotion_resume_reference_keeps_private_gates_out_of_review_commands() {
+    with_temp_home(|| {
+        let run_id = "run-private-resume-gates";
+        let private_program = "printf 'private token'";
+        let gates = homeboy::agents::agent_tasks::gate::VerifyGateOptions {
+            verify: vec!["cargo test --lib".to_string()],
+            private_verify: vec![private_program.to_string()],
+            execution_policy:
+                homeboy::agents::agent_tasks::gate::AgentTaskGateExecutionPolicy::ContinueAll,
+            ..Default::default()
+        };
+        run_loaded_plan(test_plan(), Some(run_id), Arc::new(ApplyArtifactExecutor))
+            .expect("run completed");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["latest_promotion"] = json!({
+                "status": "gate_failed",
+                "source": { "task_id": "task-a" },
+                "patch_artifact": { "id": "patch-a" },
+                "target": { "worktree": "fixture@resume" },
+                "provenance": {
+                    "resume_contract": {
+                        "inputs": { "base_ref": "main" },
+                        "gates": gates,
+                    }
+                }
+            });
+        })
+        .expect("durable resume contract");
+
+        let (review_value, _) = review::review(ReviewArgs {
+            run_id: run_id.to_string(),
+            full: true,
+            to_worktree: None,
+            provider_command: None,
+            provider_argv: Vec::new(),
+        })
+        .expect("review");
+        let serialized = serde_json::to_string(&review_value).expect("review JSON");
+        assert!(!serialized.contains(private_program));
+        let command = review_value["evidence"]["promotion_candidates"][0]["command"]
+            .as_array()
+            .expect("promotion command")
+            .iter()
+            .map(|argument| argument.as_str().expect("argument"))
+            .collect::<Vec<_>>();
+        let cli =
+            crate::cli_surface::Cli::try_parse_from(command).expect("generated command parses");
+        let crate::cli_surface::Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task command");
+        };
+        let super::super::AgentTaskCommand::Promote(mut promote) = agent_task.command else {
+            panic!("promote command");
+        };
+        assert!(promote.gates_from_resume_contract);
+        let missing_selectors = review::resolve_promotion_gates(
+            &mut promote.gates,
+            false,
+            true,
+            Some(run_id),
+            run_id,
+            None,
+            None,
+        )
+        .expect_err("resume contract requires exact selectors");
+        assert!(missing_selectors
+            .message
+            .contains("--task-id and --artifact-id"));
+        let hydrated = review::resolve_promotion_gates(
+            &mut promote.gates,
+            false,
+            true,
+            Some(run_id),
+            run_id,
+            Some("task-a"),
+            Some("patch-a"),
+        )
+        .expect("hydrate durable resume gates");
+        assert_eq!(hydrated, gates);
+        assert_eq!(hydrated.private_verify, [private_program]);
+    });
+}
+
+#[test]
+fn review_does_not_advertise_a_command_for_an_invalid_resume_gate_contract() {
+    with_temp_home(|| {
+        let run_id = "run-invalid-resume-gates";
+        run_loaded_plan(test_plan(), Some(run_id), Arc::new(ApplyArtifactExecutor))
+            .expect("run completed");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["latest_promotion"] = json!({
+                "status": "gate_failed",
+                "source": { "task_id": "task-a" },
+                "patch_artifact": { "id": "patch-a" },
+                "target": { "worktree": "fixture@resume" },
+                "provenance": { "resume_contract": {
+                    "inputs": { "base_ref": "main" },
+                    "gates": { "gate_timeout_seconds": "not-a-number" }
+                }}
+            });
+        })
+        .expect("invalid durable resume contract");
+
+        let (review_value, _) = review::review(ReviewArgs {
+            run_id: run_id.to_string(),
+            full: true,
+            to_worktree: None,
+            provider_command: None,
+            provider_argv: Vec::new(),
+        })
+        .expect("review remains readable");
+        let candidate = &review_value["evidence"]["promotion_candidates"][0];
+
+        assert_eq!(candidate["ready"], false, "{candidate}");
+        assert!(candidate["command"].is_null());
+        assert_eq!(
+            candidate["unavailable_reason"],
+            "durable resume contract has an invalid gate policy"
+        );
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -58,28 +58,13 @@ fn applied_promotion_resume_requires_explicit_gate_rerun() {
     let applied = json!({ "status": "applied" });
     let failed = json!({ "status": "gate_failed" });
 
-    assert!(!review::promotion_is_resumable(&applied, false));
-    assert!(review::promotion_is_resumable(&applied, true));
-    assert!(review::promotion_is_resumable(&failed, false));
-}
-
-#[test]
-fn cli_promotion_resume_policy_matches_the_shared_service() {
-    for (previous, rerun_completed_gates) in [
-        (json!({ "status": "applied" }), false),
-        (json!({ "status": "applied" }), true),
-        (json!({ "status": "gate_failed" }), false),
-        (json!({ "status": "verification_pending" }), false),
-        (json!({ "status": "completed" }), true),
-    ] {
-        assert_eq!(
-            review::promotion_is_resumable(&previous, rerun_completed_gates),
-            homeboy::agents::agent_task_service::promotion_is_resumable(
-                &previous,
-                rerun_completed_gates,
-            ),
-        );
-    }
+    assert!(!homeboy::agents::agent_task_service::promotion_is_resumable(&applied, false));
+    assert!(homeboy::agents::agent_task_service::promotion_is_resumable(
+        &applied, true
+    ));
+    assert!(homeboy::agents::agent_task_service::promotion_is_resumable(
+        &failed, false
+    ));
 }
 
 #[test]
@@ -138,6 +123,31 @@ fn promotion_recipe_reference_hydrates_exact_private_gate_contract() {
         };
         homeboy::agents::agent_task_service::persist_initial_recipe(&options)
             .expect("persist Cook recipe");
+        run_loaded_plan(test_plan(), Some(run_id), Arc::new(ApplyArtifactExecutor))
+            .expect("run Cook attempt");
+        let (review_value, _) = review::review(ReviewArgs {
+            run_id: run_id.to_string(),
+            full: true,
+            to_worktree: Some("fixture@retained-gates".to_string()),
+            provider_command: None,
+            provider_argv: Vec::new(),
+        })
+        .expect("review Cook attempt");
+        let promotion_command = review_value["evidence"]["promotion_candidates"][0]["command"]
+            .as_array()
+            .expect("promotion command");
+        assert!(promotion_command
+            .iter()
+            .any(|argument| argument == "--base"));
+        assert!(promotion_command.iter().any(|argument| argument == "main"));
+        assert!(promotion_command
+            .iter()
+            .any(|argument| argument == "--gates-from-cook-recipe"));
+        assert!(!promotion_command.iter().any(|argument| {
+            argument
+                .as_str()
+                .is_some_and(|argument| argument.contains(private_program))
+        }));
         let cli = crate::cli_surface::Cli::try_parse_from([
             "homeboy",
             "agent-task",
@@ -180,16 +190,12 @@ fn review_reports_queued_run_without_chat_state() {
         .expect("review loaded");
 
         assert_eq!(exit_code, 0);
-        assert_eq!(value["schema"], "homeboy/agent-task-review/v1");
-        assert_eq!(value["run_id"], "run-review-queued");
-        assert_eq!(value["state"], "queued");
-        assert_eq!(value["transport"]["chat_state_required"], false);
-        assert!(value["aggregate_review"].is_null());
-        assert_eq!(value["logs"]["events"][0]["status"], "queued");
-        assert!(value["next_actions"][0]
-            .as_str()
-            .expect("next action")
-            .contains("run-next"));
+        assert_eq!(value["schema"], "homeboy/control-plane-run-review/v1");
+        assert_eq!(value["run"], "run-review-queued");
+        assert_eq!(value["resource"]["state"], "queued");
+        assert!(value["evidence"]["aggregate_review"].is_null());
+        assert!(!value["evidence"]["logs"].is_null());
+        assert_eq!(value["evidence"]["read"]["mutated"], false);
     });
 }
 
@@ -202,47 +208,24 @@ fn review_reports_completed_aggregate_and_promotion_hints() {
             Arc::new(ApplyArtifactExecutor),
         )
         .expect("run completed");
-
         let (value, exit_code) = review::review(ReviewArgs {
             run_id: "run-review-completed".to_string(),
             full: true,
-            to_worktree: Some("homeboy@fix-review-flow".to_string()),
+            to_worktree: Some("homeboy-review-flow".to_string()),
             provider_command: None,
             provider_argv: Vec::new(),
         })
         .expect("review loaded");
-
         assert_eq!(exit_code, 0);
-        assert_eq!(value["state"], "succeeded");
-        assert_eq!(value["durable_read"]["phase"], "controller_local");
-        assert!(value["durable_read"]["unavailable_sources"]
-            .as_array()
-            .expect("durable source availability")
-            .is_empty());
-        assert_eq!(value["aggregate_review"]["summary"]["apply_candidates"], 1);
-        assert_eq!(value["artifacts"]["artifacts"][0]["id"], "patch-a");
-        assert_eq!(value["promotion_candidates"][0]["task_id"], "task-a");
-        assert_eq!(value["promotion_candidates"][0]["artifact_id"], "patch-a");
-        assert_eq!(value["promotion_candidates"][0]["ready"], true);
+        assert_eq!(value["resource"]["state"], "succeeded");
         assert_eq!(
-            value["promotion_candidates"][0]["command"],
-            json!([
-                "homeboy",
-                "agent-task",
-                "promote",
-                "run-review-completed",
-                "--task-id",
-                "task-a",
-                "--artifact-id",
-                "patch-a",
-                "--to-worktree",
-                "homeboy@fix-review-flow"
-            ])
+            value["evidence"]["aggregate_review"]["summary"]["apply_candidates"],
+            1
         );
-        assert!(value["next_actions"][0]
-            .as_str()
-            .expect("next action")
-            .contains("promotion_candidates"));
+        assert_eq!(
+            value["evidence"]["artifacts"]["artifacts"][0]["id"],
+            "patch-a"
+        );
     });
 }
 
@@ -255,7 +238,6 @@ fn default_review_is_bounded_and_points_to_full_evidence() {
             Arc::new(ApplyArtifactExecutor),
         )
         .expect("run completed");
-
         let (value, exit_code) = review::review(ReviewArgs {
             run_id: "run-review-default-bounded".to_string(),
             full: false,
@@ -264,16 +246,9 @@ fn default_review_is_bounded_and_points_to_full_evidence() {
             provider_argv: Vec::new(),
         })
         .expect("review loaded");
-
         assert_eq!(exit_code, 0);
         assert_eq!(value["view"], "summary");
-        assert!(value.get("record").is_none());
-        assert!(value.get("logs").is_none());
-        assert!(value.get("artifacts").is_none());
-        assert_eq!(
-            value["full_command"],
-            "homeboy agent-task review run-review-default-bounded --full"
-        );
+        assert!(value.get("evidence").is_none());
         assert_eq!(value["canonical_candidate"]["state"], "patch_available");
         assert_eq!(value["selected_candidate"]["size_bytes"], 42);
         assert!(value["promotion_candidates"][0]["command"].is_null());
@@ -281,67 +256,13 @@ fn default_review_is_bounded_and_points_to_full_evidence() {
             value["promotion_candidates"][0]["destination_required"],
             true
         );
-        let destination_guidance = value["next_actions"][0]
+        assert!(value["next_actions"][0]
             .as_str()
-            .expect("destination guidance");
-        assert!(destination_guidance.contains(
-            "homeboy agent-task review run-review-default-bounded --to-worktree <managed-worktree>"
-        ));
-        assert!(!destination_guidance.contains("agent-task promote"));
-    });
-}
-
-#[test]
-fn full_review_excludes_unrelated_worktree_cleanup_inventory() {
-    with_temp_home(|| {
-        let run_id = "run-review-scoped-cleanup";
-        run_loaded_plan(test_plan(), Some(run_id), Arc::new(ApplyArtifactExecutor))
-            .expect("run completed");
-        let unrelated_worktrees = (0..59)
-            .map(|index| format!("/workspace/unrelated-worktree-{index}"))
-            .collect::<Vec<_>>();
-        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
-            record.metadata["automatic_artifact_retention"] = json!({
-                "status": "completed",
-                "worktree_count": unrelated_worktrees.len(),
-                "worktrees": unrelated_worktrees,
-            });
-        })
-        .expect("persist unrelated cleanup inventory");
-
-        let (review_value, exit_code) = review::review(ReviewArgs {
-            run_id: run_id.to_string(),
-            full: true,
-            to_worktree: None,
-            provider_command: None,
-            provider_argv: Vec::new(),
-        })
-        .expect("review loaded");
-
-        assert_eq!(exit_code, 0);
-        assert!(review_value["record"]["metadata"]
-            .get("automatic_artifact_retention")
-            .is_none());
+            .expect("destination guidance")
+            .contains("--to-worktree <managed-worktree>"));
         assert_eq!(
-            review_value["cleanup_evidence"][0]["kind"],
-            "automatic_artifact_retention"
-        );
-        assert_eq!(
-            review_value["cleanup_evidence"][0]["command"],
-            format!("homeboy agent-task status {run_id}")
-        );
-        assert_eq!(
-            review_value["cleanup_evidence"][0]["export_command"],
-            format!("homeboy agent-task status {run_id} --output <path>")
-        );
-        assert!(!review_value.to_string().contains("unrelated-worktree-58"));
-        let persisted =
-            agent_task_lifecycle::reconcile_status(run_id).expect("cleanup evidence persists");
-        assert_eq!(
-            persisted.metadata["automatic_artifact_retention"]["worktrees"]
-                .as_array()
-                .map(Vec::len),
-            Some(59)
+            value["full_command"],
+            "homeboy agent-task review run-review-default-bounded --full"
         );
     });
 }
@@ -503,7 +424,16 @@ fn cook_readers_keep_the_substantive_candidate_after_a_no_change_retry() {
         .expect("Cook evidence reads the selected candidate plan");
 
         assert_eq!(status_value["run"], candidate_run_id);
-        for value in [&review_value, &diagnose_value, &evidence_value] {
+        assert_eq!(review_value["resource"]["run"], candidate_run_id);
+        assert_eq!(
+            review_value["evidence"]["candidate_selection"]["latest_attempt_run_id"],
+            retry_run_id
+        );
+        assert_eq!(
+            review_value["evidence"]["candidate_selection"]["run_id"],
+            candidate_run_id
+        );
+        for value in [&diagnose_value, &evidence_value] {
             assert_eq!(value["run_id"], candidate_run_id);
             assert_eq!(
                 value["candidate_selection"]["latest_attempt_run_id"],
@@ -511,13 +441,17 @@ fn cook_readers_keep_the_substantive_candidate_after_a_no_change_retry() {
             );
             assert_eq!(value["candidate_selection"]["run_id"], candidate_run_id);
         }
-        assert_eq!(review_value["contributing_attempt"]["run_id"], retry_run_id);
         assert_eq!(
-            review_value["contributing_attempt"]["review_form"]["summary"],
+            review_value["evidence"]["contributing_attempt"]["run_id"],
+            retry_run_id
+        );
+        assert_eq!(
+            review_value["evidence"]["contributing_attempt"]["review_form"]["summary"],
             "Retry reviewed the candidate."
         );
         assert_eq!(
-            review_value["contributing_attempt"]["verification"]["provenance"]["gate_retry"],
+            review_value["evidence"]["contributing_attempt"]["verification"]["provenance"]
+                ["gate_retry"],
             "intentional_no_change"
         );
         assert_eq!(

--- a/crates/homeboy-core/src/control_plane.rs
+++ b/crates/homeboy-core/src/control_plane.rs
@@ -87,6 +87,7 @@ pub fn review(
     requested_id: &RunId,
     request: &ControlPlaneRunReviewRequest,
 ) -> Result<ControlPlaneRunReview, ControlPlaneError> {
+    request.validate()?;
     with_provider(|provider| provider.review(requested_id, request))
 }
 

--- a/crates/homeboy-core/src/control_plane.rs
+++ b/crates/homeboy-core/src/control_plane.rs
@@ -6,8 +6,8 @@
 
 use homeboy_control_plane_contract::{
     ControlPlaneActionAcknowledgement, ControlPlaneActionRequest, ControlPlaneCapabilities,
-    ControlPlaneError, ControlPlaneEventPage, ControlPlaneOperation, ControlPlaneRun, EventCursor,
-    RunId,
+    ControlPlaneError, ControlPlaneEventPage, ControlPlaneOperation, ControlPlaneRun,
+    ControlPlaneRunReview, ControlPlaneRunReviewRequest, EventCursor, RunId,
 };
 
 /// Supplies control-plane capabilities and resource reads to the HTTP adapter.
@@ -27,6 +27,16 @@ pub trait ControlPlaneProvider: Send + Sync {
         requested_id: &RunId,
         _cursor: Option<&EventCursor>,
     ) -> Result<ControlPlaneEventPage, ControlPlaneError> {
+        Err(ControlPlaneError::not_found(format!(
+            "control-plane run not found: {requested_id}"
+        )))
+    }
+
+    fn review(
+        &self,
+        requested_id: &RunId,
+        _request: &ControlPlaneRunReviewRequest,
+    ) -> Result<ControlPlaneRunReview, ControlPlaneError> {
         Err(ControlPlaneError::not_found(format!(
             "control-plane run not found: {requested_id}"
         )))
@@ -71,6 +81,13 @@ pub fn events(
     cursor: Option<&EventCursor>,
 ) -> Result<ControlPlaneEventPage, ControlPlaneError> {
     with_provider(|provider| provider.events(requested_id, cursor))
+}
+
+pub fn review(
+    requested_id: &RunId,
+    request: &ControlPlaneRunReviewRequest,
+) -> Result<ControlPlaneRunReview, ControlPlaneError> {
+    with_provider(|provider| provider.review(requested_id, request))
 }
 
 pub fn execute_action(

--- a/crates/homeboy-core/src/http_api.rs
+++ b/crates/homeboy-core/src/http_api.rs
@@ -101,6 +101,16 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 id: (*id).to_string(),
             })
         }
+        (HttpMethod::Get, ["v1", "control-plane", "runs", id, "review"]) => {
+            Ok(HttpEndpoint::ControlPlaneRunReview {
+                id: (*id).to_string(),
+                request: homeboy_control_plane_contract::ControlPlaneRunReviewRequest {
+                    to_worktree: query_value(path, "to_worktree"),
+                    provider_command: query_value(path, "provider_command"),
+                    provider_argv: query_values(path, "provider_argv"),
+                },
+            })
+        }
         (HttpMethod::Get, ["v1", "control-plane", "runs", id, "events"]) => {
             let cursor = query_value(path, "cursor")
                 .map(homeboy_control_plane_contract::EventCursor::new)
@@ -179,6 +189,7 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 "GET /activity/:id".to_string(),
                 "GET /v1/control-plane/capabilities".to_string(),
                 "GET /v1/control-plane/runs/:id".to_string(),
+                "GET /v1/control-plane/runs/:id/review".to_string(),
                 "GET /v1/control-plane/runs/:id/events".to_string(),
                 "POST /v1/control-plane/runs/:id/actions".to_string(),
                 "GET /jobs".to_string(),
@@ -216,6 +227,9 @@ where
     match &endpoint {
         HttpEndpoint::ControlPlaneRun { id } => {
             return control_plane_run_response(endpoint.clone(), id);
+        }
+        HttpEndpoint::ControlPlaneRunReview { id, request } => {
+            return control_plane_review_response(endpoint.clone(), id, request);
         }
         HttpEndpoint::ControlPlaneRunEvents { id, cursor } => {
             return control_plane_events_response(endpoint.clone(), id, cursor.as_ref());
@@ -390,6 +404,7 @@ where
             )?,
         }),
         HttpEndpoint::ControlPlaneRun { .. }
+        | HttpEndpoint::ControlPlaneRunReview { .. }
         | HttpEndpoint::ControlPlaneRunEvents { .. }
         | HttpEndpoint::ControlPlaneRunActions { .. }
         | HttpEndpoint::ControlPlaneCapabilities => {
@@ -495,6 +510,19 @@ fn control_plane_capabilities_response() -> Result<HttpApiResponse> {
 fn control_plane_run_response(endpoint: HttpEndpoint, run_id: &str) -> Result<HttpApiResponse> {
     match control_plane_run(run_id) {
         Ok(resource) => control_plane_ok(endpoint, resource),
+        Err(error) => control_plane_err(endpoint, error),
+    }
+}
+
+fn control_plane_review_response(
+    endpoint: HttpEndpoint,
+    run_id: &str,
+    request: &homeboy_control_plane_contract::ControlPlaneRunReviewRequest,
+) -> Result<HttpApiResponse> {
+    let result = control_plane_run_id(run_id)
+        .and_then(|run_id| crate::control_plane::review(&run_id, request));
+    match result {
+        Ok(review) => control_plane_ok(endpoint, review),
         Err(error) => control_plane_err(endpoint, error),
     }
 }
@@ -1528,6 +1556,20 @@ fn query_value(path: &str, key: &str) -> Option<String> {
         let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
         (name == key && !value.is_empty()).then(|| value.to_string())
     })
+}
+
+fn query_values(path: &str, key: &str) -> Vec<String> {
+    path.split_once('?')
+        .map(|(_, query)| {
+            query
+                .split('&')
+                .filter_map(|pair| {
+                    let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
+                    (name == key && !value.is_empty()).then(|| value.to_string())
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn topology_root(kind: &str, id: &str) -> Result<ResourceTopologyResourceRef> {

--- a/crates/homeboy-core/src/http_api.rs
+++ b/crates/homeboy-core/src/http_api.rs
@@ -1552,22 +1552,18 @@ fn reconciled_stale_status_note(run: &RunRecord) -> Option<String> {
 }
 
 fn query_value(path: &str, key: &str) -> Option<String> {
-    path.split_once('?')?.1.split('&').find_map(|pair| {
-        let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
-        (name == key && !value.is_empty()).then(|| value.to_string())
-    })
+    query_values(path, key).into_iter().next()
 }
 
 fn query_values(path: &str, key: &str) -> Vec<String> {
-    path.split_once('?')
-        .map(|(_, query)| {
-            query
-                .split('&')
-                .filter_map(|pair| {
-                    let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
-                    (name == key && !value.is_empty()).then(|| value.to_string())
+    reqwest::Url::parse(&format!("http://localhost{path}"))
+        .ok()
+        .map(|url| {
+            url.query_pairs()
+                .filter_map(|(name, value)| {
+                    (name == key && !value.is_empty()).then(|| value.into_owned())
                 })
-                .collect()
+                .collect::<Vec<_>>()
         })
         .unwrap_or_default()
 }

--- a/crates/homeboy-core/src/http_api/types.rs
+++ b/crates/homeboy-core/src/http_api/types.rs
@@ -78,6 +78,10 @@ pub enum HttpEndpoint {
     ControlPlaneRun {
         id: String,
     },
+    ControlPlaneRunReview {
+        id: String,
+        request: homeboy_control_plane_contract::ControlPlaneRunReviewRequest,
+    },
     ControlPlaneRunEvents {
         id: String,
         cursor: Option<homeboy_control_plane_contract::EventCursor>,
@@ -171,6 +175,7 @@ impl HttpEndpoint {
             Self::ActivityItem { .. } => "activity.show",
             Self::ControlPlaneCapabilities => "control_plane.capabilities",
             Self::ControlPlaneRun { .. } => "control_plane.runs.show",
+            Self::ControlPlaneRunReview { .. } => "control_plane.runs.review",
             Self::ControlPlaneRunEvents { .. } => "control_plane.runs.events",
             Self::ControlPlaneRunActions { .. } => "control_plane.runs.actions",
             Self::Jobs => "jobs.list",

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -12,10 +12,11 @@ use homeboy_control_plane_contract::{
     ControlPlaneActionPayload, ControlPlaneActionRequest, ControlPlaneCapabilities,
     ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEvent, ControlPlaneEventPage,
     ControlPlaneEventSource, ControlPlaneOperation, ControlPlaneResource, ControlPlaneResult,
-    ControlPlaneRun, ControlPlaneRunState, EventCursor, EventId, MissionId, RunId, TaskId,
-    CONTROL_PLANE_ACTION_ACKNOWLEDGEMENT_SCHEMA, CONTROL_PLANE_ACTION_REQUEST_SCHEMA,
-    CONTROL_PLANE_CANCEL_PARAMETERS_SCHEMA, CONTROL_PLANE_EVENT_PAGE_SCHEMA,
-    CONTROL_PLANE_EVENT_SCHEMA, CONTROL_PLANE_RESULT_SCHEMA, CONTROL_PLANE_RUN_SCHEMA,
+    ControlPlaneRun, ControlPlaneRunReview, ControlPlaneRunReviewRequest, ControlPlaneRunState,
+    EventCursor, EventId, MissionId, RunId, TaskId, CONTROL_PLANE_ACTION_ACKNOWLEDGEMENT_SCHEMA,
+    CONTROL_PLANE_ACTION_REQUEST_SCHEMA, CONTROL_PLANE_CANCEL_PARAMETERS_SCHEMA,
+    CONTROL_PLANE_EVENT_PAGE_SCHEMA, CONTROL_PLANE_EVENT_SCHEMA, CONTROL_PLANE_RESULT_SCHEMA,
+    CONTROL_PLANE_RUN_REVIEW_SCHEMA, CONTROL_PLANE_RUN_SCHEMA,
 };
 use homeboy_resource_topology_contract::{
     ResourceTopologyResourceKind, ResourceTopologyResourceRef,
@@ -382,6 +383,22 @@ impl ControlPlaneProvider for FixtureControlPlaneProvider {
         Ok(fixture_control_plane_events(cursor))
     }
 
+    fn review(
+        &self,
+        requested_id: &RunId,
+        request: &ControlPlaneRunReviewRequest,
+    ) -> Result<ControlPlaneRunReview, ControlPlaneError> {
+        if requested_id.as_str() != CONTROL_PLANE_FIXTURE_RUN {
+            return Err(ControlPlaneError::not_found("fixture run not found"));
+        }
+        Ok(ControlPlaneRunReview {
+            schema: CONTROL_PLANE_RUN_REVIEW_SCHEMA.to_string(),
+            run: requested_id.clone(),
+            resource: fixture_control_plane_run(),
+            evidence: serde_json::json!({ "request": request }),
+        })
+    }
+
     fn execute_action(
         &self,
         requested_id: &RunId,
@@ -426,6 +443,21 @@ fn routes_versioned_control_plane_endpoints() {
     assert_eq!(
         http_api::route(
             HttpMethod::Get,
+            "/v1/control-plane/runs/run-abc/review?to_worktree=homeboy@candidate&provider_argv=homeboy&provider_argv=promote",
+        )
+        .expect("route"),
+        HttpEndpoint::ControlPlaneRunReview {
+            id: "run-abc".to_string(),
+            request: ControlPlaneRunReviewRequest {
+                to_worktree: Some("homeboy@candidate".to_string()),
+                provider_command: None,
+                provider_argv: vec!["homeboy".to_string(), "promote".to_string()],
+            },
+        }
+    );
+    assert_eq!(
+        http_api::route(
+            HttpMethod::Get,
             "/v1/control-plane/runs/run-abc/events?cursor=event-page-2",
         )
         .expect("route"),
@@ -446,6 +478,34 @@ fn routes_versioned_control_plane_endpoints() {
         .expect_err("the unversioned compatibility route is removed");
     http_api::route(HttpMethod::Get, "/v1/control-plane/missions")
         .expect_err("no extra resource family");
+}
+
+#[test]
+fn control_plane_http_review_uses_the_typed_provider_contract() {
+    register_fixture_control_plane_provider();
+    let response = http_api::handle(HttpApiRequest {
+        method: HttpMethod::Get,
+        path: format!(
+            "/v1/control-plane/runs/{CONTROL_PLANE_FIXTURE_RUN}/review?to_worktree=homeboy@candidate&provider_command=homeboy&provider_argv=promote"
+        ),
+        body: None,
+    })
+    .expect("review");
+    assert_eq!(response.status, 200);
+    assert_eq!(response.endpoint, "control_plane.runs.review");
+    let result: ControlPlaneResult<ControlPlaneRunReview> =
+        serde_json::from_value(response.body).expect("result");
+    let review = result.resource.expect("review resource");
+    assert_eq!(review.schema, CONTROL_PLANE_RUN_REVIEW_SCHEMA);
+    assert_eq!(review.run.as_str(), CONTROL_PLANE_FIXTURE_RUN);
+    assert_eq!(
+        review.evidence["request"]["to_worktree"],
+        "homeboy@candidate"
+    );
+    assert_eq!(
+        review.evidence["request"]["provider_argv"],
+        serde_json::json!(["promote"])
+    );
 }
 
 #[test]

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -443,7 +443,7 @@ fn routes_versioned_control_plane_endpoints() {
     assert_eq!(
         http_api::route(
             HttpMethod::Get,
-            "/v1/control-plane/runs/run-abc/review?to_worktree=homeboy@candidate&provider_argv=homeboy&provider_argv=promote",
+            "/v1/control-plane/runs/run-abc/review?to_worktree=homeboy%40candidate&provider_argv=homeboy&provider_argv=--config%3Dpath+with+spaces",
         )
         .expect("route"),
         HttpEndpoint::ControlPlaneRunReview {
@@ -451,7 +451,7 @@ fn routes_versioned_control_plane_endpoints() {
             request: ControlPlaneRunReviewRequest {
                 to_worktree: Some("homeboy@candidate".to_string()),
                 provider_command: None,
-                provider_argv: vec!["homeboy".to_string(), "promote".to_string()],
+                provider_argv: vec!["homeboy".to_string(), "--config=path with spaces".to_string()],
             },
         }
     );

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -486,7 +486,7 @@ fn control_plane_http_review_uses_the_typed_provider_contract() {
     let response = http_api::handle(HttpApiRequest {
         method: HttpMethod::Get,
         path: format!(
-            "/v1/control-plane/runs/{CONTROL_PLANE_FIXTURE_RUN}/review?to_worktree=homeboy@candidate&provider_command=homeboy&provider_argv=promote"
+            "/v1/control-plane/runs/{CONTROL_PLANE_FIXTURE_RUN}/review?to_worktree=homeboy%40candidate&provider_argv=homeboy&provider_argv=--config%3Dpath+with+spaces"
         ),
         body: None,
     })
@@ -504,7 +504,29 @@ fn control_plane_http_review_uses_the_typed_provider_contract() {
     );
     assert_eq!(
         review.evidence["request"]["provider_argv"],
-        serde_json::json!(["promote"])
+        serde_json::json!(["homeboy", "--config=path with spaces"])
+    );
+}
+
+#[test]
+fn control_plane_http_review_rejects_conflicting_provider_inputs() {
+    register_fixture_control_plane_provider();
+    let response = http_api::handle(HttpApiRequest {
+        method: HttpMethod::Get,
+        path: format!(
+            "/v1/control-plane/runs/{CONTROL_PLANE_FIXTURE_RUN}/review?provider_command=homeboy&provider_argv=homeboy"
+        ),
+        body: None,
+    })
+    .expect("typed review error");
+
+    assert_eq!(response.status, 400);
+    let result: ControlPlaneResult<ControlPlaneRunReview> =
+        serde_json::from_value(response.body).expect("result");
+    assert!(!result.ok);
+    assert_eq!(
+        result.error.expect("error").class,
+        homeboy_control_plane_contract::ControlPlaneErrorClass::InvalidArgument
     );
 }
 


### PR DESCRIPTION
## Summary
- add a versioned, non-mutating control-plane review resource and advertise it as a read operation rather than an action
- assemble durable review evidence once in the orchestration service, preserving aggregate availability, diagnostics, execution states, cleanup redaction, Cook gate/base replay, and contributing attempts
- expose the same typed review through CLI and `GET /v1/control-plane/runs/:id/review`, deleting the parallel CLI-owned review policy

Advances #13697.

## Verification
- `cargo test -p homeboy-control-plane-contract -- --test-threads=1`
- `cargo test -p homeboy-agents orchestration::tests --lib -- --test-threads=1`
- `cargo test -p homeboy-core control_plane_ --lib -- --test-threads=1`
- focused CLI review, compact projection, Cook recipe, cleanup-redaction, and contributing-attempt tests
- `cargo check -p homeboy-core -p homeboy-agents -p homeboy-cli`
- full local `promotion_review` selection: 8 passed; the existing native-worktree fixture `direct_cook_promotion_resolves_recovered_patch_from_run_id_and_aggregate_path` fails identically on the parent with `promotion requires an active native Homeboy worktree`

## AI Assistance
AI-assisted with OpenCode using OpenAI GPT-5.6 Sol to audit behavioral parity, implement the canonical service/transport consolidation, and run focused verification.