### PR TITLE
Add typed Extension API execute invocation

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/api/v1/operations.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1/operations.rs
@@ -11,6 +11,7 @@ mod action;
 mod agent_task_executor;
 mod deployment;
 mod environment;
+mod execute;
 mod external_check_detail;
 mod invocation;
 mod recipe_run;
@@ -18,6 +19,7 @@ pub use action::*;
 pub use agent_task_executor::*;
 pub use deployment::*;
 pub use environment::*;
+pub use execute::*;
 pub use external_check_detail::*;
 pub use invocation::*;
 pub use recipe_run::*;
@@ -82,6 +84,9 @@ pub enum ExtensionApiOperationFailureCode {
     CapabilityNotProvided,
     CapabilityExecutionFailed,
     CapabilityOutputInvalid,
+    InvalidIdempotencyKey,
+    IdempotencyConflict,
+    InvocationInProgress,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/contracts/homeboy-extension-contract/src/api/v1/operations/execute.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1/operations/execute.rs
@@ -1,0 +1,227 @@
+use serde::{Deserialize, Serialize};
+
+use super::{ExtensionApiOperationFailure, ExtensionApiVersion};
+
+pub const EXECUTE_CAPABILITY_ID: &str = "execute";
+pub const EXTENSION_API_EXECUTE_REQUEST_SCHEMA: &str = "homeboy/extension-api-execute-request/v1";
+pub const EXTENSION_API_EXECUTE_RESPONSE_SCHEMA: &str = "homeboy/extension-api-execute-response/v1";
+pub const EXTENSION_API_EXECUTE_IDEMPOTENCY_KEY_MAX_CHARS: usize = 128;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiExecutionMode {
+    Interactive,
+    Captured,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiExecuteState {
+    Completed,
+    Replayed,
+    InProgress,
+    Conflict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionApiExecuteInput {
+    pub id: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionApiExecuteStepFilter {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionApiExecuteOutput {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stdout: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stderr: String,
+}
+
+/// Invoke the advertised `execute` capability without cwd, command, or secret authority.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionApiExecuteRequest {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    pub extension_id: String,
+    pub capability_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inputs: Vec<ExtensionApiExecuteInput>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub argv: Vec<String>,
+    pub mode: ExtensionApiExecutionMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_filter: Option<ExtensionApiExecuteStepFilter>,
+    pub idempotency_key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExtensionApiExecuteResponse {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extension_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<ExtensionApiExecuteOutput>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<ExtensionApiExecuteState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ExtensionApiOperationFailure>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::v1::EXTENSION_API_V1;
+
+    fn sample_request() -> ExtensionApiExecuteRequest {
+        ExtensionApiExecuteRequest {
+            schema: EXTENSION_API_EXECUTE_REQUEST_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            extension_id: "fixture".to_string(),
+            capability_id: EXECUTE_CAPABILITY_ID.to_string(),
+            project_id: Some("site".to_string()),
+            component_id: Some("app".to_string()),
+            inputs: vec![ExtensionApiExecuteInput {
+                id: "target".to_string(),
+                value: "prod".to_string(),
+            }],
+            argv: vec!["--flag".to_string()],
+            mode: ExtensionApiExecutionMode::Captured,
+            step_filter: Some(ExtensionApiExecuteStepFilter {
+                step: Some("test".to_string()),
+                skip: Some("lint".to_string()),
+            }),
+            idempotency_key: "run-1".to_string(),
+        }
+    }
+
+    #[test]
+    fn execute_request_wire_shape_is_versioned_and_omits_implementation_authority() {
+        assert_eq!(
+            serde_json::to_value(sample_request()).expect("request JSON"),
+            serde_json::json!({
+                "schema": EXTENSION_API_EXECUTE_REQUEST_SCHEMA,
+                "api_version": { "major": 1 },
+                "extension_id": "fixture",
+                "capability_id": "execute",
+                "project_id": "site",
+                "component_id": "app",
+                "inputs": [{ "id": "target", "value": "prod" }],
+                "argv": ["--flag"],
+                "mode": "captured",
+                "step_filter": { "step": "test", "skip": "lint" },
+                "idempotency_key": "run-1"
+            })
+        );
+    }
+
+    #[test]
+    fn execute_response_wire_shape_is_typed() {
+        let response = ExtensionApiExecuteResponse {
+            schema: EXTENSION_API_EXECUTE_RESPONSE_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            extension_id: Some("fixture".to_string()),
+            project_id: Some("site".to_string()),
+            exit_code: Some(0),
+            output: Some(ExtensionApiExecuteOutput {
+                stdout: "ok".to_string(),
+                stderr: String::new(),
+            }),
+            state: Some(ExtensionApiExecuteState::Completed),
+            failure: None,
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).expect("response JSON"),
+            serde_json::json!({
+                "schema": EXTENSION_API_EXECUTE_RESPONSE_SCHEMA,
+                "api_version": { "major": 1 },
+                "extension_id": "fixture",
+                "project_id": "site",
+                "exit_code": 0,
+                "output": { "stdout": "ok" },
+                "state": "completed"
+            })
+        );
+    }
+
+    #[test]
+    fn execute_request_rejects_unknown_fields() {
+        let error = serde_json::from_value::<ExtensionApiExecuteRequest>(serde_json::json!({
+            "schema": EXTENSION_API_EXECUTE_REQUEST_SCHEMA,
+            "api_version": { "major": 1 },
+            "extension_id": "fixture",
+            "capability_id": "execute",
+            "mode": "captured",
+            "idempotency_key": "run-1",
+            "cwd": "/tmp",
+            "command": "echo"
+        }))
+        .expect_err("unknown fields");
+        let message = error.to_string();
+        assert!(message.contains("cwd") || message.contains("unknown field"));
+    }
+
+    #[test]
+    fn execute_conflict_and_in_progress_outcomes_are_typed() {
+        for (state, code, wire_state, wire_code) in [
+            (
+                ExtensionApiExecuteState::InProgress,
+                super::super::ExtensionApiOperationFailureCode::InvocationInProgress,
+                "in_progress",
+                "invocation_in_progress",
+            ),
+            (
+                ExtensionApiExecuteState::Conflict,
+                super::super::ExtensionApiOperationFailureCode::IdempotencyConflict,
+                "conflict",
+                "idempotency_conflict",
+            ),
+        ] {
+            let response = ExtensionApiExecuteResponse {
+                schema: EXTENSION_API_EXECUTE_RESPONSE_SCHEMA.to_string(),
+                api_version: EXTENSION_API_V1,
+                extension_id: Some("fixture".to_string()),
+                project_id: None,
+                exit_code: None,
+                output: None,
+                state: Some(state),
+                failure: Some(super::super::ExtensionApiOperationFailure {
+                    code,
+                    message: "typed outcome".to_string(),
+                }),
+            };
+            assert_eq!(
+                serde_json::to_value(response).expect("outcome JSON"),
+                serde_json::json!({
+                    "schema": EXTENSION_API_EXECUTE_RESPONSE_SCHEMA,
+                    "api_version": { "major": 1 },
+                    "extension_id": "fixture",
+                    "state": wire_state,
+                    "failure": { "code": wire_code, "message": "typed outcome" }
+                })
+            );
+        }
+    }
+}

--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -12,7 +12,7 @@
 //! ## 1. Versioned Extension API — [`api`]
 //!
 //! The negotiated request/response operations Homeboy serves and consumes:
-//! catalog, resolve, readiness, invocation, and the per-capability operations
+//! catalog, resolve, readiness, invocation, execute, and the per-capability operations
 //! for deployment providers, environments, external-check detail resolvers,
 //! recipe runs, and agent-task executors. Versioned explicitly; a change here is
 //! an API version change.

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -19,7 +19,10 @@ use homeboy_core::extension::catalog::{
 use homeboy_core::extension::readiness::{
     extension_ready_status_with, ExtensionReadinessMode, ExtensionReadinessState,
 };
-use homeboy_core::extension::{invoke::run_setup, resolve::is_extension_compatible};
+use homeboy_core::extension::{
+    invoke::{execute_api, execute_response_result, execute_run_request, run_setup},
+    resolve::is_extension_compatible,
+};
 use homeboy_extension_contract as extension_contract;
 use homeboy_extension_contract::action_types::ActionType;
 use homeboy_extension_contract::api::v1::{
@@ -1384,16 +1387,16 @@ fn run_extension(
     };
 
     let filter = ExtensionStepFilter { step, skip };
-
-    let result = homeboy_core::extension::invoke::run_extension(
+    let result = execute_response_result(execute_api(&execute_run_request(
         extension_id,
         project.as_deref(),
         component.as_deref(),
         inputs,
         args,
         mode,
-        filter,
-    )?;
+        &filter,
+        format!("cli:{}", uuid::Uuid::new_v4()),
+    )))?;
 
     Ok((
         ExtensionOutput::Run {
@@ -2333,6 +2336,58 @@ mod tests {
     fn extension_inventory_defaults_to_cached_readiness() {
         assert_eq!(readiness_mode(false), ExtensionReadinessMode::Cached);
         assert_eq!(readiness_mode(true), ExtensionReadinessMode::Probe);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extension_run_projects_captured_output_and_exit_code() {
+        with_isolated_home(|home| {
+            let extension_id = "fixture-run";
+            let extension_dir = home
+                .path()
+                .join(".config/homeboy/extensions")
+                .join(extension_id);
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(
+                extension_dir.join(format!("{extension_id}.json")),
+                r#"{"name":"fixture-run","version":"1.0.0","executable":{"runtime":{"run_command":"sh {{extension_path}}/run.sh"}}}"#,
+            )
+            .expect("manifest");
+            let script = extension_dir.join("run.sh");
+            fs::write(&script, "#!/bin/sh\nprintf captured-output\nexit 7\n").expect("script");
+            let mut permissions = fs::metadata(&script).expect("metadata").permissions();
+            use std::os::unix::fs::PermissionsExt;
+            permissions.set_mode(0o755);
+            fs::set_permissions(&script, permissions).expect("chmod");
+
+            let (output, exit_code) = run_extension(
+                extension_id,
+                None,
+                None,
+                Vec::new(),
+                Vec::new(),
+                false,
+                true,
+                None,
+                None,
+            )
+            .expect("extension run");
+            assert_eq!(exit_code, 7);
+            let ExtensionOutput::Run {
+                extension_id: returned_id,
+                project_id,
+                output,
+            } = output
+            else {
+                panic!("expected extension run output");
+            };
+            assert_eq!(returned_id, extension_id);
+            assert_eq!(project_id, None);
+            assert_eq!(
+                output.map(|captured| captured.stdout),
+                Some("captured-output".to_string())
+            );
+        });
     }
 
     #[test]

--- a/crates/homeboy-core/src/extension/catalog/api.rs
+++ b/crates/homeboy-core/src/extension/catalog/api.rs
@@ -18,13 +18,14 @@ use homeboy_extension_contract::api::v1::{
     COMPILER_WARNINGS_CAPABILITY_ID, COMPILER_WARNINGS_INPUT_SCHEMA,
     COMPILER_WARNINGS_OUTPUT_SCHEMA, COMPILER_WARNING_FIXES_CAPABILITY_ID,
     COMPILER_WARNING_FIXES_INPUT_SCHEMA, COMPILER_WARNING_FIXES_OUTPUT_SCHEMA,
-    DEPLOYMENT_PROVIDER_CAPABILITY_PREFIX, ENVIRONMENT_CAPABILITY_ID,
+    DEPLOYMENT_PROVIDER_CAPABILITY_PREFIX, ENVIRONMENT_CAPABILITY_ID, EXECUTE_CAPABILITY_ID,
     EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA, EXTENSION_API_ACTION_INVOKE_RESPONSE_SCHEMA,
     EXTENSION_API_CATALOG_REQUEST_SCHEMA, EXTENSION_API_CATALOG_RESPONSE_SCHEMA,
     EXTENSION_API_DEPLOYMENT_PROVIDER_INVOKE_REQUEST_SCHEMA,
     EXTENSION_API_DEPLOYMENT_PROVIDER_INVOKE_RESPONSE_SCHEMA, EXTENSION_API_DESCRIPTOR_SCHEMA,
     EXTENSION_API_ENVIRONMENT_RESOLVE_REQUEST_SCHEMA,
-    EXTENSION_API_ENVIRONMENT_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA,
+    EXTENSION_API_ENVIRONMENT_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_EXECUTE_REQUEST_SCHEMA,
+    EXTENSION_API_EXECUTE_RESPONSE_SCHEMA, EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA,
     EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA, EXTENSION_API_READINESS_REQUEST_SCHEMA,
     EXTENSION_API_READINESS_RESPONSE_SCHEMA, EXTENSION_API_RECIPE_RUN_PLAN_REQUEST_SCHEMA,
     EXTENSION_API_RECIPE_RUN_PLAN_RESPONSE_SCHEMA, EXTENSION_API_RESOLVE_REQUEST_SCHEMA,
@@ -73,7 +74,11 @@ fn api_descriptor_from_manifest(extension: &ExtensionManifest) -> ExtensionApiDe
         .and_then(|runtime| runtime.run_command.as_ref())
         .is_some()
     {
-        capabilities.push(capability_descriptor("execute"));
+        capabilities.push(schema_capability_descriptor(
+            EXECUTE_CAPABILITY_ID,
+            EXTENSION_API_EXECUTE_REQUEST_SCHEMA,
+            EXTENSION_API_EXECUTE_RESPONSE_SCHEMA,
+        ));
     }
     capabilities.extend(extension.actions.iter().map(|action| {
         schema_capability_descriptor(
@@ -844,7 +849,7 @@ mod tests {
                 vec![
                     COMPILER_WARNING_FIXES_CAPABILITY_ID,
                     COMPILER_WARNINGS_CAPABILITY_ID,
-                    "execute",
+                    EXECUTE_CAPABILITY_ID,
                     "fingerprint.php",
                     "fingerprint.rs",
                     "format.php",
@@ -858,6 +863,25 @@ mod tests {
             assert_eq!(
                 descriptor.capabilities[7].contract_version.as_deref(),
                 Some("2")
+            );
+            let execute = descriptor
+                .capabilities
+                .iter()
+                .find(|capability| capability.id == EXECUTE_CAPABILITY_ID)
+                .expect("execute capability");
+            assert_eq!(
+                execute
+                    .input_schema
+                    .as_ref()
+                    .map(|schema| schema.schema.as_str()),
+                Some(EXTENSION_API_EXECUTE_REQUEST_SCHEMA)
+            );
+            assert_eq!(
+                execute
+                    .output_schema
+                    .as_ref()
+                    .map(|schema| schema.schema.as_str()),
+                Some(EXTENSION_API_EXECUTE_RESPONSE_SCHEMA)
             );
             let warnings = descriptor
                 .capabilities

--- a/crates/homeboy-core/src/extension/invoke.rs
+++ b/crates/homeboy-core/src/extension/invoke.rs
@@ -23,6 +23,8 @@ pub(crate) mod deadline_process;
 pub(crate) mod env_provider;
 mod environment;
 mod environment_api;
+mod execute_api;
+mod execute_idempotency;
 mod runner;
 mod runtime_helper;
 mod scenario_runner;
@@ -40,12 +42,13 @@ use homeboy_extension_contract::ExtensionManifest;
 pub use api::invoke_api;
 pub use context::ResolvedExtensionInvocationContext;
 pub use env_provider::{resolve_installed, resolve_installed_all, EnvProviderContribution};
-use environment::{build_action_env, execute_extension_runtime};
+use environment::build_action_env;
 pub(crate) use environment::{build_exec_env, execute_extension_command, prepare_capability_run};
 pub use environment_api::{
     declared_environment_secret_names as declared_secret_names, resolve_environment_api,
     EnvironmentResolutionContext,
 };
+pub use execute_api::{execute_api, execute_response_result, execute_run_request};
 pub(crate) use runner::{read_extension_phase_timings, tail_lines};
 pub use runner::{ExtensionRunner, RunnerOutput, STRICT_VALIDATION_DEPENDENCIES_ENV};
 pub(crate) use runtime_helper::WRITE_TEST_RESULTS_ENV;
@@ -232,42 +235,6 @@ fn persist_setup_runtime_env(extension: &ExtensionManifest, extension_id: &str) 
 
 /// Backward-compatible alias for existing command API usage.
 pub type ExtensionStepFilter = RunnerStepFilter;
-
-/// Execute a extension with optional project context.
-pub fn run_extension(
-    extension_id: &str,
-    project_id: Option<&str>,
-    component_id: Option<&str>,
-    inputs: Vec<(String, String)>,
-    args: Vec<String>,
-    mode: ExtensionExecutionMode,
-    filter: ExtensionStepFilter,
-) -> Result<ExtensionRunResult> {
-    let is_captured = matches!(mode, ExtensionExecutionMode::Captured);
-    let execution = execute_extension_runtime(
-        extension_id,
-        project_id,
-        component_id,
-        inputs,
-        args,
-        None,
-        None,
-        mode,
-        &filter,
-    )?;
-
-    let output = if is_captured && !execution.result.output.is_empty() {
-        Some(execution.result.output)
-    } else {
-        None
-    };
-
-    Ok(ExtensionRunResult {
-        exit_code: execution.result.exit_code,
-        project_id: execution.project_id,
-        output,
-    })
-}
 
 /// Execute a extension action (API call).
 pub fn run_action(
@@ -674,15 +641,16 @@ mod tests {
             })
             .expect("project");
 
-            let result = run_extension(
+            let result = execute_response_result(execute_api(&execute_run_request(
                 "fixture-extension",
                 Some("site"),
                 Some("fixture"),
                 vec![],
                 vec![],
                 ExtensionExecutionMode::Captured,
-                ExtensionStepFilter::default(),
-            )
+                &ExtensionStepFilter::default(),
+                "test:project-attachment".to_string(),
+            )))
             .expect("extension run");
 
             assert_eq!(
@@ -713,15 +681,16 @@ mod tests {
                 "#!/bin/sh\nprintf '%s|%s' \"$HOMEBOY_COMPONENT_ID\" \"$HOMEBOY_COMPONENT_PATH\"\n",
             );
 
-            let result = run_extension(
+            let result = execute_response_result(execute_api(&execute_run_request(
                 "fixture-extension",
                 None,
                 Some("fixture"),
                 vec![],
                 vec![],
                 ExtensionExecutionMode::Captured,
-                ExtensionStepFilter::default(),
-            )
+                &ExtensionStepFilter::default(),
+                "test:component-identity".to_string(),
+            )))
             .expect("extension run");
 
             assert_eq!(

--- a/crates/homeboy-core/src/extension/invoke/execute_api.rs
+++ b/crates/homeboy-core/src/extension/invoke/execute_api.rs
@@ -1,0 +1,483 @@
+use homeboy_core::error::{Error, Result};
+use homeboy_engine_primitives::command::CapturedOutput;
+use homeboy_extension_contract::api::v1::{
+    ExtensionApiExecuteOutput, ExtensionApiExecuteRequest, ExtensionApiExecuteResponse,
+    ExtensionApiExecuteState, ExtensionApiExecutionMode, ExtensionApiOperationFailure,
+    ExtensionApiOperationFailureCode, ExtensionApiResolveRequest, EXECUTE_CAPABILITY_ID,
+    EXTENSION_API_EXECUTE_IDEMPOTENCY_KEY_MAX_CHARS, EXTENSION_API_EXECUTE_REQUEST_SCHEMA,
+    EXTENSION_API_EXECUTE_RESPONSE_SCHEMA, EXTENSION_API_RESOLVE_REQUEST_SCHEMA, EXTENSION_API_V1,
+};
+
+use super::environment::execute_extension_runtime;
+use super::execute_idempotency::{self, IdempotencyClaim};
+use super::{ExtensionExecutionMode, ExtensionRunResult, ExtensionStepFilter};
+use crate::extension::catalog::{resolve_api, validate_operation_request};
+
+pub fn execute_run_request(
+    extension_id: &str,
+    project_id: Option<&str>,
+    component_id: Option<&str>,
+    inputs: Vec<(String, String)>,
+    argv: Vec<String>,
+    mode: ExtensionExecutionMode,
+    filter: &ExtensionStepFilter,
+    idempotency_key: String,
+) -> ExtensionApiExecuteRequest {
+    use homeboy_extension_contract::api::v1::{
+        ExtensionApiExecuteInput, ExtensionApiExecuteStepFilter,
+    };
+
+    ExtensionApiExecuteRequest {
+        schema: EXTENSION_API_EXECUTE_REQUEST_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        extension_id: extension_id.to_string(),
+        capability_id: EXECUTE_CAPABILITY_ID.to_string(),
+        project_id: project_id.map(str::to_string),
+        component_id: component_id.map(str::to_string),
+        inputs: inputs
+            .into_iter()
+            .map(|(id, value)| ExtensionApiExecuteInput { id, value })
+            .collect(),
+        argv,
+        mode: match mode {
+            ExtensionExecutionMode::Interactive => ExtensionApiExecutionMode::Interactive,
+            ExtensionExecutionMode::Captured => ExtensionApiExecutionMode::Captured,
+        },
+        step_filter: (filter.step.is_some() || filter.skip.is_some()).then_some(
+            ExtensionApiExecuteStepFilter {
+                step: filter.step.clone(),
+                skip: filter.skip.clone(),
+            },
+        ),
+        idempotency_key,
+    }
+}
+
+pub fn execute_api(request: &ExtensionApiExecuteRequest) -> ExtensionApiExecuteResponse {
+    if let Some(failure) = validate_operation_request(
+        &request.schema,
+        EXTENSION_API_EXECUTE_REQUEST_SCHEMA,
+        request.api_version,
+    ) {
+        return failure_response(failure, None);
+    }
+    if request.extension_id.trim().is_empty() {
+        return failure(
+            ExtensionApiOperationFailureCode::InvalidRequestSchema,
+            "Execute requests require a non-empty extension_id".to_string(),
+        );
+    }
+    if request.capability_id != EXECUTE_CAPABILITY_ID {
+        return failure(
+            ExtensionApiOperationFailureCode::CapabilityNotProvided,
+            format!(
+                "Execute API only invokes the '{EXECUTE_CAPABILITY_ID}' capability; received '{}'",
+                request.capability_id
+            ),
+        );
+    }
+    if let Some(message) = invalid_idempotency_key(&request.idempotency_key) {
+        return failure(
+            ExtensionApiOperationFailureCode::InvalidIdempotencyKey,
+            message,
+        );
+    }
+
+    let fingerprint = request_fingerprint(request);
+    match execute_idempotency::claim(&request.idempotency_key, &fingerprint) {
+        Ok(IdempotencyClaim::Replayed(mut response)) => {
+            response.state = Some(ExtensionApiExecuteState::Replayed);
+            response
+        }
+        Ok(IdempotencyClaim::InProgress) => outcome(
+            ExtensionApiExecuteState::InProgress,
+            ExtensionApiOperationFailureCode::InvocationInProgress,
+            format!(
+                "Execute request with idempotency key '{}' is already in progress",
+                request.idempotency_key
+            ),
+            Some(request.extension_id.as_str()),
+        ),
+        Ok(IdempotencyClaim::Conflict) => outcome(
+            ExtensionApiExecuteState::Conflict,
+            ExtensionApiOperationFailureCode::IdempotencyConflict,
+            format!(
+                "Idempotency key '{}' was reused with a different execute request",
+                request.idempotency_key
+            ),
+            Some(request.extension_id.as_str()),
+        ),
+        Ok(IdempotencyClaim::Accepted) => invoke_once(request, &fingerprint),
+        Err(error) => failure(
+            ExtensionApiOperationFailureCode::CapabilityExecutionFailed,
+            format!("Failed to persist execute idempotency record: {error}"),
+        ),
+    }
+}
+
+pub fn execute_response_result(
+    response: ExtensionApiExecuteResponse,
+) -> Result<ExtensionRunResult> {
+    if let Some(failure) = response.failure {
+        return Err(Error::config(failure.message));
+    }
+    let output = response.output.and_then(|output| {
+        let captured = CapturedOutput::new(output.stdout, output.stderr);
+        (!captured.is_empty()).then_some(captured)
+    });
+    Ok(ExtensionRunResult {
+        exit_code: response.exit_code.unwrap_or(0),
+        project_id: response.project_id,
+        output,
+    })
+}
+
+fn invoke_once(
+    request: &ExtensionApiExecuteRequest,
+    fingerprint: &serde_json::Value,
+) -> ExtensionApiExecuteResponse {
+    let resolved = resolve_api(&ExtensionApiResolveRequest {
+        schema: EXTENSION_API_RESOLVE_REQUEST_SCHEMA.to_string(),
+        api_version: request.api_version,
+        extension_id: request.extension_id.clone(),
+        capability_id: request.capability_id.clone(),
+    });
+    if let Some(failure) = resolved.failure {
+        return complete_response(
+            request,
+            fingerprint,
+            failure_response(failure, Some(request.extension_id.as_str())),
+        );
+    }
+
+    let mode = match request.mode {
+        ExtensionApiExecutionMode::Interactive => ExtensionExecutionMode::Interactive,
+        ExtensionApiExecutionMode::Captured => ExtensionExecutionMode::Captured,
+    };
+    let filter = request
+        .step_filter
+        .as_ref()
+        .map(|filter| ExtensionStepFilter {
+            step: filter.step.clone(),
+            skip: filter.skip.clone(),
+        })
+        .unwrap_or_default();
+    let inputs = request
+        .inputs
+        .iter()
+        .map(|input| (input.id.clone(), input.value.clone()))
+        .collect();
+
+    let execution = match execute_extension_runtime(
+        &request.extension_id,
+        request.project_id.as_deref(),
+        request.component_id.as_deref(),
+        inputs,
+        request.argv.clone(),
+        None,
+        None,
+        mode,
+        &filter,
+    ) {
+        Ok(execution) => execution,
+        Err(error) => {
+            return complete_response(
+                request,
+                fingerprint,
+                failure_response(
+                    ExtensionApiOperationFailure {
+                        code: ExtensionApiOperationFailureCode::CapabilityExecutionFailed,
+                        message: error.to_string(),
+                    },
+                    Some(request.extension_id.as_str()),
+                ),
+            );
+        }
+    };
+
+    let output = match request.mode {
+        ExtensionApiExecutionMode::Captured if !execution.result.output.is_empty() => {
+            Some(ExtensionApiExecuteOutput {
+                stdout: execution.result.output.stdout,
+                stderr: execution.result.output.stderr,
+            })
+        }
+        _ => None,
+    };
+    let response = ExtensionApiExecuteResponse {
+        schema: EXTENSION_API_EXECUTE_RESPONSE_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        extension_id: Some(request.extension_id.clone()),
+        project_id: execution.project_id,
+        exit_code: Some(execution.result.exit_code),
+        output,
+        state: Some(ExtensionApiExecuteState::Completed),
+        failure: None,
+    };
+    complete_response(request, fingerprint, response)
+}
+
+fn complete_response(
+    request: &ExtensionApiExecuteRequest,
+    fingerprint: &serde_json::Value,
+    response: ExtensionApiExecuteResponse,
+) -> ExtensionApiExecuteResponse {
+    if let Err(error) =
+        execute_idempotency::complete(&request.idempotency_key, fingerprint, &response)
+    {
+        return failure(
+            ExtensionApiOperationFailureCode::CapabilityExecutionFailed,
+            format!("Failed to persist execute result: {error}"),
+        );
+    }
+    response
+}
+
+fn invalid_idempotency_key(key: &str) -> Option<String> {
+    if key.is_empty() || key.chars().all(char::is_whitespace) {
+        return Some("Execute requests require a non-empty idempotency key".to_string());
+    }
+    if key.len() > EXTENSION_API_EXECUTE_IDEMPOTENCY_KEY_MAX_CHARS {
+        return Some(format!(
+            "Idempotency key must be at most {EXTENSION_API_EXECUTE_IDEMPOTENCY_KEY_MAX_CHARS} characters"
+        ));
+    }
+    if !key
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':'))
+    {
+        return Some(
+            "Idempotency key may contain only ASCII letters, digits, '-', '_', '.', and ':'"
+                .to_string(),
+        );
+    }
+    None
+}
+
+fn request_fingerprint(request: &ExtensionApiExecuteRequest) -> serde_json::Value {
+    serde_json::json!({
+        "extension_id": request.extension_id,
+        "capability_id": request.capability_id,
+        "project_id": request.project_id,
+        "component_id": request.component_id,
+        "inputs": request.inputs,
+        "argv": request.argv,
+        "mode": request.mode,
+        "step_filter": request.step_filter,
+    })
+}
+
+fn failure(code: ExtensionApiOperationFailureCode, message: String) -> ExtensionApiExecuteResponse {
+    failure_response(ExtensionApiOperationFailure { code, message }, None)
+}
+
+fn failure_response(
+    failure: ExtensionApiOperationFailure,
+    extension_id: Option<&str>,
+) -> ExtensionApiExecuteResponse {
+    ExtensionApiExecuteResponse {
+        schema: EXTENSION_API_EXECUTE_RESPONSE_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        extension_id: extension_id.map(str::to_string),
+        project_id: None,
+        exit_code: None,
+        output: None,
+        state: None,
+        failure: Some(failure),
+    }
+}
+
+fn outcome(
+    state: ExtensionApiExecuteState,
+    code: ExtensionApiOperationFailureCode,
+    message: String,
+    extension_id: Option<&str>,
+) -> ExtensionApiExecuteResponse {
+    let mut response =
+        failure_response(ExtensionApiOperationFailure { code, message }, extension_id);
+    response.state = Some(state);
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy_extension_contract::api::v1::ExtensionApiExecuteInput;
+    use std::fs;
+
+    fn write_executable(path: &std::path::Path, content: &str) {
+        fs::write(path, content).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(path, permissions).unwrap();
+        }
+    }
+
+    fn write_runnable_extension(home: &std::path::Path, id: &str, script: &str) {
+        let dir = home.join(".config/homeboy/extensions").join(id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join(format!("{id}.json")),
+            serde_json::json!({
+                "name": id,
+                "version": "1.0.0",
+                "executable": { "runtime": { "run_command": "sh {{extension_path}}/run.sh {{args}}" } }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        write_executable(&dir.join("run.sh"), script);
+    }
+
+    fn captured_request(
+        extension_id: &str,
+        key: &str,
+        argv: Vec<String>,
+    ) -> ExtensionApiExecuteRequest {
+        ExtensionApiExecuteRequest {
+            schema: EXTENSION_API_EXECUTE_REQUEST_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            extension_id: extension_id.to_string(),
+            capability_id: EXECUTE_CAPABILITY_ID.to_string(),
+            project_id: None,
+            component_id: None,
+            inputs: Vec::new(),
+            argv,
+            mode: ExtensionApiExecutionMode::Captured,
+            step_filter: None,
+            idempotency_key: key.to_string(),
+        }
+    }
+
+    #[test]
+    fn execute_api_rejects_invalid_schema_and_idempotency_keys() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut request = captured_request("fixture", "run-1", Vec::new());
+            request.schema = "homeboy/extension-api-execute-request/v0".to_string();
+            assert_eq!(
+                execute_api(&request).failure.map(|failure| failure.code),
+                Some(ExtensionApiOperationFailureCode::InvalidRequestSchema)
+            );
+
+            request.schema = EXTENSION_API_EXECUTE_REQUEST_SCHEMA.to_string();
+            request.idempotency_key.clear();
+            assert_eq!(
+                execute_api(&request).failure.map(|failure| failure.code),
+                Some(ExtensionApiOperationFailureCode::InvalidIdempotencyKey)
+            );
+
+            request.idempotency_key = "bad key".to_string();
+            assert_eq!(
+                execute_api(&request).failure.map(|failure| failure.code),
+                Some(ExtensionApiOperationFailureCode::InvalidIdempotencyKey)
+            );
+        });
+    }
+
+    #[test]
+    fn execute_api_rejects_non_execute_capabilities() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            write_runnable_extension(home.path(), "fixture", "#!/bin/sh\nprintf once\n");
+            let mut request = captured_request("fixture", "run-1", Vec::new());
+            request.capability_id = "test".to_string();
+            assert_eq!(
+                execute_api(&request).failure.map(|failure| failure.code),
+                Some(ExtensionApiOperationFailureCode::CapabilityNotProvided)
+            );
+        });
+    }
+
+    #[test]
+    fn execute_api_replays_duplicate_idempotency_keys_without_a_second_run() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let marker = home.path().join("ran");
+            write_runnable_extension(
+                home.path(),
+                "fixture",
+                &format!(
+                    "#!/bin/sh\nprintf x >> '{}'\nprintf out\n",
+                    marker.display()
+                ),
+            );
+            let request = captured_request("fixture", "run-1", Vec::new());
+            let first = execute_api(&request);
+            fs::remove_dir_all(home.path().join(".config/homeboy/extensions/fixture"))
+                .expect("remove extension after execution");
+            let second = execute_api(&request);
+
+            assert_eq!(first.state, Some(ExtensionApiExecuteState::Completed));
+            assert_eq!(second.state, Some(ExtensionApiExecuteState::Replayed));
+            assert_eq!(first.exit_code, Some(0));
+            assert_eq!(second.exit_code, first.exit_code);
+            assert_eq!(second.output, first.output);
+            assert_eq!(fs::read_to_string(&marker).expect("marker"), "x");
+        });
+    }
+
+    #[test]
+    fn execute_api_replays_terminal_runtime_failures() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            write_runnable_extension(home.path(), "fixture", "#!/bin/sh\nprintf out\n");
+            let mut request = captured_request("fixture", "run-failure", Vec::new());
+            request.component_id = Some("missing-component".to_string());
+
+            let first = execute_api(&request);
+            let second = execute_api(&request);
+
+            assert_eq!(
+                first.failure.as_ref().map(|failure| failure.code),
+                Some(ExtensionApiOperationFailureCode::CapabilityExecutionFailed)
+            );
+            assert_eq!(second.state, Some(ExtensionApiExecuteState::Replayed));
+            assert_eq!(second.failure, first.failure);
+        });
+    }
+
+    #[test]
+    fn execute_api_conflicts_when_the_same_key_covers_a_different_request() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            write_runnable_extension(home.path(), "fixture", "#!/bin/sh\nprintf out\n");
+            let first = execute_api(&captured_request("fixture", "run-1", vec!["a".to_string()]));
+            let second = execute_api(&captured_request("fixture", "run-1", vec!["b".to_string()]));
+            assert_eq!(first.state, Some(ExtensionApiExecuteState::Completed));
+            assert_eq!(second.state, Some(ExtensionApiExecuteState::Conflict));
+            assert_eq!(
+                second.failure.map(|failure| failure.code),
+                Some(ExtensionApiOperationFailureCode::IdempotencyConflict)
+            );
+        });
+    }
+
+    #[test]
+    fn execute_api_preserves_captured_output_and_structured_inputs() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            write_runnable_extension(home.path(), "fixture", "#!/bin/sh\nprintf '%s' \"$1\"\n");
+            let mut request = captured_request("fixture", "run-inputs", vec!["arg".to_string()]);
+            request.inputs = vec![ExtensionApiExecuteInput {
+                id: "unused".to_string(),
+                value: "private-input-value".to_string(),
+            }];
+            let response = execute_api(&request);
+            assert!(response.failure.is_none());
+            assert_eq!(
+                response.output.map(|output| output.stdout),
+                Some("arg".to_string())
+            );
+            let records = home
+                .path()
+                .join(".local/share/homeboy/extension-execute-idempotency");
+            let record_path = fs::read_dir(records)
+                .expect("idempotency records")
+                .next()
+                .expect("idempotency record")
+                .expect("idempotency entry")
+                .path();
+            assert!(!fs::read_to_string(record_path)
+                .expect("idempotency record contents")
+                .contains("private-input-value"));
+        });
+    }
+}

--- a/crates/homeboy-core/src/extension/invoke/execute_idempotency.rs
+++ b/crates/homeboy-core/src/extension/invoke/execute_idempotency.rs
@@ -1,0 +1,120 @@
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use homeboy_engine_primitives::local_files;
+use homeboy_extension_contract::api::v1::ExtensionApiExecuteResponse;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const IDEMPOTENCY_RECORD_SCHEMA: &str = "homeboy/extension-api-execute-idempotency/v1";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum IdempotencyRecordState {
+    InProgress,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct IdempotencyRecord {
+    schema: String,
+    fingerprint: String,
+    state: IdempotencyRecordState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    response: Option<ExtensionApiExecuteResponse>,
+}
+
+pub(super) enum IdempotencyClaim {
+    Accepted,
+    Replayed(ExtensionApiExecuteResponse),
+    InProgress,
+    Conflict,
+}
+
+pub(super) fn claim(
+    idempotency_key: &str,
+    fingerprint: &serde_json::Value,
+) -> Result<IdempotencyClaim, String> {
+    let path = record_path(idempotency_key)?;
+    let fingerprint = fingerprint_digest(fingerprint)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+
+    match exclusive_create(&path) {
+        Ok(mut file) => {
+            let record = IdempotencyRecord {
+                schema: IDEMPOTENCY_RECORD_SCHEMA.to_string(),
+                fingerprint,
+                state: IdempotencyRecordState::InProgress,
+                response: None,
+            };
+            let serialized =
+                serde_json::to_string_pretty(&record).map_err(|error| error.to_string())?;
+            file.write_all(serialized.as_bytes())
+                .map_err(|error| error.to_string())?;
+            file.sync_all().map_err(|error| error.to_string())?;
+            Ok(IdempotencyClaim::Accepted)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            Ok(existing_claim(&path, &fingerprint))
+        }
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+pub(super) fn complete(
+    idempotency_key: &str,
+    fingerprint: &serde_json::Value,
+    response: &ExtensionApiExecuteResponse,
+) -> Result<(), String> {
+    let path = record_path(idempotency_key)?;
+    let record = IdempotencyRecord {
+        schema: IDEMPOTENCY_RECORD_SCHEMA.to_string(),
+        fingerprint: fingerprint_digest(fingerprint)?,
+        state: IdempotencyRecordState::Completed,
+        response: Some(response.clone()),
+    };
+    let serialized = serde_json::to_string_pretty(&record).map_err(|error| error.to_string())?;
+    local_files::write_file_atomic(&path, &serialized, "write extension execute idempotency")
+        .map_err(|error| error.to_string())
+}
+
+fn existing_claim(path: &std::path::Path, fingerprint: &str) -> IdempotencyClaim {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return IdempotencyClaim::InProgress;
+    };
+    let Ok(record) = serde_json::from_str::<IdempotencyRecord>(&contents) else {
+        return IdempotencyClaim::InProgress;
+    };
+    if record.fingerprint != fingerprint {
+        return IdempotencyClaim::Conflict;
+    }
+    match (record.state, record.response) {
+        (IdempotencyRecordState::Completed, Some(response)) => IdempotencyClaim::Replayed(response),
+        _ => IdempotencyClaim::InProgress,
+    }
+}
+
+fn fingerprint_digest(fingerprint: &serde_json::Value) -> Result<String, String> {
+    let bytes = serde_json::to_vec(fingerprint).map_err(|error| error.to_string())?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
+}
+
+fn exclusive_create(path: &std::path::Path) -> std::io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+}
+
+fn record_path(idempotency_key: &str) -> Result<PathBuf, String> {
+    let roots =
+        homeboy_core::paths::PathRoots::from_environment().map_err(|error| error.to_string())?;
+    let digest = Sha256::digest(idempotency_key.as_bytes());
+    Ok(roots
+        .data()
+        .join("extension-execute-idempotency")
+        .join(format!("{digest:x}.json")))
+}

--- a/docs/internals/development/contracts/extension-api-v1.md
+++ b/docs/internals/development/contracts/extension-api-v1.md
@@ -29,6 +29,8 @@ The wire schemas are:
 - `homeboy/extension-api-readiness-response/v1`
 - `homeboy/extension-api-invoke-request/v1`
 - `homeboy/extension-api-invoke-response/v1`
+- `homeboy/extension-api-execute-request/v1`
+- `homeboy/extension-api-execute-response/v1`
 - `homeboy/extension-api-action-invoke-request/v1`
 - `homeboy/extension-api-action-invoke-response/v1`
 - `homeboy/extension-api-environment-resolve-request/v1`
@@ -158,6 +160,32 @@ This synchronous operation is intentionally limited to analysis. It does not
 perform durable mutation and therefore has no idempotency, cancellation,
 reconciliation, activity, or terminal-result lifecycle.
 
+## Execute Invocation
+
+`extension::invoke::execute_api` runs the advertised `execute` capability after
+validating the typed request and resolving it through v1. Runtime execution is
+the authoritative readiness check so stale cached probe results do not change
+direct CLI behavior. The request selects extension and capability identity,
+optional project and component context, structured inputs, argv, execution
+mode, an optional step filter, and a required idempotency key. Command strings,
+working directory, secrets, and runner implementation details stay off the
+public contract.
+
+Core claims the key before mutable resolution and invokes the existing runtime
+execution engine once per accepted key. A repeated request with the same key
+and fingerprint returns the stored success or failure response without
+executing again. A repeated key with a different fingerprint returns
+`idempotency_conflict`. An accepted key that has not finished returns
+`invocation_in_progress`. Completed records survive process restarts within the
+same Homeboy data root. An interrupted invocation remains explicitly in
+progress rather than risking a second execution; a later slice can add recovery
+through cancel or reconcile. This slice does not advertise those operations or
+daemon transport.
+
+`homeboy extension run` constructs this request and projects the typed response
+into the existing CLI output and exit-code contract. Interactive and captured
+modes keep their previous streaming and capture behavior.
+
 ## Action Invocation
 
 `extension::invoke::action_api::invoke_action_api` executes one manifest action
@@ -277,14 +305,13 @@ stability.
 
 | Classification | Modules | Direction |
 | --- | --- | --- |
-| Stable Extension API | `api` | Versioned public descriptor, handshake, discovery, readiness, read-only invocation, environment-resolution, deployment-provider execution, recipe-provider planning, and external-check hydration envelopes. |
+| Stable Extension API | `api` | Versioned public descriptor, handshake, discovery, readiness, read-only invocation, execute invocation, environment-resolution, deployment-provider execution, recipe-provider planning, and external-check hydration envelopes. |
 | Stable API candidates | `capability`, `core_compat`, `exec_context`, `runtime_helper`, `sidecar_config` | Reuse or reference from future v1 operations after their wire semantics are reviewed. |
 | Extension-owned domain contracts | `action_types`, `agent_task_executor_declaration`, `autofix_config`, `bench_artifact`, `bench_diagnostics`, `bench_distribution`, `bench_gate`, `bench_metric_preset`, `bench_responsiveness`, `bench_result`, `bench_results`, `bench_stage`, `ci_config`, `ci_context`, `external_check_detail_resolver`, `external_storage_retention`, `fuzz_config`, `lint_result`, `lint_results`, `notification_transport_config`, `source_metadata_repair`, `test_analysis`, `test_drift`, `test_duration`, `test_inventory_config`, `test_parsing`, `test_result`, `test_results`, `test_workflow`, `trace_config`, `trace_parsing`, `trace_preview`, `trace_results`, `trace_spec`, `update_output`, `worktree_retention` | Remain portable domain schemas; the Extension API references their schema IDs rather than absorbing their fields. |
 | Manifest and implementation detail | `extension_contract_producer`, `hook_event`, `manifest`, `manifest_action_config`, `manifest_artifact_cleanup`, `manifest_capabilities`, `manifest_capability_config`, `manifest_deploy_config`, `manifest_test_config`, `manifest_toolchain_config`, `runner_contract`, `version` | Inputs and helpers used to build or execute descriptors. They are not a stable service API. |
 
 ## Next Operations
 
-The read-only invocation operation deliberately does not define a durable
-invocation lifecycle. Subsequent v1 slices will add idempotent mutation, cancel,
-reconcile, activity, and terminal-result contracts anchored to canonical
-control-plane references from issue #13697.
+Execute invocation uses durable idempotency within one Homeboy data root and
+does not define cancel, reconcile, activity, or daemon transport. Subsequent v1
+slices can add those operations without extending the control-plane kernel.


### PR DESCRIPTION
## Summary

- add a versioned, transport-neutral `execute` request/response contract for extension runtime invocation
- enforce durable idempotency with atomic claims, stable success/failure replay, explicit in-progress/conflict outcomes, and hashed request fingerprints
- migrate `homeboy extension run` to the owning API service while preserving capture, streaming, project/component context, and exit behavior
- advertise the execute schemas through extension descriptors without claiming cancel, reconcile, or daemon transport

Advances #13882.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-extension-contract -- --test-threads=1`
- `cargo test -p homeboy-core extension::invoke -- --test-threads=1`
- `cargo test -p homeboy-cli commands::extension::tests -- --test-threads=1`
- `cargo check -p homeboy-extension-contract -p homeboy-core -p homeboy-cli`

## Scope

An interrupted accepted invocation remains explicitly `in_progress` to avoid unsafe duplicate execution. Cancel/reconcile recovery and daemon transport remain later Extension API slices.

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol generated an initial implementation candidate; I directed the architecture and independently audited, corrected, tested, and finalized the contract, idempotency boundary, CLI migration, and documentation.