### PR TITLE
fix(doctor): resolve local tools without a login shell

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/checks.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/checks.rs
@@ -9,6 +9,20 @@ pub(crate) fn tool_check(spec: RunnerToolSpec, probe: &ToolProbe) -> RunnerCheck
             format!("{} is available", spec.command),
             None,
         )
+    } else if probe.probe_failed {
+        // The lookup never reached a verdict, so neither "found" nor "missing"
+        // is a truthful message. Report the probe failure and hand the operator
+        // the reason instead of a remediation for a tool that may be installed.
+        error(
+            spec.check_id,
+            format!(
+                "{} could not be probed: {}",
+                spec.command,
+                probe_reason(probe)
+            ),
+            Some(PROBE_FAILURE_REMEDIATION.to_string()),
+            probe_details(probe),
+        )
     } else if spec.required {
         error(
             spec.check_id,
@@ -25,6 +39,24 @@ pub(crate) fn tool_check(spec: RunnerToolSpec, probe: &ToolProbe) -> RunnerCheck
     }
 }
 
+pub(crate) const PROBE_FAILURE_REMEDIATION: &str =
+    "The tool lookup itself failed, so the tool may well be installed. Fix the reported environment or shell error, then re-run doctor.";
+
+fn probe_reason(probe: &ToolProbe) -> &str {
+    probe
+        .error
+        .as_deref()
+        .unwrap_or("the tool lookup failed without a reason")
+}
+
+fn probe_details(probe: &ToolProbe) -> BTreeMap<String, String> {
+    let mut details = BTreeMap::new();
+    if let Some(error) = &probe.error {
+        details.insert("probe_error".to_string(), error.clone());
+    }
+    details
+}
+
 pub(crate) fn required_tool_check(command: &str, probe: &ToolProbe) -> RunnerCheck {
     let mut details = BTreeMap::new();
     details.insert("command".to_string(), command.to_string());
@@ -36,6 +68,17 @@ pub(crate) fn required_tool_check(command: &str, probe: &ToolProbe) -> RunnerChe
         ok_with_details(
             format!("tool.required.{command}"),
             format!("Required runner tool {command} is available"),
+            details,
+        )
+    } else if probe.probe_failed {
+        details.extend(probe_details(probe));
+        error(
+            format!("tool.required.{command}"),
+            format!(
+                "Required runner tool {command} could not be probed: {}",
+                probe_reason(probe)
+            ),
+            Some(PROBE_FAILURE_REMEDIATION.to_string()),
             details,
         )
     } else {

--- a/crates/homeboy-cli/src/commands/runner/doctor/common.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/common.rs
@@ -1,5 +1,80 @@
 use super::*;
 
+/// Result of resolving an executable name against `PATH`.
+///
+/// The three cases are kept apart on purpose. A probe that cannot run has not
+/// proven the tool absent, and collapsing the two is what made `runner doctor`
+/// report a working `git` as missing (#14374).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PathLookup {
+    Found(String),
+    NotFound,
+    /// The lookup could not be performed at all.
+    Unavailable(String),
+}
+
+/// Resolve `command` against `PATH` without invoking a shell.
+///
+/// Tool presence is a property of the filesystem and the process environment,
+/// not of the operator's interactive profile. The previous implementation shelled
+/// out to `sh -lc "command -v <tool>"`, so any error in `~/.profile` (a stale
+/// rustup/nvm/conda `.` line is the common case) made dash exit non-zero before
+/// `command -v` ever ran, and every tool on the host read as absent.
+pub(crate) fn resolve_on_path(command: &str) -> PathLookup {
+    resolve_in_path(command, env::var_os("PATH").as_deref())
+}
+
+/// `resolve_on_path` with the search path supplied explicitly, so the walk can
+/// be exercised without mutating the process environment.
+pub(crate) fn resolve_in_path(command: &str, path_var: Option<&OsStr>) -> PathLookup {
+    if command.contains('/') || command.contains(std::path::MAIN_SEPARATOR) {
+        // `command -v` treats a name containing a separator as a path to test,
+        // never as a PATH lookup. Match that.
+        return match executable_path(Path::new(command)) {
+            Some(path) => PathLookup::Found(path),
+            None => PathLookup::NotFound,
+        };
+    }
+
+    let Some(path_var) = path_var else {
+        return PathLookup::Unavailable("PATH is not set for the doctor process".to_string());
+    };
+    if path_var.is_empty() {
+        return PathLookup::Unavailable("PATH is empty for the doctor process".to_string());
+    }
+
+    for directory in env::split_paths(path_var) {
+        // POSIX reads an empty PATH entry as the working directory. Resolving a
+        // runner tool relative to wherever doctor happened to be invoked is not
+        // a readiness signal, so those entries are skipped.
+        if directory.as_os_str().is_empty() {
+            continue;
+        }
+        if let Some(path) = executable_path(&directory.join(command)) {
+            return PathLookup::Found(path);
+        }
+    }
+
+    PathLookup::NotFound
+}
+
+fn executable_path(candidate: &Path) -> Option<String> {
+    // `metadata` follows symlinks, so a symlinked tool resolves like it does
+    // for exec.
+    let metadata = fs::metadata(candidate).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return None;
+        }
+    }
+    Some(display_path(candidate))
+}
+
 pub(crate) fn local_command_line(command: &str, args: &[&str]) -> Option<String> {
     let output = Command::new(command).args(args).output().ok()?;
     if !output.status.success() {
@@ -8,17 +83,41 @@ pub(crate) fn local_command_line(command: &str, args: &[&str]) -> Option<String>
     first_output_line(&output.stdout, &output.stderr)
 }
 
+/// Resolve `command` on a remote runner, keeping "shell failed" apart from
+/// "tool absent".
+///
+/// `command -v` exits non-zero and stays silent when the tool is genuinely
+/// missing. Anything written to stderr means the remote shell had its own
+/// problem — a broken profile line, a missing interpreter — and the lookup never
+/// reached a verdict about the tool.
+pub(crate) fn remote_path_lookup(client: &SshClient, command: &str) -> PathLookup {
+    let output = client.execute(&format!("command -v {}", shell_word(command)));
+    if output.success {
+        return match first_nonempty_line(&output.stdout) {
+            Some(path) => PathLookup::Found(path),
+            None => PathLookup::NotFound,
+        };
+    }
+    match first_nonempty_line(&output.stderr) {
+        Some(stderr) => PathLookup::Unavailable(stderr),
+        None => PathLookup::NotFound,
+    }
+}
+
+fn first_nonempty_line(value: &str) -> Option<String> {
+    value
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
+}
+
 pub(crate) fn remote_line(client: &SshClient, command: &str) -> Option<String> {
     let output = client.execute(command);
     if !output.success {
         return None;
     }
-    output
-        .stdout
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .map(str::to_string)
+    first_nonempty_line(&output.stdout)
 }
 
 pub(crate) fn first_output_line(stdout: &[u8], stderr: &[u8]) -> Option<String> {

--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::env;
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -144,20 +144,12 @@ pub(crate) fn required_tool_version_args(command: &str) -> Vec<String> {
 }
 
 pub(crate) fn local_tool_probe(command: &str, version_args: &[String]) -> ToolProbe {
-    let path = common::local_command_line(
-        "sh",
-        &[
-            "-lc",
-            &format!("command -v {}", common::shell_word(command)),
-        ],
-    );
-    let Some(path) = path else {
-        return ToolProbe {
-            available: false,
-            path: None,
-            version: None,
-            error: Some("not found on PATH".to_string()),
-        };
+    let path = match common::resolve_on_path(command) {
+        common::PathLookup::Found(path) => path,
+        common::PathLookup::NotFound => return ToolProbe::not_found(),
+        common::PathLookup::Unavailable(reason) => {
+            return ToolProbe::probe_failed(format!("tool lookup could not run: {reason}"))
+        }
     };
     let version = if version_args.is_empty() {
         None
@@ -174,12 +166,7 @@ pub(crate) fn local_tool_probe(command: &str, version_args: &[String]) -> ToolPr
                 }
             })
     };
-    ToolProbe {
-        available: true,
-        path: Some(path),
-        version,
-        error: None,
-    }
+    ToolProbe::found(path, version)
 }
 
 pub(crate) fn remote_tool_probe(
@@ -187,17 +174,12 @@ pub(crate) fn remote_tool_probe(
     command: &str,
     version_args: &[String],
 ) -> ToolProbe {
-    let path = common::remote_line(
-        client,
-        &format!("command -v {}", common::shell_word(command)),
-    );
-    let Some(path) = path else {
-        return ToolProbe {
-            available: false,
-            path: None,
-            version: None,
-            error: Some("not found on PATH".to_string()),
-        };
+    let path = match common::remote_path_lookup(client, command) {
+        common::PathLookup::Found(path) => path,
+        common::PathLookup::NotFound => return ToolProbe::not_found(),
+        common::PathLookup::Unavailable(stderr) => {
+            return ToolProbe::probe_failed(format!("tool probe shell failed: {stderr}"))
+        }
     };
     let version = if version_args.is_empty() {
         None
@@ -216,12 +198,7 @@ pub(crate) fn remote_tool_probe(
             ),
         )
     };
-    ToolProbe {
-        available: true,
-        path: Some(path),
-        version,
-        error: None,
-    }
+    ToolProbe::found(path, version)
 }
 
 pub(crate) fn lab_homeboy_path_checks(

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/tools.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/tools.rs
@@ -1,5 +1,153 @@
 use super::super::*;
+use common::PathLookup;
+use std::ffi::OsString;
 use types::RunnerDoctorStatus;
+
+#[cfg(unix)]
+fn write_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, "#!/bin/sh\nexit 0\n").expect("write tool");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod tool");
+}
+
+/// The probe must answer from the filesystem and `PATH`, never from a shell.
+///
+/// #14374: the old probe shelled out to `sh -lc "command -v <tool>"`, so a single
+/// broken line in `~/.profile` made dash exit before `command -v` ran and every
+/// tool on a healthy host reported as absent. A directory that only this test
+/// knows about cannot be reached through any login profile, so resolving from it
+/// pins the shell-free lookup.
+#[test]
+#[cfg(unix)]
+fn resolves_tools_from_path_without_a_shell() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tool = dir.path().join("homeboy-probe-fixture");
+    write_executable(&tool);
+
+    assert_eq!(
+        common::resolve_in_path(
+            "homeboy-probe-fixture",
+            Some(&OsString::from(dir.path().as_os_str()))
+        ),
+        PathLookup::Found(common::display_path(&tool))
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn path_lookup_skips_non_executable_and_non_file_candidates() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path_var = OsString::from(dir.path().as_os_str());
+
+    fs::write(dir.path().join("not-executable"), "plain data").expect("write data file");
+    fs::create_dir(dir.path().join("a-directory")).expect("create directory");
+
+    assert_eq!(
+        common::resolve_in_path("not-executable", Some(&path_var)),
+        PathLookup::NotFound
+    );
+    assert_eq!(
+        common::resolve_in_path("a-directory", Some(&path_var)),
+        PathLookup::NotFound
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn path_lookup_searches_entries_in_order() {
+    let first = tempfile::tempdir().expect("first dir");
+    let second = tempfile::tempdir().expect("second dir");
+    write_executable(&first.path().join("homeboy-probe-fixture"));
+    write_executable(&second.path().join("homeboy-probe-fixture"));
+
+    let path_var = env::join_paths([first.path(), second.path()]).expect("join paths");
+
+    assert_eq!(
+        common::resolve_in_path("homeboy-probe-fixture", Some(&path_var)),
+        PathLookup::Found(common::display_path(
+            first.path().join("homeboy-probe-fixture")
+        ))
+    );
+}
+
+/// A name containing a separator is a path to test, matching `command -v`.
+#[test]
+#[cfg(unix)]
+fn path_lookup_treats_separated_names_as_paths() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tool = dir.path().join("homeboy-probe-fixture");
+    write_executable(&tool);
+
+    let absolute = common::display_path(&tool);
+    assert_eq!(
+        common::resolve_in_path(&absolute, None),
+        PathLookup::Found(absolute.clone())
+    );
+    assert_eq!(
+        common::resolve_in_path(&common::display_path(dir.path().join("absent")), None),
+        PathLookup::NotFound
+    );
+}
+
+/// An unusable `PATH` is a failed lookup, not proof the tool is missing.
+#[test]
+fn unusable_path_reports_probe_failure_instead_of_absence() {
+    assert_eq!(
+        common::resolve_in_path("git", None),
+        PathLookup::Unavailable("PATH is not set for the doctor process".to_string())
+    );
+    assert_eq!(
+        common::resolve_in_path("git", Some(&OsString::from(""))),
+        PathLookup::Unavailable("PATH is empty for the doctor process".to_string())
+    );
+}
+
+#[test]
+fn probe_failure_is_reported_separately_from_absence() {
+    let missing = types::ToolProbe::not_found();
+    assert!(!missing.probe_failed);
+    assert_eq!(missing.error.as_deref(), Some(types::TOOL_NOT_FOUND_ERROR));
+
+    let failed = types::ToolProbe::probe_failed("tool probe shell failed: bad profile".to_string());
+    assert!(!failed.available);
+    assert!(failed.probe_failed);
+
+    let check = checks::required_tool_check("git", &failed);
+    assert_eq!(check.status, RunnerDoctorStatus::Error);
+    assert!(
+        check.message.contains("could not be probed"),
+        "probe failure must not claim the tool is missing: {}",
+        check.message
+    );
+    assert!(check.message.contains("bad profile"));
+    assert_eq!(
+        check.details.get("probe_error").map(String::as_str),
+        Some("tool probe shell failed: bad profile")
+    );
+    assert_eq!(
+        check.remediation.as_deref(),
+        Some(checks::PROBE_FAILURE_REMEDIATION)
+    );
+}
+
+/// The tools doctor probes are the ones doctor itself already executes, so a
+/// probe that disagrees with a direct spawn is reporting a lie.
+#[test]
+fn local_tool_probe_agrees_with_direct_execution() {
+    let probe = probes::local_tool_probe("git", &[]);
+    let spawnable = Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+
+    assert_eq!(
+        probe.available, spawnable,
+        "probe reported available={} while direct execution reported {spawnable}: {:?}",
+        probe.available, probe.error
+    );
+}
 
 #[test]
 fn shell_path_expr_expands_runner_home_relative_paths() {
@@ -26,15 +174,7 @@ fn normalizes_required_tools_before_preflight_checks() {
 
 #[test]
 fn required_tool_check_errors_with_actionable_remediation() {
-    let check = checks::required_tool_check(
-        "zip",
-        &types::ToolProbe {
-            available: false,
-            path: None,
-            version: None,
-            error: Some("not found on PATH".to_string()),
-        },
-    );
+    let check = checks::required_tool_check("zip", &types::ToolProbe::not_found());
 
     assert_eq!(check.id, "tool.required.zip");
     assert_eq!(check.status, RunnerDoctorStatus::Error);

--- a/crates/homeboy-cli/src/commands/runner/doctor/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/types.rs
@@ -163,6 +163,11 @@ pub struct DiskProbe {
 #[derive(Debug, Clone, Serialize)]
 pub struct ToolProbe {
     pub available: bool,
+    /// True when the lookup itself could not run, so absence was never
+    /// established. `available: false` alone cannot carry this: reporting a
+    /// broken probe as "not found on PATH" is the readiness lie #14374 is about.
+    #[serde(skip_serializing_if = "is_false")]
+    pub probe_failed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -170,6 +175,44 @@ pub struct ToolProbe {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+impl ToolProbe {
+    pub fn found(path: String, version: Option<String>) -> Self {
+        Self {
+            available: true,
+            probe_failed: false,
+            path: Some(path),
+            version,
+            error: None,
+        }
+    }
+
+    pub fn not_found() -> Self {
+        Self {
+            available: false,
+            probe_failed: false,
+            path: None,
+            version: None,
+            error: Some(TOOL_NOT_FOUND_ERROR.to_string()),
+        }
+    }
+
+    pub fn probe_failed(reason: String) -> Self {
+        Self {
+            available: false,
+            probe_failed: true,
+            path: None,
+            version: None,
+            error: Some(reason),
+        }
+    }
+}
+
+pub const TOOL_NOT_FOUND_ERROR: &str = "not found on PATH";
 
 #[derive(Debug, Serialize)]
 pub struct RunnerCheck {


### PR DESCRIPTION
## Summary

Fixes #14374. `runner doctor local` reported `tool.git` as **error: "git is required but was not found"** on a host where `/usr/bin/git` 2.43.0 is on `PATH` and works.

`local_tool_probe` ran `sh -lc "command -v <tool>"` — a **login** shell. A stale `. "/tmp/opencode/rustup-cargo-9430/env"` line in `~/.profile` made dash exit 2 before `command -v` ever ran, `local_command_line` collapsed the non-zero exit into `None`, and the check rendered that as "not found on PATH". The *same* doctor run then executed `git rev-parse HEAD` directly — doctor proved git present while telling the operator it was missing, and left the runner `blocked`.

## Production change

**1. The local lookup no longer uses a shell.** Tool presence is a property of the filesystem and the process environment, not of the operator's interactive profile. `common::resolve_on_path` walks `PATH` in Rust and checks for a regular, executable file. `resolve_in_path(command, path_var)` is the same walk with the search path supplied explicitly, so it is testable without mutating the process environment.

It keeps two `command -v` behaviours deliberately: a name containing a separator is a path to test rather than a PATH lookup, and symlinks resolve as they do for exec. It deliberately drops one: POSIX reads an empty `PATH` entry as the working directory, but resolving a runner tool relative to wherever doctor was invoked is not a readiness signal, so empty entries are skipped.

This also fixes the `xvfb-run`/`Xvfb` probe, which is a second caller of the same function.

**2. A failed lookup is no longer reported as absence.** `ToolProbe` gains `probe_failed`, set by the new `ToolProbe::probe_failed(reason)` constructor. `tool_check` and `required_tool_check` branch on it and say `"<tool> could not be probed: <reason>"` with a remediation that tells the operator the tool may well be installed — instead of an "install it" remediation for a tool that is already there. `ToolProbe::found` / `::not_found` replace the five struct literals so the three states cannot be mixed up at a call site.

**3. The remote probe gets the same distinction.** `command -v` exits non-zero and stays *silent* when a tool is genuinely missing, so remote stderr means the shell had its own problem and the lookup never reached a verdict. `remote_path_lookup` maps that to `probe_failed` with the stderr line, which is exactly the diagnostic that used to be discarded.

## Verification

Reproduced end-to-end against a poisoned profile (`~/.profile` containing `. "/…/definitely-gone/env"`, `/bin/sh` → dash, Ubuntu 24.04):

```
$ HOME=$FAKE sh -lc "command -v 'git'"
sh: 1: .: cannot open /…/definitely-gone/env: No such file      # exit 2

# installed homeboy 0.367.9 (pre-fix)
$ HOME=$FAKE homeboy runner doctor local
  error tool.git - git is required but was not found

# this branch
$ HOME=$FAKE ./target/debug/homeboy runner doctor local
  ok tool.git - git is available
```

Absence and probe-failure still read differently, so the fix does not paper over real gaps:

```
$ homeboy runner doctor local --require-tool homeboy-definitely-missing
  error - Required runner tool homeboy-definitely-missing was not found
          | remediation: Install homeboy-definitely-missing on the runner…

$ env -i PATH= homeboy runner doctor local --require-tool git
  error tool.git          - git could not be probed: tool lookup could not run: PATH is empty for the doctor process
  error tool.required.git - Required runner tool git could not be probed: tool lookup could not run: PATH is empty…
```

Commands run:

- `cargo fmt --all`
- `cargo check --workspace --all-targets` — clean
- `cargo test -p homeboy-cli --lib -- runner::doctor::tests::tools` — **14 passed, 0 failed**

Seven new tests in `doctor/tests/tools.rs` pin: resolution from a temp directory reachable only through an explicit `PATH` (which no login profile can reach, so it cannot pass through the old mechanism); non-executable and directory candidates skipped; first matching `PATH` entry wins; separator names treated as paths; unset and empty `PATH` reported as probe failure rather than absence; probe failure rendered as "could not be probed" with the reason in `probe_error`; and `local_tool_probe` agreeing with a direct `Command::new("git")` spawn — the contradiction the issue is built on.

Full suite routed to CI.

## AI assistance

Claude (Sonnet 4.5) via OpenCode investigated the probe path, implemented the fix, and ran the focused regression tests. Chris Huber directed and owns the work.
