### PR TITLE
test(lab-runner): root workspace prune tests off the global home lock

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -1632,6 +1632,32 @@ pub fn prune_workspaces(
     options: RunnerWorkspacePruneOptions,
 ) -> Result<(RunnerWorkspacePruneOutput, i32)> {
     let runner = load(runner_id)?;
+    prune_workspaces_for_runner(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        &runner,
+        options,
+    )
+}
+
+/// [`prune_workspaces`] against an explicitly injected root.
+///
+/// Resolving the runner ambiently while pruning an injected root would reap one
+/// installation's workspaces on another's behalf (#14362).
+#[allow(dead_code)]
+pub fn prune_workspaces_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    options: RunnerWorkspacePruneOptions,
+) -> Result<(RunnerWorkspacePruneOutput, i32)> {
+    let runner = load_in_roots(roots, runner_id)?;
+    prune_workspaces_for_runner(roots, &runner, options)
+}
+
+fn prune_workspaces_for_runner(
+    roots: &homeboy_core::paths::PathRoots,
+    runner: &crate::Runner,
+    options: RunnerWorkspacePruneOptions,
+) -> Result<(RunnerWorkspacePruneOutput, i32)> {
     let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "workspace_root",
@@ -1663,8 +1689,8 @@ pub fn prune_workspaces(
     let mut scan_complete = true;
     let receipt_path = if options.converge {
         Some(prune_convergence_receipt_path_in_roots(
-            homeboy_core::paths::PathRoots::from_environment()?.data(),
-            runner_id,
+            roots.data(),
+            &runner.id,
             workspace_root,
         ))
     } else {

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -49,30 +49,47 @@ fn prune_diagnosis(output: &crate::workspace::types::RunnerWorkspacePruneOutput)
     )
 }
 
+/// Seed a local runner definition into an explicitly injected config root, so
+/// the test never touches the process-global env lock (#14362).
+fn rooted_local_runner(roots: &homeboy_core::paths::PathRoots, id: &str, workspace_root: &Path) {
+    use homeboy_core::config::ConfigEntity;
+    fs::create_dir_all(<crate::Runner as ConfigEntity>::config_dir_in_root(
+        roots.config(),
+    ))
+    .expect("runner config dir");
+    let runner: crate::Runner = serde_json::from_str(&format!(
+        r#"{{"id":"{id}","kind":"local","workspace_root":"{}"}}"#,
+        workspace_root.display()
+    ))
+    .expect("runner spec");
+    fs::write(
+        <crate::Runner as ConfigEntity>::config_path_in_root(roots.config(), id),
+        serde_json::to_string_pretty(&runner).expect("serialize runner"),
+    )
+    .expect("write runner config");
+}
+
 #[test]
 fn prune_workspaces_previews_orphans_without_deleting_by_default() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let source_parent = tempfile::tempdir().expect("source parent");
         let source = source_parent.path().join("orphan-source");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         fs::create_dir_all(&source).expect("source dir");
         fs::write(source.join("file.txt"), "hello\n").expect("source file");
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-preview","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
-        let (synced, _) = sync_workspace(
+        rooted_local_runner(&roots, "lab-local-prune-preview", runner_root.path());
+        let (synced, _) = crate::workspace::sync::sync_workspace_in_roots(
+            &roots,
             "lab-local-prune-preview",
             sync_options(source.display().to_string()),
         )
         .expect("sync workspace");
         fs::remove_dir_all(&source).expect("remove source");
 
-        let (output, exit_code) = prune_workspaces(
+        let (output, exit_code) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-preview",
             RunnerWorkspacePruneOptions {
                 apply: false,
@@ -101,12 +118,14 @@ fn prune_workspaces_previews_orphans_without_deleting_by_default() {
             "stale_materialized_workspace_lifecycle"
         );
         assert!(Path::new(&synced.remote_path).exists());
-    });
+    }
 }
 
 #[test]
 fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let source_parent = tempfile::tempdir().expect("source parent");
         let orphan_source = source_parent.path().join("orphan-source");
         let live_source = source_parent.path().join("live-source");
@@ -115,20 +134,15 @@ fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
         fs::create_dir_all(&live_source).expect("live source dir");
         fs::write(orphan_source.join("file.txt"), "orphan\n").expect("orphan file");
         fs::write(live_source.join("file.txt"), "live\n").expect("live file");
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-apply","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
-        let (orphan, _) = sync_workspace(
+        rooted_local_runner(&roots, "lab-local-prune-apply", runner_root.path());
+        let (orphan, _) = crate::workspace::sync::sync_workspace_in_roots(
+            &roots,
             "lab-local-prune-apply",
             sync_options(orphan_source.display().to_string()),
         )
         .expect("sync orphan workspace");
-        let (live, _) = sync_workspace(
+        let (live, _) = crate::workspace::sync::sync_workspace_in_roots(
+            &roots,
             "lab-local-prune-apply",
             sync_options(live_source.display().to_string()),
         )
@@ -141,7 +155,8 @@ fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
         fs::write(unmanaged.join("file.txt"), "do not delete\n").expect("unmanaged file");
         fs::remove_dir_all(&orphan_source).expect("remove orphan source");
 
-        let (output, exit_code) = prune_workspaces(
+        let (output, exit_code) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-apply",
             RunnerWorkspacePruneOptions {
                 apply: true,
@@ -168,24 +183,19 @@ fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
         assert!(!Path::new(&orphan.remote_path).exists());
         assert!(!Path::new(&live.remote_path).exists());
         assert!(unmanaged.exists());
-    });
+    }
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 fn prune_preserves_process_owned_workspace_in_preview_and_apply() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         let workspace = runner_root.path().join("_lab_workspaces/process-owned");
         write_orphan_workspace(&workspace);
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-process-owned","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
+        rooted_local_runner(&roots, "lab-local-prune-process-owned", runner_root.path());
         let mut child = Command::new("sh")
             .arg("-c")
             .arg("sleep 30")
@@ -194,7 +204,8 @@ fn prune_preserves_process_owned_workspace_in_preview_and_apply() {
             .expect("hold workspace cwd");
 
         for apply in [false, true] {
-            let (output, exit_code) = prune_workspaces(
+            let (output, exit_code) = crate::workspace::sync::prune_workspaces_in_roots(
+                &roots,
                 "lab-local-prune-process-owned",
                 RunnerWorkspacePruneOptions {
                     apply,
@@ -213,12 +224,14 @@ fn prune_preserves_process_owned_workspace_in_preview_and_apply() {
         }
         child.kill().expect("stop held process");
         child.wait().expect("reap held process");
-    });
+    }
 }
 
 #[test]
 fn prune_preserves_job_lifecycle_lease_when_authority_is_unavailable() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         let workspace = runner_root.path().join("_lab_workspaces/active-lease");
         write_orphan_workspace(&workspace);
@@ -243,16 +256,10 @@ fn prune_preserves_job_lifecycle_lease_when_authority_is_unavailable() {
             "status": "active",
         });
         fs::write(&metadata_path, metadata.to_string()).expect("write metadata");
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-active-lease","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
+        rooted_local_runner(&roots, "lab-local-prune-active-lease", runner_root.path());
 
-        let (output, exit_code) = prune_workspaces(
+        let (output, exit_code) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-active-lease",
             RunnerWorkspacePruneOptions {
                 apply: true,
@@ -276,7 +283,7 @@ fn prune_preserves_job_lifecycle_lease_when_authority_is_unavailable() {
         assert_eq!(output.withheld_by_liveness_reason[0].workspace_count, 1);
         assert!(output.withheld_by_liveness_reason[0].bytes > 0);
         assert!(workspace.exists());
-    });
+    }
 }
 
 #[test]
@@ -565,21 +572,17 @@ fn absent_job_error() -> homeboy_core::Error {
 
 #[test]
 fn prune_workspaces_reaps_ttl_expired_lifecycle_workspace_with_live_source() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let source_parent = tempfile::tempdir().expect("source parent");
         let source = source_parent.path().join("live-source");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         fs::create_dir_all(&source).expect("source dir");
         fs::write(source.join("file.txt"), "live\n").expect("source file");
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-ttl","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
-        let (synced, _) = sync_workspace(
+        rooted_local_runner(&roots, "lab-local-prune-ttl", runner_root.path());
+        let (synced, _) = crate::workspace::sync::sync_workspace_in_roots(
+            &roots,
             "lab-local-prune-ttl",
             sync_options(source.display().to_string()),
         )
@@ -592,7 +595,8 @@ fn prune_workspaces_reaps_ttl_expired_lifecycle_workspace_with_live_source() {
         metadata["resource_lifecycle"]["ttl"] = serde_json::json!("2020-01-01T00:00:00Z");
         fs::write(&metadata_path, metadata.to_string()).expect("write metadata");
 
-        let (output, exit_code) = prune_workspaces(
+        let (output, exit_code) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-ttl",
             RunnerWorkspacePruneOptions {
                 apply: false,
@@ -611,32 +615,29 @@ fn prune_workspaces_reaps_ttl_expired_lifecycle_workspace_with_live_source() {
         assert_eq!(output.candidates[0].reason, "resource_ttl_expired");
         assert!(Path::new(&synced.remote_path).exists());
         assert!(source.exists());
-    });
+    }
 }
 
 #[test]
 fn prune_workspaces_reaps_stale_materialized_workspace_with_live_source() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let source_parent = tempfile::tempdir().expect("source parent");
         let source = source_parent.path().join("live-source");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         fs::create_dir_all(&source).expect("source dir");
         fs::write(source.join("file.txt"), "live\n").expect("source file");
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-materialized","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
-        let (synced, _) = sync_workspace(
+        rooted_local_runner(&roots, "lab-local-prune-materialized", runner_root.path());
+        let (synced, _) = crate::workspace::sync::sync_workspace_in_roots(
+            &roots,
             "lab-local-prune-materialized",
             sync_options(source.display().to_string()),
         )
         .expect("sync workspace");
 
-        let (output, exit_code) = prune_workspaces(
+        let (output, exit_code) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-materialized",
             RunnerWorkspacePruneOptions {
                 apply: true,
@@ -657,33 +658,34 @@ fn prune_workspaces_reaps_stale_materialized_workspace_with_live_source() {
         );
         assert!(!Path::new(&synced.remote_path).exists());
         assert!(source.exists());
-    });
+    }
 }
 
 #[test]
 fn prune_workspaces_prefers_stale_materialized_lifecycle_when_source_is_missing() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let source_parent = tempfile::tempdir().expect("source parent");
         let source = source_parent.path().join("removed-source");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         fs::create_dir_all(&source).expect("source dir");
         fs::write(source.join("file.txt"), "removed\n").expect("source file");
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-materialized-missing","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
-        let (synced, _) = sync_workspace(
+        rooted_local_runner(
+            &roots,
+            "lab-local-prune-materialized-missing",
+            runner_root.path(),
+        );
+        let (synced, _) = crate::workspace::sync::sync_workspace_in_roots(
+            &roots,
             "lab-local-prune-materialized-missing",
             sync_options(source.display().to_string()),
         )
         .expect("sync workspace");
         fs::remove_dir_all(&source).expect("remove source");
 
-        let (output, exit_code) = prune_workspaces(
+        let (output, exit_code) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-materialized-missing",
             RunnerWorkspacePruneOptions {
                 apply: true,
@@ -703,7 +705,7 @@ fn prune_workspaces_prefers_stale_materialized_lifecycle_when_source_is_missing(
             "stale_materialized_workspace_lifecycle"
         );
         assert!(!Path::new(&synced.remote_path).exists());
-    });
+    }
 }
 
 #[test]
@@ -863,7 +865,9 @@ fn uncertain_handoff_disarms_ttl_pruning() {
 
 #[test]
 fn prune_workspaces_preview_reports_synthetic_odd_path_without_deleting() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         let workspace = runner_root
             .path()
@@ -885,16 +889,10 @@ fn prune_workspaces_preview_reports_synthetic_odd_path_without_deleting() {
             .to_string(),
         )
         .expect("write metadata");
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-odd-preview","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
+        rooted_local_runner(&roots, "lab-local-prune-odd-preview", runner_root.path());
 
-        let (output, exit_code) = prune_workspaces(
+        let (output, exit_code) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-odd-preview",
             RunnerWorkspacePruneOptions {
                 apply: false,
@@ -920,12 +918,14 @@ fn prune_workspaces_preview_reports_synthetic_odd_path_without_deleting() {
         assert_eq!(output.candidates[0].reason, "source_path_missing");
         assert!(workspace.exists());
         assert!(output.removed.is_empty());
-    });
+    }
 }
 
 #[test]
 fn prune_workspaces_reports_remaining_bytes_and_drain_command_when_limited() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let source_parent = tempfile::tempdir().expect("source parent");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         let source_a = source_parent.path().join("orphan-source-a");
@@ -934,20 +934,15 @@ fn prune_workspaces_reports_remaining_bytes_and_drain_command_when_limited() {
         fs::create_dir_all(&source_b).expect("source b dir");
         fs::write(source_a.join("file.txt"), "a\n").expect("source a file");
         fs::write(source_b.join("file.txt"), "larger b\n").expect("source b file");
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-limited","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
-        sync_workspace(
+        rooted_local_runner(&roots, "lab-local-prune-limited", runner_root.path());
+        crate::workspace::sync::sync_workspace_in_roots(
+            &roots,
             "lab-local-prune-limited",
             sync_options(source_a.display().to_string()),
         )
         .expect("sync source a");
-        sync_workspace(
+        crate::workspace::sync::sync_workspace_in_roots(
+            &roots,
             "lab-local-prune-limited",
             sync_options(source_b.display().to_string()),
         )
@@ -955,7 +950,8 @@ fn prune_workspaces_reports_remaining_bytes_and_drain_command_when_limited() {
         fs::remove_dir_all(&source_a).expect("remove source a");
         fs::remove_dir_all(&source_b).expect("remove source b");
 
-        let (output, exit_code) = prune_workspaces(
+        let (output, exit_code) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-limited",
             RunnerWorkspacePruneOptions {
                 apply: false,
@@ -986,12 +982,14 @@ fn prune_workspaces_reports_remaining_bytes_and_drain_command_when_limited() {
             .as_deref()
             .is_some_and(|command| command.contains(&format!("--cursor {cursor}"))));
         assert!(output.drain_command.contains(&format!("--cursor {cursor}")));
-    });
+    }
 }
 
 #[test]
 fn prune_workspaces_apply_passes_drain_until_empty() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let source_parent = tempfile::tempdir().expect("source parent");
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         let source_a = source_parent.path().join("drain-source-a");
@@ -1000,20 +998,15 @@ fn prune_workspaces_apply_passes_drain_until_empty() {
         fs::create_dir_all(&source_b).expect("source b dir");
         fs::write(source_a.join("file.txt"), "a\n").expect("source a file");
         fs::write(source_b.join("file.txt"), "b\n").expect("source b file");
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-drain","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
-        let (workspace_a, _) = sync_workspace(
+        rooted_local_runner(&roots, "lab-local-prune-drain", runner_root.path());
+        let (workspace_a, _) = crate::workspace::sync::sync_workspace_in_roots(
+            &roots,
             "lab-local-prune-drain",
             sync_options(source_a.display().to_string()),
         )
         .expect("sync source a");
-        let (workspace_b, _) = sync_workspace(
+        let (workspace_b, _) = crate::workspace::sync::sync_workspace_in_roots(
+            &roots,
             "lab-local-prune-drain",
             sync_options(source_b.display().to_string()),
         )
@@ -1021,7 +1014,8 @@ fn prune_workspaces_apply_passes_drain_until_empty() {
         fs::remove_dir_all(&source_a).expect("remove source a");
         fs::remove_dir_all(&source_b).expect("remove source b");
 
-        let (output, exit_code) = prune_workspaces(
+        let (output, exit_code) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-drain",
             RunnerWorkspacePruneOptions {
                 apply: true,
@@ -1045,12 +1039,14 @@ fn prune_workspaces_apply_passes_drain_until_empty() {
         assert!(output.next_command.is_none());
         assert!(!Path::new(&workspace_a.remote_path).exists());
         assert!(!Path::new(&workspace_b.remote_path).exists());
-    });
+    }
 }
 
 #[test]
 fn prune_convergence_resumes_durable_receipts_across_more_than_twenty_pages() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         const REMOVABLE_COUNT: usize = 23;
         const WORKSPACE_COUNT: usize = REMOVABLE_COUNT + 2;
         let runner_root = tempfile::tempdir().expect("runner root");
@@ -1082,14 +1078,7 @@ fn prune_convergence_resumes_durable_receipts_across_more_than_twenty_pages() {
             "cleanup_command": null,
         });
         fs::write(&metadata_path, metadata.to_string()).expect("write unknown metadata");
-        crate::create(
-            &format!(
-                r#"{{"id":"lab-local-prune-convergence","kind":"local","workspace_root":"{}"}}"#,
-                runner_root.path().display()
-            ),
-            false,
-        )
-        .expect("create runner");
+        rooted_local_runner(&roots, "lab-local-prune-convergence", runner_root.path());
         let mut child = Command::new("sh")
             .arg("-c")
             .arg("sleep 30")
@@ -1097,7 +1086,8 @@ fn prune_convergence_resumes_durable_receipts_across_more_than_twenty_pages() {
             .spawn()
             .expect("hold active workspace cwd");
 
-        let (interrupted, _) = prune_workspaces(
+        let (interrupted, _) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-convergence",
             RunnerWorkspacePruneOptions {
                 apply: true,
@@ -1117,7 +1107,8 @@ fn prune_convergence_resumes_durable_receipts_across_more_than_twenty_pages() {
         assert!(Path::new(&interrupted.receipt_path).is_file());
         assert_eq!(interrupted.cursor_history.len(), interrupted.pass_count * 2);
 
-        let (resumed, _) = prune_workspaces(
+        let (resumed, _) = crate::workspace::sync::prune_workspaces_in_roots(
+            &roots,
             "lab-local-prune-convergence",
             RunnerWorkspacePruneOptions {
                 apply: true,
@@ -1158,7 +1149,7 @@ fn prune_convergence_resumes_durable_receipts_across_more_than_twenty_pages() {
         );
         child.kill().expect("stop active workspace holder");
         child.wait().expect("reap active workspace holder");
-    });
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Converts 11 tests in `workspace/tests/prune.rs` to store-rooted isolation and adds the rooted prune entry point they need.

Second slice of #14362, after #14367 did `snapshot.rs`.

## Measured
| | run 1 | run 2 | run 3 |
|---|---|---|---|
| this branch | 29.14s | 26.55s | 36.57s |
| baseline `main` | 45.95s | 62.11s | 52.56s |

**~45% faster.** 29 passed / 0 failed on both sides — exact parity.

## Production change
`prune_workspaces` was ambient-only. It now splits the same way the sync path did:

- `prune_workspaces(runner_id, ..)` — ambient wrapper, unchanged behavior
- `prune_workspaces_in_roots(roots, runner_id, ..)` — rooted entry point
- `prune_workspaces_for_runner(roots, runner, ..)` — shared body

The body also contained a second ambient leak: it called `PathRoots::from_environment()?.data()` to build the convergence receipt path, so even a rooted caller would have written that receipt into the ambient data root. It now uses the injected roots. Same class of defect as the one #14367 fixed in the snapshot path — that makes two rooted APIs found silently falling back to ambient.

## Why the suite is this slow
Worth recording: `homeboy_refresh::tests::part_b` runs in **98.04s with `--test-threads=1` and 91.42s with `--test-threads=8`**. Parallelism buys ~7%. The crate is effectively serial today, which is the mechanism behind #14362 rather than any individual slow test — no test in that module takes more than ~0.8s on its own.

## Not converted
5 of the 16 isolated tests here remain on `with_isolated_home`:
- 3 drive `MaterializedWorkspace::retain_for_reconciliation`, which writes workspace metadata through an ambient path. Converting them produced a real failure (`job_id` came back `Null`), so they were excluded rather than forced.
- 2 call other ambient-only entry points.

The conversion only rewrites tests whose entire call surface has a rooted equivalent.

## AI Assistance
OpenAI GPT-5.6 Sol through OpenCode added the rooted prune entry point, found and fixed the ambient receipt-path leak in its body, converted the eligible tests, and measured both sides against a baseline worktree. Chris Huber directed the work and remains responsible for acceptance.