### PR TITLE
Fix runner refresh authority arguments

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -2491,7 +2491,11 @@ fn materialize_script(
         quote_path(binary_path),
         allow_downgrade,
     );
-    let authority_commits = quote_path(&authority_commits.join(" "));
+    let authority_commits = authority_commits
+        .iter()
+        .map(|authority| quote_path(authority))
+        .collect::<Vec<_>>()
+        .join(" ");
     let downgrade_guard = format!(
         "preflight=$(mktemp -d)\ntrap 'rm -rf \"$preflight\"' EXIT HUP INT TERM\ngit -C \"$preflight\" init --bare --quiet\nif ! git -C \"$preflight\" fetch --quiet \"$source\" \"$ref\"; then\n  echo \"Homeboy ref not found: $ref\" >&2\n  exit 1\nfi\ntarget=$(git -C \"$preflight\" rev-parse --verify --quiet FETCH_HEAD^{{commit}})\nif [ -z \"$target\" ]; then\n  echo \"Homeboy ref did not resolve to a commit: $ref\" >&2\n  exit 1\nfi\nfor authority in {authority_commits}; do\n  if [ -z \"$authority\" ] || [ \"$authority\" = \"$target\" ]; then\n    continue\n  fi\n  if ! git -C \"$preflight\" fetch --quiet \"$source\" \"$authority\"; then\n    if [ \"$allow_downgrade\" != true ]; then\n      echo \"Cannot prove requested Homeboy ref is not a downgrade; use --allow-downgrade only for an intentional rollback\" >&2\n      exit 1\n    fi\n    continue\n  fi\n  if git -C \"$preflight\" merge-base --is-ancestor \"$target\" \"$authority\"; then\n    echo \"HOMEBOY_REFRESH_DOWNGRADE_PREVIOUS=$authority\" >&2\n    echo \"HOMEBOY_REFRESH_DOWNGRADE_REQUESTED=$ref\" >&2\n    echo \"HOMEBOY_REFRESH_DOWNGRADE_RESOLVED=$target\" >&2\n    if [ \"$allow_downgrade\" != true ]; then\n      echo \"Refusing Homeboy runner downgrade; use --allow-downgrade only for an intentional rollback\" >&2\n      exit 1\n    fi\n  fi\ndone\nrm -rf \"$preflight\"\ntrap - EXIT HUP INT TERM\n"
     );

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -625,6 +625,20 @@ fn materialize_plan_rejects_implicit_git_ancestry_downgrades() {
 }
 
 #[test]
+fn materialize_plan_checks_each_refresh_authority_individually() {
+    let script = materialize_script(
+        "https://example.test/homeboy.git",
+        "v0.295.0",
+        "/runner/ws/homeboy-clean",
+        "/runner/ws/homeboy-clean/target/release/homeboy",
+        false,
+        &["controller-authority", "daemon-authority"],
+    );
+
+    assert!(script.contains("for authority in 'controller-authority' 'daemon-authority'; do"));
+}
+
+#[test]
 fn materialize_plan_allows_an_explicit_git_ancestry_downgrade() {
     let script = materialize_script(
         "https://example.test/homeboy.git",


### PR DESCRIPTION
## Summary\n- pass each refresh promotion authority as an individual shell-quoted Git ref\n- cover controller and daemon authority generation in the materialization script\n\n## Verification\n- 
running 4 tests
test homeboy_refresh::tests::part_a::materialize_plan_checks_each_refresh_authority_individually ... ok
test homeboy_refresh::tests::part_a::materialize_plan_allows_an_explicit_git_ancestry_downgrade ... ok
test homeboy_refresh::tests::part_a::materialize_plan_uses_clean_runner_cache ... ok
test homeboy_refresh::tests::part_a::materialize_plan_rejects_implicit_git_ancestry_downgrades ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 2013 filtered out; finished in 0.00s\n\nAI assistance: GPT-6 Astra via OpenCode identified the generated shell argument defect, implemented the scoped fix, and ran the focused test suite.