### PR TITLE
fix(invocation): make the exported TMPDIR socket-safe after canonicalization

### DIFF
--- a/crates/homeboy-core/src/engine/invocation.rs
+++ b/crates/homeboy-core/src/engine/invocation.rs
@@ -21,9 +21,11 @@ pub use child::{
     InvocationChildRecord,
 };
 pub use runtime::{
-    enforce_path_budget, invocation_runtime_root, short_invocation_id,
+    canonical_budget_path, enforce_path_budget, invocation_runtime_root, short_invocation_id,
     HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, SOCKET_HEADROOM_BYTES, SUN_PATH_CAPACITY,
 };
+
+use super::temp::TempPlacement;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct InvocationRequirements {
@@ -216,8 +218,13 @@ impl InvocationGuard {
             return Err(error);
         }
 
-        let (runtime_tmp_dir, runtime_tmp_pin) =
-            match super::temp::managed_run_temp_dir_for_producer(
+        // Socket-safe allocation: the exported TMPDIR is canonicalized by real
+        // workloads before they bind sockets under it, so the *durable* path —
+        // not just the short alias pointing at it — has to fit the
+        // `sockaddr_un` budget (#14384).
+        let (runtime_tmp_dir, runtime_tmp_pin, tmp_placement) =
+            match super::temp::socket_safe_run_temp_dir(
+                &short,
                 "homeboy-invocation-tmp",
                 Some("invocation"),
             ) {
@@ -236,17 +243,21 @@ impl InvocationGuard {
             let _ = fs::remove_dir_all(&artifact_dir);
             return Err(error);
         }
-        let (exported_tmp_dir, runtime_tmp_alias) =
-            match exported_runtime_tmp_dir(&runtime_root, &short, &runtime_tmp_dir) {
-                Ok(exported) => exported,
-                Err(error) => {
-                    let _ = fs::remove_dir_all(&runtime_tmp_dir);
-                    let _ = fs::remove_file(lease_path_in_root(&config_root, &id));
-                    let _ = fs::remove_dir_all(&state_dir);
-                    let _ = fs::remove_dir_all(&artifact_dir);
-                    return Err(error);
-                }
-            };
+        let (exported_tmp_dir, runtime_tmp_alias) = match exported_runtime_tmp_dir(
+            &runtime_root,
+            &short,
+            &runtime_tmp_dir,
+            tmp_placement,
+        ) {
+            Ok(exported) => exported,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&runtime_tmp_dir);
+                let _ = fs::remove_file(lease_path_in_root(&config_root, &id));
+                let _ = fs::remove_dir_all(&state_dir);
+                let _ = fs::remove_dir_all(&artifact_dir);
+                return Err(error);
+            }
+        };
         let cleanup_paths = [state_dir.clone(), artifact_dir.clone()];
         Ok(Self {
             env: InvocationEnv {
@@ -403,14 +414,31 @@ impl Drop for InvocationGuard {
     }
 }
 
+/// Resolve the `TMPDIR` handed to child workloads, and the alias to remove on
+/// teardown when one was created.
+///
+/// The alias exists to keep the *handed-out* string short. It cannot make the
+/// target short, and a workload that calls `realpath()` on `$TMPDIR` — which is
+/// what anything creating a UNIX socket or proving symlink-free containment
+/// does — binds against the target. So the target is budget-checked here too;
+/// checking only the alias made the guarantee decorative (#14384).
+///
+/// A fallback-placed owner is already under the short runtime root, so it is
+/// exported directly with no alias at all.
 #[cfg(unix)]
 pub(crate) fn exported_runtime_tmp_dir(
     runtime_root: &Path,
     short: &str,
     runtime_tmp_dir: &Path,
+    placement: TempPlacement,
 ) -> Result<(PathBuf, Option<PathBuf>)> {
+    if placement == TempPlacement::InvocationRuntimeRoot {
+        return Ok((runtime_tmp_dir.to_path_buf(), None));
+    }
     let alias = runtime_root.join(format!("{short}.t"));
     enforce_path_budget(&alias)?;
+    // The alias resolves here; a consumer that canonicalizes gets this path.
+    enforce_path_budget(runtime_tmp_dir)?;
     std::os::unix::fs::symlink(runtime_tmp_dir, &alias).map_err(|error| {
         Error::internal_io(
             format!(
@@ -429,6 +457,7 @@ pub(crate) fn exported_runtime_tmp_dir(
     _runtime_root: &Path,
     _short: &str,
     runtime_tmp_dir: &Path,
+    _placement: TempPlacement,
 ) -> Result<(PathBuf, Option<PathBuf>)> {
     Ok((runtime_tmp_dir.to_path_buf(), None))
 }

--- a/crates/homeboy-core/src/engine/invocation/runtime.rs
+++ b/crates/homeboy-core/src/engine/invocation/runtime.rs
@@ -33,6 +33,13 @@
 //!   metadata-backed durable runtime-temp owner so cleanup can classify
 //!   child-created bytes after the invocation exits.
 //!
+//!   The alias keeps the *handed-out* string short; it cannot make the target
+//!   short. Workloads routinely `realpath()` `$TMPDIR` before binding a socket
+//!   under it, so the durable owner is itself named for the short id and the
+//!   budget is enforced against the resolved path (#14384). When the data
+//!   volume is too deep to host even that, the owner is allocated directly
+//!   under this root and no alias is created.
+//!
 //! There is no `s/a` subdir layer — that would burn `sockaddr_un` budget for
 //! no isolation gain since the invocation is already 1:1 with a single
 //! workload run. Workloads that need internal subdirs under STATE_DIR can
@@ -188,15 +195,54 @@ fn current_uid() -> libc::uid_t {
     unsafe { libc::getuid() }
 }
 
+/// Resolve `path` to the form the kernel will actually see.
+///
+/// A budget check on an unresolved path is decorative: the workload binds
+/// against whatever `realpath()` returns, not against the string Homeboy
+/// handed it. `/tmp` is a symlink to `/private/tmp` on macOS, and any
+/// operator-supplied root can sit behind a symlink on any platform, so the
+/// unresolved and resolved lengths routinely differ.
+///
+/// The path being checked usually does not exist yet — callers deliberately
+/// enforce the budget *before* creating directories so they fail fast. So
+/// this canonicalizes the deepest ancestor that does exist and re-appends the
+/// components below it, which is exact for the only thing that can change a
+/// path's length: a symlink in an existing prefix.
+pub fn canonical_budget_path(path: &Path) -> PathBuf {
+    let mut suffix = Vec::new();
+    let mut cursor = path;
+    loop {
+        if let Ok(resolved) = cursor.canonicalize() {
+            let mut out = resolved;
+            for component in suffix.iter().rev() {
+                out.push(component);
+            }
+            return out;
+        }
+        let Some(parent) = cursor.parent() else {
+            return path.to_path_buf();
+        };
+        let Some(name) = cursor.file_name() else {
+            return path.to_path_buf();
+        };
+        suffix.push(name.to_os_string());
+        cursor = parent;
+    }
+}
+
 /// Verify that handing out `path` leaves room for a realistic
 /// workload-relative socket name within the `sockaddr_un` budget.
+///
+/// The check is applied to [`canonical_budget_path`] of `path`, because that
+/// is the string a workload gets from `realpath()` and passes to `bind()`.
 ///
 /// Fails fast with a clear error message that names `sockaddr_un`, the
 /// platform-specific limit, the actual headroom available, and the override
 /// env var when the platform budget cannot accommodate at least
 /// [`SOCKET_HEADROOM_BYTES`] beyond `path`'s length.
 pub fn enforce_path_budget(path: &Path) -> Result<()> {
-    let path_str = path.to_string_lossy();
+    let canonical = canonical_budget_path(path);
+    let path_str = canonical.to_string_lossy();
     let path_len = path_str.len();
     // +1 reserves the path-separator byte before the workload's filename.
     let needed = path_len
@@ -204,12 +250,21 @@ pub fn enforce_path_budget(path: &Path) -> Result<()> {
         .saturating_add(SOCKET_HEADROOM_BYTES);
     if needed > SUN_PATH_CAPACITY {
         let headroom = SUN_PATH_CAPACITY.saturating_sub(path_len).saturating_sub(1);
+        // Name the unresolved path too when it differs, so an operator reading
+        // this error can see that the length came from resolving a symlink and
+        // not from the string Homeboy appears to be handing out.
+        let requested = path.to_string_lossy();
+        let subject = if requested == path_str {
+            format!("path: {path_str}")
+        } else {
+            format!("path: {requested} resolves to {path_str}")
+        };
         return Err(Error::internal_unexpected(format!(
             "Homeboy invocation runtime path exceeds the platform sockaddr_un budget: \
              path is {path_len} bytes, leaving {headroom} bytes of headroom for a downstream \
              socket name, but Homeboy guarantees at least {SOCKET_HEADROOM_BYTES} bytes of \
              headroom under the {SUN_PATH_CAPACITY}-byte sun_path capacity. Set \
-             {HOMEBOY_INVOCATION_RUNTIME_DIR_ENV} to a shorter root (path: {path_str})."
+             {HOMEBOY_INVOCATION_RUNTIME_DIR_ENV} to a shorter root ({subject})."
         )));
     }
     Ok(())
@@ -288,6 +343,62 @@ mod tests {
     fn budget_accepts_short_path() {
         let path = PathBuf::from("/tmp/hb-501/abc1234567/state");
         enforce_path_budget(&path).expect("short path fits");
+    }
+
+    /// The budget must be measured against what `realpath()` returns.
+    ///
+    /// #14384: `TMPDIR` was a 25-byte symlink to a 120-byte target. Checking
+    /// the link kept the guarantee green while every workload that
+    /// canonicalized its temp root — anything binding a socket under it — got
+    /// a path no socket could live at.
+    #[cfg(unix)]
+    #[test]
+    fn budget_measures_the_resolved_path_not_the_link() {
+        let _guard = home_env_guard();
+        let dir = tempfile::tempdir_in("/tmp").expect("short tempdir");
+        let target = dir.path().join("d".repeat(90));
+        std::fs::create_dir(&target).expect("long target");
+        let link = dir.path().join("s");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+        // The literal string is nowhere near the limit — this is exactly the
+        // shape that used to pass while handing out an unusable directory.
+        assert!(link.as_os_str().len() + 1 + SOCKET_HEADROOM_BYTES <= SUN_PATH_CAPACITY);
+
+        let error = enforce_path_budget(&link).expect_err("the resolved target must not pass");
+        let message = error.to_string();
+        assert!(message.contains("sockaddr_un"));
+        assert!(
+            message.contains("resolves to"),
+            "the error must name both the requested and resolved paths: {message}"
+        );
+        assert_eq!(canonical_budget_path(&link), target.canonicalize().unwrap());
+    }
+
+    /// The check runs before the directory exists, which is the whole point of
+    /// failing fast, so resolution has to work on a path that is not there yet.
+    #[cfg(unix)]
+    #[test]
+    fn canonical_path_resolves_an_existing_prefix_under_a_missing_suffix() {
+        let _guard = home_env_guard();
+        let dir = tempfile::tempdir_in("/tmp").expect("short tempdir");
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).expect("real dir");
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        let resolved = canonical_budget_path(&link.join("absent").join("deeper"));
+        assert_eq!(
+            resolved,
+            real.canonicalize().unwrap().join("absent").join("deeper"),
+            "the existing prefix resolves and the missing suffix is preserved"
+        );
+    }
+
+    #[test]
+    fn canonical_path_returns_the_input_when_nothing_resolves() {
+        let path = PathBuf::from("/homeboy-nonexistent-root-14384/a/b");
+        assert_eq!(canonical_budget_path(&path), path);
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-core/src/engine/temp.rs
+++ b/crates/homeboy-core/src/engine/temp.rs
@@ -1,8 +1,8 @@
 mod implementation;
 
 pub(crate) use implementation::{
-    bind_run_dir_owner, managed_run_temp_dir, managed_run_temp_dir_for_producer,
-    mark_run_dir_succeeded, pin_runtime_temp_dir, retain_failed_run_dir, RuntimeTempPin,
+    bind_run_dir_owner, managed_run_temp_dir, mark_run_dir_succeeded, pin_runtime_temp_dir,
+    retain_failed_run_dir, socket_safe_run_temp_dir, RuntimeTempPin, TempPlacement,
 };
 pub use implementation::{
     cleanup_runtime_tmp, cleanup_runtime_tmp_bounded, present_runtime_temp_cleanup,

--- a/crates/homeboy-core/src/engine/temp/implementation.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation.rs
@@ -76,8 +76,13 @@ pub struct RuntimeTempOwner {
 
 impl RuntimeTempOwner {
     /// Allocate a metadata-backed child temp root before launching a workload.
+    ///
+    /// The temp root is exported to the child as `TMPDIR`, so it carries the
+    /// same socket-safety obligation as the invocation temp root and is
+    /// allocated through the same placement logic (#14384).
     pub fn allocate(prefix: &str, producer: &str) -> Result<Self> {
-        let (path, pin) = managed_run_temp_dir_for_producer(prefix, Some(producer))?;
+        let short = crate::engine::invocation::short_invocation_id();
+        let (path, pin, placement) = socket_safe_run_temp_dir(&short, prefix, Some(producer))?;
         let exported = (|| {
             let runtime_root = crate::engine::invocation::invocation_runtime_root()?;
             fs::create_dir_all(&runtime_root).map_err(|error| {
@@ -91,8 +96,9 @@ impl RuntimeTempOwner {
             })?;
             crate::engine::invocation::exported_runtime_tmp_dir(
                 &runtime_root,
-                &crate::engine::invocation::short_invocation_id(),
+                &short,
                 &path,
+                placement,
             )
         })();
         let (exported_path, runtime_tmp_alias) = match exported {
@@ -244,6 +250,47 @@ struct RuntimeRunOwner {
     /// Absent values are legacy entries and retain their existing treatment.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     producer: Option<String>,
+    /// Which root this owner was allocated under, when it was not the default
+    /// data-volume runtime root.
+    ///
+    /// Socket-safe allocations degrade to the short invocation runtime root
+    /// when the data-volume path cannot satisfy the `sockaddr_un` budget
+    /// (#14384). Recording that here is what lets an operator reading
+    /// `cleanup` output tell a deliberate degradation from a stray directory
+    /// under `/tmp`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    placement: Option<String>,
+    /// The allocation prefix this owner would have carried in its directory
+    /// name.
+    ///
+    /// A socket-safe owner's directory is named for its short id alone, because
+    /// a `<prefix>-<uuid>-<nanos>` name cannot fit the `sockaddr_un` budget
+    /// (#14384). `cleanup --prefix` is an operator affordance that predates
+    /// that, so the prefix is recorded here and the filter honors it. Absent on
+    /// entries whose name already carries the prefix.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    allocation_prefix: Option<String>,
+}
+
+/// Where a socket-safe managed temp owner was allocated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TempPlacement {
+    /// The default: the data-volume runtime root, per #11125.
+    DataRoot,
+    /// The short invocation runtime root, chosen because the data-volume path
+    /// could not satisfy the `sockaddr_un` budget.
+    InvocationRuntimeRoot,
+}
+
+impl TempPlacement {
+    fn owner_value(self) -> Option<String> {
+        match self {
+            // Absent means "the default", which keeps every pre-existing owner
+            // record valid without a migration.
+            Self::DataRoot => None,
+            Self::InvocationRuntimeRoot => Some("invocation-runtime-root".to_string()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -428,7 +475,91 @@ pub(crate) fn managed_run_temp_dir_for_producer(
     producer: Option<&str>,
 ) -> Result<(PathBuf, RuntimeTempPin)> {
     let root = ensure_runtime_tmp_dir()?;
-    let path = root.join(unique_name(prefix, ""));
+    managed_run_temp_dir_in_root(
+        &root,
+        &unique_name(prefix, ""),
+        prefix,
+        producer,
+        TempPlacement::DataRoot,
+    )
+}
+
+/// Allocate a metadata-backed temp owner whose path a workload can safely
+/// `realpath()` and then bind a UNIX socket under.
+///
+/// The default `<prefix>-<uuid>-<nanos>` name is ~74 bytes, which no data root
+/// is short enough to absorb: the Linux budget for the whole path is 75 bytes.
+/// A workload that canonicalizes `$TMPDIR` — standard practice before creating
+/// sockets or doing containment proofs — therefore got a path that could not
+/// hold a socket, even though the short `.t` alias it was handed could
+/// (#14384).
+///
+/// So the directory name here is just the caller's short id. The uuid and the
+/// creation time are not lost: they live in `owner.json` as `owner_id` and
+/// `created_at`, which is already where cleanup reads an entry's age from.
+///
+/// When even the short name cannot fit under the data root — a long `$HOME` or
+/// `HOMEBOY_DATA_DIR` — the owner is allocated under the short invocation
+/// runtime root instead and the degradation is recorded in `owner.json`.
+/// #11125 (durable bytes follow the data volume) is preserved everywhere it
+/// can be honored, and given up only where honoring it would silently hand out
+/// an unusable `TMPDIR`.
+pub(crate) fn socket_safe_run_temp_dir(
+    short: &str,
+    prefix: &str,
+    producer: Option<&str>,
+) -> Result<(PathBuf, RuntimeTempPin, TempPlacement)> {
+    // Resolved without creating anything: a root that cannot host a socket-safe
+    // owner should not be materialized, and `ensure_runtime_tmp_dir` also runs
+    // capacity preflight and automatic retention against whatever it is handed.
+    let data_root = runtime_root()?;
+    if crate::engine::invocation::enforce_path_budget(&data_root.join(short)).is_ok() {
+        let data_root = ensure_runtime_tmp_dir()?;
+        let (path, pin) = managed_run_temp_dir_in_root(
+            &data_root,
+            short,
+            prefix,
+            producer,
+            TempPlacement::DataRoot,
+        )?;
+        return Ok((path, pin, TempPlacement::DataRoot));
+    }
+
+    let fallback_root = crate::engine::invocation::invocation_runtime_root()?;
+    fs::create_dir_all(&fallback_root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "create socket-safe runtime temp root {}",
+                fallback_root.display()
+            )),
+        )
+    })?;
+    // The `.t` suffix keeps the fallback owner from colliding with the
+    // invocation's own STATE_DIR (`<short>`) and ARTIFACT_DIR (`<short>.a`)
+    // siblings under the same root.
+    let name = format!("{short}.t");
+    // Fail closed rather than hand out a path no socket can live under. The
+    // error already names the override env var, which is the operator's way out.
+    crate::engine::invocation::enforce_path_budget(&fallback_root.join(&name))?;
+    let (path, pin) = managed_run_temp_dir_in_root(
+        &fallback_root,
+        &name,
+        prefix,
+        producer,
+        TempPlacement::InvocationRuntimeRoot,
+    )?;
+    Ok((path, pin, TempPlacement::InvocationRuntimeRoot))
+}
+
+fn managed_run_temp_dir_in_root(
+    root: &Path,
+    name: &str,
+    prefix: &str,
+    producer: Option<&str>,
+    placement: TempPlacement,
+) -> Result<(PathBuf, RuntimeTempPin)> {
+    let path = root.join(name);
     // Cleanup ignores this short-lived staging name. Renaming after durable owner
     // metadata and a live pin exist prevents cleanup from observing a half-owned run.
     let staging = root.join(format!(
@@ -455,6 +586,8 @@ pub(crate) fn managed_run_temp_dir_for_producer(
         completed_at: None,
         reason: None,
         producer: producer.map(str::to_string),
+        placement: placement.owner_value(),
+        allocation_prefix: (!name.starts_with(prefix)).then(|| prefix.to_string()),
     };
     if let Err(error) = write_run_owner(&staging, &owner) {
         let _ = fs::remove_dir_all(&staging);
@@ -1070,7 +1203,8 @@ fn cleanup_runtime_tmp_bounded_with_remover(
     options: RuntimeTempCleanupOptions<'_>,
     remover: RuntimeTempEntryRemover,
 ) -> Result<RuntimeTempCleanupOutput> {
-    let mut output = cleanup_runtime_tmp_root(runtime_root()?, options, remover)?;
+    let mut output =
+        cleanup_runtime_tmp_root(runtime_root()?, options, remover, RootSweepScope::All)?;
 
     for superseded in superseded_runtime_roots() {
         // The bound is shared across roots so an aggregate sweep still returns
@@ -1090,7 +1224,12 @@ fn cleanup_runtime_tmp_bounded_with_remover(
         let mut superseded_options = options;
         superseded_options.cursor = None;
         superseded_options.limit = remaining;
-        let drained = cleanup_runtime_tmp_root(superseded.clone(), superseded_options, remover)?;
+        let drained = cleanup_runtime_tmp_root(
+            superseded.clone(),
+            superseded_options,
+            remover,
+            RootSweepScope::All,
+        )?;
         merge_runtime_temp_cleanup(&mut output, drained);
         if options.apply {
             // Best effort, and only ever succeeds once the root is genuinely
@@ -1100,7 +1239,115 @@ fn cleanup_runtime_tmp_bounded_with_remover(
         }
     }
 
+    // Drain socket-safe fallback owners. `socket_safe_run_temp_dir` places an
+    // owner here when the data-volume path cannot satisfy the `sockaddr_un`
+    // budget, so on a long-`$HOME` host this is where the durable temp bytes
+    // actually accumulate. Not sweeping it would leak them permanently — the
+    // #11125 failure mode, moved to a new root.
+    if let Some(fallback) = socket_safe_fallback_root() {
+        let remaining = options.limit.max(1).saturating_sub(output.rows.len());
+        if remaining > 0 && !options.budget_spent() {
+            let mut fallback_options = options;
+            fallback_options.cursor = None;
+            fallback_options.limit = remaining;
+            let drained = cleanup_runtime_tmp_root(
+                fallback,
+                fallback_options,
+                remover,
+                // Managed-only. This root also holds every live invocation's
+                // STATE_DIR and ARTIFACT_DIR, which carry no owner record and
+                // are owned by the invocation lease, not by this sweep.
+                // Treating them as unmanaged strays would delete the working
+                // directories of running workloads.
+                RootSweepScope::ManagedOnly,
+            )?;
+            merge_runtime_temp_cleanup(&mut output, drained);
+        } else {
+            output.has_more = true;
+        }
+    }
+
     Ok(output)
+}
+
+/// The socket-safe fallback root, when this host actually has bytes there.
+///
+/// This root is shared: it also holds the state and artifact directories of
+/// every live invocation on the machine, including other processes'. So it is
+/// swept only when there is a reason to, which is either of
+///
+/// 1. the current configuration would allocate a fallback owner here, or
+/// 2. a previous configuration already did.
+///
+/// (2) is not redundant. An operator who moves `HOMEBOY_DATA_DIR` to a shorter
+/// path stops producing fallback owners but does not reclaim the ones already
+/// written, and abandoning them is the #11125 leak with a new address.
+fn socket_safe_fallback_root() -> Option<PathBuf> {
+    let fallback = crate::engine::invocation::invocation_runtime_root().ok()?;
+    if !fallback.is_dir() {
+        return None;
+    }
+    // Under the `HOMEBOY_INVOCATION_RUNTIME_DIR` override these can name the
+    // same directory; sweeping it twice would double-count every row.
+    let active = runtime_root().ok()?;
+    if fallback == active || superseded_runtime_roots().contains(&fallback) {
+        return None;
+    }
+
+    let allocates_here = crate::engine::invocation::enforce_path_budget(
+        // Any short id has the same length, so this measures the shape the
+        // allocator would produce rather than a specific allocation.
+        &active.join("0".repeat(SHORT_INVOCATION_ID_LEN)),
+    )
+    .is_err();
+    if allocates_here || root_holds_fallback_owner(&fallback) {
+        return Some(fallback);
+    }
+    None
+}
+
+/// Length of a `short_invocation_id`, which is the whole name of a socket-safe
+/// managed temp directory.
+const SHORT_INVOCATION_ID_LEN: usize = 10;
+
+/// Whether a managed entry satisfies `cleanup --prefix`.
+///
+/// A socket-safe owner's directory name is its short id, so the prefix it was
+/// allocated under lives in `owner.json` instead. Falling back to the record
+/// keeps `--prefix homeboy-invocation-tmp` selecting invocation temp after
+/// #14384 shortened the name. The record is only read when the cheap name test
+/// fails, so an unfiltered sweep costs nothing extra.
+fn managed_entry_matches_prefix(path: &Path, name: &str, prefix: &str) -> bool {
+    if name.starts_with(prefix) {
+        return true;
+    }
+    read_run_owner(path)
+        .ok()
+        .and_then(|owner| owner.allocation_prefix)
+        .is_some_and(|recorded| recorded.starts_with(prefix))
+}
+
+fn root_holds_fallback_owner(root: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(root) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        read_run_owner(&entry.path())
+            .ok()
+            .and_then(|owner| owner.placement)
+            .is_some()
+    })
+}
+
+/// Which entries a single-root sweep is allowed to consider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RootSweepScope {
+    /// Managed owners plus unmanaged strays: the contract for a root Homeboy
+    /// owns end to end.
+    All,
+    /// Managed owners only, for a shared root that also holds directories
+    /// belonging to another lifecycle.
+    ManagedOnly,
 }
 
 /// Fold a superseded-root sweep into the active-root report.
@@ -1130,6 +1377,7 @@ fn cleanup_runtime_tmp_root(
     root: PathBuf,
     options: RuntimeTempCleanupOptions<'_>,
     remover: RuntimeTempEntryRemover,
+    scope: RootSweepScope,
 ) -> Result<RuntimeTempCleanupOutput> {
     let lock = acquire_cleanup_lock(&root, "runtime-temp.cleanup")?;
     let mut output = RuntimeTempCleanupOutput {
@@ -1200,7 +1448,7 @@ fn cleanup_runtime_tmp_root(
         }
         if entry.path().join(RUN_OWNER_FILE).is_file() {
             managed.push(entry);
-        } else {
+        } else if scope == RootSweepScope::All {
             unmanaged.push(entry);
         }
     }
@@ -1260,7 +1508,7 @@ fn cleanup_runtime_tmp_root(
         last_inspected_name = Some(name.clone());
         if options
             .prefix
-            .is_some_and(|prefix| !name.starts_with(prefix))
+            .is_some_and(|prefix| !managed_entry_matches_prefix(&path, &name, prefix))
         {
             output.skipped_count += 1;
             output
@@ -1306,6 +1554,8 @@ fn cleanup_runtime_tmp_root(
                     completed_at: None,
                     reason: Some(error.message.clone()),
                     producer: None,
+                    placement: None,
+                    allocation_prefix: None,
                 };
                 let warning = format!("owner metadata is corrupt: {}", error.message);
                 if age < CORRUPT_OWNER_GRACE {
@@ -2227,6 +2477,8 @@ mod tests {
             completed_at: Some(now),
             reason: None,
             producer: Some("legacy_producer".to_string()),
+            placement: None,
+            allocation_prefix: None,
         };
         write_run_owner(&path, &owner).expect("superseded owner record");
         fs::write(path.join("evidence.bin"), vec![b'x'; 64]).expect("superseded evidence");

--- a/crates/homeboy-core/src/engine/temp/implementation/tests/retention_tests.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation/tests/retention_tests.rs
@@ -17,6 +17,8 @@ fn active_invocation_lease_survives_transient_pin_loss() {
     #[cfg(not(unix))]
     let path = exported_path.clone();
     fs::remove_file(path.join(RUNTIME_TEMP_PIN_FILE)).expect("simulate pin loss");
+    // The directory is named for the invocation short id now, so this filter
+    // is resolved through the prefix recorded in `owner.json` (#14384).
     let mut options = bounded_options(false, Some("homeboy-invocation-tmp"));
     options.older_than_days = 0;
 
@@ -788,5 +790,206 @@ fn external_hardlink_is_not_reported_as_reclaimable_allocation() {
     assert_eq!(output.removed_count, 1);
     assert!(external.exists());
     assert!(output.verified_reclaimed_bytes <= output.removed_allocated_bytes);
+    env::remove_var(runtime_tmpdir_env());
+}
+
+/// Restore an invocation-runtime-root override on drop.
+struct InvocationRootGuard(Option<String>);
+
+impl InvocationRootGuard {
+    fn set(path: &Path) -> Self {
+        let prior = env::var(crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
+        env::set_var(
+            crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+            path,
+        );
+        Self(prior)
+    }
+}
+
+impl Drop for InvocationRootGuard {
+    fn drop(&mut self) {
+        match self.0.take() {
+            Some(prior) => env::set_var(
+                crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+                prior,
+            ),
+            None => env::remove_var(crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV),
+        }
+    }
+}
+
+/// The reported bug, end to end.
+///
+/// #14384: `TMPDIR` was a short symlink onto a
+/// `homeboy-invocation-tmp-<uuid>-<nanos>` directory, ~74 bytes of name before
+/// any root. Every workload that canonicalizes its temp root before creating
+/// sockets — WP Codebox's native MariaDB provider does it as part of a
+/// symlink-free containment proof — got a path that could not hold a socket.
+/// Binding through `realpath` is the assertion the old contract could not pass.
+#[cfg(unix)]
+#[test]
+fn exported_tmpdir_holds_a_socket_after_canonicalization() {
+    use std::os::unix::net::UnixListener;
+
+    let _guard = home_env_guard();
+    let runtime_root = tempfile::tempdir_in("/tmp").expect("short runtime root");
+    let _root_guard = InvocationRootGuard::set(runtime_root.path());
+    let data_root = tempfile::tempdir().expect("data volume runtime temp root");
+    env::set_var(runtime_tmpdir_env(), data_root.path());
+
+    let run_dir = super::super::super::run_dir::RunDir::create().expect("run dir");
+    let invocation = super::super::super::invocation::InvocationGuard::acquire(
+        &run_dir,
+        &super::super::super::invocation::InvocationRequirements::default(),
+    )
+    .expect("invocation");
+
+    let exported = invocation.context().tmp_dir;
+    let canonical = exported
+        .canonicalize()
+        .expect("canonicalize exported TMPDIR");
+    let socket = canonical.join("server.sock");
+    assert!(
+        socket.as_os_str().len() < 108,
+        "socket path under the resolved TMPDIR must fit sun_path: {} bytes ({})",
+        socket.as_os_str().len(),
+        socket.display()
+    );
+    let listener = UnixListener::bind(&socket).expect("bind a socket under the resolved TMPDIR");
+
+    // The durable owner still lives on the data volume (#11125) — the fix buys
+    // socket safety by shortening the name, not by moving the bytes.
+    assert!(
+        canonical.starts_with(data_root.path().canonicalize().expect("data root")),
+        "durable temp must stay on the data volume: {}",
+        canonical.display()
+    );
+    // The uuid and the creation time left the directory name; they are still
+    // recorded where cleanup actually reads them.
+    let owner = read_run_owner(&canonical).expect("owner record");
+    assert!(!owner.owner_id.is_empty());
+    assert!(!owner.created_at.is_empty());
+    assert_eq!(owner.producer.as_deref(), Some("invocation"));
+    assert_eq!(owner.placement, None, "default placement is the data root");
+
+    drop(listener);
+    drop(invocation);
+    run_dir.cleanup();
+    env::remove_var(runtime_tmpdir_env());
+}
+
+/// A data root too long for even a 10-byte name degrades placement instead of
+/// handing out a `TMPDIR` no socket can live under.
+#[cfg(unix)]
+#[test]
+fn a_data_root_over_budget_falls_back_to_the_short_runtime_root() {
+    use std::os::unix::net::UnixListener;
+
+    let _guard = home_env_guard();
+    let runtime_root = tempfile::tempdir_in("/tmp").expect("short runtime root");
+    let _root_guard = InvocationRootGuard::set(runtime_root.path());
+    let data_root = tempfile::tempdir().expect("data volume root");
+    // Deep enough that no invocation name fits the sockaddr_un budget beneath
+    // it — the long-$HOME host the fallback exists for.
+    let long_data_root = data_root.path().join("d".repeat(80));
+    fs::create_dir_all(&long_data_root).expect("long data root");
+    env::set_var(runtime_tmpdir_env(), &long_data_root);
+
+    let run_dir = super::super::super::run_dir::RunDir::create().expect("run dir");
+    let invocation = super::super::super::invocation::InvocationGuard::acquire(
+        &run_dir,
+        &super::super::super::invocation::InvocationRequirements::default(),
+    )
+    .expect("invocation");
+
+    let exported = invocation.context().tmp_dir;
+    let canonical = exported
+        .canonicalize()
+        .expect("canonicalize exported TMPDIR");
+    assert!(
+        canonical.starts_with(runtime_root.path().canonicalize().expect("runtime root")),
+        "over-budget data root must degrade to the short runtime root: {}",
+        canonical.display()
+    );
+    // No alias: the owner is already short, so nothing is indirected.
+    assert!(
+        !fs::symlink_metadata(&exported)
+            .expect("exported metadata")
+            .file_type()
+            .is_symlink(),
+        "a fallback-placed owner is exported directly"
+    );
+    let listener = UnixListener::bind(canonical.join("server.sock"))
+        .expect("bind a socket under the fallback TMPDIR");
+
+    let owner = read_run_owner(&canonical).expect("owner record");
+    assert_eq!(
+        owner.placement.as_deref(),
+        Some("invocation-runtime-root"),
+        "the degradation must be recorded so cleanup and operators can see it"
+    );
+
+    drop(listener);
+    drop(invocation);
+    run_dir.cleanup();
+    env::remove_var(runtime_tmpdir_env());
+}
+
+/// Cleanup has to find fallback-placed bytes, and must not mistake a live
+/// invocation's state directories — siblings in the same root, with no owner
+/// record — for strays.
+#[cfg(unix)]
+#[test]
+fn cleanup_reclaims_fallback_owners_and_spares_live_invocation_dirs() {
+    let _guard = home_env_guard();
+    let runtime_root = tempfile::tempdir_in("/tmp").expect("short runtime root");
+    let _root_guard = InvocationRootGuard::set(runtime_root.path());
+    let data_root = tempfile::tempdir().expect("data volume root");
+    let long_data_root = data_root.path().join("d".repeat(80));
+    fs::create_dir_all(&long_data_root).expect("long data root");
+    env::set_var(runtime_tmpdir_env(), &long_data_root);
+
+    let run_dir = super::super::super::run_dir::RunDir::create().expect("run dir");
+    let invocation = super::super::super::invocation::InvocationGuard::acquire(
+        &run_dir,
+        &super::super::super::invocation::InvocationRequirements::default(),
+    )
+    .expect("invocation");
+    let context = invocation.context();
+    let fallback_owner = context.tmp_dir.clone();
+    let state_dir = context.state_dir.clone();
+    let artifact_dir = context.artifact_dir.clone();
+    fs::write(fallback_owner.join("payload.bin"), vec![b'x'; 4096]).expect("payload");
+
+    let mut options = bounded_options(true, None);
+    options.older_than_days = 0;
+
+    // While the invocation is live nothing under the shared root is reclaimed.
+    let live = cleanup_runtime_tmp_bounded(options).expect("live sweep");
+    assert_eq!(live.removed_count, 0);
+    assert!(fallback_owner.exists());
+    assert!(state_dir.exists());
+    assert!(artifact_dir.exists());
+    assert!(
+        !live
+            .rows
+            .iter()
+            .any(|row| row.path == state_dir.display().to_string()
+                || row.path == artifact_dir.display().to_string()),
+        "live invocation directories must not be inspected as runtime-temp strays"
+    );
+
+    drop(invocation);
+    assert!(!state_dir.exists(), "invocation teardown removes STATE_DIR");
+
+    let reclaimed = cleanup_runtime_tmp_bounded(options).expect("terminal sweep");
+    assert_eq!(
+        reclaimed.removed_count, 1,
+        "the fallback-placed owner is reclaimed once its invocation ends"
+    );
+    assert!(!fallback_owner.exists());
+
+    run_dir.cleanup();
     env::remove_var(runtime_tmpdir_env());
 }


### PR DESCRIPTION
## Summary

Fixes #14384, implementing option **C**.

`$TMPDIR` under a Homeboy invocation was a 25-byte symlink onto a 120-byte durable owner. Any workload that `realpath()`s its temp root before creating sockets — WP Codebox's native MariaDB provider does it as part of a symlink-free containment proof — got a path that blew the `sockaddr_un` budget the invocation runtime exists to protect.

The alias keeps the *handed-out* string short. It cannot make the target short, and `bind()` sees the target.

## Production change

**1. The budget is measured against the resolved path.** `enforce_path_budget` now checks `canonical_budget_path(path)`. Callers deliberately enforce the budget *before* creating directories so they fail fast, so resolution canonicalizes the deepest ancestor that exists and re-appends the components below it — exact for the only thing that changes a path's length, a symlink in an existing prefix. This makes the check honest at all three call sites, not just the one in the report; STATE_DIR and ARTIFACT_DIR were also being measured unresolved, which matters on macOS where `/tmp` is a symlink to `/private/tmp`. The error now names both the requested and resolved paths when they differ.

**2. The durable owner has a short name.** `<prefix>-<uuid>-<nanos>` is ~74 bytes and the entire Linux budget is 75, so no data root was ever short enough — this was not a long-`$HOME` problem. The directory is now named for the invocation short id alone. The uuid and creation time are not lost: they are `owner_id` and `created_at` in `owner.json`, which is already where the sweep reads an entry's age from, so retention decisions are unchanged.

**3. `exported_runtime_tmp_dir` budget-checks the symlink target**, not only the alias.

**4. Fallback placement.** When even the short name cannot fit under the data root, the owner is allocated under the short invocation runtime root and no alias is created. The degradation is recorded as `placement: "invocation-runtime-root"` in `owner.json`. #11125 is preserved everywhere it can be honored and given up only where honoring it would silently hand out an unusable `TMPDIR`.

**5. `cleanup` drains the fallback root — managed entries only.** That root also holds every live invocation's `STATE_DIR` and `ARTIFACT_DIR`, including other processes'. Those carry no owner record, so an unscoped sweep would classify the working directories of running workloads as strays. It is swept only when the current config would allocate there *or* a previous one already did; the second condition is not redundant, since an operator who shortens `HOMEBOY_DATA_DIR` stops producing fallback owners without reclaiming the existing ones — the #11125 leak at a new address.

`RuntimeTempOwner::allocate` exports `TMPDIR` the same way and carried the same defect, so it routes through the same placement logic.

## One consequence worth flagging

The sweep's directory name is load-bearing in two places I had to preserve:

- **`cleanup --prefix`** filtered on `name.starts_with(prefix)`, so `--prefix homeboy-invocation-tmp` would have stopped matching. The prefix that left the name is recorded as `allocation_prefix` and the filter falls back to it. The record is read only when the cheap name test fails, so an unfiltered sweep costs nothing extra.
- **`unique_name_timestamp`** is the newest-first sort key and the pagination cursor. Short-named entries return 0 and fall through to the total name-descending tiebreak, so ordering stays deterministic and pagination stays correct. Retention is unaffected because it reads `owner.created_at`, not the name. Keeping a nanos field in the name was not an option — at 19 bytes plus a separator it does not fit the budget on a normal host, which is why the issue's option A moves it into `owner.json`.

## Verification

The headline test binds a real `UnixListener` under `realpath($TMPDIR)`. Proven red against the unfixed code by reverting only the two production changes and re-running:

```
# name shortening reverted
invocation: ... path is 128 bytes, leaving 0 bytes of headroom ...
  (path: /var/tmp/.../homeboy-invocation-tmp-9e48fae1-...-1788794552593830070)

# name shortening AND the target budget check reverted -> the reported symptom
socket path under the resolved TMPDIR must fit sun_path: 140 bytes
  (/var/tmp/.../homeboy-invocation-tmp-bf8b8c34-...-1788794585780513287/server.sock)

# this branch
test ...::exported_tmpdir_holds_a_socket_after_canonicalization ... ok
```

Commands run:

- `cargo fmt --all --check`
- `cargo check --workspace --all-targets` — clean, no new warnings
- `cargo test -p homeboy-core --lib -- engine::invocation engine::temp` — **86 passed, 0 failed**
- `cargo test -p homeboy-lab-runner --lib -- socket_safe` — the existing alias-bind test still passes

New tests: socket bind through a canonicalized `$TMPDIR` with the owner still on the data volume; an over-budget data root degrading to the short root with `placement` recorded and a socket bound under it; cleanup reclaiming a fallback owner while leaving a live invocation's `STATE_DIR`/`ARTIFACT_DIR` untouched and un-inspected; and unit coverage for symlink resolution, missing-suffix resolution, and the budget rejecting a short link onto a long target.

Full suite routed to CI.

## AI assistance

Claude (Sonnet 4.5) via OpenCode investigated the allocation and sweep paths, implemented the fix, and ran the focused regression tests including the red-proof revert. Chris Huber diagnosed the bug, chose the design, and owns the work.
