### PR TITLE
Fix Cook promotion setup evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -2417,16 +2417,27 @@ fn gate_setup_outcome_failure(
     classification: &str,
     outcome: &homeboy_core::deps::DependencyHydrationOutcome,
 ) -> Error {
+    let mut bounded_outcome = outcome.clone();
+    bounded_outcome.cwd = bounded_setup_error_text(&bounded_outcome.cwd);
+    bounded_outcome.stdout = bounded_setup_error_text(&bounded_outcome.stdout);
+    bounded_outcome.stderr = bounded_setup_error_text(&bounded_outcome.stderr);
+    let logs = [
+        (!bounded_outcome.stdout.is_empty()).then(|| format!("stdout: {}", bounded_outcome.stdout)),
+        (!bounded_outcome.stderr.is_empty()).then(|| format!("stderr: {}", bounded_outcome.stderr)),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
     Error::dependency_step_failed(
         "promotion.gate_setup",
         outcome.provider_id.clone(),
         outcome.exit_code,
-        Vec::new(),
+        logs,
         Vec::new(),
         Some(outcome.command.join(" ")),
         Some(serde_json::json!({
             "classification": classification,
-            "outcome": outcome,
+            "outcome": bounded_outcome,
             "retry_action": "retry_dependency_hydration",
         })),
     )

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -2171,14 +2171,14 @@ fn promotion_setup_failure_is_bounded_and_never_dispatches_a_gate() {
         std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
         std::fs::write(
             workspace.join("component/homeboy-deps.json"),
-            r#"{"provider":"fixture-provider","commands":{"install":{"argv":["sh","-c","exit 23"]}}}"#,
+            r#"{"provider":"fixture-provider","commands":{"install":{"argv":["sh","-c","printf 'install output'; printf 'install failure' >&2; exit 23"]}}}"#,
         )
         .expect("provider declaration");
         git(&workspace, &["add", "."]);
         git(&workspace, &["commit", "-m", "base"]);
         let (source_path, source) = write_patch_source(&temp);
         let mut provider = FakePromotionWorkspaceProvider {
-            workspace_path: Some(workspace),
+            workspace_path: Some(workspace.clone()),
             apply_to_git: true,
             ..Default::default()
         };
@@ -2211,6 +2211,23 @@ fn promotion_setup_failure_is_bounded_and_never_dispatches_a_gate() {
         assert_eq!(
             error.details["cause"]["classification"],
             "destination_gate_setup"
+        );
+        assert_eq!(error.details["status"], 23);
+        assert_eq!(
+            error.details["cause"]["outcome"]["cwd"],
+            workspace.join("component").display().to_string()
+        );
+        assert_eq!(
+            error.details["cause"]["outcome"]["stdout"],
+            "install output"
+        );
+        assert_eq!(
+            error.details["cause"]["outcome"]["stderr"],
+            "install failure"
+        );
+        assert_eq!(
+            error.details["logs"],
+            serde_json::json!(["stdout: install output", "stderr: install failure"])
         );
         assert!(error.details["cause"]["outcome"].to_string().len() <= 20 * 1024);
         assert!(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -18016,11 +18016,14 @@ fn failed_attempt_manual_preflight_hydrates_serialized_intent_and_publishes() {
                 package_root: ".".to_string(),
                 provider_id: "fixture".to_string(),
                 command: vec!["fixture-install".to_string()],
+                cwd: "/fixture".to_string(),
                 reason: "deterministic fixture".to_string(),
                 duration_ms: 17,
                 termination: homeboy_core::deps::DependencyHydrationTermination::Completed,
                 status: homeboy_core::deps::DependencyHydrationStatus::Succeeded,
                 exit_code: Some(0),
+                stdout: String::new(),
+                stderr: String::new(),
             });
         let candidate = crate::agent_task_finalization::AgentTaskPrCandidateState::Committed {
             changed_files: vec!["src/lib.rs".to_string()],

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -502,6 +502,12 @@ fn render_status_summary(payload: &Value) -> Option<String> {
 }
 
 fn control_plane_next_action(payload: &Value, run_id: &str) -> String {
+    if string_value(payload, &["blocker", "code"]) == Some("controller_failure")
+        && string_value(payload, &["candidate", "state"]) == Some("verification_pending")
+    {
+        let cook_id = string_value(payload, &["mission"]).unwrap_or(run_id);
+        return format!("homeboy agent-task cook-continue {cook_id}");
+    }
     const PREFERRED: [&str; 5] = ["reconcile", "resume", "retry", "review", "promote"];
     let Some(actions) = payload
         .pointer("/action_eligibility/actions")
@@ -1766,6 +1772,38 @@ mod tests {
         assert!(summary.contains("Artifacts: 1\n"), "{summary}");
         assert!(
             summary.contains("Next: homeboy agent-task review agent-task-cook-attempt-1\n"),
+            "{summary}"
+        );
+    }
+
+    #[test]
+    fn status_summary_routes_pending_cook_controller_failure_to_continuation() {
+        let payload = json!({
+            "schema": "homeboy/control-plane-run/v1",
+            "mission": "cook-14357",
+            "run": "cook-14357-attempt-1",
+            "state": "succeeded",
+            "candidate": { "state": "verification_pending" },
+            "blocker": {
+                "code": "controller_failure",
+                "message": "dependency hydration failed"
+            },
+            "artifacts": [],
+            "action_eligibility": {
+                "actions": [{
+                    "action": "review",
+                    "availability": "available"
+                }]
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+        assert!(
+            summary.contains("Next: homeboy agent-task cook-continue cook-14357\n"),
+            "{summary}"
+        );
+        assert!(
+            !summary.contains("Next: homeboy agent-task review"),
             "{summary}"
         );
     }

--- a/crates/homeboy-core/src/deps.rs
+++ b/crates/homeboy-core/src/deps.rs
@@ -106,12 +106,18 @@ pub struct DependencyHydrationOutcome {
     pub package_root: String,
     pub provider_id: String,
     pub command: Vec<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub cwd: String,
     pub reason: String,
     pub duration_ms: u64,
     pub termination: DependencyHydrationTermination,
     pub status: DependencyHydrationStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stdout: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stderr: String,
 }
 
 #[derive(Debug, Clone)]
@@ -189,26 +195,26 @@ pub fn hydrate_declared_dependencies(
             let reusable_command = crate::redaction::redact_argv(&reusable.command.argv());
             let reusable_reason = crate::redaction::redact_string(&reusable.reusable_reason);
             stale_reason = crate::redaction::redact_string(&reusable.stale_reason);
-            let execution = match assessment {
-                Ok(execution) => execution,
-                Err(termination) => {
-                    outcomes.push(hydration_outcome(
-                        workspace,
-                        package_root,
-                        provider_id,
-                        reusable_command,
-                        "reusable_state_assessment_failed".to_string(),
-                        started.elapsed(),
-                        termination,
-                        DependencyHydrationStatus::Failed,
-                        None,
-                    ));
-                    break;
-                }
-            };
+            if assessment.termination != DependencyHydrationTermination::Completed {
+                outcomes.push(hydration_outcome(
+                    workspace,
+                    package_root,
+                    provider_id,
+                    reusable_command,
+                    reusable.command.cwd.display().to_string(),
+                    "reusable_state_assessment_failed".to_string(),
+                    started.elapsed(),
+                    assessment.termination,
+                    DependencyHydrationStatus::Failed,
+                    assessment.exit_code,
+                    assessment.stdout,
+                    assessment.stderr,
+                ));
+                break;
+            }
             if reusable
                 .reusable_exit_codes
-                .contains(&execution.exit_code.unwrap_or(-1))
+                .contains(&assessment.exit_code.unwrap_or(-1))
                 && declared_outputs_ready(path, &plan.outputs)
             {
                 outcomes.push(hydration_outcome(
@@ -216,11 +222,14 @@ pub fn hydrate_declared_dependencies(
                     package_root,
                     provider_id,
                     install_command,
+                    plan.install.cwd.display().to_string(),
                     reusable_reason,
                     started.elapsed(),
                     DependencyHydrationTermination::NotStarted,
                     DependencyHydrationStatus::Reused,
                     None,
+                    String::new(),
+                    String::new(),
                 ));
                 continue;
             }
@@ -230,11 +239,14 @@ pub fn hydrate_declared_dependencies(
                 package_root,
                 provider_id,
                 install_command,
+                plan.install.cwd.display().to_string(),
                 "provider_declared_outputs_ready".to_string(),
                 started.elapsed(),
                 DependencyHydrationTermination::NotStarted,
                 DependencyHydrationStatus::Reused,
                 None,
+                String::new(),
+                String::new(),
             ));
             continue;
         }
@@ -246,24 +258,24 @@ pub fn hydrate_declared_dependencies(
             elapsed_ms: started.elapsed().as_millis(),
             last_progress_ms_ago: None,
         });
-        let execution =
-            match run_hydration_command(&plan.install, &provider_id, "installing", policy) {
-                Ok(execution) => execution,
-                Err(termination) => {
-                    outcomes.push(hydration_outcome(
-                        workspace,
-                        package_root,
-                        provider_id,
-                        install_command,
-                        stale_reason,
-                        started.elapsed(),
-                        termination,
-                        DependencyHydrationStatus::Failed,
-                        None,
-                    ));
-                    break;
-                }
-            };
+        let execution = run_hydration_command(&plan.install, &provider_id, "installing", policy);
+        if execution.termination != DependencyHydrationTermination::Completed {
+            outcomes.push(hydration_outcome(
+                workspace,
+                package_root,
+                provider_id,
+                install_command,
+                plan.install.cwd.display().to_string(),
+                stale_reason,
+                started.elapsed(),
+                execution.termination,
+                DependencyHydrationStatus::Failed,
+                execution.exit_code,
+                execution.stdout,
+                execution.stderr,
+            ));
+            break;
+        }
         let exit_code = execution.exit_code;
         if !exit_code.is_some_and(|code| plan.install_success_exit_codes.contains(&code)) {
             outcomes.push(hydration_outcome(
@@ -271,11 +283,14 @@ pub fn hydrate_declared_dependencies(
                 package_root,
                 provider_id,
                 install_command,
+                plan.install.cwd.display().to_string(),
                 stale_reason,
                 started.elapsed(),
                 DependencyHydrationTermination::ExitFailure,
                 DependencyHydrationStatus::Failed,
                 exit_code,
+                execution.stdout,
+                execution.stderr,
             ));
             break;
         }
@@ -285,11 +300,14 @@ pub fn hydrate_declared_dependencies(
                 package_root,
                 provider_id,
                 install_command,
+                plan.install.cwd.display().to_string(),
                 "provider_declared_outputs_missing_after_install".to_string(),
                 started.elapsed(),
                 DependencyHydrationTermination::OutputValidationFailed,
                 DependencyHydrationStatus::Failed,
                 exit_code,
+                execution.stdout,
+                execution.stderr,
             ));
             break;
         }
@@ -298,11 +316,14 @@ pub fn hydrate_declared_dependencies(
             package_root,
             provider_id,
             install_command,
+            plan.install.cwd.display().to_string(),
             stale_reason,
             started.elapsed(),
             DependencyHydrationTermination::Completed,
             DependencyHydrationStatus::Succeeded,
             exit_code,
+            String::new(),
+            String::new(),
         ));
     }
 
@@ -311,6 +332,9 @@ pub fn hydrate_declared_dependencies(
 
 struct HydrationCommandExecution {
     exit_code: Option<i32>,
+    termination: DependencyHydrationTermination,
+    stdout: String,
+    stderr: String,
 }
 
 fn run_hydration_command(
@@ -318,9 +342,14 @@ fn run_hydration_command(
     provider_id: &str,
     phase: &str,
     policy: &DependencyHydrationPolicy,
-) -> std::result::Result<HydrationCommandExecution, DependencyHydrationTermination> {
+) -> HydrationCommandExecution {
     if (policy.is_cancelled)() {
-        return Err(DependencyHydrationTermination::Cancelled);
+        return HydrationCommandExecution {
+            exit_code: None,
+            termination: DependencyHydrationTermination::Cancelled,
+            stdout: String::new(),
+            stderr: String::new(),
+        };
     }
     let declared_program = Path::new(&command.program);
     let resolved_program =
@@ -337,12 +366,17 @@ fn run_hydration_command(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     homeboy_engine_primitives::command::isolate_process_tree(&mut process);
-    let mut child = process
-        .spawn()
-        .map_err(|_| DependencyHydrationTermination::SpawnFailed)?;
+    let Ok(mut child) = process.spawn() else {
+        return HydrationCommandExecution {
+            exit_code: None,
+            termination: DependencyHydrationTermination::SpawnFailed,
+            stdout: String::new(),
+            stderr: String::new(),
+        };
+    };
     let progress = Arc::clone(&policy.on_progress);
     let cancellation = Arc::clone(&policy.is_cancelled);
-    let output =
+    let Ok(output) =
         homeboy_engine_primitives::command::wait_with_bounded_output_supervised_with_progress(
             &mut child,
             DEPENDENCY_HYDRATION_OUTPUT_LIMIT_BYTES,
@@ -355,15 +389,26 @@ fn run_hydration_command(
                 Ok(())
             },
         )
-        .map_err(|_| DependencyHydrationTermination::SpawnFailed)?;
+    else {
+        return HydrationCommandExecution {
+            exit_code: None,
+            termination: DependencyHydrationTermination::SpawnFailed,
+            stdout: String::new(),
+            stderr: String::new(),
+        };
+    };
     use homeboy_engine_primitives::command::SupervisedCommandTermination;
-    match output.termination {
-        SupervisedCommandTermination::Completed => Ok(HydrationCommandExecution {
-            exit_code: output.output.status.code(),
-        }),
-        SupervisedCommandTermination::Cancelled => Err(DependencyHydrationTermination::Cancelled),
-        SupervisedCommandTermination::TimedOut => Err(DependencyHydrationTermination::TimedOut),
-        SupervisedCommandTermination::NoProgress => Err(DependencyHydrationTermination::NoProgress),
+    let termination = match output.termination {
+        SupervisedCommandTermination::Completed => DependencyHydrationTermination::Completed,
+        SupervisedCommandTermination::Cancelled => DependencyHydrationTermination::Cancelled,
+        SupervisedCommandTermination::TimedOut => DependencyHydrationTermination::TimedOut,
+        SupervisedCommandTermination::NoProgress => DependencyHydrationTermination::NoProgress,
+    };
+    HydrationCommandExecution {
+        exit_code: output.output.status.code(),
+        termination,
+        stdout: crate::redaction::redact_string(&String::from_utf8_lossy(&output.output.stdout)),
+        stderr: crate::redaction::redact_string(&String::from_utf8_lossy(&output.output.stderr)),
     }
 }
 
@@ -405,11 +450,14 @@ fn hydration_outcome(
     package_root: &str,
     provider_id: String,
     command: Vec<String>,
+    cwd: String,
     reason: String,
     duration: Duration,
     termination: DependencyHydrationTermination,
     status: DependencyHydrationStatus,
     exit_code: Option<i32>,
+    stdout: String,
+    stderr: String,
 ) -> DependencyHydrationOutcome {
     DependencyHydrationOutcome {
         schema: DEPENDENCY_HYDRATION_SCHEMA.to_string(),
@@ -417,11 +465,14 @@ fn hydration_outcome(
         package_root: package_root.to_string(),
         provider_id,
         command,
+        cwd: crate::redaction::redact_string(&cwd),
         reason: crate::redaction::redact_string(&reason),
         duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
         termination,
         status,
         exit_code,
+        stdout,
+        stderr,
     }
 }
 
@@ -1457,6 +1508,35 @@ mod tests {
     }
 
     #[test]
+    fn failed_declared_install_retains_bounded_command_evidence() {
+        crate::test_support::with_isolated_home(|_| {
+            let root = tempfile::tempdir().expect("provider workspace");
+            std::fs::write(
+                root.path().join("homeboy-deps.json"),
+                r#"{"provider":"fixture-provider","commands":{"install":{"argv":["sh","-c","printf 'install output'; printf 'install failure' >&2; exit 23"]}}}"#,
+            )
+            .expect("provider manifest");
+
+            let outcomes = hydrate_declared_dependencies(
+                root.path(),
+                "fixture",
+                ".",
+                &hydration_policy(
+                    Arc::new(AtomicBool::new(false)),
+                    Arc::new(Mutex::new(Vec::new())),
+                ),
+            )
+            .expect("failed hydration outcome");
+
+            assert_eq!(outcomes[0].status, DependencyHydrationStatus::Failed);
+            assert_eq!(outcomes[0].exit_code, Some(23));
+            assert_eq!(outcomes[0].cwd, root.path().display().to_string());
+            assert_eq!(outcomes[0].stdout, "install output");
+            assert_eq!(outcomes[0].stderr, "install failure");
+        });
+    }
+
+    #[test]
     fn cancellation_stops_declared_install() {
         crate::test_support::with_isolated_home(|_| {
             let root = tempfile::tempdir().expect("provider workspace");
@@ -1492,7 +1572,7 @@ mod tests {
             let root = tempfile::tempdir().expect("provider workspace");
             std::fs::write(
                 root.path().join("install-fixture"),
-                "#!/bin/sh\nprintf ready > prepared.state\n",
+                "#!/bin/sh\nprintf 'fixture-secret-value'\nprintf ready > prepared.state\n",
             )
             .expect("fixture installer");
             use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
Fixes #14357

## Summary
- retain redacted, bounded cwd/stdout/stderr for failed dependency hydration
- expose hydration output through typed promotion setup failure logs
- route verification-pending Cook controller failures to `cook-continue` in status output

## Verification
- `cargo test -p homeboy-core deps::tests::`
- `cargo test -p homeboy-agents agent_task_promotion::tests::`
- `cargo test -p homeboy-agents failed_attempt_manual_preflight_hydrates_serialized_intent_and_publishes`
- `cargo test -p homeboy-cli status_summary_routes_pending_cook_controller_failure_to_continuation`

The broader agent-task summary suite has an unrelated existing failure in `review_summary_keeps_a_pre_apply_candidate_out_of_the_promoted_outcome`. Clippy is currently blocked by the existing `homeboy-runner-contract` `large_enum_variant` denial.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the Cook promotion and continuation paths, implemented the bounded evidence projection and status routing, and ran the focused verification. Chris Huber directed the workflow.