### PR TITLE
fix(agent-task): recover merged finalizations

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -432,6 +432,54 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
         None
     };
     let existing = backend.find_open_pr(&options.path, &options.base, &head)?;
+    if existing.is_none() {
+        if let Some(merged) = backend.find_merged_pr(&options.path, &options.base, &head)? {
+            let observed_remote_sha =
+                backend.verify_remote_candidate(&options.path, &head, commit_sha)?;
+            if observed_remote_sha != commit_sha {
+                return Err(publication_drift_error(
+                    commit_sha,
+                    &observed_remote_sha,
+                    None,
+                    "no PR mutation performed",
+                ));
+            }
+            let binding = backend.verify_publication_binding(
+                &options.path,
+                &options.base,
+                &head,
+                commit_sha,
+                &changed_files,
+                &merged,
+            )?;
+            if let Err(_error) = validate_publication_binding(&binding, commit_sha, &changed_files)
+            {
+                return Err(publication_drift_error(
+                    commit_sha,
+                    &binding.remote_sha,
+                    Some(&binding.pr_head_sha),
+                    "no PR mutation performed",
+                ));
+            }
+            return Ok(report(
+                &options,
+                intent,
+                &head,
+                "review_ready",
+                "already_merged",
+                Some(merged.number),
+                Some(merged.url),
+                changed_files,
+                Some(proof),
+                commit_required,
+                push_required,
+                Some(git_identity),
+                git_tracking,
+                Some(binding),
+                durable_acceptance,
+            ));
+        }
+    }
     let publication_base_sha = backend.publication_base_sha(&options.path, &options.base)?;
     intent.target.publication_base_sha = publication_base_sha.clone();
     let base_observation = match publication_base_sha {
@@ -1590,7 +1638,7 @@ fn finalization_outcome(
     committed: bool,
     pushed: bool,
 ) -> AgentTaskPrFinalizationOutcome {
-    let published = matches!(pr_action, "created" | "updated");
+    let published = matches!(pr_action, "created" | "updated" | "already_merged");
     AgentTaskPrFinalizationOutcome {
         schema: AGENT_TASK_PR_FINALIZATION_OUTCOME_SCHEMA.to_string(),
         run_id: intent.run_id.clone(),

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -472,6 +472,29 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         }))
     }
 
+    fn find_merged_pr(
+        &mut self,
+        path: &str,
+        base: &str,
+        head: &str,
+    ) -> Result<Option<AgentTaskPrRef>> {
+        let output = pr_find(
+            None,
+            PrFindOptions {
+                base: Some(base.to_string()),
+                head: Some(head.to_string()),
+                state: PrState::Merged,
+                limit: 10,
+                path: Some(path.to_string()),
+            },
+        )?;
+        Ok(output.items.into_iter().next().map(|item| AgentTaskPrRef {
+            number: item.number,
+            url: item.url,
+            is_draft: item.is_draft,
+        }))
+    }
+
     fn verify_remote_candidate(
         &mut self,
         path: &str,

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -30,6 +30,7 @@ struct MockBackend {
     pr_lookup_complete: bool,
     publication_observed_after_pr_lookup: bool,
     existing_pr: Option<AgentTaskPrRef>,
+    merged_pr: Option<AgentTaskPrRef>,
     create_error: bool,
     push_error: bool,
     identity_error: bool,
@@ -292,6 +293,15 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
     ) -> Result<Option<AgentTaskPrRef>> {
         self.pr_lookup_complete = true;
         Ok(self.existing_pr.clone())
+    }
+
+    fn find_merged_pr(
+        &mut self,
+        _path: &str,
+        _base: &str,
+        _head: &str,
+    ) -> Result<Option<AgentTaskPrRef>> {
+        Ok(self.merged_pr.clone())
     }
 
     fn verify_remote_candidate(
@@ -1094,6 +1104,35 @@ fn updates_existing_pr_for_same_branch() {
     assert_eq!(report.pr_number, Some(77));
     assert!(backend.updated);
     assert!(!backend.created);
+}
+
+#[test]
+fn recovers_a_merged_pr_without_republishing() {
+    let mut backend = MockBackend {
+        candidate_state: Some(AgentTaskPrCandidateState::Committed {
+            changed_files: vec!["src/lib.rs".to_string()],
+            push_required: false,
+        }),
+        merged_pr: Some(AgentTaskPrRef {
+            number: 76,
+            url: "https://github.com/Extra-Chill/homeboy/pull/76".to_string(),
+            is_draft: false,
+        }),
+        ..Default::default()
+    };
+
+    let report = finalize_pr_with_backend(options(), &mut backend).expect("merged receipt");
+
+    assert_eq!(report.status, "review_ready");
+    assert_eq!(report.pr_action, "already_merged");
+    assert_eq!(report.pr_number, Some(76));
+    assert_eq!(
+        report.finalization_outcome.publication_action,
+        "already_merged"
+    );
+    assert!(report.finalization_outcome.published);
+    assert!(!backend.created && !backend.updated);
+    assert_eq!(backend.publication_binding_calls, 1);
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -508,6 +508,15 @@ pub trait AgentTaskPrFinalizationBackend {
         base: &str,
         head: &str,
     ) -> Result<Option<AgentTaskPrRef>>;
+    /// Finds a prior merged publication for this exact base/head tuple.
+    fn find_merged_pr(
+        &mut self,
+        _path: &str,
+        _base: &str,
+        _head: &str,
+    ) -> Result<Option<AgentTaskPrRef>> {
+        Ok(None)
+    }
     /// Re-reads the live candidate branch immediately before a GitHub mutation.
     /// This is separate from post-mutation binding verification because a remote
     /// writer can advance the branch between Homeboy's push and PR mutation.

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -4253,7 +4253,10 @@ fn valid_manual_finalization_receipt(
         && report.publication_proof.status == "review_ready"
         && report.finalization_outcome.schema
             == crate::agent_task_finalization::AGENT_TASK_PR_FINALIZATION_OUTCOME_SCHEMA
-        && matches!(report.pr_action.as_str(), "created" | "updated")
+        && matches!(
+            report.pr_action.as_str(),
+            "created" | "updated" | "already_merged"
+        )
         && report.publication_proof.adapter_action.as_deref() == Some(report.pr_action.as_str())
         && report.publication_proof.adapter_ref == report.pr_url
         && report.pr_number.is_some()

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -14652,6 +14652,7 @@ struct CaptureBackend {
     created: bool,
     updated: bool,
     existing_pr: Option<AgentTaskPrRef>,
+    merged_pr: Option<AgentTaskPrRef>,
     candidate_state: Option<crate::agent_task_finalization::AgentTaskPrCandidateState>,
     committed_sha: Option<String>,
     hydrate_run_id: Option<String>,
@@ -14871,6 +14872,14 @@ impl AgentTaskPrFinalizationBackend for CaptureBackend {
         _head: &str,
     ) -> Result<Option<AgentTaskPrRef>> {
         Ok(self.existing_pr.clone())
+    }
+    fn find_merged_pr(
+        &mut self,
+        _path: &str,
+        _base: &str,
+        _head: &str,
+    ) -> Result<Option<AgentTaskPrRef>> {
+        Ok(self.merged_pr.clone())
     }
     fn verify_remote_candidate(
         &mut self,
@@ -17396,7 +17405,7 @@ fn cook_backed_manual_recovery_failure_persists_structured_git_evidence() {
 }
 
 #[test]
-fn standalone_manual_preflight_continuation_recovers_and_is_idempotent() {
+fn standalone_manual_preflight_recovers_merged_publication_without_republishing() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let run_id = "manual-11974";
         let target = tempfile::tempdir().expect("fixture target");
@@ -17456,13 +17465,19 @@ fn standalone_manual_preflight_continuation_recovers_and_is_idempotent() {
         );
         let mut publish_backend = CaptureBackend {
             candidate_state: Some(candidate),
+            merged_pr: Some(AgentTaskPrRef {
+                number: 11974,
+                url: "https://github.com/Extra-Chill/homeboy/pull/11974".to_string(),
+                is_draft: false,
+            }),
             ..Default::default()
         };
         let published =
             recover_cook_pr_with_backend(run_id, Vec::new(), false, &mut publish_backend)
                 .expect("continuation resolves standalone validated intent");
         assert_eq!(published["status"], "review_ready");
-        assert!(publish_backend.created);
+        assert_eq!(published["pr_action"], "already_merged");
+        assert!(!publish_backend.created && !publish_backend.updated);
 
         let mut repeated_backend = CaptureBackend::default();
         assert_eq!(


### PR DESCRIPTION
## Summary

Prevent manual finalization recovery from creating a second PR when the first publication merged before its durable receipt was persisted.

- Look up a merged PR after no open PR matches the requested base/head.
- Revalidate candidate SHA, remote SHA, base/head, repository, and PR head SHA before recording the terminal receipt.
- Record `review_ready` with the typed `already_merged` publication action, without creating or updating a PR.
- Accept that action in manual receipt validation.

## Test

- `cargo test -p homeboy-agents agent_task_finalization --lib`
- `cargo test -p homeboy-agents standalone_manual_preflight_recovers_merged_publication_without_republishing --lib`
- `cargo fmt --check`

Fixes #14401.

## AI Assistance

OpenAI GPT-5.6 Terra via direct OpenCode execution implemented and tested the repair. OpenAI GPT-6 Astra via OpenCode orchestration assigned the investigation. Chris Huber requested the work and remains responsible.
