### PR TITLE
Fix retained artifact availability validation

### DIFF
--- a/crates/homeboy-core/src/artifact_links.rs
+++ b/crates/homeboy-core/src/artifact_links.rs
@@ -269,6 +269,97 @@ pub fn public_artifact_url_is_reachable_or_legacy(artifact: &ArtifactRecord) -> 
     }
 }
 
+/// Integrity-aware availability of a controller-retained artifact.
+///
+/// Local SHA-256-verified bytes are the required evidence. An optional public
+/// alias probe is metadata: HTTP 404 does not make retained evidence invalid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetainedArtifactAvailability {
+    Available {
+        unreachable_aliases: Vec<PublicArtifactUrlValidation>,
+    },
+    Missing {
+        reason: String,
+    },
+    ChecksumMismatch {
+        expected: String,
+        actual: String,
+    },
+}
+
+impl RetainedArtifactAvailability {
+    pub fn is_available(&self) -> bool {
+        matches!(self, Self::Available { .. })
+    }
+
+    pub fn unreachable_aliases(&self) -> &[PublicArtifactUrlValidation] {
+        match self {
+            Self::Available {
+                unreachable_aliases,
+            } => unreachable_aliases,
+            Self::Missing { .. } | Self::ChecksumMismatch { .. } => &[],
+        }
+    }
+}
+
+/// Classify retained-artifact availability from local bytes and optional alias
+/// metadata. Required missing or checksum-mismatched evidence fails; an
+/// unreachable public alias is exposed without invalidating verified bytes.
+pub fn classify_retained_artifact_availability(
+    artifact: &ArtifactRecord,
+) -> Result<RetainedArtifactAvailability> {
+    let path = Path::new(&artifact.path);
+    let expected_sha256 = artifact.sha256.as_deref().filter(|sha| !sha.is_empty());
+    if !path.is_file() {
+        return Ok(RetainedArtifactAvailability::Missing {
+            reason: "required retained artifact file is missing".to_string(),
+        });
+    }
+    let Some(expected_sha256) = expected_sha256 else {
+        return Ok(RetainedArtifactAvailability::Missing {
+            reason: "required retained artifact checksum is missing".to_string(),
+        });
+    };
+    let actual = crate::artifact_metadata::sha256_file(path)?;
+    if actual != expected_sha256 {
+        return Ok(RetainedArtifactAvailability::ChecksumMismatch {
+            expected: expected_sha256.to_string(),
+            actual,
+        });
+    }
+    Ok(RetainedArtifactAvailability::Available {
+        unreachable_aliases: unreachable_public_artifact_aliases(artifact),
+    })
+}
+
+/// Public aliases that were probed and are not reviewer-reachable.
+pub fn unreachable_public_artifact_aliases(
+    artifact: &ArtifactRecord,
+) -> Vec<PublicArtifactUrlValidation> {
+    let Some(validation) = artifact.metadata_json.get("public_url_validation") else {
+        return Vec::new();
+    };
+    if validation.get("reachable").and_then(Value::as_bool) == Some(true) {
+        return Vec::new();
+    }
+    vec![PublicArtifactUrlValidation {
+        url: validation
+            .get("url")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        reachable: false,
+        status_code: validation
+            .get("status_code")
+            .and_then(Value::as_u64)
+            .and_then(|code| u16::try_from(code).ok()),
+        error: validation
+            .get("error")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    }]
+}
+
 pub fn annotate_public_artifact_url_validation(
     artifact: &mut ArtifactRecord,
 ) -> Option<PublicArtifactUrlValidation> {
@@ -566,6 +657,82 @@ mod tests {
         assert!(public_artifact_url_is_reachable_or_legacy(&legacy));
         assert!(public_artifact_url_is_reachable_or_legacy(&reachable));
         assert!(!public_artifact_url_is_reachable_or_legacy(&unreachable));
+    }
+
+    #[test]
+    fn retained_sha256_verified_artifact_stays_available_when_public_alias_returns_404() {
+        let public_url = serve_once(404);
+        let source = tempfile::NamedTempFile::new().expect("retained artifact");
+        std::fs::write(source.path(), b"retained bytes").expect("write retained bytes");
+        let sha256 = crate::artifact_metadata::sha256_file(source.path()).expect("sha256");
+        let artifact = ArtifactRecord {
+            artifact_type: "file".to_string(),
+            path: source.path().display().to_string(),
+            sha256: Some(sha256),
+            size_bytes: Some(14),
+            metadata_json: serde_json::json!({
+                "public_url_validation": public_artifact_url_validation_json(
+                    &validate_public_artifact_url(&public_url),
+                )
+            }),
+            ..viewer_artifact()
+        };
+
+        let availability =
+            classify_retained_artifact_availability(&artifact).expect("classify availability");
+        let RetainedArtifactAvailability::Available {
+            unreachable_aliases,
+        } = availability
+        else {
+            panic!("verified local bytes must remain available: {availability:?}");
+        };
+        assert_eq!(unreachable_aliases.len(), 1);
+        assert_eq!(unreachable_aliases[0].status_code, Some(404));
+        assert_eq!(
+            unreachable_aliases[0].error.as_deref(),
+            Some("public artifact URL returned HTTP 404")
+        );
+    }
+
+    #[test]
+    fn required_missing_retained_artifact_fails_availability() {
+        let artifact = ArtifactRecord {
+            artifact_type: "file".to_string(),
+            path: "/tmp/homeboy-missing-retained-artifact".to_string(),
+            sha256: Some("abc".to_string()),
+            ..viewer_artifact()
+        };
+
+        let availability =
+            classify_retained_artifact_availability(&artifact).expect("classify availability");
+        match availability {
+            RetainedArtifactAvailability::Missing { reason } => {
+                assert!(reason.contains("missing"));
+            }
+            other => panic!("missing required evidence must fail: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn checksum_mismatched_retained_artifact_fails_availability() {
+        let source = tempfile::NamedTempFile::new().expect("retained artifact");
+        std::fs::write(source.path(), b"altered bytes").expect("write retained bytes");
+        let artifact = ArtifactRecord {
+            artifact_type: "file".to_string(),
+            path: source.path().display().to_string(),
+            sha256: Some("0".repeat(64)),
+            ..viewer_artifact()
+        };
+
+        let availability =
+            classify_retained_artifact_availability(&artifact).expect("classify availability");
+        match availability {
+            RetainedArtifactAvailability::ChecksumMismatch { expected, actual } => {
+                assert_eq!(expected, "0".repeat(64));
+                assert_ne!(actual, expected);
+            }
+            other => panic!("checksum-mismatched evidence must fail: {other:?}"),
+        }
     }
 
     struct EnvGuard {

--- a/crates/homeboy-core/src/extension/bench/artifact_persistence.rs
+++ b/crates/homeboy-core/src/extension/bench/artifact_persistence.rs
@@ -342,12 +342,12 @@ fn persist_bench_artifact(
 }
 
 /// Attach the recorded artifact's observation id, public URL, and validated
-/// viewer links back onto the bench artifact, returning a diagnostic when the
-/// public URL is unreachable.
+/// viewer links back onto the bench artifact. A failed public-alias probe does
+/// not invalidate controller-retained evidence.
 pub fn apply_recorded_bench_artifact_links(
-    scenario_id: &str,
-    run_index: Option<usize>,
-    name: &str,
+    _scenario_id: &str,
+    _run_index: Option<usize>,
+    _name: &str,
     artifact: &mut BenchArtifact,
     record: &ArtifactRecord,
 ) -> Option<BenchDiagnostic> {
@@ -368,28 +368,7 @@ pub fn apply_recorded_bench_artifact_links(
             .map(|link| link.url.clone());
         None
     } else {
-        let validation = record
-            .metadata_json
-            .get("public_url_validation")
-            .expect("unreachable new artifact has validation metadata");
-        let error = validation
-            .get("error")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("public artifact URL was not reachable");
-        Some(bench_artifact_diagnostic(
-                scenario_id,
-                run_index,
-                name,
-                "bench_public_artifact_url_unreachable",
-                format!(
-                    "public artifact URL for bench artifact `{name}` is not reachable; viewer links were not published: {error}"
-                ),
-                serde_json::json!({
-                    "url": validation.get("url").cloned().unwrap_or(serde_json::Value::Null),
-                    "status_code": validation.get("status_code").cloned().unwrap_or(serde_json::Value::Null),
-                    "error": validation.get("error").cloned().unwrap_or(serde_json::Value::Null),
-                }),
-            ))
+        None
     }
 }
 

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -168,6 +168,19 @@ pub fn controller_artifact_metadata(runs: &[RunRecord]) -> Result<Vec<JobArtifac
                 "homeboy runs artifact get {} {} -o <path>",
                 controller_run_id, artifact.id
             );
+            let unreachable_aliases =
+                homeboy_core::artifact_links::unreachable_public_artifact_aliases(&artifact)
+                    .iter()
+                    .map(homeboy_core::artifact_links::public_artifact_url_validation_json)
+                    .collect::<Vec<_>>();
+            let mut metadata = json!({
+                "controller_run_id": controller_run_id,
+                "controller_owned": true,
+                "fetch_command": fetch_command,
+            });
+            if !unreachable_aliases.is_empty() {
+                metadata["unreachable_aliases"] = json!(unreachable_aliases);
+            }
             Ok(JobArtifactMetadata {
                 id: artifact.id,
                 name: None,
@@ -179,11 +192,7 @@ pub fn controller_artifact_metadata(runs: &[RunRecord]) -> Result<Vec<JobArtifac
                     .and_then(|size| u64::try_from(size).ok()),
                 sha256: artifact.sha256,
                 content_base64: None,
-                metadata: Some(json!({
-                    "controller_run_id": controller_run_id,
-                    "controller_owned": true,
-                    "fetch_command": fetch_command,
-                })),
+                metadata: Some(metadata),
             })
         })
         .collect()
@@ -206,18 +215,19 @@ fn validate_controller_artifact(artifact: &ArtifactRecord) -> Result<()> {
             None,
         )
     })?;
-    let expected_sha256 = artifact
+    if artifact
         .sha256
         .as_deref()
         .filter(|sha| !sha.is_empty())
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "artifact.sha256",
-                "terminal artifact is missing controller checksum metadata",
-                Some(artifact.id.clone()),
-                None,
-            )
-        })?;
+        .is_none()
+    {
+        return Err(Error::validation_invalid_argument(
+            "artifact.sha256",
+            "terminal artifact is missing controller checksum metadata",
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
     if artifact.mime.as_deref().is_none_or(str::is_empty) {
         return Err(Error::validation_invalid_argument(
             "artifact.mime",
@@ -240,15 +250,25 @@ fn validate_controller_artifact(artifact: &ArtifactRecord) -> Result<()> {
             None,
         ));
     }
-    if homeboy_core::artifact_metadata::sha256_file(path)? != expected_sha256 {
-        return Err(Error::validation_invalid_argument(
-            "artifact.sha256",
-            "terminal artifact bytes do not match controller checksum metadata",
-            Some(artifact.id.clone()),
-            None,
-        ));
+    match homeboy_core::artifact_links::classify_retained_artifact_availability(artifact)? {
+        homeboy_core::artifact_links::RetainedArtifactAvailability::Available { .. } => Ok(()),
+        homeboy_core::artifact_links::RetainedArtifactAvailability::Missing { reason } => {
+            Err(Error::validation_invalid_argument(
+                "artifact.path",
+                reason,
+                Some(artifact.id.clone()),
+                None,
+            ))
+        }
+        homeboy_core::artifact_links::RetainedArtifactAvailability::ChecksumMismatch { .. } => {
+            Err(Error::validation_invalid_argument(
+                "artifact.sha256",
+                "terminal artifact bytes do not match controller checksum metadata",
+                Some(artifact.id.clone()),
+                None,
+            ))
+        }
     }
-    Ok(())
 }
 
 /// Takes the caller's roots because the evidence this mirrors describes the run

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -291,6 +291,75 @@ fn controller_terminal_metadata_keeps_fetch_fallback_without_public_origin() {
 }
 
 #[test]
+fn controller_terminal_metadata_keeps_verified_bytes_when_public_alias_returns_404() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let public_url = serve_public_alias(404);
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(NewRunRecord::builder("runner-exec").build())
+            .expect("run");
+        let path = home.path().join("report.txt");
+        let bytes = b"controller bytes";
+        fs::write(&path, bytes).expect("artifact");
+        let sha256 = homeboy_core::artifact_metadata::sha256_file(&path).expect("sha256");
+        let validation = homeboy_core::artifact_links::validate_public_artifact_url(&public_url);
+        store
+            .import_artifact(&ArtifactRecord {
+                id: "report".to_string(),
+                run_id: run.id.clone(),
+                kind: "report".to_string(),
+                artifact_type: "file".to_string(),
+                path: path.display().to_string(),
+                sha256: Some(sha256),
+                size_bytes: Some(bytes.len() as i64),
+                mime: Some("text/plain".to_string()),
+                metadata_json: json!({
+                    "public_url_validation": homeboy_core::artifact_links::public_artifact_url_validation_json(&validation),
+                }),
+                created_at: "2026-09-07T00:00:00Z".to_string(),
+                ..Default::default()
+            })
+            .expect("import retained artifact");
+
+        let metadata =
+            controller_artifact_metadata(std::slice::from_ref(&run)).expect("terminal metadata");
+        assert_eq!(metadata.len(), 1);
+        assert_eq!(metadata[0].id, "report");
+        assert_eq!(
+            metadata[0].metadata.as_ref().expect("metadata")["fetch_command"],
+            format!("homeboy runs artifact get {} report -o <path>", run.id)
+        );
+        assert_eq!(
+            metadata[0].metadata.as_ref().expect("metadata")["unreachable_aliases"][0]
+                ["status_code"],
+            404
+        );
+        assert_eq!(
+            metadata[0].metadata.as_ref().expect("metadata")["unreachable_aliases"][0]["error"],
+            "public artifact URL returned HTTP 404"
+        );
+    });
+}
+
+fn serve_public_alias(status: u16) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind public alias");
+    let addr = listener.local_addr().expect("alias address");
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept alias probe");
+        let mut buffer = [0; 1024];
+        let _ = stream.read(&mut buffer);
+        let body = "missing";
+        write!(
+            stream,
+            "HTTP/1.1 {status} Not Found\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+        .expect("write alias response");
+    });
+    format!("http://{addr}/artifact")
+}
+
+#[test]
 fn test_download_remote_artifact_rejects_non_runner_token() {
     let err = download_remote_artifact("/tmp/raw-file", None).expect_err("reject raw path");
     assert_eq!(err.code.as_str(), "validation.invalid_argument");

--- a/tests/commands/bench/observation_artifact_test.rs
+++ b/tests/commands/bench/observation_artifact_test.rs
@@ -1,4 +1,7 @@
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
 
 use homeboy::core::engine::run_dir::{self, RunDir};
 use homeboy_core::extension::bench::artifact::BenchArtifact;
@@ -112,6 +115,97 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
                 .is_none()
         );
     });
+}
+
+#[test]
+fn bench_observation_keeps_retained_artifact_when_public_alias_returns_404() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let public_alias = serve_public_alias(404);
+        let prior_public_base = std::env::var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL").ok();
+        std::env::set_var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL", &public_alias);
+        let run_dir = RunDir::create().expect("run dir");
+        fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+        fs::write(run_dir.path().join("retained.json"), b"{}").expect("retained artifact");
+        let mut results = bench_results("homeboy", "cold", 42.0);
+        results.scenarios[0].artifacts.insert(
+            "retained".to_string(),
+            BenchArtifact {
+                path: Some("retained.json".to_string()),
+                required_durable: true,
+                ..BenchArtifact::default()
+            },
+        );
+        let mut workflow = BenchRunWorkflowResult {
+            status: "passed".to_string(),
+            component: "homeboy".to_string(),
+            exit_code: 0,
+            iterations: 1,
+            results: Some(results),
+            gate_results: Vec::new(),
+            gate_failures: Vec::new(),
+            baseline_comparison: None,
+            hints: None,
+            failure: None,
+            diagnostics: Vec::new(),
+        };
+        let args = bench_args();
+        let observation = start(BenchObservationStart {
+            component_id: "homeboy",
+            component_label: "homeboy",
+            source_path: home.path(),
+            args: &args,
+            selected_scenarios: &["cold".to_string()],
+            rig_id: None,
+            rig_snapshot: None,
+            run_dir: &run_dir,
+        })
+        .expect("start observation");
+
+        finish_success(Some(observation), &mut workflow, &run_dir).expect("observation summary");
+
+        assert_eq!(workflow.status, "passed");
+        assert!(workflow.diagnostics.is_empty());
+        let artifact_id = workflow.results.as_ref().unwrap().scenarios[0].artifacts["retained"]
+            .observation_artifact_id
+            .as_ref()
+            .expect("retained artifact id");
+        let store =
+            homeboy::core::observation::ObservationStore::open_initialized().expect("store");
+        let artifact = store
+            .get_artifact(artifact_id)
+            .expect("artifact lookup")
+            .expect("retained artifact");
+        assert_eq!(
+            artifact.metadata_json["public_url_validation"]["reachable"],
+            false
+        );
+        assert_eq!(
+            artifact.metadata_json["public_url_validation"]["status_code"],
+            404
+        );
+
+        match prior_public_base {
+            Some(value) => std::env::set_var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL", value),
+            None => std::env::remove_var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL"),
+        }
+    });
+}
+
+fn serve_public_alias(status: u16) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind public alias");
+    let address = listener.local_addr().expect("public alias address");
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept public alias probe");
+        let mut buffer = [0; 1024];
+        let _ = stream.read(&mut buffer);
+        write!(
+            stream,
+            "HTTP/1.1 {status} Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        )
+        .expect("write public alias response");
+    });
+    format!("http://{address}/artifact")
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- retain SHA-256-verified bench artifacts when an optional public alias returns 404
- keep missing and checksum-mismatched controller evidence fail-closed
- expose unreachable public aliases in terminal artifact metadata with the controller retrieval command

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli bench_observation_keeps_retained_artifact_when_public_alias_returns_404`
- `cargo test -p homeboy-core --lib artifact_links`
- `cargo test -p homeboy-lab-runner --lib controller_terminal_metadata`

## AI assistance
GPT-6 Astra via OpenCode orchestration investigated the retained-artifact validation path, implemented the scoped repair, and ran focused regression tests. Chris Huber directed and owns the work.