### PR TITLE
fix(agent-task): retain manual retry scope

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -3202,7 +3202,8 @@ pub fn persist_manual_finalization_retry_intent(
     )?;
     agent_task_lifecycle::record_manual_finalization_retry(run_id)?;
     let candidate = crate::agent_task_promotion::candidate_fingerprint(&report.path)?;
-    let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint } = candidate
+    let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { mut fingerprint } =
+        candidate
     else {
         return Err(Error::validation_invalid_argument(
             "path",
@@ -3211,6 +3212,9 @@ pub fn persist_manual_finalization_retry_intent(
             None,
         ));
     };
+    // A committed checkout is clean, but its preflight dossier has already
+    // authenticated the candidate's changed-file scope for receipt recovery.
+    fingerprint.changed_files = report.changed_files.clone();
     agent_task_lifecycle::record_manual_finalization_retry_candidate(
         run_id,
         serde_json::to_value(fingerprint).expect("candidate fingerprint serializes"),
@@ -4333,7 +4337,13 @@ fn receipt_matches_manual_preflight(
             )
             .is_ok_and(|candidate| {
                 candidate.tree == binding.candidate_tree
-                    && candidate.changed_files == binding.changed_files
+                    && (candidate.changed_files == binding.changed_files
+                        // Older retryable manual finalizations fingerprinted a
+                        // clean committed checkout, which has no working-tree
+                        // changes. Their validated intent remains the durable
+                        // source of the preflight candidate scope.
+                        || (candidate.changed_files.is_empty()
+                            && intent.changed_files == binding.changed_files))
             })
         } else {
             intent_git_identity.commit_sha.is_some()
@@ -4385,7 +4395,13 @@ fn require_manual_retry_candidate(
     };
     // Hooks may stage the exact candidate before rejecting it. Bind semantic
     // content and paths, not the transient staged/unstaged representation.
-    if actual.tree != expected.tree || actual.changed_files != expected.changed_files {
+    let legacy_scope_matches = expected.changed_files.is_empty()
+        && manual_finalization_intent_for_run(record, &record.run_id)
+            .map(|intent| intent.changed_files == actual.changed_files)
+            .unwrap_or(false);
+    if actual.tree != expected.tree
+        || (actual.changed_files != expected.changed_files && !legacy_scope_matches)
+    {
         return Err(Error::validation_invalid_argument(
             "manual_finalization_retry_candidate",
             "manual publication candidate changed after the direct preflight; rerun finalization with the current candidate",

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -17309,6 +17309,13 @@ fn cook_backed_manual_recovery_failure_persists_structured_git_evidence() {
         .expect("preflight direct manual publication");
         super::super::cook_promotion::persist_manual_finalization_retry_intent(run_id, &intent)
             .expect("persist direct retry intent");
+        assert_eq!(
+            agent_task_lifecycle::reconcile_status(run_id)
+                .expect("read retry intent")
+                .metadata["manual_finalization_retry_candidate"]["changed_files"],
+            serde_json::json!(intent.changed_files),
+            "retry recovery retains the preflight candidate scope even after commit"
+        );
         let hook = target.path().join(".git/hooks/pre-commit");
         std::fs::write(
             &hook,
@@ -17336,6 +17343,12 @@ fn cook_backed_manual_recovery_failure_persists_structured_git_evidence() {
         let record =
             agent_task_lifecycle::reconcile_status(run_id).expect("failed Cook manual record");
         assert_eq!(record.state, AgentTaskRunState::Failed);
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            // Simulate the clean-checkout fingerprint written before #14395.
+            record.metadata["manual_finalization_retry_candidate"]["changed_files"] =
+                serde_json::json!([]);
+        })
+        .expect("persist legacy empty retry scope");
         // The rejecting hook staged the original bytes. A real content change
         // must still invalidate the retry's semantic tree/path binding.
         std::fs::write(target.path().join("src/lib.rs"), "drifted\n")


### PR DESCRIPTION
## Summary
- retain the validated preflight changed-file scope when recording retryable manual-finalization candidates
- recover legacy empty-scope retry fingerprints only when their candidate tree and validated intent scope still match
- preserve fail-closed tree, candidate, and scope validation for all other retries

Closes #14395.

## Verification
- cargo fmt --all --check
- cargo test -p homeboy-agents cook_backed_manual_recovery_failure_persists_structured_git_evidence --lib -- --test-threads=1
- cargo test -p homeboy-agents manual_preflight --lib -- --test-threads=1
- cargo check -p homeboy-agents

## AI Assistance
OpenAI GPT-5.6 Terra via direct OpenCode execution implemented, tested, and reproduced the durable retry-receipt recovery. OpenAI GPT-6 Astra via OpenCode orchestration assigned the investigation. Chris Huber requested the repair and remains responsible.