### PR TITLE
Recover mirrored runner evidence from the job-owning generation

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/jobs.rs
+++ b/crates/homeboy-cli/src/commands/runner/jobs.rs
@@ -678,9 +678,11 @@ fn classify_follow_error(
     if message.contains("404") || message.contains("not found") {
         return homeboy::core::Error::validation_invalid_argument(
             "job_id",
-            format!("runner job `{job_id}` is absent after authoritative generation recovery; its retained log history was evicted or the job ID is invalid. Resume evidence is unavailable after cursor {cursor}"),
+            format!("runner job `{job_id}` evidence is unavailable after authoritative generation recovery: the exact job was not retained by its job-owning daemon generation. No terminal status is inferred and no unrelated runner run was selected. Resume evidence is unavailable after cursor {cursor}"),
             Some(job_id.to_string()),
-            None,
+            Some(vec![
+                "Inspect the controller record for the exact durable run before retrying: homeboy runs show <run-id>.".to_string(),
+            ]),
         );
     }
     follow_recovery_error(runner_id, job_id, cursor, poll_ms, error)
@@ -1200,7 +1202,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_job_after_recovery_is_classified_as_retention_or_eviction() {
+    fn missing_job_after_recovery_reports_explicit_evidence_unavailability() {
         let error = homeboy::core::Error::validation_invalid_argument(
             "job_id",
             "daemon request returned HTTP 404",
@@ -1209,7 +1211,14 @@ mod tests {
         );
         let classified = classify_follow_error("lab", "job-42", 9, 250, error);
 
-        assert!(classified.message.contains("evicted"));
+        assert!(classified.message.contains("evidence is unavailable"));
+        assert!(classified
+            .message
+            .contains("No terminal status is inferred"));
+        assert!(classified
+            .message
+            .contains("no unrelated runner run was selected"));
+        assert!(!classified.message.contains("evicted"));
         assert!(classified.message.contains("cursor 9"));
     }
 }

--- a/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
@@ -381,9 +381,9 @@ pub fn refresh_selected_mirrored_daemon_evidence(
                     serde_json::json!({
                         "runner_id": runner_id,
                         "job_id": job_id,
-                        "status": "not_found",
+                        "status": "evidence_unavailable",
                         "lifecycle_state": "stale",
-                        "stale_reason": "daemon_job_not_found",
+                        "stale_reason": "authoritative_generation_did_not_retain_job",
                         "retryable": false,
                         "diagnostic": {
                             "code": err.code.as_str(),

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -693,7 +693,7 @@ mod tests {
     }
 
     #[test]
-    fn selected_daemon_job_not_found_becomes_stale_diagnostics() {
+    fn selected_authoritative_job_absence_becomes_evidence_unavailable() {
         let _lock = provider_lock().lock().expect("provider lock");
         with_isolated_home(|_| {
             let store = ObservationStore::open_initialized().expect("store");
@@ -719,7 +719,11 @@ mod tests {
             assert_eq!(refreshed.status, RunStatus::Stale.as_str());
             assert_eq!(
                 refreshed.metadata_json["runner_terminal_evidence"]["stale_reason"],
-                "daemon_job_not_found"
+                "authoritative_generation_did_not_retain_job"
+            );
+            assert_eq!(
+                refreshed.metadata_json["runner_terminal_evidence"]["status"],
+                "evidence_unavailable"
             );
             assert_eq!(
                 refreshed.metadata_json["runner_terminal_evidence"]["diagnostic"]["details"]

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -688,10 +688,8 @@ pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRe
         Some(broker_url) => {
             crate::connection::reverse_broker_job_snapshot_at(broker_url, &runner_id, &job_id)?
         }
-        None => (
-            fetch_daemon_job(&runner_id, &job_id)?,
-            fetch_daemon_events(&runner_id, &job_id)?,
-        ),
+        None => runner_job_log_snapshot_with_owner_recovery(&runner_id, &job_id)
+            .map(|snapshot| (snapshot.job, snapshot.events))?,
     };
     let result = result_event_data(&events).unwrap_or_else(|| json!({}));
     let cwd = run.cwd.as_deref().unwrap_or("");
@@ -828,6 +826,55 @@ pub fn runner_job_log_snapshot(runner_id: &str, job_id: &str) -> Result<RunnerJo
         job: fetch_daemon_job(runner_id, job_id)?,
         events: fetch_daemon_events(runner_id, job_id)?,
     })
+}
+
+/// Refresh one mirrored run through its original daemon generation when the
+/// mutable admission daemon has rotated away from that job.
+fn runner_job_log_snapshot_with_owner_recovery(
+    runner_id: &str,
+    job_id: &str,
+) -> Result<RunnerJobLogSnapshot> {
+    runner_job_log_snapshot_with_owner_recovery_with(
+        runner_id,
+        job_id,
+        || runner_job_log_snapshot(runner_id, job_id),
+        |runner_id, job_id| crate::connection::reconnect_job_log_owner(runner_id, job_id),
+        |session, job_id| runner_job_log_snapshot_for_session(session, job_id),
+        crate::connection::close_reconnected_job_log_owner,
+    )
+}
+
+/// Keep the routing transaction independent from its direct-SSH transport so
+/// the exact owner selection remains deterministic and testable.
+pub(super) fn runner_job_log_snapshot_with_owner_recovery_with<
+    Owner,
+    Current,
+    Reconnect,
+    Snapshot,
+    Close,
+>(
+    runner_id: &str,
+    job_id: &str,
+    current: Current,
+    reconnect: Reconnect,
+    snapshot: Snapshot,
+    close: Close,
+) -> Result<RunnerJobLogSnapshot>
+where
+    Current: FnOnce() -> Result<RunnerJobLogSnapshot>,
+    Reconnect: FnOnce(&str, &str) -> Result<Owner>,
+    Snapshot: FnOnce(&Owner, &str) -> Result<RunnerJobLogSnapshot>,
+    Close: FnOnce(&Owner),
+{
+    match current() {
+        Ok(snapshot) => Ok(snapshot),
+        Err(_) => {
+            let owner = reconnect(runner_id, job_id)?;
+            let recovered = snapshot(&owner, job_id);
+            close(&owner);
+            recovered
+        }
+    }
 }
 
 pub fn runner_job_log_snapshot_for_session(

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -39,8 +39,8 @@ use super::mirror::{
     mirror_remote_observation_runs_by_id_with_downloader, mirror_reverse_broker_evidence,
     mirror_terminal_job_artifacts_with, mirrored_patch_result, mirrored_runner_job_identity,
     primary_mirrored_run, refresh_mirrored_daemon_evidence, refresh_mirrored_daemon_evidence_with,
-    MirrorEvidenceRequest, ReverseBrokerEvidenceContext, MIRRORED_REMOTE_EVENT_LIMIT,
-    MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
+    runner_job_log_snapshot_with_owner_recovery_with, MirrorEvidenceRequest,
+    ReverseBrokerEvidenceContext, MIRRORED_REMOTE_EVENT_LIMIT, MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
 };
 
 use super::tokens::{
@@ -68,6 +68,72 @@ fn runner_execution_record_resolves_its_authoritative_job_identity() {
             "homeboy-lab".to_string(),
             "c2d54086-5e83-4268-88a7-51232fa05a0c".to_string()
         ))
+    );
+}
+
+#[test]
+fn mirror_refresh_recovers_terminal_evidence_from_the_exact_retained_generation() {
+    let job_id = "00000000-0000-0000-0000-000000000123";
+    let mut retained_job = terminal_runner_job();
+    retained_job.id = Uuid::parse_str("00000000-0000-0000-0000-000000000123").expect("job ID");
+    let retained_events = vec![JobEvent {
+        sequence: 1,
+        job_id: retained_job.id,
+        kind: JobEventKind::Result,
+        timestamp_ms: retained_job.updated_at_ms,
+        message: Some("old generation terminal result".to_string()),
+        data: Some(json!({ "exit_code": 0, "stdout": "exact retained evidence" })),
+    }];
+    let mut reconnected = false;
+    let mut closed = false;
+
+    let recovered = runner_job_log_snapshot_with_owner_recovery_with(
+        "homeboy-lab",
+        job_id,
+        || {
+            Err(Error::validation_invalid_argument(
+                "job_id",
+                "current admission generation returned HTTP 404",
+                None,
+                None,
+            ))
+        },
+        |runner_id, requested_job_id| {
+            assert_eq!(runner_id, "homeboy-lab");
+            assert_eq!(requested_job_id, job_id);
+            reconnected = true;
+            Ok("generation-a")
+        },
+        |generation, requested_job_id| {
+            assert_eq!(*generation, "generation-a");
+            assert_eq!(requested_job_id, job_id);
+            Ok(homeboy_core::api_jobs::RunnerJobLogSnapshot {
+                job: retained_job.clone(),
+                events: retained_events.clone(),
+            })
+        },
+        |generation| {
+            assert_eq!(*generation, "generation-a");
+            closed = true;
+        },
+    )
+    .expect("exact retained generation recovers terminal evidence");
+
+    assert!(reconnected);
+    assert!(closed);
+    assert_eq!(recovered.job.id.to_string(), job_id);
+    assert_eq!(recovered.job.status, JobStatus::Succeeded);
+    assert_eq!(recovered.events.len(), 1);
+    assert_eq!(
+        recovered.events[0].message.as_deref(),
+        Some("old generation terminal result")
+    );
+    assert_eq!(
+        recovered.events[0]
+            .data
+            .as_ref()
+            .and_then(|data| data.get("stdout")),
+        Some(&json!("exact retained evidence"))
     );
 }
 


### PR DESCRIPTION
## Summary
Related to #9181.

- Retry direct-runner mirrored evidence refresh through the persisted job-owning generation when the current admission daemon cannot supply the job snapshot.
- Reuse the existing exact-owner reconnect and close contracts; preserve the CLI follow-session recovery and cursor behavior.
- Record authoritative job absence as stale evidence_unavailable, without inferring success or substituting another run.
- Replace the unsupported eviction claim in log-recovery diagnostics.

## Failure
An accepted runner job can outlive admission-daemon rotation. Mirrored evidence refresh previously read only the current daemon, despite an existing persisted job-owner mapping. A current-generation miss therefore prevented retrieval of evidence retained by the original generation.

## Verification
Focused tests passed during implementation:

```sh
cargo test -p homeboy-lab-runner mirror_refresh_recovers_terminal_evidence_from_the_exact_retained_generation
cargo test -p homeboy-core selected_authoritative_job_absence_becomes_evidence_unavailable
cargo test -p homeboy-cli missing_job_after_recovery_reports_explicit_evidence_unavailability
cargo test -p homeboy-cli dropped_transport_reconnects_to_authoritative_generation_without_replaying_events
cargo test -p homeboy-agents accepted_handoff_adopts_a_job_found_on_another_known_generation
cargo test -p homeboy-agents accepted_handoff_fails_after_confirmed_absence_across_generations
```

Formatting and git diff --check passed. Tests cover recovery routing with injected transport callbacks, persisted stale-state classification, and existing follow/ownership behavior. The full workspace suite and a live daemon-rotation reproduction were not run.

## Limits
Recovery requires the owning-generation mapping and retained job evidence. This change cannot reconstruct permanently missing records or recover a result by choosing an unrelated latest run. No running daemon was restarted or upgraded during this work.

## AI Assistance
GPT-6 Astra through OpenCode assisted with investigation, implementation, and PR preparation. Implementation and focused test execution were delegated through OpenCode and reviewed in the coordinating session. Chris Huber directed the work and authorized this PR.