### PR TITLE
Recover applied candidates with pending verification

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1239,11 +1239,14 @@ pub fn record_replacement_gate_proof(
             None,
         ));
     }
-    if original.status != AgentTaskPromotionStatus::GateFailed || !original.status.patch_promoted()
+    if !matches!(
+        original.status,
+        AgentTaskPromotionStatus::GateFailed | AgentTaskPromotionStatus::VerificationPending
+    ) || !original.status.patch_promoted()
     {
         return Err(Error::validation_invalid_argument(
             "latest_promotion.status",
-            "replacement gate proof is only valid for an already-applied candidate whose original gates failed",
+            "replacement gate proof is only valid for an already-applied candidate whose verification failed or did not complete",
             Some(run_id.to_string()),
             None,
         ));
@@ -1323,6 +1326,10 @@ pub fn record_replacement_gate_proof(
                 Some("serialize original promotion history".to_string()),
             )
         })?);
+    let reason = match original.status {
+        AgentTaskPromotionStatus::VerificationPending => "interrupted_original_verification",
+        _ => "infrastructure_invalid_original_gates",
+    };
     replacement.provenance["replacement_gate_proof"] = serde_json::json!({
         "schema": "homeboy/agent-task-replacement-gate-proof/v1",
         "original_history": {
@@ -1333,7 +1340,7 @@ pub fn record_replacement_gate_proof(
             "deterministic_gate_count": original.deterministic_gates.len(),
             "sha256": original_digest,
         },
-        "reason": "infrastructure_invalid_original_gates",
+        "reason": reason,
         "operator_authorization": external_authorization,
         "externally_produced": true,
         "accept_inherited_failures": accept_inherited_failures,
@@ -1644,11 +1651,14 @@ fn verify_replacement_gates_owned(
     if replacement_gate_execution_started(lifecycle_store, run_id)? {
         return Err(interrupted_replacement_gate_execution_error(run_id));
     }
-    if original.status != AgentTaskPromotionStatus::GateFailed || !original.status.patch_promoted()
+    if !matches!(
+        original.status,
+        AgentTaskPromotionStatus::GateFailed | AgentTaskPromotionStatus::VerificationPending
+    ) || !original.status.patch_promoted()
     {
         return Err(Error::validation_invalid_argument(
             "latest_promotion.status",
-            "replacement gates require an already-applied candidate whose original gates failed",
+            "replacement gates require an already-applied candidate whose verification failed or did not complete",
             Some(run_id.to_string()),
             None,
         ));

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -15440,7 +15440,7 @@ fn cook_owned_unpushed_candidate_requires_one_exact_promoted_commit() {
 }
 
 #[test]
-fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
+fn verify_replacement_gates_recovers_pending_verification_and_replays_completed_proof() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");
         let source = temp.path().join("source");
@@ -15522,6 +15522,7 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
         .expect("serialize failed promotion");
         failed["source"]["task_id"] =
             serde_json::json!(options.identity.initial_plan.tasks[0].task_id.clone());
+        failed["status"] = serde_json::json!("verification_pending");
         failed["patch_artifact"]["id"] = serde_json::json!("committed-changes");
         failed["verified_base"]["sha"] =
             serde_json::json!(
@@ -15663,7 +15664,11 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
         assert_eq!(
             record.metadata["latest_promotion"]["provenance"]["replacement_gate_proof"]
                 ["original_history"]["status"],
-            "gate_failed"
+            "verification_pending"
+        );
+        assert_eq!(
+            record.metadata["latest_promotion"]["provenance"]["replacement_gate_proof"]["reason"],
+            "interrupted_original_verification"
         );
         assert_eq!(
             record.metadata["latest_promotion"]["provenance"]["replacement_gate_proof"]
@@ -18938,6 +18943,10 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
         assert_eq!(original_reference["index"], 0);
         assert_eq!(original_reference["status"], "gate_failed");
         assert_eq!(original_reference["deterministic_gate_count"], 1);
+        assert_eq!(
+            record.metadata["latest_promotion"]["provenance"]["replacement_gate_proof"]["reason"],
+            "infrastructure_invalid_original_gates"
+        );
         assert_eq!(
             original_reference["sha256"],
             homeboy_engine_primitives::content_hash::sha256_hex(


### PR DESCRIPTION
## Summary

- admit applied `verification_pending` candidates to replacement gate execution and proof recording
- preserve all existing candidate, base, target, artifact, scope, authorization, and execution-fence validation
- distinguish interrupted verification from failed original gates in durable proof provenance
- exercise pending recovery and both provenance reasons in existing end-to-end tests

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents replacement_gate -- --nocapture` (3 passed)
- `cargo test -p homeboy-agents replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_republishing` (1 passed)

Closes #14366.
Related to #14357 and #12788.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the stranded Cook through supported recovery commands, implemented the bounded status-admission and provenance changes, and ran the focused regression suites. Chris Huber directed the work and reviewed the resulting scope.