### PR TITLE
test: share one git output helper across crates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -758,15 +758,7 @@ mod committed_harvest_tests {
         std::env::remove_var(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV);
     }
 
-    fn git(cwd: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(cwd)
-            .output()
-            .expect("git command runs");
-        assert!(output.status.success(), "git {args:?} failed");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
+    use homeboy_core::test_support::git_command_output as git;
 
     fn gate_feedback_request(
         workspace: &Path,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2671,20 +2671,7 @@ fn observe_and_fetch_base(path: &str, base: &str) -> Result<String> {
 mod moving_base_tests {
     use super::*;
 
-    fn git(path: &std::path::Path, args: &[&str]) -> String {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
+    use homeboy_core::test_support::git_command_output as git;
 
     #[test]
     fn moving_base_overlap_is_rejected_before_destination_mutation() {

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -11805,18 +11805,5 @@ esac
         );
     }
 
-    fn git(path: &std::path::Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run Git fixture command");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
+    use homeboy_core::test_support::git_command_output as git;
 }

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -3424,19 +3424,7 @@ mod tests {
     }
     use homeboy_core::test_support::{exec_capable_tempdir, with_isolated_home};
 
-    fn run_git(dir: &Path, args: &[&str]) -> String {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
+    use crate::test_support::git_command_output as run_git;
 
     fn clean_repo() -> tempfile::TempDir {
         let temp = tempfile::tempdir().expect("temp dir");

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1693,6 +1693,27 @@ fn git_repo_fixture(name: &str, committed: bool) -> (TempDir, PathBuf) {
 /// Use this when the test configures its own `user.name` / `user.email` and may
 /// assert on the resulting authorship. [`run_git_fixture_command`] pins a fixed
 /// fixture identity, which would override that configuration.
+/// Run a git command in `repo`, assert it succeeded, and return its trimmed
+/// stdout, without injecting any author or committer identity.
+///
+/// The output counterpart of [`run_git_command`]. Use [`git_fixture_output`]
+/// instead when the test wants the pinned fixture identity.
+pub fn git_command_output(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git command");
+    assert!(
+        output.status.success(),
+        "git command {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
 pub fn run_git_command(repo: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)

--- a/crates/homeboy-deploy/src/preparation.rs
+++ b/crates/homeboy-deploy/src/preparation.rs
@@ -1048,18 +1048,7 @@ mod tests {
 
     #[test]
     fn exact_ref_preparation_builds_detached_bytes_and_cleans_owned_resources() {
-        fn git(path: &Path, args: &[&str]) -> String {
-            let output = std::process::Command::new("git")
-                .args(args)
-                .current_dir(path)
-                .output()
-                .expect("run git");
-            assert!(output.status.success(), "git {:?}: {:?}", args, output);
-            String::from_utf8(output.stdout)
-                .expect("git output")
-                .trim()
-                .to_string()
-        }
+        use homeboy_core::test_support::git_command_output as git;
 
         let repo = tempfile::tempdir().expect("repo");
         git(repo.path(), &["init", "-q"]);
@@ -1134,18 +1123,7 @@ mod tests {
     #[test]
     fn exact_ref_default_extension_build_replaces_stale_artifact_and_records_source_commit() {
         homeboy_core::test_support::with_isolated_home(|home| {
-            fn git(path: &Path, args: &[&str]) -> String {
-                let output = std::process::Command::new("git")
-                    .args(args)
-                    .current_dir(path)
-                    .output()
-                    .expect("run git");
-                assert!(output.status.success(), "git {:?}: {:?}", args, output);
-                String::from_utf8(output.stdout)
-                    .expect("git output")
-                    .trim()
-                    .to_string()
-            }
+            use homeboy_core::test_support::git_command_output as git;
 
             let extension_dir = home
                 .path()

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -1534,20 +1534,7 @@ mod tests {
         assert!(status.success(), "initialize git checkout");
     }
 
-    fn git(path: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {}: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
+    use homeboy_core::test_support::git_command_output as git;
 
     fn local_runner() -> super::super::Runner {
         super::super::Runner {

--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -634,20 +634,7 @@ mod tests {
         super::recovery_path_in_roots(test_roots().data(), component_id)
     }
 
-    fn run_git(path: &Path, args: &[&str]) -> String {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {:?}: {}",
-            args,
-            String::from_utf8_lossy(&output.stderr)
-        );
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
+    use homeboy_core::test_support::git_command_output as run_git;
 
     fn write_release_artifact(path: &Path) {
         let file = std::fs::File::create(path).expect("create release artifact");

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -1168,20 +1168,7 @@ mod git_steps {
     use crate::pipeline::run_pipeline;
     use crate::spec::{ComponentSpec, GitOp, PipelineStep, RigSpec};
 
-    fn run_git(repo: &std::path::Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(repo)
-            .output()
-            .expect("spawn git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: {}",
-            args,
-            String::from_utf8_lossy(&output.stderr)
-        );
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    }
+    use homeboy_core::test_support::git_command_output as run_git;
 
     fn rig_with_git_step(component_path: String, op: GitOp) -> RigSpec {
         let mut components = HashMap::new();


### PR DESCRIPTION
## Summary
Eight test modules across six crates each defined an identical `git` / `run_git` helper that runs git, asserts success, and returns trimmed stdout. They now share one helper, with call sites unchanged:

```rust
use homeboy_core::test_support::git_command_output as git;
```

Net **-86 lines**. Completes the helper consolidation in #13227.

Crates: release, deploy, core, cli, agents, lab-runner, plus the rig pipeline test mounted from `tests/`.

## Why a new helper again
`git_fixture_output` already existed but pins a fixed identity through `GitFixture::with_identity`, exactly like `run_git_fixture_command`. The helpers being replaced inject no identity. Rather than repeat the authorship mistake #14351 uncovered, this adds `git_command_output`: assert-only, identity-neutral, trimmed stdout — matching the replaced helpers exactly.

`test_support` now offers both contracts explicitly, and the docs on each say which to reach for.

## Production helpers were left alone
Several files contain a similarly-named git helper in production code — `agent_task_candidate_baseline`, `agent_task_promotion/fingerprint`, `agent_task_service/cook_promotion`, `git_dependency_materialization`. Those return `Result<...>` rather than `String`, and `test_support` is `cfg`-gated, so touching them would be wrong. The rewrite matches on an exact `-> String` signature, which excludes every production variant. Two files here contain both shapes; only the test one changed.

The `-> bool` variants are a third shape and are not part of this pass.

## Verification
| crate | result | baseline |
|---|---|---|
| release | 572 passed, 0 failed | clean |
| deploy | 325 passed, 5 failed | same 5 as `main` |
| core (`extension::test::run`) | 73 passed, 0 failed | — |
| agents (`harvest`, `cook_promotion`) | 26 passed, 0 failed | — |
| cli (`fanout`) | 174 passed, 0 failed | — |
| lab-runner (`rig_materialization`) | 64 passed, 0 failed | — |
| rig (`pipeline`) | 75 passed, 0 failed | — |

One deploy run reported 319 passed / 11 failed before settling back to the baseline 325/5 on re-run, so that crate has some parallel sensitivity of its own beyond the 5 known failures.

## AI Assistance
OpenAI GPT-5.6 Sol through OpenCode added an identity-neutral output helper rather than reusing the identity-pinning one, excluded production helpers by return-type signature, and verified each affected crate. Chris Huber directed the work and remains responsible for acceptance.