### PR TITLE
Retain full Homeboy source commit identity

### DIFF
--- a/crates/homeboy-product-identity/build.rs
+++ b/crates/homeboy-product-identity/build.rs
@@ -90,7 +90,7 @@ fn emit_git_identity(root: &Path) {
             provenance.dirty
         );
     } else {
-        if let Some(commit) = git_output(root, &["rev-parse", "--short=12", "HEAD"]) {
+        if let Some(commit) = git_output(root, &["rev-parse", "HEAD"]) {
             println!("cargo:rustc-env=HOMEBOY_PRODUCT_GIT_COMMIT={commit}");
         }
         if let Some(status) = git_output(root, &["status", "--porcelain"]) {
@@ -150,7 +150,7 @@ fn synthetic_snapshot_provenance(root: &Path) -> Option<SyntheticSnapshotProvena
         _ => return None,
     };
     Some(SyntheticSnapshotProvenance {
-        commit: source_head[..12].to_string(),
+        commit: source_head.to_string(),
         dirty,
     })
 }


### PR DESCRIPTION
## Summary
- Preserve full 40-character source commit IDs in normal and snapshot build identities.
- Let runner refresh authority checks fetch exact immutable commits instead of abbreviated SHAs.
- Follow up on #14385.

## Verification
- Five build-identity tests passed.
- The built binary’s `self identity` output reports the full commit ID: `9d13b565fa87a6a2063b2834796add0f346f1ab6`.
- End-to-end runner refresh remains to be verified after this repair is released. These checks do not establish completion of the runner update or downstream releases.

## AI Assistance
GPT-6 Astra via OpenCode identified the truncated commit-identity regression, implemented the scoped repair, and ran the reported verification. The PR description was reviewed and corrected before merge.