### PR TITLE
fix(dev): compare full build identities

### DIFF
--- a/scripts/dev-build
+++ b/scripts/dev-build
@@ -11,7 +11,7 @@ if [[ "$target_dir" != /* ]]; then
     target_dir="$root/$target_dir"
 fi
 binary="$target_dir/debug/homeboy"
-expected_commit="$(git rev-parse --short=12 HEAD)"
+expected_commit="$(git rev-parse HEAD)"
 
 if [[ ! -x "$binary" ]]; then
     printf 'expected development binary was not produced: %s\n' "$binary" >&2

--- a/tests/dev_build_test.rs
+++ b/tests/dev_build_test.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn dev_build_accepts_matching_full_identity_and_rejects_mismatch() {
+    let fixture = tempfile::tempdir().expect("fixture directory");
+    let tools = fixture.path().join("tools");
+    let target = fixture.path().join("target");
+    fs::create_dir(&tools).expect("fixture tools directory");
+
+    write_executable(
+        &tools.join("cargo"),
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+binary="$CARGO_TARGET_DIR/debug/homeboy"
+mkdir -p "$(dirname "$binary")"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "{\\"data\\":{\\"git_commit\\":\\"%s\\"}}\\n" "$HOMEBOY_TEST_BINARY_COMMIT"' > "$binary"
+chmod +x "$binary"
+"#,
+    );
+    write_executable(
+        &tools.join("jq"),
+        "#!/usr/bin/env bash\nprintf '%s\\n' \"$HOMEBOY_TEST_BINARY_COMMIT\"\n",
+    );
+
+    let expected = git_head();
+    let matching = run_dev_build(&tools, &target, &expected);
+    assert!(
+        matching.status.success(),
+        "matching full identity failed: {}",
+        String::from_utf8_lossy(&matching.stderr)
+    );
+    assert!(String::from_utf8_lossy(&matching.stdout).contains(&expected));
+
+    let mismatch = run_dev_build(&tools, &target, "different-commit");
+    assert!(!mismatch.status.success());
+    assert!(String::from_utf8_lossy(&mismatch.stderr).contains(&format!(
+        "development binary identity mismatch: expected {expected}, got different-commit"
+    )));
+}
+
+fn run_dev_build(tools: &Path, target: &Path, binary_commit: &str) -> std::process::Output {
+    let path = format!(
+        "{}:{}",
+        tools.display(),
+        std::env::var("PATH").expect("PATH")
+    );
+    Command::new(env!("CARGO_MANIFEST_DIR").to_owned() + "/scripts/dev-build")
+        .env("PATH", path)
+        .env("CARGO_TARGET_DIR", target)
+        .env("HOMEBOY_TEST_BINARY_COMMIT", binary_commit)
+        .output()
+        .expect("run dev-build")
+}
+
+fn git_head() -> String {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("resolve fixture HEAD");
+    assert!(output.status.success());
+    String::from_utf8(output.stdout)
+        .expect("HEAD is UTF-8")
+        .trim()
+        .to_string()
+}
+
+fn write_executable(path: &Path, content: &str) {
+    fs::write(path, content).expect("write fixture executable");
+    let mut permissions = fs::metadata(path)
+        .expect("fixture executable metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("make fixture executable");
+}


### PR DESCRIPTION
## Summary
Compare development build identities as full immutable commits.

## What changed
- dev-build now resolves HEAD to its full immutable SHA before comparing the binary identity.
- A hermetic shell fixture accepts a matching full SHA and rejects a different identity.

## How to test
1. Run `cargo fmt --check`; expect passes.
2. Run `cargo test --test dev_build_test`; expect passes.
3. Run `bash scripts/dev-build`; expect builds homeboy and reports the full current commit.

## Compatibility
No public CLI change; the documented development build path now accepts its canonical full source identity while retaining mismatch rejection.

## Evidence
- Base unchanged since verification: main remains at 234c29c00aa716bb6da67da3ece959fc3c2b0b07.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/14406
- Verified finalization base: main at 234c29c00aa716bb6da67da3ece959fc3c2b0b07
- dev-build-fixture: passed (cargo test --test dev\_build\_test) (Passed)
- dev-build: passed (bash scripts/dev-build) (Passed)
- format: passed (cargo fmt --check) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Direct implementation by gpt-5.6-terra through OpenCode; orchestration by gpt-6-astra through OpenCode.

## Source relationships
- Closes #14406
