### PR TITLE
Resolve candidate adoption from managed destinations

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -313,18 +313,21 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
             "recipe_finalization",
         ),
     };
-    let source_worktree = options
-        .workspace
-        .source_worktree_path
-        .clone()
+    let source_worktree = match options.workspace.source_worktree_path.clone() {
+        Some(path) => path,
+        None => homeboy_core::worktree_provider::resolve_native_worktree_mutation_target(
+            &options.workspace.to_worktree,
+        )?
+        .map(|worktree| PathBuf::from(worktree.path))
         .ok_or_else(|| {
             Error::validation_invalid_argument(
                 "candidate_ref",
-                "candidate adoption requires the recorded source worktree",
+                "candidate adoption requires a recorded source worktree or registered destination",
                 None,
                 None,
             )
-        })?;
+        })?,
+    };
     let gate_workspace = super::cook_promotion::component_workspace_path(&options)?
         .unwrap_or_else(|| source_worktree.clone());
     // Resolve the caller input to the commit object before durable ownership is

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -12551,7 +12551,7 @@ fn adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_fin
         let run_id = "cook-adopt-review-form-attempt-1";
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
         options.identity.initial_run_id = run_id.to_string();
-        options.workspace.source_worktree_path = Some(target.clone());
+        options.workspace.source_worktree_path = None;
         options.workspace.task_base_sha = Some(base.clone());
         options.provider_transport.provider_command = Some(provider.display().to_string());
         options.provider_transport.attempt_dispatcher = None;


### PR DESCRIPTION
## Summary

- keep a recipe’s explicit source worktree authoritative when present
- otherwise resolve the recorded destination through Homeboy’s native managed-worktree registry
- retain rejection for missing paths and unregistered handles
- exercise the fallback through the existing end-to-end adoption, gate, review-form, and finalization workflow

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_finalizes -- --nocapture`
- `cargo test -p homeboy-agents historical_orphan_recipe_adoption_uses_recorded_policy_without_provider_replay -- --nocapture`

Closes #14369.
Related to #14357 and #14366.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode compared durable and committed candidate identities, traced adoption source resolution, implemented the managed-worktree fallback, and ran the end-to-end adoption regressions. Chris Huber directed the recovery and scope.