### PR TITLE
Make reserve-pressure Cook failures actionable

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/agent_task_outcome.rs
+++ b/crates/contracts/homeboy-lab-contract/src/agent_task_outcome.rs
@@ -61,6 +61,8 @@ pub enum AgentTaskFailureClassification {
     ProviderCredentialsExhausted,
     PolicyDenied,
     CapabilityMissing,
+    /// Local resource policy refused work before it reached a provider.
+    Capacity,
     InvalidInput,
     ExecutionFailed,
     Unknown,

--- a/crates/homeboy-agents/src/agent_task_contract.rs
+++ b/crates/homeboy-agents/src/agent_task_contract.rs
@@ -484,6 +484,7 @@ fn agent_task_failure_classifications() -> Vec<String> {
         AgentTaskFailureClassification::ProviderCredentialsExhausted,
         AgentTaskFailureClassification::PolicyDenied,
         AgentTaskFailureClassification::CapabilityMissing,
+        AgentTaskFailureClassification::Capacity,
         AgentTaskFailureClassification::InvalidInput,
         AgentTaskFailureClassification::ExecutionFailed,
         AgentTaskFailureClassification::Unknown,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -873,6 +873,9 @@ fn pre_execution_failure_classification(error: &Error) -> AgentTaskFailureClassi
     if error.details["pre_execution_phase"] == "gate_toolchain_preflight" {
         return AgentTaskFailureClassification::CapabilityMissing;
     }
+    if error.code == homeboy_core::ErrorCode::ResourceCapacityReserve {
+        return AgentTaskFailureClassification::Capacity;
+    }
     if error.retryable == Some(true) {
         AgentTaskFailureClassification::Transient
     } else {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -3755,6 +3755,28 @@ fn non_retryable_pre_execution_failure_remains_invalid_input() {
     assert_eq!(outcome.metadata["provider_executions_consumed"], 0);
 }
 
+#[test]
+fn reserve_pressure_pre_execution_failure_is_classified_as_capacity() {
+    let plan = test_plan();
+    let outcome = build_pre_execution_failure_outcome(
+        "cook-reserve-pressure",
+        &plan.tasks[0],
+        "worktree_capacity_admission",
+        &Error::capacity_reserve(homeboy_core::error::CapacityReserveDetails {
+            filesystem: "/worktrees/new-task".to_string(),
+            available_bytes: 90,
+            reserve_bytes: 100,
+            shortfall_bytes: 10,
+        }),
+    );
+
+    assert_eq!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::Capacity)
+    );
+    assert_eq!(outcome.outputs["error_code"], "resource.capacity_reserve");
+}
+
 /// Rooted in an explicit store rather than a mutated process environment
 /// (#7505). The repair is a write: status rewrites `plan_path` back to the
 /// controller-owned file. Deciding that repair from one home and committing it

--- a/crates/homeboy-agents/src/agent_task_notify_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_notify_tests.rs
@@ -145,6 +145,36 @@ fn failed_cook_forwards_its_own_legal_recovery_commands() {
 }
 
 #[test]
+fn reserve_pressure_notification_names_the_filesystem_and_scoped_inventory() {
+    let mut failed = report("pre_execution_failure", None);
+    failed.terminal_failure_classification = Some("capacity".to_string());
+    failed.stop_reason = Some(
+        "Filesystem reserve shortfall at /worktrees/new-task: 90 bytes available, 100 bytes reserved, 10 bytes short".to_string(),
+    );
+    let mut context = failure_context();
+    context.phase = "worktree_capacity_admission".to_string();
+    context.reason_code = "resource.capacity_reserve".to_string();
+    context.legal_actions = vec![AgentTaskCookRecoveryAction {
+        action: "inspect reclaimable artifacts across repository worktrees".to_string(),
+        command:
+            "homeboy cleanup artifacts --path /worktrees/repository --all-worktrees --merged-only"
+                .to_string(),
+    }];
+    failed.failure_context = Some(context);
+
+    let payload = terminal_payload(&failed, None, 1);
+    let body = payload.render_body();
+
+    assert!(body.contains("Filesystem reserve shortfall at /worktrees/new-task"));
+    assert!(body.contains("Failure classification: capacity"));
+    assert!(body.contains("Reason code: resource.capacity_reserve"));
+    assert!(payload.actions.iter().any(|action| {
+        action.command
+            == "homeboy cleanup artifacts --path /worktrees/repository --all-worktrees --merged-only"
+    }));
+}
+
+#[test]
 fn failed_cook_forwards_a_recovery_action_once_when_report_sections_overlap() {
     let mut failed = report("pre_execution_failure", None);
     let recovery = AgentTaskCookRecoveryAction {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -5757,6 +5757,13 @@ pub fn cook_failure_context(
     let pre_execution_diagnostic = record.as_ref().and_then(|record| {
         let failure = record.metadata.get("pre_execution_failure")?;
         let details = failure.get("details")?;
+        if failure.get("error_code").and_then(Value::as_str) == Some("resource.capacity_reserve") {
+            return Some(serde_json::json!({
+                "code": "resource.capacity_reserve",
+                "message": failure.get("message"),
+                "details": details,
+            }));
+        }
         details
             .get("worktree_provider_failure")
             .cloned()
@@ -5871,26 +5878,33 @@ pub fn cook_failure_context(
             None,
         )
     };
-    let recovery_actions = dirty_candidate_adoption_recovery_actions(
-        &recipe,
-        record.as_ref(),
-        cook_id,
-        &chronological_latest_run_id,
-    )
-    .unwrap_or_else(|| {
-        cook_recovery_actions(
-            status,
-            &chronological_latest_run_id,
-            recovery_legal,
-            blocking_claim.is_some(),
-            record
-                .as_ref()
-                .is_some_and(|record| super::retry_admission(&record.run_id).is_ok()),
-            exact_checkpoint_candidate_mismatch(&diagnostic),
-            ambiguous_promotion_artifact_ids(record_run_id, promotion_diagnostic.as_ref(), &recipe),
-            record.as_ref().and_then(lab_handoff_runtime_recovery),
-        )
-    });
+    let recovery_actions = capacity_reserve_recovery_actions(record.as_ref())
+        .or_else(|| {
+            dirty_candidate_adoption_recovery_actions(
+                &recipe,
+                record.as_ref(),
+                cook_id,
+                &chronological_latest_run_id,
+            )
+        })
+        .unwrap_or_else(|| {
+            cook_recovery_actions(
+                status,
+                &chronological_latest_run_id,
+                recovery_legal,
+                blocking_claim.is_some(),
+                record
+                    .as_ref()
+                    .is_some_and(|record| super::retry_admission(&record.run_id).is_ok()),
+                exact_checkpoint_candidate_mismatch(&diagnostic),
+                ambiguous_promotion_artifact_ids(
+                    record_run_id,
+                    promotion_diagnostic.as_ref(),
+                    &recipe,
+                ),
+                record.as_ref().and_then(lab_handoff_runtime_recovery),
+            )
+        });
     let promotion_provenance = promotion.cloned();
     Some(super::AgentTaskCookFailureContext {
         cook_id: cook_id.to_string(),
@@ -5916,6 +5930,55 @@ pub fn cook_failure_context(
         recovery_reason: recovery_actions.reason,
         next_actions: recovery_actions.next_actions,
         legal_actions: recovery_actions.legal_actions,
+    })
+}
+
+/// A persisted failure is normally not trusted to manufacture shell commands.
+/// Reserve admission actions are core-owned, explicitly read-only, and retain
+/// their structured identifier, so the terminal Cook notification can safely
+/// forward only the inventory action. The confirmation-gated apply action stays
+/// in durable diagnostic evidence.
+fn capacity_reserve_recovery_actions(
+    record: Option<&agent_task_lifecycle::AgentTaskRunRecord>,
+) -> Option<CookRecoveryActions> {
+    let failure = record?.metadata.get("pre_execution_failure")?;
+    if failure.get("error_code").and_then(Value::as_str) != Some("resource.capacity_reserve") {
+        return None;
+    }
+    let actions = failure
+        .pointer("/details/_homeboy_actions")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter(|action| {
+            action
+                .get("id")
+                .and_then(Value::as_str)
+                .is_some_and(|id| id.starts_with("capacity.reserve."))
+                && action.get("program").and_then(Value::as_str) == Some("homeboy")
+                && action.get("safety").and_then(Value::as_str) == Some("read_only")
+        })
+        .filter_map(|action| {
+            let label = action.get("label")?.as_str()?;
+            let args = action
+                .get("args")?
+                .as_array()?
+                .iter()
+                .map(Value::as_str)
+                .collect::<Option<Vec<_>>>()?
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            Some(super::AgentTaskCookRecoveryAction {
+                action: label.to_string(),
+                command: format!("homeboy {}", quote_args(&args)),
+            })
+        })
+        .take(1)
+        .collect::<Vec<_>>();
+    (!actions.is_empty()).then(|| CookRecoveryActions {
+        reason: "Filesystem reserve pressure blocked admission. Inspect the protected scoped inventory before approving any removal.".to_string(),
+        legal_actions: actions.clone(),
+        next_actions: actions,
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5885,6 +5885,80 @@ fn dirty_destination_recovery_actions_commit_review_and_adopt_through_publicatio
 }
 
 #[test]
+fn reserve_pressure_cook_context_forwards_only_the_scoped_inventory_action() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let fixture = CandidateAdoptionFixture::new_without_recovery(
+            "cook-reserve-pressure",
+            2,
+            1,
+            false,
+            None,
+        );
+        let error =
+            homeboy_core::Error::capacity_reserve(homeboy_core::error::CapacityReserveDetails {
+                filesystem: "/worktrees/new-task".to_string(),
+                available_bytes: 90,
+                reserve_bytes: 100,
+                shortfall_bytes: 10,
+            })
+            .with_action(homeboy_core::error::ExecutableAction::new(
+                "capacity.reserve.inspect_repository_artifacts",
+                "inspect reclaimable artifacts across repository worktrees",
+                "homeboy",
+                [
+                    "cleanup",
+                    "artifacts",
+                    "--path",
+                    "/worktrees/repository",
+                    "--all-worktrees",
+                    "--merged-only",
+                ],
+                homeboy_core::error::ActionSafety::ReadOnly,
+            ))
+            .with_action(
+                homeboy_core::error::ExecutableAction::new(
+                    "capacity.reserve.apply_repository_artifacts",
+                    "remove approved artifacts from merged repository worktrees",
+                    "homeboy",
+                    ["cleanup", "artifacts", "--apply"],
+                    homeboy_core::error::ActionSafety::Mutating,
+                )
+                .requiring_confirmation("approve removal"),
+            );
+        super::super::materialize_initial_cook_attempt(&fixture.options)
+            .expect("materialize Cook attempt");
+        agent_task_lifecycle::record_pre_execution_failure(
+            &fixture.run_id,
+            &fixture.options.identity.initial_plan,
+            "worktree_capacity_admission",
+            &error,
+        )
+        .expect("persist capacity failure");
+
+        let report = cook_report(CookReportInput {
+            cook_id: fixture.cook_id.clone(),
+            status: "pre_execution_failure",
+            disposition: CookDisposition::Terminal,
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: Some(error.message.clone()),
+            exit_code: 1,
+            invocation_latest_run_id: Some(&fixture.run_id),
+        })
+        .value;
+        let context = report.failure_context.expect("capacity recovery context");
+
+        assert_eq!(context.reason_code, "resource.capacity_reserve");
+        assert_eq!(context.next_actions.len(), 1);
+        assert_eq!(
+            context.next_actions[0].command,
+            "homeboy cleanup artifacts --path /worktrees/repository --all-worktrees --merged-only"
+        );
+        assert!(report.stop_reason.unwrap().contains("/worktrees/new-task"));
+    });
+}
+
+#[test]
 fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execution() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let primary = tempfile::tempdir().expect("primary repository");

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -2268,6 +2268,9 @@ fn classification_next_actions(
             actions.extend(provider_readiness_actions(runner_id));
             actions
         }
+        // Capacity admission records its scoped cleanup plan in the failure
+        // evidence. Do not offer a retry until an operator has inspected it.
+        AgentTaskFailureClassification::Capacity => vec![failure_evidence],
         // The request the provider received was malformed. Replaying the
         // boundary shows the exact rejected input; a retry would resend it.
         AgentTaskFailureClassification::InvalidInput => {

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -517,7 +517,7 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
         // that happened to be holding the pen when the filesystem gave out. It
         // shares the operational exit code so a wrapper can distinguish it from
         // an internal error and route to cleanup (#11127).
-        ErrorCode::StorageExhausted => 20,
+        ErrorCode::ResourceCapacityReserve | ErrorCode::StorageExhausted => 20,
 
         // A contended runtime promotion (another owner holds the lease) is a
         // transient "busy" condition, not a hard failure — map it to the
@@ -3014,6 +3014,40 @@ mod tests {
             payload.expect_err("error payload").code,
             ErrorCode::ValidationMissingArgument
         );
+    }
+
+    #[test]
+    fn reserve_pressure_keeps_a_resource_exit_code_and_actionable_recovery() {
+        let error = Error::capacity_reserve(homeboy::core::error::CapacityReserveDetails {
+            filesystem: "/workspace".to_string(),
+            available_bytes: 90,
+            reserve_bytes: 100,
+            shortfall_bytes: 10,
+        })
+        .with_action(ExecutableAction::new(
+            "capacity.reserve.inspect_cleanup",
+            "inspect scoped rebuildable artifacts",
+            "homeboy",
+            ["cleanup", "artifacts", "--path", "/workspace"],
+            homeboy::core::error::ActionSafety::ReadOnly,
+        ));
+        let (payload, exit_code) = map_cmd_result_to_json::<serde_json::Value>(Err(error));
+        let error = payload.expect_err("reserve pressure error");
+        let response = CommandResultEnvelope::<()>::from_error(
+            &CommandIdentity::top_level("agent-task"),
+            &error,
+            exit_code,
+        );
+        let value = serde_json::to_value(response).expect("response json");
+
+        assert_eq!(exit_code, 20);
+        assert_eq!(value["diagnostics"]["code"], "resource.capacity_reserve");
+        assert_eq!(value["diagnostics"]["details"]["shortfall_bytes"], 10);
+        assert_eq!(
+            value["next_actions"][0]["command"],
+            "homeboy cleanup artifacts --path /workspace"
+        );
+        assert_eq!(value["next_actions"][0]["action"]["safety"], "read_only");
     }
 
     #[test]

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -323,46 +323,74 @@ fn reconstructable_admission_error(
 ) -> Error {
     let available_bytes = available_bytes.expect("measured reserve breach has available bytes");
     let path = root.display().to_string();
+    let (inspect_action, apply_action) = if let Ok(repository_root) = git_root(root) {
+        let repository_root = repository_root.display().to_string();
+        (
+            ExecutableAction::new(
+                "capacity.reserve.inspect_repository_artifacts",
+                "inspect reclaimable artifacts across repository worktrees",
+                "homeboy",
+                [
+                    "cleanup",
+                    "artifacts",
+                    "--path",
+                    repository_root.as_str(),
+                    "--all-worktrees",
+                    "--merged-only",
+                    "--sort",
+                    "size",
+                    "--limit",
+                    "100",
+                ],
+                ActionSafety::ReadOnly,
+            ),
+            ExecutableAction::new(
+                "capacity.reserve.apply_repository_artifacts",
+                "remove approved artifacts from merged repository worktrees",
+                "homeboy",
+                [
+                    "cleanup",
+                    "artifacts",
+                    "--path",
+                    repository_root.as_str(),
+                    "--all-worktrees",
+                    "--merged-only",
+                    "--sort",
+                    "size",
+                    "--limit",
+                    "100",
+                    "--apply",
+                ],
+                ActionSafety::Mutating,
+            ),
+        )
+    } else {
+        (
+            ExecutableAction::new(
+                "capacity.reserve.inspect_registered_repository_artifacts",
+                "inspect reclaimable artifacts in registered repositories",
+                "homeboy",
+                ["cleanup", "--include", "repo-artifacts"],
+                ActionSafety::ReadOnly,
+            ),
+            ExecutableAction::new(
+                "capacity.reserve.apply_registered_repository_artifacts",
+                "remove approved artifacts in registered repositories",
+                "homeboy",
+                ["cleanup", "--include", "repo-artifacts", "--apply"],
+                ActionSafety::Mutating,
+            ),
+        )
+    };
     Error::capacity_reserve(CapacityReserveDetails {
         filesystem: path.clone(),
         available_bytes,
         reserve_bytes,
         shortfall_bytes: reserve_bytes.saturating_sub(available_bytes),
     })
-    .with_action(ExecutableAction::new(
-        "capacity.reserve.inspect_cleanup",
-        "inspect scoped rebuildable artifacts",
-        "homeboy",
-        [
-            "cleanup",
-            "artifacts",
-            "--path",
-            path.as_str(),
-            "--sort",
-            "size",
-            "--limit",
-            "100",
-        ],
-        ActionSafety::ReadOnly,
-    ))
+    .with_action(inspect_action)
     .with_action(
-        ExecutableAction::new(
-            "capacity.reserve.apply_cleanup",
-            "remove approved scoped rebuildable artifacts",
-            "homeboy",
-            [
-                "cleanup",
-                "artifacts",
-                "--path",
-                path.as_str(),
-                "--sort",
-                "size",
-                "--limit",
-                "100",
-                "--apply",
-            ],
-            ActionSafety::Mutating,
-        )
+        apply_action
         .requiring_confirmation("approve scoped rebuildable artifact removal"),
     )
     .with_hint("Inspect scoped rebuildable artifacts, then explicitly approve their removal if appropriate.")
@@ -3316,6 +3344,14 @@ mod tests {
                 error.details["_homeboy_actions"][1]["required_confirmations"][0],
                 "approve scoped rebuildable artifact removal"
             );
+            assert_eq!(
+                error.details["_homeboy_actions"][0]["args"][4],
+                "--all-worktrees"
+            );
+            assert_eq!(
+                error.details["_homeboy_actions"][0]["args"][5],
+                "--merged-only"
+            );
             assert!(repo.path().join("target/debug/app").exists());
         });
     }
@@ -3338,6 +3374,10 @@ mod tests {
 
             assert_eq!(error.code.as_str(), "resource.capacity_reserve");
             assert_eq!(error.details["reserve_bytes"], u64::MAX);
+            assert_eq!(
+                error.details["_homeboy_actions"][0]["args"],
+                json!(["cleanup", "--include", "repo-artifacts"])
+            );
         });
     }
 

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -9,7 +9,7 @@ use homeboy_engine_primitives::fs_index_lock::{FsIndexLock, FsIndexLockConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::error::StorageExhaustedDetails;
+use crate::error::{ActionSafety, CapacityReserveDetails, ExecutableAction};
 use crate::observation::disk_budget::disk_budget;
 use crate::resource_cleanup_intent::ResourceCleanupIntent;
 use crate::{git, Error, Result};
@@ -238,7 +238,6 @@ pub fn admit_reconstructable_artifact_work_in_root(
             return Err(reconstructable_admission_error(
                 root,
                 budget.available_bytes,
-                budget.available_inodes,
                 reserve_bytes,
             ));
         }
@@ -320,18 +319,53 @@ fn below_reconstructable_reserve(root: &Path, reserve_bytes: u64) -> bool {
 fn reconstructable_admission_error(
     root: &Path,
     available_bytes: Option<u64>,
-    available_inodes: Option<u64>,
     reserve_bytes: u64,
 ) -> Error {
-    Error::storage_exhausted_detailed(StorageExhaustedDetails {
-        error: "managed worktree filesystem remains below the reconstructable-artifact reserve after bounded retention".to_string(),
-        context: Some("admission before managed work".to_string()),
-        path: Some(root.display().to_string()),
+    let available_bytes = available_bytes.expect("measured reserve breach has available bytes");
+    let path = root.display().to_string();
+    Error::capacity_reserve(CapacityReserveDetails {
+        filesystem: path.clone(),
         available_bytes,
-        available_inodes,
-        reserve_bytes: Some(reserve_bytes),
-        reserve_inodes: None,
+        reserve_bytes,
+        shortfall_bytes: reserve_bytes.saturating_sub(available_bytes),
     })
+    .with_action(ExecutableAction::new(
+        "capacity.reserve.inspect_cleanup",
+        "inspect scoped rebuildable artifacts",
+        "homeboy",
+        [
+            "cleanup",
+            "artifacts",
+            "--path",
+            path.as_str(),
+            "--sort",
+            "size",
+            "--limit",
+            "100",
+        ],
+        ActionSafety::ReadOnly,
+    ))
+    .with_action(
+        ExecutableAction::new(
+            "capacity.reserve.apply_cleanup",
+            "remove approved scoped rebuildable artifacts",
+            "homeboy",
+            [
+                "cleanup",
+                "artifacts",
+                "--path",
+                path.as_str(),
+                "--sort",
+                "size",
+                "--limit",
+                "100",
+                "--apply",
+            ],
+            ActionSafety::Mutating,
+        )
+        .requiring_confirmation("approve scoped rebuildable artifact removal"),
+    )
+    .with_hint("Inspect scoped rebuildable artifacts, then explicitly approve their removal if appropriate.")
 }
 
 fn run_automatic_artifact_retention_in(
@@ -3266,8 +3300,22 @@ mod tests {
             let error = admit_reconstructable_artifact_work(vec![repo.path().to_path_buf()])
                 .expect_err("a measured reserve breach must refuse new managed work");
 
-            assert!(error.is_storage_exhausted());
+            assert_eq!(error.code.as_str(), "resource.capacity_reserve");
             assert_eq!(error.details["reserve_bytes"], u64::MAX);
+            assert_eq!(
+                error.details["shortfall_bytes"],
+                u64::MAX - error.details["available_bytes"].as_u64().unwrap()
+            );
+            assert_eq!(
+                error.details["filesystem"],
+                repo.path().display().to_string()
+            );
+            assert_eq!(error.details["_homeboy_actions"][0]["safety"], "read_only");
+            assert_eq!(error.details["_homeboy_actions"][1]["safety"], "mutating");
+            assert_eq!(
+                error.details["_homeboy_actions"][1]["required_confirmations"][0],
+                "approve scoped rebuildable artifact removal"
+            );
             assert!(repo.path().join("target/debug/app").exists());
         });
     }
@@ -3288,7 +3336,7 @@ mod tests {
             let error = admit_reconstructable_artifact_work(vec![build_root.path().to_path_buf()])
                 .expect_err("a measured reserve breach must still refuse non-repository work");
 
-            assert!(error.is_storage_exhausted());
+            assert_eq!(error.code.as_str(), "resource.capacity_reserve");
             assert_eq!(error.details["reserve_bytes"], u64::MAX);
         });
     }

--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -159,6 +159,10 @@ pub enum ErrorCode {
 
     ObservationStoreBusy,
 
+    /// Admission was refused because measured free capacity is below a policy
+    /// reserve, while the filesystem can still accept writes.
+    ResourceCapacityReserve,
+
     /// The filesystem could not accept a write because it is out of bytes or
     /// out of inodes. Distinct from [`ErrorCode::InternalIoError`] so callers
     /// can degrade instead of retrying, and so an operator reads "disk full"
@@ -229,6 +233,8 @@ impl ErrorCode {
             ErrorCode::GitCommandFailed => "git.command_failed",
 
             ErrorCode::ObservationStoreBusy => "observation_store.busy",
+
+            ErrorCode::ResourceCapacityReserve => "resource.capacity_reserve",
 
             ErrorCode::StorageExhausted => "storage.exhausted",
 
@@ -512,6 +518,17 @@ pub struct StorageExhaustedDetails {
     pub reserve_inodes: Option<u64>,
 }
 
+/// Evidence for an admission refusal that preserves configured capacity headroom.
+/// This is deliberately separate from [`StorageExhaustedDetails`]: a reserve
+/// breach is a policy decision, not proof that the next filesystem write fails.
+#[derive(Debug, Serialize)]
+pub struct CapacityReserveDetails {
+    pub filesystem: String,
+    pub available_bytes: u64,
+    pub reserve_bytes: u64,
+    pub shortfall_bytes: u64,
+}
+
 /// `ENOSPC` on every unix target homeboy builds for.
 ///
 /// Checked alongside [`std::io::ErrorKind::StorageFull`] rather than instead of
@@ -744,6 +761,20 @@ impl Error {
              store-independent categories: `homeboy cleanup --include orphaned-artifact-bytes \
              --include runtime-tmp --apply`.",
         )
+    }
+
+    /// Refuse new work below a configured capacity reserve without conflating
+    /// the policy guard with an actual ENOSPC write failure.
+    pub fn capacity_reserve(details: CapacityReserveDetails) -> Self {
+        Self::new(
+            ErrorCode::ResourceCapacityReserve,
+            format!(
+                "Filesystem reserve shortfall: {} bytes available, {} bytes reserved, {} bytes short",
+                details.available_bytes, details.reserve_bytes, details.shortfall_bytes
+            ),
+            to_details(details),
+        )
+        .with_retryable(false)
     }
 
     /// Classify a live `io::Error`, keeping storage exhaustion distinguishable.
@@ -1679,6 +1710,22 @@ mod storage_exhaustion_tests {
             Error::storage_exhausted("full", None).retryable,
             Some(false)
         );
+    }
+
+    #[test]
+    fn reserve_pressure_is_distinct_from_physical_storage_exhaustion() {
+        let error = Error::capacity_reserve(CapacityReserveDetails {
+            filesystem: "/var/lib/homeboy".to_string(),
+            available_bytes: 157_541_830_656,
+            reserve_bytes: 161_061_273_600,
+            shortfall_bytes: 3_519_442_944,
+        });
+
+        assert_eq!(error.code, ErrorCode::ResourceCapacityReserve);
+        assert!(!error.is_storage_exhausted());
+        assert_eq!(error.details["filesystem"], "/var/lib/homeboy");
+        assert_eq!(error.details["shortfall_bytes"], 3_519_442_944_u64);
+        assert!(error.message.contains("157541830656 bytes available"));
     }
 
     /// The remedy has to name the *store-independent* categories. Pointing a

--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -769,8 +769,8 @@ impl Error {
         Self::new(
             ErrorCode::ResourceCapacityReserve,
             format!(
-                "Filesystem reserve shortfall: {} bytes available, {} bytes reserved, {} bytes short",
-                details.available_bytes, details.reserve_bytes, details.shortfall_bytes
+                "Filesystem reserve shortfall at {}: {} bytes available, {} bytes reserved, {} bytes short",
+                details.filesystem, details.available_bytes, details.reserve_bytes, details.shortfall_bytes
             ),
             to_details(details),
         )


### PR DESCRIPTION
## Summary
Reserve-pressure admission reports measured headroom and routes recovery through protected existing cleanup inventory.

## What changed
- Classifies reserve pressure separately from ENOSPC and invalid input.
- Scopes repository recovery across merged sibling worktrees and projects it through Cook notifications.

## How to test
1. Run `cargo test -p homeboy-agents reserve_pressure_ --lib`; expect passes as recorded by Homeboy's deterministic gate.
2. Run `cargo test -p homeboy-core cleanup::tests::pressure_admission --lib`; expect passes as recorded by Homeboy's deterministic gate.

## Compatibility
Adds resource.capacity\_reserve and capacity failure classification; existing ENOSPC and invalid-input codes remain unchanged.

## Evidence
- Base advanced after verification: verified main at a4047c458b956bc726dd57712ad314ebff988ca5; publication observed 66d52810c4ccdac7e7c1f2066683df84a5fa7ab8. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/14390
- Verified finalization base: main at a4047c458b956bc726dd57712ad314ebff988ca5
- manual-verify-1: passed (cargo test -p homeboy-agents reserve\_pressure\_ --lib) (Passed)
- manual-verify-2: passed (cargo test -p homeboy-core cleanup::tests::pressure\_admission --lib) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenAI gpt-5.6-terra via OpenCode direct execution; OpenAI gpt-6-astra via OpenCode orchestration)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented reserve-pressure diagnostics, reviewed recovery scope, and ran verification under Chris Huber's direction.

## Source relationships
- Closes Extra-Chill/homeboy#14390
- Relates to Extra-Chill/homeboy#14099
- Relates to Extra-Chill/homeboy#14100
