### PR TITLE
fix(lab): defer provider credentials to runner

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/secrets.rs
+++ b/crates/homeboy-lab-runner/src/lab/secrets.rs
@@ -341,12 +341,16 @@ pub(super) fn hydrate_agent_task_secret_env(
 
 fn hydrate_agent_task_secret_env_with_providers(
     args: &[String],
-    env: &mut HashMap<String, String>,
+    _env: &mut HashMap<String, String>,
     providers: &[AgentTaskExecutorProvider],
 ) -> Result<serde_json::Value> {
-    let mut names = declared_agent_task_controller_secret_env_with_providers(args, providers)?;
+    let names = declared_agent_task_controller_secret_env_with_providers(args, providers)?;
     let mut runner_deferred_names =
         declared_agent_task_run_plan_secret_env_with_providers(args, providers);
+    // Provider credentials belong to the execution runner. Carry their names in
+    // the existing secret plan so the runner resolves its own references after
+    // durable replay; never materialize values into a broker submission.
+    runner_deferred_names.extend(names.iter().cloned());
     runner_deferred_names.sort();
     runner_deferred_names.dedup();
     if names.is_empty() && runner_deferred_names.is_empty() {
@@ -363,33 +367,6 @@ fn hydrate_agent_task_secret_env_with_providers(
         })
         .transpose()?
         .unwrap_or_default();
-    let controller_source_run_plan_names = runner_deferred_names
-        .iter()
-        .filter(|name| fallback_sources.contains_key(name.as_str()))
-        .cloned()
-        .collect::<Vec<_>>();
-    if !controller_source_run_plan_names.is_empty() {
-        names.extend(controller_source_run_plan_names.iter().cloned());
-        names.sort();
-        names.dedup();
-        runner_deferred_names.retain(|name| !controller_source_run_plan_names.contains(name));
-    }
-    if !names.is_empty() {
-        let resolved = agent_task_secrets::resolve_secret_env_with_fallbacks(&names, &fallback_sources).map_err(|error| {
-            Error::validation_invalid_argument(
-                "secret-env",
-                error.message,
-                None,
-                Some(vec![
-                    "Configure provider secrets with Homeboy's global agent-task secret config, for example `homeboy agent-task auth map-env` or `homeboy agent-task auth set-keychain`.".to_string(),
-                ]),
-            )
-        })?;
-        for (name, value) in resolved {
-            env.insert(name, value);
-        }
-    }
-
     Ok(serde_json::json!({
         "schema": "homeboy/lab-agent-task-secret-env/v1",
         "secret_env": agent_task_secrets::secret_env_status_with_fallbacks(&names, &fallback_sources),

--- a/crates/homeboy-lab-runner/src/lab/secrets/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/lab/secrets/tests/part_b.rs
@@ -53,13 +53,7 @@ fn declared_agent_task_controller_run_from_spec_includes_dispatch_provider_confi
 }
 
 #[test]
-fn lab_secret_env_handoff_plan_hydrates_controller_dispatch_provider_config_secret() {
-    let _secret = RemovedEnvVar::new("HOMEBOY_CONTROLLER_PROVIDER_TOKEN");
-    std::env::set_var(
-        "HOMEBOY_CONTROLLER_PROVIDER_TOKEN",
-        "controller-secret-value",
-    );
-
+fn lab_secret_env_handoff_plan_defers_provider_credentials_to_runner_references() {
     let plan = build_lab_secret_env_handoff_plan(
         &[LabSecretEnvSource::AgentTask],
         &[
@@ -83,39 +77,34 @@ fn lab_secret_env_handoff_plan_hydrates_controller_dispatch_provider_config_secr
         plan.secret_env_names,
         vec!["HOMEBOY_CONTROLLER_PROVIDER_TOKEN".to_string()]
     );
+    assert!(plan.env_delta.is_empty());
     assert_eq!(
-        plan.env_delta
-            .get("HOMEBOY_CONTROLLER_PROVIDER_TOKEN")
-            .map(String::as_str),
-        Some("controller-secret-value")
+        plan.runner_deferred_secret_env,
+        vec!["HOMEBOY_CONTROLLER_PROVIDER_TOKEN".to_string()]
     );
-    assert_eq!(
-        plan.env_delta,
-        plan.secret_env_plan
-            .materialize([(
-                "HOMEBOY_CONTROLLER_PROVIDER_TOKEN".to_string(),
-                "controller-secret-value".to_string(),
-            )])
-            .into_iter()
-            .collect::<HashMap<_, _>>()
-    );
+    let runner = fixture_runner(HashMap::from([(
+        "HOMEBOY_CONTROLLER_PROVIDER_TOKEN".to_string(),
+        RunnerSecretEnvRef {
+            env: Some("HOMEBOY_CONTROLLER_PROVIDER_TOKEN".to_string()),
+            file: None,
+            secret: None,
+        },
+    )]));
+    preflight_lab_secret_env_handoff("lab-a", Some(&runner), &plan.env_delta, &plan)
+        .expect("runner-owned reference admits the provider handoff");
     assert!(plan
         .diagnostics
         .to_string()
         .contains("HOMEBOY_CONTROLLER_PROVIDER_TOKEN"));
-    assert!(!plan
-        .diagnostics
-        .to_string()
-        .contains("controller-secret-value"));
 }
 
 #[test]
-fn hydrate_agent_task_secret_env_fails_missing_controller_dispatch_provider_config_secret() {
+fn hydrate_agent_task_secret_env_defers_missing_controller_dispatch_provider_config_secret() {
     let _secret = RemovedEnvVar::new("HOMEBOY_CONTROLLER_MISSING_PROVIDER_TOKEN");
     homeboy_core::test_support::with_isolated_home(|_| {
         let mut env = HashMap::new();
 
-        let err = hydrate_agent_task_secret_env(
+        let metadata = hydrate_agent_task_secret_env(
             &[
                 "homeboy".to_string(),
                 "agent-task".to_string(),
@@ -131,14 +120,13 @@ fn hydrate_agent_task_secret_env_fails_missing_controller_dispatch_provider_conf
             ],
             &mut env,
         )
-        .expect_err("missing controller dispatch provider config secret should fail");
+        .expect("provider credential should be deferred to the runner");
 
-        assert_eq!(err.details["field"].as_str(), Some("secret-env"));
-        assert!(err
-            .message
-            .contains("HOMEBOY_CONTROLLER_MISSING_PROVIDER_TOKEN"));
-        assert!(err.message.contains("missing"));
-        assert!(err.details.to_string().contains("agent-task auth map-env"));
+        assert!(env.is_empty());
+        assert_eq!(
+            runner_deferred_secret_env_names(&metadata),
+            vec!["HOMEBOY_CONTROLLER_MISSING_PROVIDER_TOKEN".to_string()]
+        );
     });
 }
 
@@ -456,7 +444,7 @@ fn hydrate_agent_task_secret_env_defers_run_plan_secrets_to_runner() {
 }
 
 #[test]
-fn hydrate_agent_task_secret_env_resolves_provider_default_run_plan_secrets_on_controller() {
+fn hydrate_agent_task_secret_env_defers_provider_default_run_plan_secrets_to_runner_refs() {
     let _access_token_env = RemovedEnvVar::new("EXAMPLE_PROVIDER_ACCESS_TOKEN");
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -502,23 +490,15 @@ fn hydrate_agent_task_secret_env_resolves_provider_default_run_plan_secrets_on_c
             &mut env,
             std::slice::from_ref(&provider),
         )
-        .expect("provider default source should resolve on controller");
+        .expect("provider default source should defer to the runner");
 
-        assert!(matches!(
-            env.get("EXAMPLE_PROVIDER_ACCESS_TOKEN").map(String::as_str),
-            Some("controller-access-token")
-        ));
+        assert!(env.is_empty());
         assert_eq!(
             diagnostics["runner_deferred_secret_env"],
-            serde_json::json!([])
-        );
-        assert_eq!(
-            diagnostics["secret_env"],
             serde_json::json!([
                 {
                     "name": "EXAMPLE_PROVIDER_ACCESS_TOKEN",
-                    "configured": true,
-                    "source": "json-file"
+                    "source": "runner"
                 }
             ])
         );
@@ -527,7 +507,7 @@ fn hydrate_agent_task_secret_env_resolves_provider_default_run_plan_secrets_on_c
 }
 
 #[test]
-fn hydrate_agent_task_secret_env_uses_the_bound_fallback_source_on_conflict() {
+fn provider_run_plan_credential_handoff_uses_runner_ref_without_serializing_value() {
     let _access_token_env = RemovedEnvVar::new("EXAMPLE_PROVIDER_ACCESS_TOKEN");
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -582,17 +562,44 @@ fn hydrate_agent_task_secret_env_uses_the_bound_fallback_source_on_conflict() {
         .expect("write bound plan");
         let mut env = HashMap::new();
 
-        hydrate_agent_task_secret_env_with_providers(
+        let diagnostics = hydrate_agent_task_secret_env_with_providers(
             &run_plan_args(&plan_path),
             &mut env,
             &[primary, fallback],
         )
-        .expect("bound fallback source resolves on controller");
+        .expect("bound fallback source defers to the runner");
 
+        assert!(env.is_empty());
         assert_eq!(
-            env.get("EXAMPLE_PROVIDER_ACCESS_TOKEN").map(String::as_str),
-            Some("fallback-token")
+            diagnostics["runner_deferred_secret_env"],
+            serde_json::json!([
+                {
+                    "name": "EXAMPLE_PROVIDER_ACCESS_TOKEN",
+                    "source": "runner"
+                }
+            ])
         );
+        assert!(!diagnostics.to_string().contains("primary-token"));
+        assert!(!diagnostics.to_string().contains("fallback-token"));
+
+        let runner = fixture_runner(HashMap::from([(
+            "EXAMPLE_PROVIDER_ACCESS_TOKEN".to_string(),
+            RunnerSecretEnvRef {
+                env: Some("EXAMPLE_PROVIDER_ACCESS_TOKEN".to_string()),
+                file: None,
+                secret: None,
+            },
+        )]));
+        let args = run_plan_args(&plan_path);
+        let secret_env_plan = secret_env_plan_from_args(&args);
+        preflight_agent_task_runner_secret_env_plan(
+            "lab-a",
+            &runner,
+            &args,
+            &env,
+            &secret_env_plan,
+        )
+        .expect("runner-owned provider credential should be admitted without an inline value");
     });
 }
 


### PR DESCRIPTION
## Summary
- Defer Lab agent-task provider credentials to runner-owned secret references.
- Preserve redacted secret handoff diagnostics and preflight runner references.

Closes #14386

OpenAI GPT-5.6 Astra via OpenCode coordinated evidence collection and task orchestration; OpenAI GPT-5.6 Terra via OpenCode directly analyzed, implemented, tested, and prepared this change. No Homeboy agent dispatch was used.