### PR TITLE
fix(test-scope): treat test-harness config as source-relevant

### DIFF
--- a/crates/homeboy-core/src/extension/test/drift.rs
+++ b/crates/homeboy-core/src/extension/test/drift.rs
@@ -536,6 +536,43 @@ pub fn is_source_relevant_change(opts: &DriftOptions, path: &str) -> bool {
     matches_any_pattern(path, &opts.source_patterns)
         || matches_any_pattern(path, &opts.test_patterns)
         || is_test_path(path)
+        || is_test_harness_config_path(path)
+}
+
+/// True when `path` configures how tests are discovered, provisioned, or run.
+///
+/// These files are config by extension, so no source pattern matches them and
+/// the docs/config fallback treats them as inert. That made a change to the
+/// test harness itself select zero tests and pass, which is the one change for
+/// which a green run proves the least: the harness was never exercised.
+///
+/// Deliberately narrow. Only the files that define test execution qualify, not
+/// configuration generally — a component's application config stays inert.
+pub fn is_test_harness_config_path(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    let file_name = lower.rsplit('/').next().unwrap_or(&lower);
+
+    // CI workflow definitions own dependency pins, provisioning, and which
+    // suites execute at all.
+    if lower.contains(".github/workflows/") {
+        return true;
+    }
+
+    // Homeboy's own component manifest declares suites, runtime settings, and
+    // validation dependencies.
+    if file_name == "homeboy.json" {
+        return true;
+    }
+
+    // Test runner configuration: phpunit.xml(.dist), jest/vitest/playwright
+    // configs, and the PHP/JS test bootstraps they reference.
+    file_name.starts_with("phpunit")
+        && (file_name.ends_with(".xml") || file_name.ends_with(".xml.dist"))
+        || file_name.starts_with("jest.config.")
+        || file_name.starts_with("vitest.config.")
+        || file_name.starts_with("playwright.config.")
+        || file_name == "phpunit.xml"
+        || file_name == "phpunit.xml.dist"
 }
 
 /// Documentation, config, and other non-source file suffixes/paths that are
@@ -612,7 +649,7 @@ impl DriftOptions {
 /// unconfigured component still flags real source changes instead of silently
 /// passing a zero-test scope. (#8927)
 pub fn is_source_relevant_change_unconfigured(path: &str) -> bool {
-    is_test_path(path) || !is_docs_or_config_path(path)
+    is_test_path(path) || is_test_harness_config_path(path) || !is_docs_or_config_path(path)
 }
 
 /// Defined symbol names (fn/struct/enum/trait/method/class) added and removed
@@ -1285,10 +1322,15 @@ mod tests {
         assert!(!is_source_relevant_change_unconfigured("docs/guide.md"));
         assert!(!is_source_relevant_change_unconfigured("Cargo.toml"));
         assert!(!is_source_relevant_change_unconfigured("Cargo.lock"));
-        assert!(!is_source_relevant_change_unconfigured(
+        assert!(!is_source_relevant_change_unconfigured("LICENSE"));
+
+        // A CI workflow was previously asserted irrelevant alongside docs.
+        // It is not inert: it decides which suites run and against what, so a
+        // zero-test pass on a workflow change evidences nothing about the
+        // change itself. See test_harness_config_is_source_relevant.
+        assert!(is_source_relevant_change_unconfigured(
             ".github/workflows/ci.yml"
         ));
-        assert!(!is_source_relevant_change_unconfigured("LICENSE"));
     }
 
     #[test]
@@ -1310,6 +1352,67 @@ mod tests {
             inline_tests: false,
         };
         assert!(!empty.has_usable_patterns());
+    }
+
+    #[test]
+    fn test_harness_config_is_source_relevant() {
+        // Config by extension, so no source pattern matches these and the
+        // docs/config fallback treated them as inert. A change here previously
+        // selected zero tests and passed without exercising the harness.
+        for path in [
+            ".github/workflows/homeboy.yml",
+            ".github/workflows/booking-attachment-mysql.yml",
+            "homeboy.json",
+            "phpunit.xml.dist",
+            "phpunit-booking-mysql.xml.dist",
+            "jest.config.js",
+            "vitest.config.ts",
+        ] {
+            assert!(
+                is_test_harness_config_path(path),
+                "expected {path} to be treated as test-harness config"
+            );
+            assert!(
+                is_source_relevant_change_unconfigured(path),
+                "expected {path} to be source-relevant without drift patterns"
+            );
+        }
+
+        // Ordinary docs and application config stay inert, so a docs-only
+        // change still passes with a legitimate no-test scope.
+        for path in [
+            "README.md",
+            "docs/CHANGELOG.md",
+            "composer.lock",
+            "package.json",
+            "src/config/app-settings.json",
+            ".editorconfig",
+        ] {
+            assert!(
+                !is_test_harness_config_path(path),
+                "expected {path} not to be treated as test-harness config"
+            );
+        }
+    }
+
+    #[test]
+    fn harness_config_is_relevant_even_with_source_patterns_configured() {
+        // The configured path matches against source/test globs, which a .yml
+        // or .xml.dist file never satisfies. Without the harness check a
+        // workflow-only change is invisible to the zero-test gate.
+        let opts = DriftOptions {
+            root: PathBuf::from("/tmp"),
+            since: "HEAD".to_string(),
+            source_patterns: vec!["**/*.php".to_string()],
+            test_patterns: vec!["tests/**/*Test.php".to_string()],
+            inline_tests: false,
+        };
+        assert!(is_source_relevant_change(
+            &opts,
+            ".github/workflows/homeboy.yml"
+        ));
+        assert!(is_source_relevant_change(&opts, "phpunit-managed.xml.dist"));
+        assert!(!is_source_relevant_change(&opts, "README.md"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -1369,9 +1369,7 @@ fn run_main_test_workflow_inner(
                 // suite proves it still works. Say that instead.
                 let harness_only = impacted
                     .iter()
-                    .all(|file| {
-                        crate::extension::test::drift::is_test_harness_config_path(file)
-                    });
+                    .all(|file| crate::extension::test::drift::is_test_harness_config_path(file));
 
                 let message = if harness_only {
                     format!(

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -1364,22 +1364,52 @@ fn run_main_test_workflow_inner(
                     preview
                 };
 
-                let message = format!(
-                    "Changed-scope test gate selected zero tests, but {} source file(s) changed since {changed_ref}: {impacted_summary}. Zero selection is not valid test evidence for a source change.",
-                    impacted.len(),
-                );
+                // A harness-config change cannot be answered by "add a test":
+                // the changed file decides how tests run, so only executing the
+                // suite proves it still works. Say that instead.
+                let harness_only = impacted
+                    .iter()
+                    .all(|file| {
+                        crate::extension::test::drift::is_test_harness_config_path(file)
+                    });
+
+                let message = if harness_only {
+                    format!(
+                        "Changed-scope test gate selected zero tests, but {} test-harness config file(s) changed since {changed_ref}: {impacted_summary}. A harness change is the one change a zero-test run cannot evidence, because the harness itself was never exercised.",
+                        impacted.len(),
+                    )
+                } else {
+                    format!(
+                        "Changed-scope test gate selected zero tests, but {} source file(s) changed since {changed_ref}: {impacted_summary}. Zero selection is not valid test evidence for a source change.",
+                        impacted.len(),
+                    )
+                };
                 let findings = Some(vec![HomeboyFinding::builder("test", message.clone())
-                    .rule("changed_scope_zero_tests_for_source_change")
+                    .rule(if harness_only {
+                        "changed_scope_zero_tests_for_harness_change"
+                    } else {
+                        "changed_scope_zero_tests_for_source_change"
+                    })
                     .category("test-scope")
                     .severity("error")
                     .build()]);
-                let hints = Some(vec![
-                    format!(
-                        "Add or route a test for the changed source, or run the full suite: homeboy review test {}",
-                        args.component_id
-                    ),
-                    "If these changes are intentionally test-exempt, exclude them from the release/test scope so the gate can pass with a typed reason.".to_string(),
-                ]);
+                let hints = Some(if harness_only {
+                    vec![
+                        format!(
+                            "Run the full suite so the harness change is exercised: homeboy review test {}",
+                            args.component_id
+                        ),
+                        "A green changed-scope run here would only mean no source changed, not that the harness still works.".to_string(),
+                    ]
+                } else {
+                    vec![
+                        format!(
+                            "Add or route a test for the changed source, or run the full suite: homeboy review test {}",
+                            args.component_id
+                        ),
+                        "If these changes are intentionally test-exempt, exclude them from the release/test scope so the gate can pass with a typed reason.".to_string(),
+                    ]
+                });
 
                 return Ok(TestRunWorkflowResult {
                     status: "failed".to_string(),


### PR DESCRIPTION
## Problem

A changed scope containing only CI workflows, `homeboy.json`, or PHPUnit configs selects zero tests and **passes**:

```json
"summary": { "exit_code": 0, "failed": 0, "passed": 0, "skipped": 0, "total": 0 }
```
```
"No impacted tests found for --changed-since <sha> (no production or test source changed)"
```

This inverts the guarantee. A harness change is the one change a zero-test run cannot evidence, because the changed file decides how tests are discovered, provisioned, and executed — and none of it ran.

## How it happened

`is_source_relevant_change` matches against source and test globs, which a `.yml` or `.xml.dist` file never satisfies. The unconfigured fallback then classifies them via `is_docs_or_config_path`, whose suffix list includes `.yml`, `.yaml`, and `.json` — so a workflow sat in the same bucket as `README.md`.

Both paths therefore reported "no source changed", and the existing `changed_scope_zero_tests_for_source_change` guard never engaged.

## Observed impact

In `Extra-Chill/extrachill-events#804` a PR converting six PHPUnit suites to a new managed-suite runner passed `Homeboy (review test)` with `total: 0`. Forcing a real source change into the scope revealed the conversion was wrong — every suite failed with `PHPUNIT_ZERO_TESTS cause=changed_file_filter_mismatch`.

Without that manual step it would have merged green while breaking the suite it configured.

## Change

Add `is_test_harness_config_path` and consult it from both relevance paths, so the existing zero-test guard fails closed for harness changes.

Deliberately narrow — only files that define test execution qualify:

- `.github/workflows/**`
- `homeboy.json`
- `phpunit*.xml` / `phpunit*.xml.dist`
- `jest.config.*`, `vitest.config.*`, `playwright.config.*`

Application config stays inert. `README.md`, `composer.lock`, `package.json`, and `src/config/app-settings.json` remain non-relevant, so docs and settings-only changes keep passing with a legitimate no-test scope.

## Distinct diagnostic

"Add or route a test for the changed source" is wrong advice for a workflow edit. A harness change gets its own rule and hint:

```
changed_scope_zero_tests_for_harness_change

A harness change is the one change a zero-test run cannot evidence,
because the harness itself was never exercised.

Run the full suite so the harness change is exercised: homeboy review test <component>
```

## An existing test asserted the old behaviour

`unconfigured_relevance_flags_source_but_not_docs` asserted `!is_source_relevant_change_unconfigured(".github/workflows/ci.yml")` alongside `README.md` and `LICENSE`.

That assertion encoded the bug, so it is inverted here with the reasoning recorded inline rather than silently edited.

## Verification

- `cargo test -p homeboy-core --lib drift::` — 35 passed, 0 failed
- `cargo test -p homeboy-core --lib extension::test::run::` — 73 passed, 0 failed
- `cargo check -p homeboy-core` — clean (3 pre-existing warnings)

Two new tests cover the pattern-configured path, the unconfigured fallback, and the inert-config cases.

The full `--lib` run hits a harness timeout (exit 124) with ~20 failures in `cleanup`, `daemon`, `worktree`, and `http_api`. Those sets differ run-to-run and reproduce on `main` — none are in `drift` or `extension::test`, and the affected modules pass in isolation.
