### PR TITLE
fix(agent-task): recover interrupted replacement gates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1546,6 +1546,7 @@ pub fn verify_replacement_gates(
     cook_or_attempt_id: &str,
     gates: crate::agent_task_gate::VerifyGateOptions,
     external_authorization: String,
+    interrupted_rerun_authorization: Option<String>,
 ) -> Result<AgentTaskPromotionReport> {
     let run_id = super::cook_recipe::resolve_cook_continuation_run_id(cook_or_attempt_id)?;
     let lifecycle_store =
@@ -1591,6 +1592,7 @@ pub fn verify_replacement_gates(
                 &run_id,
                 gates,
                 external_authorization,
+                interrupted_rerun_authorization,
             );
             match result {
                 Ok(report) => {
@@ -1623,6 +1625,7 @@ fn verify_replacement_gates_owned(
     run_id: &str,
     gates: crate::agent_task_gate::VerifyGateOptions,
     external_authorization: String,
+    interrupted_rerun_authorization: Option<String>,
 ) -> Result<AgentTaskPromotionReport> {
     let accept_inherited_failures = gates.accept_inherited_failures;
     let gate_timeout = gates.gate_timeout();
@@ -1648,8 +1651,17 @@ fn verify_replacement_gates_owned(
             None,
         ));
     }
-    if replacement_gate_execution_started(lifecycle_store, run_id)? {
+    let interrupted_rerun_authorization =
+        interrupted_rerun_authorization.filter(|authorization| !authorization.trim().is_empty());
+    let recovering_interrupted_execution =
+        replacement_gate_execution_started(lifecycle_store, run_id)?;
+    if recovering_interrupted_execution && interrupted_rerun_authorization.is_none() {
         return Err(interrupted_replacement_gate_execution_error(run_id));
+    }
+    if recovering_interrupted_execution
+        && replacement_gate_execution_is_live(lifecycle_store, run_id)?
+    {
+        return Err(live_replacement_gate_execution_error(run_id));
     }
     if !matches!(
         original.status,
@@ -1780,6 +1792,15 @@ fn verify_replacement_gates_owned(
                 },
             ),
     );
+    if recovering_interrupted_execution {
+        let authorization = interrupted_rerun_authorization
+            .expect("interrupted execution recovery requires explicit authorization");
+        replacement.provenance["replacement_gate_execution_recovery"] = serde_json::json!({
+            "schema": "homeboy/agent-task-replacement-gate-execution-recovery/v1",
+            "operator_authorization": authorization,
+            "automatic_rerun": false,
+        });
+    }
     record_replacement_gate_proof(
         &run_id,
         replacement,
@@ -1862,6 +1883,21 @@ pub(crate) fn replacement_gate_execution_started(
         .is_some())
 }
 
+fn replacement_gate_execution_is_live(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
+    let record = lifecycle_store.read_record(run_id)?;
+    Ok(record
+        .metadata
+        .pointer(&format!(
+            "/{REPLACEMENT_GATE_EXECUTION_FENCES_KEY}/verify-replacement/owner_pid"
+        ))
+        .and_then(Value::as_u64)
+        .and_then(|pid| u32::try_from(pid).ok())
+        .is_some_and(homeboy_core::process::pid_is_running))
+}
+
 pub(crate) fn mark_replacement_gate_execution_started(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     run_id: &str,
@@ -1880,6 +1916,7 @@ pub(crate) fn mark_replacement_gate_execution_started(
         fences["verify-replacement"] = serde_json::json!({
             "schema": "homeboy/agent-task-replacement-gate-execution-fence/v1",
             "state": "started",
+            "owner_pid": std::process::id(),
         });
         true
     })?;
@@ -1899,8 +1936,26 @@ fn interrupted_replacement_gate_execution_error(run_id: &str) -> Error {
         "kind": "external_candidate_bound_proof_required",
         "run_id": run_id,
         "command": format!(
+            "homeboy agent-task verify-replacement {run_id} --authorize-external-proof <proof-authorization> --authorize-interrupted-rerun <rerun-authorization> --verify '<candidate-bound command>'"
+        ),
+        "external_proof_command": format!(
             "homeboy agent-task record-replacement-gate-proof {run_id} --promotion @replacement.json --authorize-external-proof <authorization>"
         ),
+    });
+    error
+}
+
+fn live_replacement_gate_execution_error(run_id: &str) -> Error {
+    let mut error = Error::validation_invalid_argument(
+        "replacement_gate_proof",
+        "replacement gate execution still has a live owner; Homeboy will not rerun shell gates concurrently",
+        Some(run_id.to_string()),
+        Some(vec![format!("homeboy agent-task status {run_id}")]),
+    );
+    error.details["recovery"] = serde_json::json!({
+        "kind": "replacement_gate_execution_live",
+        "run_id": run_id,
+        "status_command": format!("homeboy agent-task status {run_id}"),
     });
     error
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -15562,6 +15562,7 @@ fn verify_replacement_gates_recovers_pending_verification_and_replays_completed_
                 ..Default::default()
             },
             "Chris approved corrected gate evidence".to_string(),
+            None,
         )
         .expect_err("artifact preflight fails before shell execution");
         assert!(!replacement_gate_execution_started(
@@ -15570,6 +15571,28 @@ fn verify_replacement_gates_recovers_pending_verification_and_replays_completed_
         )
         .expect("read replacement gate fence"));
         std::fs::rename(&unavailable_patch, &patch_path).expect("restore promotion artifact");
+        mark_replacement_gate_execution_started(&test_lifecycle_store(), "run-verify-replacement")
+            .expect("persist interrupted replacement execution");
+        agent_task_lifecycle::rewrite_record_for_test("run-verify-replacement", |record| {
+            record.metadata["replacement_gate_execution_fences"]["verify-replacement"]
+                ["owner_pid"] = serde_json::json!(u32::MAX);
+        })
+        .expect("simulate terminated interrupted executor");
+        let interrupted = verify_replacement_gates(
+            "cook-verify-replacement",
+            VerifyGateOptions {
+                verify: vec![reviewer_gate.clone()],
+                ..Default::default()
+            },
+            "Chris approved corrected gate evidence".to_string(),
+            None,
+        )
+        .expect_err("interrupted gates require explicit rerun authority");
+        assert_eq!(
+            interrupted.details["recovery"]["kind"],
+            "external_candidate_bound_proof_required"
+        );
+        assert!(!gate_log.exists());
         let replacement = verify_replacement_gates(
             "cook-verify-replacement",
             VerifyGateOptions {
@@ -15580,6 +15603,7 @@ fn verify_replacement_gates_recovers_pending_verification_and_replays_completed_
                 ..Default::default()
             },
             "Chris approved corrected gate evidence".to_string(),
+            Some("Chris approved rerunning after the interrupted executor".to_string()),
         )
         .expect("replacement gates complete");
 
@@ -15629,6 +15653,7 @@ fn verify_replacement_gates_recovers_pending_verification_and_replays_completed_
                 ..Default::default()
             },
             "Chris approved corrected gate evidence".to_string(),
+            None,
         )
         .expect_err("completed inherited failure needs renewed authorization");
         assert_eq!(error.details["field"], "accept_inherited_failures");
@@ -15640,6 +15665,7 @@ fn verify_replacement_gates_recovers_pending_verification_and_replays_completed_
                 ..Default::default()
             },
             "Chris approved corrected gate evidence".to_string(),
+            None,
         )
         .expect("completed replacement proof replays without rerunning gates");
         assert_eq!(replay.status, replacement.status);
@@ -15674,6 +15700,11 @@ fn verify_replacement_gates_recovers_pending_verification_and_replays_completed_
             record.metadata["latest_promotion"]["provenance"]["replacement_gate_proof"]
                 ["accept_inherited_failures"],
             true
+        );
+        assert_eq!(
+            record.metadata["latest_promotion"]["provenance"]
+                ["replacement_gate_execution_recovery"]["operator_authorization"],
+            "Chris approved rerunning after the interrupted executor"
         );
     });
 }
@@ -15715,6 +15746,7 @@ fn interrupted_replacement_gate_fence_requires_external_proof_without_rerunning(
                 ..Default::default()
             },
             "Chris approved corrected gate evidence".to_string(),
+            None,
         )
         .expect_err("interrupted execution must fail closed");
 
@@ -15722,6 +15754,20 @@ fn interrupted_replacement_gate_fence_requires_external_proof_without_rerunning(
         assert_eq!(
             error.details["recovery"]["kind"],
             "external_candidate_bound_proof_required"
+        );
+        let live_error = verify_replacement_gates(
+            cook_id,
+            VerifyGateOptions {
+                verify: vec![format!("printf ran > {}", gate_log.display())],
+                ..Default::default()
+            },
+            "Chris approved corrected gate evidence".to_string(),
+            Some("Chris approved rerunning after the interrupted executor".to_string()),
+        )
+        .expect_err("a live interrupted owner must veto an authorized rerun");
+        assert_eq!(
+            live_error.details["recovery"]["kind"],
+            "replacement_gate_execution_live"
         );
         assert!(!gate_log.exists());
         assert!(

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -831,6 +831,9 @@ pub struct VerifyReplacementArgs {
     /// Explicit operator authorization for the replacement proof recorded by this command.
     #[arg(long, value_name = "TEXT")]
     pub authorize_external_proof: String,
+    /// Explicit operator authorization to rerun gates after an interrupted replacement execution. Homeboy still refuses while the original operation lease is live.
+    #[arg(long, value_name = "TEXT")]
+    pub authorize_interrupted_rerun: Option<String>,
     /// Verification gate configuration for the replacement candidate.
     #[command(flatten)]
     pub gates: VerifyGateArgs,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1101,6 +1101,7 @@ pub(crate) fn verify_replacement(mut args: VerifyReplacementArgs) -> CmdResult<V
         &args.cook_or_attempt_id,
         args.gates.into(),
         args.authorize_external_proof,
+        args.authorize_interrupted_rerun,
     )?;
     let run_id = report.source.run_id.clone().ok_or_else(|| {
         homeboy::core::Error::internal_unexpected(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -4768,6 +4768,8 @@ fn verify_replacement_command_accepts_corrected_gates_and_authorization() {
         "cargo test exact::replacement",
         "--authorize-external-proof",
         "Chris approved corrected gate evidence",
+        "--authorize-interrupted-rerun",
+        "Chris approved rerunning after the interrupted executor",
     ])
     .expect("replacement verification command parses");
     let Commands::AgentTask(args) = cli.command else {
@@ -4781,6 +4783,10 @@ fn verify_replacement_command_accepts_corrected_gates_and_authorization() {
     assert_eq!(
         args.authorize_external_proof,
         "Chris approved corrected gate evidence"
+    );
+    assert_eq!(
+        args.authorize_interrupted_rerun.as_deref(),
+        Some("Chris approved rerunning after the interrupted executor")
     );
 }
 


### PR DESCRIPTION
## Summary
Recover interrupted replacement verification with explicit rerun authority.

## What changed
- Add an explicit authorized rerun path for interrupted replacement verification.
- Retain candidate binding and veto reruns while the recorded gate owner is live.

## How to test
1. Run `git diff --check`; expect passes as recorded by Homeboy's deterministic gate.

## Compatibility
New optional CLI flag; default interrupted-gate behavior remains fail-closed.

## Evidence
- Base unchanged since verification: main remains at a4047c458b956bc726dd57712ad314ebff988ca5.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/14389
- Verified finalization base: main at a4047c458b956bc726dd57712ad314ebff988ca5
- manual-verify: passed (git diff --check) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** OpenAI GPT-5.6 Terra via direct OpenCode execution implemented and verified; OpenAI GPT-6 Astra via OpenCode orchestration investigated and assigned the work.

## Source relationships
- Closes Extra-Chill/homeboy#14389
