### PR TITLE
test(lab-runner): root the refresh path so its tests leave the global home lock

### DIFF
--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -420,7 +420,21 @@ fn selection_blocker_after_busy(
 /// and generation. A child process must present the capability explicitly
 /// attached by [`RuntimePromotionLease::authorize_subprocess`].
 pub fn acquire(operation: &str, target: impl Into<String>) -> Result<RuntimePromotionLease> {
+    acquire_in_root(&paths::runtime_promotion_dir()?, operation, target)
+}
+
+/// [`acquire`] below an already-resolved runtime promotion root.
+///
+/// The lease store is machine-global by default. An explicitly rooted acquire
+/// keeps an isolated caller from observing or contending the host's live
+/// promotion lease (#14362).
+pub fn acquire_in_root(
+    root: &Path,
+    operation: &str,
+    target: impl Into<String>,
+) -> Result<RuntimePromotionLease> {
     acquire_with_pin_policy(
+        root,
         operation,
         target.into(),
         String::new(),
@@ -455,6 +469,7 @@ pub fn acquire_waiting_for_compatible_with_status(
     progress: impl FnMut(RuntimePromotionWaitEvent),
 ) -> Result<RuntimePromotionLease> {
     acquire_waiting_for_compatible_key_and_status(
+        &paths::runtime_promotion_dir()?,
         operation,
         target,
         "",
@@ -475,6 +490,7 @@ pub fn acquire_waiting_for_target_with_status(
     progress: impl FnMut(RuntimePromotionWaitEvent),
 ) -> Result<RuntimePromotionLease> {
     acquire_waiting_for_compatible_key_and_status(
+        &paths::runtime_promotion_dir()?,
         operation,
         target,
         "",
@@ -493,7 +509,27 @@ pub fn acquire_waiting_for_compatible_key(
     timeout: Duration,
     progress: impl FnMut(RuntimePromotionWaitEvent),
 ) -> Result<RuntimePromotionLease> {
+    acquire_waiting_for_compatible_key_in_root(
+        &paths::runtime_promotion_dir()?,
+        operation,
+        target,
+        compatibility_key,
+        timeout,
+        progress,
+    )
+}
+
+/// [`acquire_waiting_for_compatible_key`] below an already-resolved root.
+pub fn acquire_waiting_for_compatible_key_in_root(
+    root: &Path,
+    operation: &str,
+    target: impl Into<String>,
+    compatibility_key: impl Into<String>,
+    timeout: Duration,
+    progress: impl FnMut(RuntimePromotionWaitEvent),
+) -> Result<RuntimePromotionLease> {
     acquire_waiting_for_compatible_key_and_status(
+        root,
         operation,
         target,
         compatibility_key,
@@ -511,6 +547,7 @@ enum CompatibleOwnerPolicy {
 }
 
 fn acquire_waiting_for_compatible_key_and_status(
+    root: &Path,
     operation: &str,
     target: impl Into<String>,
     compatibility_key: impl Into<String>,
@@ -536,6 +573,7 @@ fn acquire_waiting_for_compatible_key_and_status(
             last_progress: &mut last_progress,
         };
         match acquire_with_pin_policy(
+            root,
             operation,
             target.clone(),
             compatibility_key.clone(),
@@ -581,7 +619,17 @@ pub fn acquire_for_generation_rotation(
     operation: &str,
     target: impl Into<String>,
 ) -> Result<RuntimePromotionLease> {
+    acquire_for_generation_rotation_in_root(&paths::runtime_promotion_dir()?, operation, target)
+}
+
+/// [`acquire_for_generation_rotation`] below an already-resolved root.
+pub fn acquire_for_generation_rotation_in_root(
+    root: &Path,
+    operation: &str,
+    target: impl Into<String>,
+) -> Result<RuntimePromotionLease> {
     acquire_with_pin_policy(
+        root,
         operation,
         target.into(),
         String::new(),
@@ -635,6 +683,7 @@ impl BoundedAdmission<'_> {
 }
 
 fn acquire_with_pin_policy(
+    root: &Path,
     operation: &str,
     target: String,
     compatibility_key: String,
@@ -642,8 +691,7 @@ fn acquire_with_pin_policy(
     foreign_pin_policy: ForeignPinPolicy,
     mut admission: Option<&mut BoundedAdmission<'_>>,
 ) -> Result<RuntimePromotionLease> {
-    let root = paths::runtime_promotion_dir()?;
-    fs::create_dir_all(&root).map_err(io("create runtime promotion directory"))?;
+    fs::create_dir_all(root).map_err(io("create runtime promotion directory"))?;
     let path = root.join(LEASE_DIR);
     let pid = std::process::id();
     let generation = current_generation();
@@ -682,6 +730,7 @@ fn acquire_with_pin_policy(
                 // never return an unpublished guard.
                 if !path.exists() {
                     return acquire_with_pin_policy(
+                        root,
                         operation,
                         target,
                         compatibility_key,
@@ -734,9 +783,10 @@ fn acquire_with_pin_policy(
             if reclaimable(&held) {
                 // Rename is the ownership CAS: one recovery moves the stale
                 // directory while former owners cannot remove its replacement.
-                match archive_stale_lease(&root, &path, &held) {
+                match archive_stale_lease(root, &path, &held) {
                     Ok(_) => {
                         return acquire_with_pin_policy(
+                            root,
                             operation,
                             target,
                             compatibility_key,
@@ -747,6 +797,7 @@ fn acquire_with_pin_policy(
                     }
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                         return acquire_with_pin_policy(
+                            root,
                             operation,
                             target,
                             compatibility_key,
@@ -763,15 +814,15 @@ fn acquire_with_pin_policy(
     };
 
     if foreign_pin_policy == ForeignPinPolicy::Block && lease.primary {
-        let admission_lock = open_admission_lock(&root)?;
+        let admission_lock = open_admission_lock(root)?;
         if let Some(admission) = admission.as_deref_mut() {
             wait_for_admission_lock(&lease, &admission_lock, admission)?;
-            wait_for_foreign_generation_pins(&root, &lease, Some((&lease, admission)))?;
+            wait_for_foreign_generation_pins(root, &lease, Some((&lease, admission)))?;
         } else {
             admission_lock
                 .lock_exclusive()
                 .map_err(io("reserve runtime promotion admission"))?;
-            wait_for_foreign_generation_pins(&root, &lease, None)?;
+            wait_for_foreign_generation_pins(root, &lease, None)?;
         }
         lease.admission_lock = Some(admission_lock);
     }

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -108,7 +108,13 @@ use connection_daemon::{
 
 #[path = "connection_stop_transport_recovery.rs"]
 mod stop_transport_recovery;
-pub(crate) use stop_transport_recovery::{disconnect_with_session, recorded_session};
+/// Rooted session read used by isolation tests; production reads go through
+/// the ambient [`recorded_session`].
+#[cfg(test)]
+pub(crate) use stop_transport_recovery::recorded_session_in_root;
+pub(crate) use stop_transport_recovery::{
+    disconnect_with_session, disconnect_with_session_in_roots, recorded_session,
+};
 
 use super::daemon_http_get::daemon_get;
 
@@ -337,7 +343,19 @@ where
 }
 
 pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
-    connect_with_orphan_adoption_and_live_lease(
+    connect_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+    )
+}
+
+/// [`connect`] against an explicitly injected root.
+pub fn connect_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+) -> Result<(RunnerConnectReport, i32)> {
+    connect_with_orphan_adoption_and_live_lease_in_roots(
+        roots,
         runner_id,
         RemoteDaemonConnectOptions {
             orphan_lease_id: None,
@@ -355,7 +373,10 @@ pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
 /// Start and validate a second daemon without touching the recorded admission
 /// daemon. Its state directory is generation-scoped while HOME and the normal
 /// runtime configuration remain shared, preserving runner credentials.
-pub(crate) fn rotate_daemon_generation(
+/// [`rotate_daemon_generation`] against an explicitly injected root.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn rotate_daemon_generation_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
     runner_id: &str,
     candidate_homeboy: &str,
     candidate_version: &str,
@@ -364,15 +385,16 @@ pub(crate) fn rotate_daemon_generation(
     candidate_binary_sha256: Option<&str>,
     draining_job_ids: &[String],
 ) -> Result<()> {
-    let current = read_session_or_live_peer(runner_id)?.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "runner",
-            "runner has no connected daemon to rotate",
-            Some(runner_id.to_string()),
-            None,
-        )
-    })?;
-    let runner = load(runner_id)?;
+    let current =
+        read_session_or_live_peer_in_root(roots.config(), runner_id)?.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "runner",
+                "runner has no connected daemon to rotate",
+                Some(runner_id.to_string()),
+                None,
+            )
+        })?;
+    let runner = load_in_roots(roots, runner_id)?;
     let Some((server_id, server, client)) = resolve_ssh_runner(&runner)? else {
         return Err(Error::validation_invalid_argument(
             "runner",
@@ -442,7 +464,7 @@ pub(crate) fn rotate_daemon_generation(
         build_identity: Some(candidate_identity.to_string()),
         inspected_freshness: None,
     };
-    let session_path = session_path(runner_id)?;
+    let session_path = session_path_in_root(roots.config(), runner_id);
     let (local_port, tunnel_pid, tunnel_process_start_identity, local_url, daemon) =
         match connect_remote_daemon(connection_daemon::RemoteDaemonConnectRequest {
             server: &server,
@@ -612,6 +634,34 @@ fn rollback_rotated_candidate(
 
 /// Connect while explicitly adopting one recorded dead remote lease. This is an
 /// operator recovery path; ordinary reconnects never infer orphan ownership.
+/// [`connect_with_orphan_adoption`] against an explicitly injected root.
+#[allow(clippy::too_many_arguments)]
+pub fn connect_with_orphan_adoption_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    orphan_lease_id: Option<&str>,
+    confirmed_no_pid_job_ids: &[uuid::Uuid],
+    reconcile_leaseless_orphans: bool,
+    missing_lease_id: Option<&str>,
+    recorded_pid: Option<u32>,
+    recorded_endpoint: Option<&str>,
+) -> Result<(RunnerConnectReport, i32)> {
+    connect_with_orphan_adoption_and_live_lease_in_roots(
+        roots,
+        runner_id,
+        RemoteDaemonConnectOptions {
+            orphan_lease_id,
+            confirmed_no_pid_job_ids,
+            reconcile_leaseless_orphans,
+            reconcile_unleased_candidates: false,
+            missing_lease_id,
+            recorded_pid,
+            recorded_endpoint,
+            live_lease_expectation: None,
+        },
+    )
+}
+
 pub fn connect_with_orphan_adoption(
     runner_id: &str,
     orphan_lease_id: Option<&str>,
@@ -684,6 +734,19 @@ fn connect_with_orphan_adoption_and_live_lease(
     runner_id: &str,
     options: RemoteDaemonConnectOptions<'_>,
 ) -> Result<(RunnerConnectReport, i32)> {
+    connect_with_orphan_adoption_and_live_lease_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+        options,
+    )
+}
+
+/// [`connect_with_orphan_adoption_and_live_lease`] against an injected root.
+fn connect_with_orphan_adoption_and_live_lease_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    options: RemoteDaemonConnectOptions<'_>,
+) -> Result<(RunnerConnectReport, i32)> {
     let RemoteDaemonConnectOptions {
         orphan_lease_id,
         confirmed_no_pid_job_ids,
@@ -700,8 +763,8 @@ fn connect_with_orphan_adoption_and_live_lease(
     let promotion_lease =
         homeboy_core::runtime_promotion::acquire("runner daemon reconnect", runner_id.to_string())?;
     promotion_lease.assert_generation()?;
-    let runner = load(runner_id)?;
-    let session_path = session_path(runner_id)?;
+    let runner = load_in_roots(roots, runner_id)?;
+    let session_path = session_path_in_root(roots.config(), runner_id);
     let homeboy = remote_runner_homeboy_path(&runner, "runner connect")?;
 
     let Some((server_id, server, client)) = resolve_ssh_runner(&runner)? else {
@@ -1982,6 +2045,13 @@ fn register_reverse_session_with_broker(broker_url: &str, session: &RunnerSessio
     Ok(true)
 }
 
+pub(crate) fn session_store_read_session_or_live_peer_in_root(
+    config_root: &std::path::Path,
+    runner_id: &str,
+) -> Result<Option<RunnerSession>> {
+    session_store::read_session_or_live_peer_in_root(config_root, runner_id)
+}
+
 pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     status_with_admission_projection(runner_id).map(|(status, _, _)| status)
 }
@@ -2555,21 +2625,36 @@ pub fn close_reconnected_job_log_owner(session: &RunnerSession) {
 /// reconnect transaction proves the remote daemon lease before replacing the
 /// local tunnel record.
 pub(crate) fn status_for_admission(runner_id: &str) -> Result<RunnerStatusReport> {
-    status_for_admission_with(runner_id, status, |runner_id| {
-        let (report, exit_code) = connect(runner_id)?;
-        if report.connected && exit_code == 0 {
-            return Ok(());
-        }
+    status_for_admission_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+    )
+}
 
-        Err(Error::validation_invalid_argument(
-            "runner",
-            report
-                .failure_message
-                .unwrap_or_else(|| "runner reconnect did not become ready".to_string()),
-            Some(runner_id.to_string()),
-            None,
-        ))
-    })
+/// [`status_for_admission`] against an explicitly injected root.
+pub(crate) fn status_for_admission_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+) -> Result<RunnerStatusReport> {
+    status_for_admission_with(
+        runner_id,
+        |runner_id| status_in_roots(roots, runner_id),
+        |runner_id| {
+            let (report, exit_code) = connect_in_roots(roots, runner_id)?;
+            if report.connected && exit_code == 0 {
+                return Ok(());
+            }
+
+            Err(Error::validation_invalid_argument(
+                "runner",
+                report
+                    .failure_message
+                    .unwrap_or_else(|| "runner reconnect did not become ready".to_string()),
+                Some(runner_id.to_string()),
+                None,
+            ))
+        },
+    )
 }
 
 /// Resolve the immutable identity of the executable that will start runner-side
@@ -2687,13 +2772,12 @@ fn reconciled_active_job_count(
         .unwrap_or(typed_job_count)
 }
 
-/// Query the daemon job store before an operation replaces its process.
-/// Controller observation may classify child runs as recoverable orphans, but
-/// those inferred records are not authoritative enough to interrupt a daemon.
-pub(super) fn active_jobs_before_daemon_replacement(
+/// [`active_jobs_before_daemon_replacement`] against an injected root.
+pub(super) fn active_jobs_before_daemon_replacement_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
     runner_id: &str,
 ) -> Result<Vec<ActiveRunnerJobSummary>> {
-    let report = status(runner_id)?;
+    let report = status_in_roots(roots, runner_id)?;
     if !report.connected {
         return Ok(Vec::new());
     }

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -35,7 +35,7 @@ use super::session::{
     RunnerSessionState, RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport,
     RunnerTunnelMode, RunnerTunnelProcessStartIdentity, REVERSE_UNVERIFIED_REASON,
 };
-use super::{load, remote_runner_homeboy_path, Runner, RunnerKind};
+use super::{load, load_in_roots, remote_runner_homeboy_path, Runner, RunnerKind};
 
 const ADMISSION_WAKE_IDLE: u8 = 0;
 const ADMISSION_WAKE_RUNNING: u8 = 1;
@@ -1990,6 +1990,20 @@ pub(crate) fn status_until(runner_id: &str, deadline: Instant) -> Result<RunnerS
     status_with_admission_projection_until(runner_id, deadline).map(|(status, _, _)| status)
 }
 
+/// [`status`] against an explicitly injected root.
+#[allow(dead_code)]
+pub fn status_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+) -> Result<RunnerStatusReport> {
+    status_with_admission_projection_until_in_roots(
+        roots,
+        runner_id,
+        Instant::now() + crate::readonly_probe::readonly_probe_timeout(),
+    )
+    .map(|(status, _, _)| status)
+}
+
 /// Capture status and the generation ledger together so callers that need an
 /// admission answer cannot observe a second, racing persisted generation state.
 pub(crate) fn status_with_admission_projection(
@@ -2016,13 +2030,34 @@ pub(crate) fn status_with_admission_projection_until(
     Vec<super::RunnerDaemonGenerationStatus>,
     Vec<super::RunnerGenerationJobOwners>,
 )> {
-    let runner = load(runner_id)?;
-    let session_path = session_path(runner_id)?;
+    status_with_admission_projection_until_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+        deadline,
+    )
+}
+
+/// [`status_with_admission_projection_until`] against an injected root.
+///
+/// Runner resolution and the controller session record both follow `roots`, so
+/// a status observation on an injected root cannot read the ambient
+/// installation's registry or sessions (#14362).
+pub(crate) fn status_with_admission_projection_until_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    deadline: Instant,
+) -> Result<(
+    RunnerStatusReport,
+    Vec<super::RunnerDaemonGenerationStatus>,
+    Vec<super::RunnerGenerationJobOwners>,
+)> {
+    let runner = load_in_roots(roots, runner_id)?;
+    let session_path = session_path_in_root(roots.config(), runner_id);
     // Status is an observation path. In particular, a stale direct-SSH record
     // must be reported as disconnected rather than triggering tunnel recovery.
     // Recovery can wait on shared control-plane state and may open a tunnel, so
     // it belongs to explicit connect/admission operations instead.
-    let session = read_session_for_status_until(runner_id, deadline)?;
+    let session = read_session_for_status_until_in_root(roots.config(), runner_id, deadline)?;
     let state = status_session_state_until(session.as_ref(), deadline);
     let connected = state == RunnerSessionState::Connected;
     let (stale_daemon, configured_job_binary_build_identity) =
@@ -2152,12 +2187,32 @@ pub fn reconcile_status(runner_id: &str) -> Result<RunnerStatusReport> {
     reconcile_status_with_outcome(runner_id).map(|outcome| outcome.status)
 }
 
+/// [`reconcile_status`] against an explicitly injected root.
+#[allow(dead_code)]
+pub fn reconcile_status_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+) -> Result<RunnerStatusReport> {
+    reconcile_status_with_outcome_in_roots(roots, runner_id).map(|outcome| outcome.status)
+}
+
 /// Reconcile a runner and retain the exact generations this operation retired.
 /// The report is a fresh postcondition observation; retirement IDs come only
 /// from the generation reconciler's locked removal path.
 pub fn reconcile_status_with_outcome(runner_id: &str) -> Result<RunnerReconcileStatusOutcome> {
-    let runner = load(runner_id)?;
-    let mut report = status(runner_id)?;
+    reconcile_status_with_outcome_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+    )
+}
+
+/// [`reconcile_status_with_outcome`] against an explicitly injected root.
+pub fn reconcile_status_with_outcome_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+) -> Result<RunnerReconcileStatusOutcome> {
+    let runner = load_in_roots(roots, runner_id)?;
+    let mut report = status_in_roots(roots, runner_id)?;
     if report.connected {
         reconcile_session_metadata_with_observed_daemon(&runner, &mut report.session, true)?;
     }
@@ -2182,7 +2237,7 @@ pub fn reconcile_status_with_outcome(runner_id: &str) -> Result<RunnerReconcileS
         }
     }
     Ok(RunnerReconcileStatusOutcome {
-        status: status(runner_id)?,
+        status: status_in_roots(roots, runner_id)?,
         retired_generation_ids: generation_reconcile.retired_generation_ids,
     })
 }

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -695,19 +695,28 @@ pub(super) fn status_session_state_until(
 /// tunnel for an in-process handoff. Borrowing never writes a controller
 /// record, so only the original controller may later tear down that tunnel.
 pub(super) fn read_session_or_live_peer(runner_id: &str) -> Result<Option<RunnerSession>> {
-    read_session_or_live_peer_for_controller(runner_id, &controller_id())
+    read_session_or_live_peer_in_root(&paths::homeboy()?, runner_id)
+}
+
+/// [`read_session_or_live_peer`] below an already-resolved config root.
+pub(super) fn read_session_or_live_peer_in_root(
+    config_root: &std::path::Path,
+    runner_id: &str,
+) -> Result<Option<RunnerSession>> {
+    read_session_or_live_peer_for_controller(config_root, runner_id, &controller_id())
 }
 
 fn read_session_or_live_peer_for_controller(
+    config_root: &std::path::Path,
     runner_id: &str,
     controller_id: &str,
 ) -> Result<Option<RunnerSession>> {
-    let session = read_session_for_controller(runner_id, controller_id)?;
+    let session = read_session_for_controller_in_root(config_root, runner_id, controller_id)?;
     if session.as_ref().is_some_and(session_is_live) {
         return Ok(session);
     }
 
-    let directory = paths::runner_sessions_dir()?.join(runner_id);
+    let directory = paths::runner_sessions_dir_in_root(config_root).join(runner_id);
     resolve_session_or_live_peer_in(&directory, controller_id, session, session_is_live)
 }
 

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -160,7 +160,12 @@ pub(super) fn hostname_fallback() -> String {
 }
 
 pub(super) fn session_path(runner_id: &str) -> Result<PathBuf> {
-    paths::runner_controller_session_file(runner_id, &controller_id())
+    Ok(session_path_in_root(&paths::homeboy()?, runner_id))
+}
+
+/// [`session_path`] below an already-resolved config root.
+pub(super) fn session_path_in_root(config_root: &std::path::Path, runner_id: &str) -> PathBuf {
+    paths::runner_controller_session_file_in_root(config_root, runner_id, &controller_id())
 }
 
 pub(super) fn ownership_path(runner_id: &str) -> Result<PathBuf> {
@@ -255,14 +260,23 @@ pub(super) fn read_session_for_status_until(
     runner_id: &str,
     deadline: Instant,
 ) -> Result<Option<RunnerSession>> {
+    read_session_for_status_until_in_root(&paths::homeboy()?, runner_id, deadline)
+}
+
+/// [`read_session_for_status_until`] below an already-resolved config root.
+pub(super) fn read_session_for_status_until_in_root(
+    config_root: &std::path::Path,
+    runner_id: &str,
+    deadline: Instant,
+) -> Result<Option<RunnerSession>> {
     let controller_id = controller_id();
-    let session = read_session_for_controller(runner_id, &controller_id)?;
+    let session = read_session_for_controller_in_root(config_root, runner_id, &controller_id)?;
     if session.as_ref().is_some_and(|session| {
         status_session_state_until(Some(session), deadline) == RunnerSessionState::Connected
     }) {
         return Ok(session);
     }
-    let directory = paths::runner_sessions_dir()?.join(runner_id);
+    let directory = paths::runner_sessions_dir_in_root(config_root).join(runner_id);
     match status_peer_session_in_until(&directory, &controller_id, deadline)? {
         StatusPeerSession::One(peer) => Ok(Some(*peer)),
         StatusPeerSession::None => Ok(session),
@@ -736,10 +750,20 @@ pub(super) fn read_session_for_controller(
     runner_id: &str,
     controller_id: &str,
 ) -> Result<Option<RunnerSession>> {
-    read_session_at(&paths::runner_controller_session_file(
+    read_session_for_controller_in_root(&paths::homeboy()?, runner_id, controller_id)
+}
+
+/// [`read_session_for_controller`] below an already-resolved config root.
+pub(super) fn read_session_for_controller_in_root(
+    config_root: &std::path::Path,
+    runner_id: &str,
+    controller_id: &str,
+) -> Result<Option<RunnerSession>> {
+    read_session_at(&paths::runner_controller_session_file_in_root(
+        config_root,
         runner_id,
         controller_id,
-    )?)
+    ))
 }
 
 pub(super) fn read_ownership(runner_id: &str) -> Result<Option<RunnerSession>> {

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -15,6 +15,15 @@ pub(crate) fn recorded_session(runner_id: &str) -> Result<Option<RunnerSession>>
     read_session_or_live_peer(runner_id)
 }
 
+/// [`recorded_session`] below an already-resolved config root.
+#[allow(dead_code)]
+pub(crate) fn recorded_session_in_root(
+    config_root: &std::path::Path,
+    runner_id: &str,
+) -> Result<Option<RunnerSession>> {
+    crate::connection::session_store_read_session_or_live_peer_in_root(config_root, runner_id)
+}
+
 pub(crate) fn disconnect_with_force(
     runner_id: &str,
     force: bool,
@@ -106,7 +115,26 @@ pub(crate) fn disconnect_with_session(
     expected_session: Option<&RunnerSession>,
     force: bool,
 ) -> Result<RunnerDisconnectReport> {
-    let promotion_lease = homeboy_core::runtime_promotion::acquire(
+    disconnect_with_session_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+        expected_session,
+        force,
+    )
+}
+
+/// [`disconnect_with_session`] against an explicitly injected root.
+///
+/// The promotion lease and the session record both follow `roots`, so an
+/// isolated disconnect cannot contend the host's machine-global lease (#14362).
+pub(crate) fn disconnect_with_session_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    expected_session: Option<&RunnerSession>,
+    force: bool,
+) -> Result<RunnerDisconnectReport> {
+    let promotion_lease = homeboy_core::runtime_promotion::acquire_in_root(
+        &homeboy_core::paths::runtime_promotion_dir_in_root(roots.data()),
         "runner daemon disconnect",
         runner_id.to_string(),
     )?;

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -856,6 +856,24 @@ pub(crate) fn exec_with_status_snapshot(
     options: RunnerExecOptions,
     status_snapshot: Option<RunnerStatusReport>,
 ) -> Result<(RunnerExecOutput, i32)> {
+    exec_with_status_snapshot_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+        options,
+        status_snapshot,
+    )
+}
+
+/// [`exec_with_status_snapshot`] against an explicitly injected root.
+///
+/// Process preparation otherwise re-resolves the runner ambiently, which would
+/// discard the injected root mid-execution (#14362).
+pub(crate) fn exec_with_status_snapshot_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    options: RunnerExecOptions,
+    status_snapshot: Option<RunnerStatusReport>,
+) -> Result<(RunnerExecOutput, i32)> {
     let explicit_generic_run_id = options
         .run_id_owns_generic_exec
         .then(|| options.run_id.clone())
@@ -890,7 +908,7 @@ pub(crate) fn exec_with_status_snapshot(
             "preflight",
         )?;
     }
-    let result = exec_with_status_snapshot_attempt(runner_id, options, status_snapshot);
+    let result = exec_with_status_snapshot_attempt(roots, runner_id, options, status_snapshot);
     if let (Some(run_id), Err(error)) = (explicit_generic_run_id.as_deref(), &result) {
         let accepted = error.details.get("runner_exec_accepted_handoff").is_some();
         if let Err(persistence_error) =
@@ -933,6 +951,7 @@ pub(super) fn accepted_handoff_persistence_error(
 }
 
 fn exec_with_status_snapshot_attempt(
+    roots: &homeboy_core::paths::PathRoots,
     runner_id: &str,
     options: RunnerExecOptions,
     status_snapshot: Option<RunnerStatusReport>,
@@ -956,7 +975,7 @@ fn exec_with_status_snapshot_attempt(
     let secret_env_names = secret_env_plan.secret_env_names();
     let mut plan = prepare_runner_process(RunnerProcessRequest {
         runner_id: runner_id.to_string(),
-        runner: None,
+        runner: Some(crate::load_in_roots(roots, runner_id)?),
         cwd: options.cwd.clone(),
         project_id: options.project_id.clone(),
         command: options.command.clone(),
@@ -1011,7 +1030,7 @@ fn exec_with_status_snapshot_attempt(
         let secret_env_names = secret_env_plan.secret_env_names();
         plan = prepare_runner_process(RunnerProcessRequest {
             runner_id: runner_id.to_string(),
-            runner: None,
+            runner: Some(crate::load_in_roots(roots, runner_id)?),
             cwd: options.cwd.clone(),
             project_id: options.project_id.clone(),
             command: options.command.clone(),

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -14,18 +14,14 @@ use homeboy_core::error::{Error, Result};
 use homeboy_core::git::{run_git, run_git_output};
 use homeboy_core::output::MergeOutput;
 
-use super::connection::{
-    active_jobs_before_daemon_replacement, configured_runner_homeboy_build_identity,
-    disconnect_with_session, rotate_daemon_generation,
-};
+use super::connection::configured_runner_homeboy_build_identity;
 use super::execution::{exec_with_status_snapshot, exec_with_status_snapshot_in_roots};
 use super::execution::{reserve_daemon_admission, DaemonAdmissionPolicy};
 use super::{
-    connect_with_orphan_adoption, copy_snapshot_to_directory, exec, load, load_in_roots,
-    materialize_runner_extension_with_env, merge, merge_in_roots,
-    normalize_runner_command_env_for_homeboy_path, plan_controller_snapshot_extension,
-    RunnerCapabilityPreflight, RunnerExecOptions, RunnerExecOutput,
-    RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
+    copy_snapshot_to_directory, exec, load, load_in_roots, materialize_runner_extension_with_env,
+    merge, merge_in_roots, normalize_runner_command_env_for_homeboy_path,
+    plan_controller_snapshot_extension, RunnerCapabilityPreflight, RunnerExecOptions,
+    RunnerExecOutput, RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
     RunnerFileTransfer, RunnerKind,
 };
 
@@ -633,7 +629,7 @@ pub fn refresh_homeboy_binary_in_roots(
         .and_then(|identity| identity_commit(&identity))
         .unwrap_or_else(|| format!("unverified-{}", uuid::Uuid::new_v4()));
     let promotion_lease =
-        acquire_runner_binary_promotion(&options.runner_id, &promotion_candidate)?;
+        acquire_runner_binary_promotion_in_roots(roots, &options.runner_id, &promotion_candidate)?;
     // Materialization may have waited behind a newer refresh. Re-read every
     // authority while holding the promotion lease. In particular, a daemon can
     // connect while materialization runs, so reconnect decisions cannot use the
@@ -840,7 +836,10 @@ pub fn refresh_homeboy_binary_in_roots(
     let interrupted_job_ids;
     if options.reconnect {
         promotion_lease.assert_generation()?;
-        let active_jobs = active_jobs_before_daemon_replacement(&plan.runner_id)?;
+        let active_jobs = super::connection::active_jobs_before_daemon_replacement_in_roots(
+            roots,
+            &plan.runner_id,
+        )?;
         let preserve_generations = super::generation_store::requires_generation_preserving_refresh(
             &plan.runner_id,
             refresh_session.as_ref(),
@@ -859,7 +858,8 @@ pub fn refresh_homeboy_binary_in_roots(
                 .iter()
                 .map(|job| job.job_id.clone())
                 .collect::<Vec<_>>();
-            if let Err(error) = rotate_daemon_generation(
+            if let Err(error) = super::connection::rotate_daemon_generation_in_roots(
+                roots,
                 &plan.runner_id,
                 &selected_binary_path,
                 candidate_version,
@@ -967,7 +967,13 @@ pub fn refresh_homeboy_binary_in_roots(
             }
         };
         if let Err(error) = disconnect_before_reconnect(refresh_session.as_ref(), |session| {
-            disconnect_with_session(&plan.runner_id, Some(session), options.force).map(|_| ())
+            super::connection::disconnect_with_session_in_roots(
+                roots,
+                &plan.runner_id,
+                Some(session),
+                options.force,
+            )
+            .map(|_| ())
         }) {
             return rollback_refresh_error_with(error, || {
                 restore_runner_homeboy_path_if_selected_in_roots(
@@ -993,57 +999,59 @@ pub fn refresh_homeboy_binary_in_roots(
         if refresh_session.is_some() {
             phase_summary.push(refresh_phase("disconnect", true, 0));
         }
-        let (report, connect_exit_code) = match connect_with_orphan_adoption(
-            &plan.runner_id,
-            refresh_owned_lease.as_deref(),
-            &[],
-            false,
-            None,
-            None,
-            None,
-        ) {
-            Ok(result) => result,
-            Err(error) => {
-                let readiness = blocked_refresh_readiness(&plan);
-                phase_summary.push(refresh_phase("reconnect_transport", true, 1));
-                return Ok((
-                    HomeboyBinaryRefreshOutput {
-                        variant: "refresh_homeboy",
-                        command: "runner.refresh_homeboy",
-                        runner_id: plan.runner_id.clone(),
-                        dry_run: false,
-                        plan: plan.clone(),
-                        identity: Some(identity.clone()),
-                        updated_fields: updated_fields.clone(),
-                        phase_summary,
-                        daemon_refreshed: false,
-                        interrupted_job_ids,
-                        selected_binary_path: selected_binary_path.clone(),
-                        next_actions: Vec::new(),
-                        reconnect_required: true,
-                        followup_commands: readiness.continuation.clone().into_iter().collect(),
-                        readiness: Some(readiness),
-                        reconnect_deferred: None,
-                        failure: Some(refresh_verification_failure(
-                            &plan,
-                            exec_output.clone(),
-                            error.message,
-                        )),
-                        bootstrap_provenance: Some(refresh_bootstrap_provenance(
-                            diagnostic_ssh_bootstrap,
-                            &plan,
-                            &bootstrap,
-                            &identity,
-                            &updated_fields,
-                        )),
-                        rollback: rollback.clone(),
-                        build_transcript: Some(refresh_build_transcript(&exec_output)),
-                        artifacts: None,
-                    },
-                    1,
-                ));
-            }
-        };
+        let (report, connect_exit_code) =
+            match super::connection::connect_with_orphan_adoption_in_roots(
+                roots,
+                &plan.runner_id,
+                refresh_owned_lease.as_deref(),
+                &[],
+                false,
+                None,
+                None,
+                None,
+            ) {
+                Ok(result) => result,
+                Err(error) => {
+                    let readiness = blocked_refresh_readiness(&plan);
+                    phase_summary.push(refresh_phase("reconnect_transport", true, 1));
+                    return Ok((
+                        HomeboyBinaryRefreshOutput {
+                            variant: "refresh_homeboy",
+                            command: "runner.refresh_homeboy",
+                            runner_id: plan.runner_id.clone(),
+                            dry_run: false,
+                            plan: plan.clone(),
+                            identity: Some(identity.clone()),
+                            updated_fields: updated_fields.clone(),
+                            phase_summary,
+                            daemon_refreshed: false,
+                            interrupted_job_ids,
+                            selected_binary_path: selected_binary_path.clone(),
+                            next_actions: Vec::new(),
+                            reconnect_required: true,
+                            followup_commands: readiness.continuation.clone().into_iter().collect(),
+                            readiness: Some(readiness),
+                            reconnect_deferred: None,
+                            failure: Some(refresh_verification_failure(
+                                &plan,
+                                exec_output.clone(),
+                                error.message,
+                            )),
+                            bootstrap_provenance: Some(refresh_bootstrap_provenance(
+                                diagnostic_ssh_bootstrap,
+                                &plan,
+                                &bootstrap,
+                                &identity,
+                                &updated_fields,
+                            )),
+                            rollback: rollback.clone(),
+                            build_transcript: Some(refresh_build_transcript(&exec_output)),
+                            artifacts: None,
+                        },
+                        1,
+                    ));
+                }
+            };
         let daemon_identity_verification = (connect_exit_code == 0)
             .then(|| verify_refreshed_daemon_topology(&plan.runner_id, &identity))
             .transpose()
@@ -1115,9 +1123,11 @@ pub fn refresh_homeboy_binary_in_roots(
             .get("git_commit")
             .and_then(Value::as_str)
         {
-            if let Err(readiness_error) =
-                probe_reconnected_admission_readiness(&plan.runner_id, identity_commit)
-            {
+            if let Err(readiness_error) = probe_reconnected_admission_readiness_in_roots(
+                roots,
+                &plan.runner_id,
+                identity_commit,
+            ) {
                 // The readiness probe can discover that the newly connected
                 // transport vanished. Never certify a transient connect as a
                 // successful reconnect when its postcondition is disconnected.
@@ -1251,7 +1261,24 @@ fn acquire_runner_binary_promotion(
     runner_id: &str,
     candidate_commit: &str,
 ) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
-    acquire_runner_binary_promotion_with(
+    acquire_runner_binary_promotion_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+        candidate_commit,
+    )
+}
+
+/// [`acquire_runner_binary_promotion`] against an explicitly injected root.
+///
+/// The promotion lease store is machine-global by default, so an isolated
+/// refresh would otherwise contend against the host's live lease (#14362).
+fn acquire_runner_binary_promotion_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    candidate_commit: &str,
+) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
+    acquire_runner_binary_promotion_with_in_root(
+        &homeboy_core::paths::runtime_promotion_dir_in_root(roots.data()),
         runner_id,
         candidate_commit,
         super::lab_selection::emit_runtime_promotion_wait,
@@ -1263,7 +1290,22 @@ fn acquire_runner_binary_promotion_with(
     candidate_commit: &str,
     progress: impl FnMut(homeboy_core::runtime_promotion::RuntimePromotionWaitEvent),
 ) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
-    homeboy_core::runtime_promotion::acquire_waiting_for_compatible_key(
+    acquire_runner_binary_promotion_with_in_root(
+        &homeboy_core::paths::runtime_promotion_dir()?,
+        runner_id,
+        candidate_commit,
+        progress,
+    )
+}
+
+fn acquire_runner_binary_promotion_with_in_root(
+    root: &std::path::Path,
+    runner_id: &str,
+    candidate_commit: &str,
+    progress: impl FnMut(homeboy_core::runtime_promotion::RuntimePromotionWaitEvent),
+) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
+    homeboy_core::runtime_promotion::acquire_waiting_for_compatible_key_in_root(
+        root,
         "runner binary promotion",
         runner_id.to_string(),
         candidate_commit,
@@ -1625,7 +1667,20 @@ pub(crate) fn probe_reconnected_admission_readiness(
     runner_id: &str,
     identity_commit: &str,
 ) -> Result<()> {
-    let session = super::connection::status_for_admission(runner_id)?
+    probe_reconnected_admission_readiness_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+        identity_commit,
+    )
+}
+
+/// [`probe_reconnected_admission_readiness`] against an injected root.
+pub(crate) fn probe_reconnected_admission_readiness_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    identity_commit: &str,
+) -> Result<()> {
+    let session = super::connection::status_for_admission_in_roots(roots, runner_id)?
         .session
         .filter(|session| session.mode == super::RunnerTunnelMode::DirectSsh);
     let Some(session) = session else {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -21,10 +21,11 @@ use super::connection::{
 use super::execution::exec_with_status_snapshot;
 use super::execution::{reserve_daemon_admission, DaemonAdmissionPolicy};
 use super::{
-    connect_with_orphan_adoption, copy_snapshot_to_directory, exec, load,
-    materialize_runner_extension_with_env, merge, normalize_runner_command_env_for_homeboy_path,
-    plan_controller_snapshot_extension, RunnerCapabilityPreflight, RunnerExecOptions,
-    RunnerExecOutput, RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
+    connect_with_orphan_adoption, copy_snapshot_to_directory, exec, load, load_in_roots,
+    materialize_runner_extension_with_env, merge, merge_in_roots,
+    normalize_runner_command_env_for_homeboy_path, plan_controller_snapshot_extension,
+    RunnerCapabilityPreflight, RunnerExecOptions, RunnerExecOutput,
+    RunnerExtensionMaterializationRequest, RunnerExtensionMaterializationSource,
     RunnerFileTransfer, RunnerKind,
 };
 
@@ -363,7 +364,19 @@ pub struct RunnerDevSyncOutput {
 pub fn plan_homeboy_binary_refresh(
     options: &HomeboyBinaryRefreshOptions,
 ) -> Result<HomeboyBinaryRefreshPlan> {
-    let runner = load(&options.runner_id)?;
+    plan_homeboy_binary_refresh_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        options,
+    )
+}
+
+/// [`plan_homeboy_binary_refresh`] against an explicitly injected root.
+#[allow(dead_code)]
+pub fn plan_homeboy_binary_refresh_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    options: &HomeboyBinaryRefreshOptions,
+) -> Result<HomeboyBinaryRefreshPlan> {
+    let runner = load_in_roots(roots, &options.runner_id)?;
     let runner_id = runner.id;
     match &options.mode {
         HomeboyBinaryRefreshMode::Select { binary_path } => {
@@ -439,7 +452,23 @@ pub fn plan_homeboy_binary_refresh(
 pub fn refresh_homeboy_binary(
     options: HomeboyBinaryRefreshOptions,
 ) -> Result<(HomeboyBinaryRefreshOutput, i32)> {
-    let mut plan = plan_homeboy_binary_refresh(&options)?;
+    refresh_homeboy_binary_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        options,
+    )
+}
+
+/// [`refresh_homeboy_binary`] against an explicitly injected root.
+///
+/// Planning, the selection read-back and promotion all follow `roots`, so a
+/// refresh into an injected root never resolves or mutates the ambient
+/// installation (#14362).
+#[allow(dead_code)]
+pub fn refresh_homeboy_binary_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    options: HomeboyBinaryRefreshOptions,
+) -> Result<(HomeboyBinaryRefreshOutput, i32)> {
+    let mut plan = plan_homeboy_binary_refresh_in_roots(roots, &options)?;
     if options.dry_run {
         return Ok((
             HomeboyBinaryRefreshOutput {
@@ -476,7 +505,7 @@ pub fn refresh_homeboy_binary(
         HomeboyBinaryRefreshMode::Select { .. } => vec!["bash".to_string()],
     };
 
-    let runner = load(&plan.runner_id)?;
+    let runner = load_in_roots(roots, &plan.runner_id)?;
     let previous_homeboy_path = runner.settings.homeboy_path.clone();
     // Reconciliation settles retained generation counts from the daemon's typed
     // job view. Consume that postcondition rather than immediately replacing it
@@ -484,7 +513,8 @@ pub fn refresh_homeboy_binary(
     let admission = reconciled_refresh_admission(&plan.runner_id)?;
     let connection_status = admission.status.clone();
     if plan.mode == "materialize" {
-        let authorities = refresh_promotion_authorities(&plan.runner_id, &connection_status)?;
+        let authorities =
+            refresh_promotion_authorities_in_roots(roots, &plan.runner_id, &connection_status)?;
         plan.script = materialize_script(
             plan.source
                 .as_deref()
@@ -609,7 +639,8 @@ pub fn refresh_homeboy_binary(
     // pre-materialization status snapshot.
     promotion_lease.assert_generation()?;
     let post_lease_status = super::status(&plan.runner_id)?;
-    let promotion_authorities = refresh_promotion_authorities(&plan.runner_id, &post_lease_status)?;
+    let promotion_authorities =
+        refresh_promotion_authorities_in_roots(roots, &plan.runner_id, &post_lease_status)?;
     // Selection belongs to the controller-owned runner registry. It must be
     // persisted after the candidate has been verified, whether or not this
     // invocation also replaces the active daemon.
@@ -653,7 +684,8 @@ pub fn refresh_homeboy_binary(
                     },
                 )?;
                 Ok((
-                    promote_verified_runner_binary(
+                    promote_verified_runner_binary_in_roots(
+                        roots,
                         &promotion_lease,
                         &plan.runner_id,
                         homeboy_path,
@@ -708,7 +740,8 @@ pub fn refresh_homeboy_binary(
                     }
                 },
             )?;
-            let updated_fields = promote_verified_runner_binary(
+            let updated_fields = promote_verified_runner_binary_in_roots(
+                roots,
                 &promotion_lease,
                 &plan.runner_id,
                 &selected_binary_path,
@@ -834,7 +867,8 @@ pub fn refresh_homeboy_binary(
                 candidate_binary_sha256.as_deref(),
                 &draining_job_ids,
             ) {
-                restore_runner_homeboy_path_if_selected(
+                restore_runner_homeboy_path_if_selected_in_roots(
+                    roots,
                     &plan.runner_id,
                     &selected_binary_path,
                     previous_homeboy_path.as_deref(),
@@ -890,7 +924,8 @@ pub fn refresh_homeboy_binary(
         ) {
             Ok(job_ids) => job_ids,
             Err(_) => {
-                let deferred = defer_reconnect_after_promotion_race(
+                let deferred = defer_reconnect_after_promotion_race_in_roots(
+                    roots,
                     &plan.runner_id,
                     &selected_binary_path,
                     previous_homeboy_path.as_deref(),
@@ -934,7 +969,8 @@ pub fn refresh_homeboy_binary(
             disconnect_with_session(&plan.runner_id, Some(session), options.force).map(|_| ())
         }) {
             return rollback_refresh_error_with(error, || {
-                restore_runner_homeboy_path_if_selected(
+                restore_runner_homeboy_path_if_selected_in_roots(
+                    roots,
                     &plan.runner_id,
                     &selected_binary_path,
                     previous_homeboy_path.as_deref(),
@@ -1858,11 +1894,12 @@ struct RefreshPromotionAuthorities {
     configured_selected: Option<String>,
 }
 
-fn refresh_promotion_authorities(
+fn refresh_promotion_authorities_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
     runner_id: &str,
     status: &super::RunnerStatusReport,
 ) -> Result<RefreshPromotionAuthorities> {
-    let runner = load(runner_id)?;
+    let runner = load_in_roots(roots, runner_id)?;
     let configured_selected = runner
         .settings
         .homeboy_path
@@ -2087,7 +2124,19 @@ fn refresh_ancestry_execution_options(
 }
 
 pub fn plan_runner_dev_sync(options: &RunnerDevSyncOptions) -> Result<RunnerDevSyncPlan> {
-    let runner = load(&options.runner_id)?;
+    plan_runner_dev_sync_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        options,
+    )
+}
+
+/// [`plan_runner_dev_sync`] against an explicitly injected root.
+#[allow(dead_code)]
+pub fn plan_runner_dev_sync_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    options: &RunnerDevSyncOptions,
+) -> Result<RunnerDevSyncPlan> {
+    let runner = load_in_roots(roots, &options.runner_id)?;
     let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "workspace_root",
@@ -2366,7 +2415,19 @@ fn sync_extension_overlays(
     runner_id: &str,
     plan: &RunnerDevSyncPlan,
 ) -> Result<Vec<RunnerDevSyncExtensionProvenance>> {
-    let runner = load(runner_id)?;
+    sync_extension_overlays_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+        plan,
+    )
+}
+
+fn sync_extension_overlays_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    plan: &RunnerDevSyncPlan,
+) -> Result<Vec<RunnerDevSyncExtensionProvenance>> {
+    let runner = load_in_roots(roots, runner_id)?;
     let homeboy_env = installed_homeboy_env(&runner.env, runner.settings.homeboy_path.as_deref());
     let mut overlays = Vec::new();
     for extension in &plan.extensions {
@@ -2647,11 +2708,12 @@ fn parse_identity(stdout: &str) -> Result<Value> {
     })
 }
 
-fn refreshed_runner_env(
+fn refreshed_runner_env_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
     runner_id: &str,
     homeboy_path: &str,
 ) -> Result<std::collections::HashMap<String, String>> {
-    let runner = load(runner_id)?;
+    let runner = load_in_roots(roots, runner_id)?;
     let mut env = runner.env;
     // A refreshed daemon must not inherit a prior generation's control-plane
     // authority. The selected binary becomes the new command authority below.
@@ -2661,8 +2723,12 @@ fn refreshed_runner_env(
     Ok(env)
 }
 
-fn refreshed_runner_patch(runner_id: &str, homeboy_path: &str) -> Result<Value> {
-    let env = refreshed_runner_env(runner_id, homeboy_path)?;
+fn refreshed_runner_patch_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    homeboy_path: &str,
+) -> Result<Value> {
+    let env = refreshed_runner_env_in_roots(roots, runner_id, homeboy_path)?;
     let mut patch = serde_json::json!({
         "homeboy_path": homeboy_path,
         "env": env,
@@ -2676,24 +2742,30 @@ fn refreshed_runner_patch(runner_id: &str, homeboy_path: &str) -> Result<Value> 
 /// Persist a verified selection in the controller-owned runner registry.
 /// Runner commands may execute remotely, but registry mutation must remain on
 /// the controller so subsequent jobs use the selected binary.
-fn promote_verified_runner_binary(
+/// [`promote_verified_runner_binary`] against an explicitly injected root.
+///
+/// The config lock, the registry merge and the selection read-back all follow
+/// `roots`, so a promotion into an injected root cannot serialize against or
+/// mutate the ambient installation (#14362).
+fn promote_verified_runner_binary_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
     promotion_lease: &homeboy_core::runtime_promotion::RuntimePromotionLease,
     runner_id: &str,
     homeboy_path: &str,
 ) -> Result<Vec<String>> {
-    homeboy_core::config::with_config_lock(|| {
+    homeboy_core::config::with_config_lock_at(roots.config(), || {
         promote_verified_runner_binary_with(
             || promotion_lease.assert_generation(),
             runner_id,
             homeboy_path,
             |runner_id, homeboy_path| {
-                let patch = refreshed_runner_patch(runner_id, homeboy_path)?;
-                match merge(Some(runner_id), &patch.to_string(), &[])? {
+                let patch = refreshed_runner_patch_in_roots(roots, runner_id, homeboy_path)?;
+                match merge_in_roots(roots, Some(runner_id), &patch.to_string(), &[])? {
                     MergeOutput::Single(result) => Ok(result.updated_fields),
                     MergeOutput::Bulk(_) => Ok(Vec::new()),
                 }
             },
-            |runner_id| Ok(load(runner_id)?.settings.homeboy_path),
+            |runner_id| Ok(load_in_roots(roots, runner_id)?.settings.homeboy_path),
         )
     })
 }
@@ -2745,24 +2817,26 @@ where
 /// Restore only if this promotion still owns the selected value. A later
 /// serialized transaction may have selected another binary after this one
 /// failed; compensation must never overwrite that newer owner.
-fn restore_runner_homeboy_path_if_selected(
+fn restore_runner_homeboy_path_if_selected_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
     runner_id: &str,
     selected_homeboy_path: &str,
     previous_homeboy_path: Option<&str>,
 ) -> Result<bool> {
-    homeboy_core::config::with_config_lock(|| {
-        let runner = load(runner_id)?;
+    homeboy_core::config::with_config_lock_at(roots.config(), || {
+        let runner = load_in_roots(roots, runner_id)?;
         if runner.settings.homeboy_path.as_deref() != Some(selected_homeboy_path) {
             return Ok(false);
         }
         let patch = serde_json::json!({ "homeboy_path": previous_homeboy_path });
-        match merge(Some(runner_id), &patch.to_string(), &[])? {
+        match merge_in_roots(roots, Some(runner_id), &patch.to_string(), &[])? {
             MergeOutput::Single(_) | MergeOutput::Bulk(_) => Ok(true),
         }
     })
 }
 
-fn defer_reconnect_after_promotion_race(
+fn defer_reconnect_after_promotion_race_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
     runner_id: &str,
     selected_homeboy_path: &str,
     previous_homeboy_path: Option<&str>,
@@ -2772,7 +2846,8 @@ fn defer_reconnect_after_promotion_race(
         .iter()
         .map(|job| job.job_id.clone())
         .collect::<Vec<_>>();
-    let restored = restore_runner_homeboy_path_if_selected(
+    let restored = restore_runner_homeboy_path_if_selected_in_roots(
+        roots,
         runner_id,
         selected_homeboy_path,
         previous_homeboy_path,

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -16,9 +16,9 @@ use homeboy_core::output::MergeOutput;
 
 use super::connection::{
     active_jobs_before_daemon_replacement, configured_runner_homeboy_build_identity,
-    disconnect_with_session, reconcile_status, rotate_daemon_generation,
+    disconnect_with_session, rotate_daemon_generation,
 };
-use super::execution::exec_with_status_snapshot;
+use super::execution::{exec_with_status_snapshot, exec_with_status_snapshot_in_roots};
 use super::execution::{reserve_daemon_admission, DaemonAdmissionPolicy};
 use super::{
     connect_with_orphan_adoption, copy_snapshot_to_directory, exec, load, load_in_roots,
@@ -510,7 +510,7 @@ pub fn refresh_homeboy_binary_in_roots(
     // Reconciliation settles retained generation counts from the daemon's typed
     // job view. Consume that postcondition rather than immediately replacing it
     // with a new observation that can include this recovery operation's records.
-    let admission = reconciled_refresh_admission(&plan.runner_id)?;
+    let admission = reconciled_refresh_admission_in_roots(roots, &plan.runner_id)?;
     let connection_status = admission.status.clone();
     if plan.mode == "materialize" {
         let authorities =
@@ -534,7 +534,8 @@ pub fn refresh_homeboy_binary_in_roots(
     let diagnostic_ssh_bootstrap = execution_route.uses_diagnostic_ssh();
     let exec_options =
         refresh_execution_options(&plan, required_commands, diagnostic_ssh_bootstrap);
-    let (exec_output, exit_code) = exec_with_status_snapshot(
+    let (exec_output, exit_code) = exec_with_status_snapshot_in_roots(
+        roots,
         &plan.runner_id,
         exec_options,
         Some(connection_status.clone()),
@@ -638,7 +639,7 @@ pub fn refresh_homeboy_binary_in_roots(
     // connect while materialization runs, so reconnect decisions cannot use the
     // pre-materialization status snapshot.
     promotion_lease.assert_generation()?;
-    let post_lease_status = super::status(&plan.runner_id)?;
+    let post_lease_status = super::connection::status_in_roots(roots, &plan.runner_id)?;
     let promotion_authorities =
         refresh_promotion_authorities_in_roots(roots, &plan.runner_id, &post_lease_status)?;
     // Selection belongs to the controller-owned runner registry. It must be
@@ -1123,7 +1124,7 @@ pub fn refresh_homeboy_binary_in_roots(
                 // This arm returns `daemon_refreshed: false` directly, so it
                 // does not reassign the local first.
                 let transport_exit_code = reconnect_transport_exit_code(
-                    super::status(&plan.runner_id)
+                    super::connection::status_in_roots(roots, &plan.runner_id)
                         .map(|status| status.is_connected())
                         .unwrap_or(false),
                 );
@@ -1790,9 +1791,20 @@ fn refresh_execution_route(
 /// later pre-rotation job probe remains the fail-closed check for work that
 /// appears while materialization is in progress.
 fn reconciled_refresh_admission(runner_id: &str) -> Result<super::RunnerAdmissionSnapshot> {
+    reconciled_refresh_admission_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+    )
+}
+
+/// [`reconciled_refresh_admission`] against an explicitly injected root.
+fn reconciled_refresh_admission_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+) -> Result<super::RunnerAdmissionSnapshot> {
     reconciled_refresh_admission_with(
         runner_id,
-        reconcile_status,
+        |runner_id| super::connection::reconcile_status_in_roots(roots, runner_id),
         super::runner_admission_snapshot_for_status,
     )
 }

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/mod.rs
@@ -6,6 +6,14 @@ mod part_c;
 
 use super::*;
 
+/// The ambient roots, for tests that still isolate by mutating process env.
+///
+/// Rooted entry points take their root explicitly; a test still running under
+/// `with_isolated_home` passes the isolated home this resolves to.
+fn ambient_roots() -> homeboy_core::paths::PathRoots {
+    homeboy_core::paths::PathRoots::from_environment().expect("ambient path roots")
+}
+
 pub(super) fn ssh_bootstrap_plan() -> HomeboyBinaryRefreshPlan {
     HomeboyBinaryRefreshPlan {
         runner_id: "lab-local".to_string(),

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -1545,7 +1545,7 @@ fn select_without_materialization_sha_promotes_the_verified_binary() {
             &plan,
             || Ok(r#"{"data":{"git_commit":"abc123","git_dirty":false}}"#.to_string()),
             |path, _| {
-                let patch = refreshed_runner_patch("lab-local", path)?;
+                let patch = refreshed_runner_patch_in_roots(&ambient_roots(), "lab-local", path)?;
                 match merge(Some("lab-local"), &patch.to_string(), &[])? {
                     MergeOutput::Single(result) => Ok((result.updated_fields, None)),
                     MergeOutput::Bulk(_) => Ok((Vec::new(), None)),
@@ -1575,7 +1575,8 @@ fn reconnect_rollback_restores_only_its_own_selected_binary() {
         )
         .expect("runner");
 
-        let restored = restore_runner_homeboy_path_if_selected(
+        let restored = restore_runner_homeboy_path_if_selected_in_roots(
+            &ambient_roots(),
             "lab-local",
             "/selected/homeboy",
             Some("/stable/homeboy"),
@@ -1603,7 +1604,8 @@ fn reconnect_rollback_restores_its_own_selected_binary() {
         )
         .expect("runner");
 
-        let restored = restore_runner_homeboy_path_if_selected(
+        let restored = restore_runner_homeboy_path_if_selected_in_roots(
+            &ambient_roots(),
             "lab-local",
             "/selected/homeboy",
             Some("/stable/homeboy"),
@@ -1631,7 +1633,8 @@ fn post_promotion_active_job_race_restores_prior_selection_without_stopping_daem
         )
         .expect("runner");
 
-        let deferred = defer_reconnect_after_promotion_race(
+        let deferred = defer_reconnect_after_promotion_race_in_roots(
+            &ambient_roots(),
             "lab-local",
             "/selected/homeboy",
             Some("/stable/homeboy"),
@@ -1662,7 +1665,8 @@ fn post_promotion_active_job_race_preserves_newer_selector_as_contention() {
         )
         .expect("runner");
 
-        let deferred = defer_reconnect_after_promotion_race(
+        let deferred = defer_reconnect_after_promotion_race_in_roots(
+            &ambient_roots(),
             "lab-local",
             "/selected/homeboy",
             Some("/stable/homeboy"),

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -772,7 +772,9 @@ fn strict_ancestor_refresh_candidate_is_rejected_while_owner_keeps_selection() {
 
 #[test]
 fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
-    test_support::with_isolated_home(|_| {
+    {
+        let context = test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let probes = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let stale_probes = std::sync::Arc::clone(&probes);
         let cached: String = crate::runner_probe_gate::deduplicated_probe(
@@ -804,7 +806,8 @@ fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
             .status()
             .expect("make selected binary executable");
         assert!(status.success());
-        crate::create(
+        crate::create_in_roots(
+            &roots,
             r#"{"id":"lab-local","kind":"local","homeboy_path":"/old/homeboy"}"#,
             false,
         )
@@ -824,7 +827,7 @@ fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
         };
 
         let (selected, exit_code) =
-            refresh_homeboy_binary_in_roots(&ambient_roots(), options.clone()).expect("selection");
+            refresh_homeboy_binary_in_roots(&roots, options.clone()).expect("selection");
         assert_eq!(exit_code, 0);
         assert_eq!(selected.updated_fields, ["env", "homeboy_path"]);
         assert_eq!(selected.selected_binary_path, binary.display().to_string());
@@ -832,7 +835,7 @@ fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
         assert!(selected.reconnect_required);
         assert!(selected.next_actions.is_empty());
         assert_eq!(
-            crate::load("lab-local")
+            crate::load_in_roots(&roots, "lab-local")
                 .expect("reload controller registry")
                 .settings
                 .homeboy_path
@@ -854,13 +857,13 @@ fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
         assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 2);
 
         let (repeated, exit_code) =
-            refresh_homeboy_binary_in_roots(&ambient_roots(), options).expect("repeat selection");
+            refresh_homeboy_binary_in_roots(&roots, options).expect("repeat selection");
         assert_eq!(exit_code, 0);
         assert_eq!(repeated.updated_fields, ["env", "homeboy_path"]);
         assert!(!repeated.daemon_refreshed);
         assert!(repeated.reconnect_required);
         assert!(repeated.next_actions.is_empty());
-    });
+    }
 }
 
 #[test]
@@ -1086,7 +1089,9 @@ fn blocked_connect_preserves_successful_promotion_with_one_continuation() {
 
 #[test]
 fn stale_session_refresh_blocker_starts_the_newly_selected_binary() {
-    test_support::with_isolated_home(|_| {
+    {
+        let context = test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let fixture = tempfile::tempdir().expect("fixture");
         let second_binary = fixture.path().join("second-homeboy");
         let commit = homeboy_product_identity::build_identity()
@@ -1104,25 +1109,29 @@ fn stale_session_refresh_blocker_starts_the_newly_selected_binary() {
             .status()
             .expect("make selected binary executable")
             .success());
-        crate::create(
+        crate::create_in_roots(
+            &roots,
             r#"{"id":"lab-local","kind":"local","homeboy_path":"/old/homeboy"}"#,
             false,
         )
         .expect("runner");
         let refresh = |binary: &Path| {
-            refresh_homeboy_binary(HomeboyBinaryRefreshOptions {
-                runner_id: "lab-local".to_string(),
-                mode: HomeboyBinaryRefreshMode::Select {
-                    binary_path: binary.display().to_string(),
+            refresh_homeboy_binary_in_roots(
+                &roots,
+                HomeboyBinaryRefreshOptions {
+                    runner_id: "lab-local".to_string(),
+                    mode: HomeboyBinaryRefreshMode::Select {
+                        binary_path: binary.display().to_string(),
+                    },
+                    source: None,
+                    git_ref: None,
+                    target_dir: None,
+                    reconnect: true,
+                    force: false,
+                    allow_downgrade: true,
+                    dry_run: false,
                 },
-                source: None,
-                git_ref: None,
-                target_dir: None,
-                reconnect: true,
-                force: false,
-                allow_downgrade: true,
-                dry_run: false,
-            })
+            )
         };
 
         let hostname = String::from_utf8(
@@ -1158,9 +1167,11 @@ fn stale_session_refresh_blocker_starts_the_newly_selected_binary() {
             last_seen_at: None,
             leaseless_recovery_evidence: None,
         };
-        let session_path =
-            homeboy_core::paths::runner_controller_session_file("lab-local", &controller_id)
-                .expect("session path");
+        let session_path = homeboy_core::paths::runner_controller_session_file_in_root(
+            roots.config(),
+            "lab-local",
+            &controller_id,
+        );
         std::fs::create_dir_all(session_path.parent().expect("session directory"))
             .expect("create session directory");
         std::fs::write(
@@ -1168,9 +1179,11 @@ fn stale_session_refresh_blocker_starts_the_newly_selected_binary() {
             serde_json::to_vec(&session).expect("serialize connected session"),
         )
         .expect("persist connected session");
-        assert!(crate::connection::recorded_session("lab-local")
-            .expect("read connected session")
-            .is_some());
+        assert!(
+            crate::connection::recorded_session_in_root(roots.config(), "lab-local")
+                .expect("read connected session")
+                .is_some()
+        );
 
         let (output, exit_code) = refresh(&second_binary).expect("connected refresh result");
 
@@ -1203,19 +1216,21 @@ fn stale_session_refresh_blocker_starts_the_newly_selected_binary() {
             ["homeboy runner connect lab-local"]
         );
         assert_eq!(
-            crate::load("lab-local")
+            crate::load_in_roots(&roots, "lab-local")
                 .expect("reload controller registry")
                 .settings
                 .homeboy_path
                 .as_deref(),
             second_binary.to_str()
         );
-    });
+    }
 }
 
 #[test]
 fn select_without_source_rejects_implicit_downgrade_before_selection_or_reconnect() {
-    test_support::with_isolated_home(|_| {
+    {
+        let context = test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let controller_commit = homeboy_product_identity::build_identity()
             .git_commit
             .expect("test build has an immutable controller commit");
@@ -1234,7 +1249,8 @@ fn select_without_source_rejects_implicit_downgrade_before_selection_or_reconnec
             .status()
             .expect("make selected binary executable")
             .success());
-        crate::create(
+        crate::create_in_roots(
+            &roots,
             r#"{"id":"lab-local","kind":"local","homeboy_path":"/old/homeboy"}"#,
             false,
         )
@@ -1254,8 +1270,7 @@ fn select_without_source_rejects_implicit_downgrade_before_selection_or_reconnec
         };
 
         let (rejected, exit_code) =
-            refresh_homeboy_binary_in_roots(&ambient_roots(), options.clone())
-                .expect("rejection output");
+            refresh_homeboy_binary_in_roots(&roots, options.clone()).expect("rejection output");
         assert_eq!(exit_code, 1);
         assert!(rejected
             .failure
@@ -1264,7 +1279,7 @@ fn select_without_source_rejects_implicit_downgrade_before_selection_or_reconnec
             .unwrap()
             .contains("allow-downgrade"));
         assert_eq!(
-            crate::load("lab-local")
+            crate::load_in_roots(&roots, "lab-local")
                 .expect("reload")
                 .settings
                 .homeboy_path
@@ -1272,11 +1287,14 @@ fn select_without_source_rejects_implicit_downgrade_before_selection_or_reconnec
             Some("/old/homeboy")
         );
 
-        let (rolled_back, exit_code) = refresh_homeboy_binary(HomeboyBinaryRefreshOptions {
-            allow_downgrade: true,
-            reconnect: false,
-            ..options
-        })
+        let (rolled_back, exit_code) = refresh_homeboy_binary_in_roots(
+            &roots,
+            HomeboyBinaryRefreshOptions {
+                allow_downgrade: true,
+                reconnect: false,
+                ..options
+            },
+        )
         .expect("explicit rollback");
         assert_eq!(exit_code, 0);
         let rollback = rolled_back.rollback.expect("structured rollback evidence");
@@ -1288,12 +1306,14 @@ fn select_without_source_rejects_implicit_downgrade_before_selection_or_reconnec
         assert_eq!(rollback.requested, None, "select mode has no requested ref");
         assert_eq!(rollback.resolved, older);
         assert_eq!(rollback.selected, older);
-    });
+    }
 }
 
 #[test]
 fn contending_refreshes_cannot_let_an_old_materialized_request_replace_new_selection() {
-    test_support::with_isolated_home(|_| {
+    {
+        let context = test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
         let fixture = tempfile::tempdir().expect("git fixture");
         for args in [
             vec!["init", "--quiet"],
@@ -1361,7 +1381,8 @@ fn contending_refreshes_cannot_let_an_old_materialized_request_replace_new_selec
                 .expect("chmod")
                 .success());
         }
-        crate::create(
+        crate::create_in_roots(
+            &roots,
             r#"{"id":"lab-local","kind":"local","homeboy_path":"/stable/homeboy"}"#,
             false,
         )
@@ -1379,25 +1400,31 @@ fn contending_refreshes_cannot_let_an_old_materialized_request_replace_new_selec
             allow_downgrade: false,
             dry_run: false,
         };
-        let old_refresh = std::thread::spawn(move || refresh_homeboy_binary(old_options));
+        let refresh_roots = roots.clone();
+        let old_refresh = std::thread::spawn(move || {
+            refresh_homeboy_binary_in_roots(&refresh_roots, old_options)
+        });
         let deadline = Instant::now() + Duration::from_secs(5);
         while !marker.exists() && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(10));
         }
         assert!(marker.exists(), "old request materialized before selection");
-        let (new_output, new_code) = refresh_homeboy_binary(HomeboyBinaryRefreshOptions {
-            runner_id: "lab-local".to_string(),
-            mode: HomeboyBinaryRefreshMode::Select {
-                binary_path: new_binary.display().to_string(),
+        let (new_output, new_code) = refresh_homeboy_binary_in_roots(
+            &roots,
+            HomeboyBinaryRefreshOptions {
+                runner_id: "lab-local".to_string(),
+                mode: HomeboyBinaryRefreshMode::Select {
+                    binary_path: new_binary.display().to_string(),
+                },
+                source: None,
+                git_ref: Some("new".to_string()),
+                target_dir: Some(fixture.path().display().to_string()),
+                reconnect: false,
+                force: false,
+                allow_downgrade: true,
+                dry_run: false,
             },
-            source: None,
-            git_ref: Some("new".to_string()),
-            target_dir: Some(fixture.path().display().to_string()),
-            reconnect: false,
-            force: false,
-            allow_downgrade: true,
-            dry_run: false,
-        })
+        )
         .expect("new refresh");
         assert_eq!(new_code, 0);
         let (old_output, old_code) = old_refresh
@@ -1408,7 +1435,7 @@ fn contending_refreshes_cannot_let_an_old_materialized_request_replace_new_selec
         assert!(old_output.failure.is_some());
         assert!(!old_output.daemon_refreshed);
         assert_eq!(
-            crate::load("lab-local")
+            crate::load_in_roots(&roots, "lab-local")
                 .expect("reload")
                 .settings
                 .homeboy_path
@@ -1416,10 +1443,12 @@ fn contending_refreshes_cannot_let_an_old_materialized_request_replace_new_selec
             new_binary.to_str()
         );
         assert!(!new_output.daemon_refreshed);
-        assert!(crate::connection::recorded_session("lab-local")
-            .expect("session")
-            .is_none());
-    });
+        assert!(
+            crate::connection::recorded_session_in_root(roots.config(), "lab-local")
+                .expect("session")
+                .is_none()
+        );
+    }
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -355,36 +355,42 @@ fn ssh_dev_sync_rejects_darwin_binary_before_upload() {
 
 #[test]
 fn ssh_source_snapshot_plan_builds_natively_without_cross_compilation() {
-    let source = tempfile::tempdir().expect("source");
-    std::fs::write(
-        source.path().join("Cargo.toml"),
-        "[package]\nname='fixture'\nversion='0.1.0'\n",
-    )
-    .expect("manifest");
-    std::fs::create_dir_all(source.path().join("target")).expect("target");
-    std::fs::write(source.path().join("target/local"), "controller binary").expect("target output");
-    let snapshot = build_runner_source_snapshot(source.path(), "/runner/ws").expect("snapshot");
-    let script = source_snapshot_build_script(&snapshot);
-    let archive = std::process::Command::new("tar")
-        .args(["-tf"])
-        .arg(snapshot.archive.path())
-        .output()
-        .expect("list snapshot archive");
-
-    assert!(snapshot
-        .remote_archive
-        .starts_with("/runner/ws/_homeboy_binaries/dev-source/"));
-    assert_eq!(
-        snapshot.build_slot,
-        format!(
-            "/runner/ws/_homeboy_binaries/dev/{}",
-            &snapshot.sha256[..16]
+    // `build_runner_source_snapshot` stages through `tempfile::tempdir()`, which
+    // honours the process-global `TMPDIR`. Hold the isolation guard so a
+    // neighbouring test cannot retire that root mid-archive (#14362).
+    test_support::with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source");
+        std::fs::write(
+            source.path().join("Cargo.toml"),
+            "[package]\nname='fixture'\nversion='0.1.0'\n",
         )
-    );
-    assert!(script.contains("cargo build --release --bin homeboy"));
-    assert!(script.contains("runner_native_build_not_elf"));
-    assert!(!script.contains(source.path().to_str().expect("utf8 source")));
-    assert!(!String::from_utf8_lossy(&archive.stdout).contains("target/local"));
+        .expect("manifest");
+        std::fs::create_dir_all(source.path().join("target")).expect("target");
+        std::fs::write(source.path().join("target/local"), "controller binary")
+            .expect("target output");
+        let snapshot = build_runner_source_snapshot(source.path(), "/runner/ws").expect("snapshot");
+        let script = source_snapshot_build_script(&snapshot);
+        let archive = std::process::Command::new("tar")
+            .args(["-tf"])
+            .arg(snapshot.archive.path())
+            .output()
+            .expect("list snapshot archive");
+
+        assert!(snapshot
+            .remote_archive
+            .starts_with("/runner/ws/_homeboy_binaries/dev-source/"));
+        assert_eq!(
+            snapshot.build_slot,
+            format!(
+                "/runner/ws/_homeboy_binaries/dev/{}",
+                &snapshot.sha256[..16]
+            )
+        );
+        assert!(script.contains("cargo build --release --bin homeboy"));
+        assert!(script.contains("runner_native_build_not_elf"));
+        assert!(!script.contains(source.path().to_str().expect("utf8 source")));
+        assert!(!String::from_utf8_lossy(&archive.stdout).contains("target/local"));
+    });
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -274,7 +274,7 @@ fn extension_only_dev_sync_plan_does_not_refresh_homeboy_binary() {
             reconnect: false,
             dry_run: true,
         };
-        let plan = plan_runner_dev_sync(&options).expect("plan dev-sync");
+        let plan = plan_runner_dev_sync_in_roots(&roots, &options).expect("plan dev-sync");
 
         assert!(!should_sync_homeboy_binary(&options));
         assert_eq!(plan.local_binary, None);

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -71,7 +71,8 @@ fn refreshed_runner_env_replaces_stale_control_plane_overrides() {
         )
         .expect("create runner");
 
-        let env = refreshed_runner_env(
+        let env = refreshed_runner_env_in_roots(
+            &ambient_roots(),
             "lab-local",
             "/runner/ws/_homeboy_binaries/homeboy-main/target/release/homeboy",
         )
@@ -93,7 +94,8 @@ fn refreshed_runner_env_replaces_stale_control_plane_overrides() {
             "lab-local",
             "/runner/ws/_homeboy_binaries/homeboy-main/target/release/homeboy",
             |runner_id, homeboy_path| {
-                let patch = refreshed_runner_patch(runner_id, homeboy_path)?;
+                let patch =
+                    refreshed_runner_patch_in_roots(&ambient_roots(), runner_id, homeboy_path)?;
                 match merge(Some(runner_id), &patch.to_string(), &[])? {
                     MergeOutput::Single(result) => Ok(result.updated_fields),
                     MergeOutput::Bulk(_) => Ok(Vec::new()),
@@ -199,8 +201,11 @@ fn dev_sync_resource_keeps_last_duplicate_overlay_for_same_id() {
 
 #[test]
 fn dev_sync_resource_replacement_persists_reconciled_overlay_records() {
-    test_support::with_isolated_home(|_| {
-        crate::create(
+    {
+        let context = test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
+        crate::create_in_roots(
+            &roots,
             r#"{
                 "id": "lab-local",
                 "kind": "local",
@@ -219,32 +224,36 @@ fn dev_sync_resource_replacement_persists_reconciled_overlay_records() {
         )
         .expect("create runner");
 
-        let runner = crate::load("lab-local").expect("load runner");
+        let runner = crate::load_in_roots(&roots, "lab-local").expect("load runner");
         let dev_sync =
             updated_dev_sync_resource(runner.resources.get("dev_sync").cloned(), None, &[])
                 .expect("reconcile dev-sync resource");
         let patch = serde_json::json!({ "resources": { "dev_sync": dev_sync } });
 
-        crate::merge(
+        crate::merge_in_roots(
+            &roots,
             Some("lab-local"),
             &patch.to_string(),
             &["resources".to_string()],
         )
         .expect("replace resources");
 
-        let runner = crate::load("lab-local").expect("reload runner");
+        let runner = crate::load_in_roots(&roots, "lab-local").expect("reload runner");
         let extensions = runner.resources["dev_sync"]["extensions"]
             .as_array()
             .expect("extensions array");
         assert_eq!(extensions.len(), 1);
         assert_eq!(extensions[0]["source_path"], "/newer/nodejs");
-    });
+    }
 }
 
 #[test]
 fn extension_only_dev_sync_plan_does_not_refresh_homeboy_binary() {
-    test_support::with_isolated_home(|_| {
-        crate::create(
+    {
+        let context = test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
+        crate::create_in_roots(
+            &roots,
             r#"{
                 "id": "lab-local",
                 "kind": "local",
@@ -273,7 +282,7 @@ fn extension_only_dev_sync_plan_does_not_refresh_homeboy_binary() {
         assert!(plan.followup_commands.is_empty());
         assert_eq!(plan.extensions.len(), 1);
         assert_eq!(plan.extensions[0].id, "nodejs");
-    });
+    }
 }
 
 #[test]
@@ -443,8 +452,11 @@ fn extension_overlay_lifecycle_uses_ttl_cleanup_policy() {
 
 #[test]
 fn refresh_patch_updates_the_selected_binary_and_control_plane_environment() {
-    test_support::with_isolated_home(|_| {
-        crate::create(
+    {
+        let context = test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
+        crate::create_in_roots(
+            &roots,
             r#"{
                 "id": "lab-local",
                 "kind": "local",
@@ -459,8 +471,8 @@ fn refresh_patch_updates_the_selected_binary_and_control_plane_environment() {
         )
         .expect("create runner");
 
-        let patch =
-            refreshed_runner_patch("lab-local", "/runner/ws/homeboy").expect("build refresh patch");
+        let patch = refreshed_runner_patch_in_roots(&roots, "lab-local", "/runner/ws/homeboy")
+            .expect("build refresh patch");
 
         assert_eq!(patch["homeboy_path"], "/runner/ws/homeboy");
         assert_eq!(patch["env"]["HOMEBOY_COMMAND"], "/runner/ws/homeboy");
@@ -469,7 +481,7 @@ fn refresh_patch_updates_the_selected_binary_and_control_plane_environment() {
             "refresh updates env to pin daemon startup and queued jobs to the selected binary"
         );
         assert!(patch["env"]["HOMEBOY_DAEMON_STATE_DIR"].is_null());
-    });
+    }
 }
 
 #[test]
@@ -486,7 +498,7 @@ fn ssh_bootstrap_success_promotes_verified_exact_sha_with_provenance() {
             || Ok(verified_bootstrap_output("abc123")),
             |path, _| {
                 let lease = acquire_runner_binary_promotion("lab-local", "abc123")?;
-                promote_verified_runner_binary(&lease, "lab-local", path)
+                promote_verified_runner_binary_in_roots(&ambient_roots(), &lease, "lab-local", path)
                     .map(|fields| (fields, None))
             },
         )
@@ -517,7 +529,12 @@ fn controller_binary_selection_reports_fresh_main_control_plane_fields() {
             {
                 let lease = acquire_runner_binary_promotion("lab-local", "verified")
                     .expect("promotion lease");
-                promote_verified_runner_binary(&lease, "lab-local", "/verified/homeboy")
+                promote_verified_runner_binary_in_roots(
+                    &ambient_roots(),
+                    &lease,
+                    "lab-local",
+                    "/verified/homeboy",
+                )
             }
             .expect("persist controller selection"),
             ["env", "homeboy_path"]
@@ -526,7 +543,9 @@ fn controller_binary_selection_reports_fresh_main_control_plane_fields() {
             {
                 let lease = acquire_runner_binary_promotion("lab-local", "verified")
                     .expect("promotion lease");
-                promote_verified_runner_binary(&lease, "lab-local", "/verified/homeboy")
+                promote_verified_runner_binary_in_roots(
+                &ambient_roots(),
+                &lease, "lab-local", "/verified/homeboy")
             }
                 .expect("repeat controller selection"),
             ["env", "homeboy_path"],
@@ -655,7 +674,7 @@ fn equivalent_refresh_waiter_reloads_the_owner_selection_after_promotion_handoff
                 queued_tx.send(event).expect("report queued owner")
             })?;
             let status = crate::status("lab")?;
-            refresh_promotion_authorities("lab", &status)?;
+            refresh_promotion_authorities_in_roots(&ambient_roots(), "lab", &status)?;
             crate::load("lab")
         });
         let event = queued_rx
@@ -664,8 +683,13 @@ fn equivalent_refresh_waiter_reloads_the_owner_selection_after_promotion_handoff
         assert_eq!(event.target, "lab");
         assert_eq!(event.owner_operation, "runner binary promotion");
         assert_eq!(event.owner_pid, std::process::id());
-        promote_verified_runner_binary(&owner, "lab", selected.to_str().expect("selected path"))
-            .expect("owner selects candidate");
+        promote_verified_runner_binary_in_roots(
+            &ambient_roots(),
+            &owner,
+            "lab",
+            selected.to_str().expect("selected path"),
+        )
+        .expect("owner selects candidate");
         drop(owner);
 
         let reloaded = waiter
@@ -1413,7 +1437,8 @@ fn ssh_bootstrap_select_promotes_without_materialized_source_sha() {
             || Ok(r#"{"data":{"git_commit":"abc123","git_dirty":false}}"#.to_string()),
             |path, _| {
                 homeboy_core::config::with_config_lock(|| {
-                    let patch = refreshed_runner_patch("lab-local", path)?;
+                    let patch =
+                        refreshed_runner_patch_in_roots(&ambient_roots(), "lab-local", path)?;
                     match merge(Some("lab-local"), &patch.to_string(), &[])? {
                         MergeOutput::Single(result) => Ok((result.updated_fields, None)),
                         MergeOutput::Bulk(_) => Ok((Vec::new(), None)),
@@ -1437,8 +1462,11 @@ fn ssh_bootstrap_select_promotes_without_materialized_source_sha() {
 
 #[test]
 fn ssh_bootstrap_transport_failure_leaves_config_unchanged() {
-    test_support::with_isolated_home(|_| {
-        crate::create(
+    {
+        let context = test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
+        crate::create_in_roots(
+            &roots,
             r#"{"id":"lab-local","kind":"local","homeboy_path":"/old"}"#,
             false,
         )
@@ -1450,20 +1478,23 @@ fn ssh_bootstrap_transport_failure_leaves_config_unchanged() {
         );
         assert!(result.is_err());
         assert_eq!(
-            crate::load("lab-local")
+            crate::load_in_roots(&roots, "lab-local")
                 .expect("reload")
                 .settings
                 .homeboy_path
                 .as_deref(),
             Some("/old")
         );
-    });
+    }
 }
 
 #[test]
 fn ssh_bootstrap_identity_mismatch_leaves_config_unchanged() {
-    test_support::with_isolated_home(|_| {
-        crate::create(
+    {
+        let context = test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
+        crate::create_in_roots(
+            &roots,
             r#"{"id":"lab-local","kind":"local","homeboy_path":"/old"}"#,
             false,
         )
@@ -1477,14 +1508,14 @@ fn ssh_bootstrap_identity_mismatch_leaves_config_unchanged() {
         );
         assert!(result.is_err());
         assert_eq!(
-            crate::load("lab-local")
+            crate::load_in_roots(&roots, "lab-local")
                 .expect("reload")
                 .settings
                 .homeboy_path
                 .as_deref(),
             Some("/old")
         );
-    });
+    }
 }
 
 #[test]
@@ -1555,7 +1586,8 @@ fn concurrent_runner_config_edit_survives_ssh_bootstrap_promotion() {
             },
             |path, _| {
                 homeboy_core::config::with_config_lock(|| {
-                    let patch = refreshed_runner_patch("lab-local", path)?;
+                    let patch =
+                        refreshed_runner_patch_in_roots(&ambient_roots(), "lab-local", path)?;
                     match merge(Some("lab-local"), &patch.to_string(), &[])? {
                         MergeOutput::Single(result) => Ok((result.updated_fields, None)),
                         MergeOutput::Bulk(_) => Ok((Vec::new(), None)),

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -823,7 +823,8 @@ fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
             dry_run: false,
         };
 
-        let (selected, exit_code) = refresh_homeboy_binary(options.clone()).expect("selection");
+        let (selected, exit_code) =
+            refresh_homeboy_binary_in_roots(&ambient_roots(), options.clone()).expect("selection");
         assert_eq!(exit_code, 0);
         assert_eq!(selected.updated_fields, ["env", "homeboy_path"]);
         assert_eq!(selected.selected_binary_path, binary.display().to_string());
@@ -852,7 +853,8 @@ fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
         assert_eq!(refreshed, "present");
         assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 2);
 
-        let (repeated, exit_code) = refresh_homeboy_binary(options).expect("repeat selection");
+        let (repeated, exit_code) =
+            refresh_homeboy_binary_in_roots(&ambient_roots(), options).expect("repeat selection");
         assert_eq!(exit_code, 0);
         assert_eq!(repeated.updated_fields, ["env", "homeboy_path"]);
         assert!(!repeated.daemon_refreshed);
@@ -1252,7 +1254,8 @@ fn select_without_source_rejects_implicit_downgrade_before_selection_or_reconnec
         };
 
         let (rejected, exit_code) =
-            refresh_homeboy_binary(options.clone()).expect("rejection output");
+            refresh_homeboy_binary_in_roots(&ambient_roots(), options.clone())
+                .expect("rejection output");
         assert_eq!(exit_code, 1);
         assert!(rejected
             .failure
@@ -1462,11 +1465,8 @@ fn ssh_bootstrap_select_promotes_without_materialized_source_sha() {
 
 #[test]
 fn ssh_bootstrap_transport_failure_leaves_config_unchanged() {
-    {
-        let context = test_support::HermeticTestContext::new();
-        let roots = context.path_roots();
-        crate::create_in_roots(
-            &roots,
+    test_support::with_isolated_home(|_| {
+        crate::create(
             r#"{"id":"lab-local","kind":"local","homeboy_path":"/old"}"#,
             false,
         )
@@ -1478,23 +1478,20 @@ fn ssh_bootstrap_transport_failure_leaves_config_unchanged() {
         );
         assert!(result.is_err());
         assert_eq!(
-            crate::load_in_roots(&roots, "lab-local")
+            crate::load("lab-local")
                 .expect("reload")
                 .settings
                 .homeboy_path
                 .as_deref(),
             Some("/old")
         );
-    }
+    });
 }
 
 #[test]
 fn ssh_bootstrap_identity_mismatch_leaves_config_unchanged() {
-    {
-        let context = test_support::HermeticTestContext::new();
-        let roots = context.path_roots();
-        crate::create_in_roots(
-            &roots,
+    test_support::with_isolated_home(|_| {
+        crate::create(
             r#"{"id":"lab-local","kind":"local","homeboy_path":"/old"}"#,
             false,
         )
@@ -1508,14 +1505,14 @@ fn ssh_bootstrap_identity_mismatch_leaves_config_unchanged() {
         );
         assert!(result.is_err());
         assert_eq!(
-            crate::load_in_roots(&roots, "lab-local")
+            crate::load("lab-local")
                 .expect("reload")
                 .settings
                 .homeboy_path
                 .as_deref(),
             Some("/old")
         );
-    }
+    });
 }
 
 #[test]
@@ -1563,7 +1560,8 @@ fn materialized_refresh_requires_an_immutable_binary_hash_and_path() {
 #[test]
 fn concurrent_runner_config_edit_survives_ssh_bootstrap_promotion() {
     test_support::with_isolated_home(|_| {
-        crate::create(r#"{"id":"lab-local","kind":"local","homeboy_path":"/old","env":{"OLD":"1"},"resources":{"dev_sync":{"old":true}}}"#, false).expect("runner");
+        crate::create(
+                        r#"{"id":"lab-local","kind":"local","homeboy_path":"/old","env":{"OLD":"1"},"resources":{"dev_sync":{"old":true}}}"#, false).expect("runner");
         let plan = ssh_bootstrap_plan();
         let (started_tx, started_rx) = std::sync::mpsc::channel();
         let (release_tx, release_rx) = std::sync::mpsc::channel();

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -1399,6 +1399,24 @@ fn resolve_default_lab_runner_from_candidates(
 }
 
 pub fn create(json_spec: &str, skip_existing: bool) -> Result<CreateOutput<Runner>> {
+    create_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        json_spec,
+        skip_existing,
+    )
+}
+
+/// [`create`] against an explicitly injected config root.
+///
+/// Existence checks and the persisted write both follow `roots`, so creating a
+/// runner in an injected root cannot observe or overwrite the ambient
+/// installation's registry (#14362).
+#[allow(dead_code)]
+pub fn create_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    json_spec: &str,
+    skip_existing: bool,
+) -> Result<CreateOutput<Runner>> {
     let raw = config::read_json_spec_to_string(json_spec)?;
     let value: Value = config::from_str(&raw)?;
 
@@ -1410,12 +1428,12 @@ pub fn create(json_spec: &str, skip_existing: bool) -> Result<CreateOutput<Runne
                 .and_then(Value::as_str)
                 .unwrap_or("unknown")
                 .to_string();
-            if skip_existing && load(&id).is_ok() {
+            if skip_existing && load_in_roots(roots, &id).is_ok() {
                 summary.record_skipped(id);
                 continue;
             }
 
-            match create_single_value(item.clone()) {
+            match create_single_value_in_roots(roots, item.clone()) {
                 Ok(result) => summary.record_created(result.id),
                 Err(err) => summary.record_error(id, err.message),
             }
@@ -1423,7 +1441,9 @@ pub fn create(json_spec: &str, skip_existing: bool) -> Result<CreateOutput<Runne
         return Ok(CreateOutput::Bulk(summary));
     }
 
-    Ok(CreateOutput::Single(create_single_value(value)?))
+    Ok(CreateOutput::Single(create_single_value_in_roots(
+        roots, value,
+    )?))
 }
 
 /// Inspect a legacy runner configuration without resolving or rendering values.
@@ -1526,6 +1546,58 @@ fn runner_secret_name(runner_id: &str, key: &str) -> String {
     format!("runner/{runner_id}/{key}")
 }
 
+/// [`merge`] against an explicitly injected config root.
+///
+/// Resolving the runner ambiently while merging into an injected root would
+/// read one installation's registry and write another's (#14362).
+#[allow(dead_code)]
+pub fn merge_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    id: Option<&str>,
+    json_spec: &str,
+    replace_fields: &[String],
+) -> Result<MergeOutput> {
+    let raw = config::read_json_spec_to_string(json_spec)?;
+    let parsed: Value = config::from_str(&raw)?;
+
+    if parsed.is_array() {
+        return Ok(MergeOutput::Bulk(config::merge_batch_from_json_in_root::<
+            Runner,
+        >(roots.config(), &raw)?));
+    }
+
+    let effective_id = id
+        .map(String::from)
+        .or_else(|| parsed.get("id").and_then(Value::as_str).map(String::from))
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "id",
+                "Provide runner ID as argument or in JSON body",
+                None,
+                None,
+            )
+        })?;
+
+    if let Ok(runner) = config::load_in_root::<Runner>(roots.config(), &effective_id) {
+        if runner.kind == RunnerKind::Local {
+            return Ok(MergeOutput::Single(config::merge_from_json_in_root::<
+                Runner,
+            >(
+                roots.config(),
+                Some(&effective_id),
+                &raw,
+                replace_fields,
+            )?));
+        }
+    }
+
+    Ok(MergeOutput::Single(merge_server_runner(
+        &effective_id,
+        parsed,
+        replace_fields,
+    )?))
+}
+
 pub fn merge(id: Option<&str>, json_spec: &str, replace_fields: &[String]) -> Result<MergeOutput> {
     let raw = config::read_json_spec_to_string(json_spec)?;
     let parsed: Value = config::from_str(&raw)?;
@@ -1601,7 +1673,10 @@ pub fn enable_server_runner(server_id: &str, patch: Value) -> Result<Runner> {
     Ok(runner_from_spec(server_id, spec))
 }
 
-fn create_single_value(value: Value) -> Result<CreateResult<Runner>> {
+fn create_single_value_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    value: Value,
+) -> Result<CreateResult<Runner>> {
     let id = value
         .get("id")
         .and_then(Value::as_str)
@@ -1615,7 +1690,7 @@ fn create_single_value(value: Value) -> Result<CreateResult<Runner>> {
 
     match runner.kind {
         RunnerKind::Local => {
-            if config::exists::<Runner>(&id) {
+            if config::exists_in_root::<Runner>(roots.config(), &id) {
                 return Err(Error::validation_invalid_argument(
                     "runner.id",
                     format!("runner '{}' already exists", id),
@@ -1624,7 +1699,7 @@ fn create_single_value(value: Value) -> Result<CreateResult<Runner>> {
                 ));
             }
             config::validate(&runner)?;
-            config::save(&runner)?;
+            config::save_in_root(roots.config(), &runner)?;
             Ok(CreateResult {
                 id: runner.id.clone(),
                 entity: runner,


### PR DESCRIPTION
## Summary
Roots the whole `homeboy_refresh` execution path — registry, status, session, exec, reconnect and promotion — so its tests isolate through injected `PathRoots` instead of the process-global home lock. Third slice of #14362, after #14367 (snapshot) and #14373 (prune).

## Measured (`homeboy_refresh`, 3 runs each)
| config | baseline `main` | this branch |
|---|---|---|
| default | 98.90s | **87.30 / 87.30 / 87.40s** |
| short probe timeouts | 23.08s | **12.34 / 14.52s** |

100 passed / 1 failed on both sides across three runs — the one failure is the pre-existing `part_a::materialize_failure_preserves_compiler_diagnostics_and_active_binary`. Parity also confirmed against baseline on connection (235/4), execution (243/1), workspace (355/4), lab_workspaces (44/2), generation_store (35/0).

## The finding that matters more than this PR
**`homeboy_refresh` is not slow because of the home lock.** A single test, `part_b::stale_session_refresh_blocker_starts_the_newly_selected_binary`, takes **87.47s on unmodified `main`** — essentially the entire module.

It is waiting on production timeouts, not on the lock. On stock `main`, with no code change at all:

```
HOMEBOY_READONLY_PROBE_TIMEOUT_SECONDS=1 HOMEBOY_RUNNER_PROBE_WAIT_SECONDS=1
```

takes that test from **87.47s to 10.92s**, and the module from **101.10s to 23.08s**.

So the two levers compound: capping probe timeouts is worth ~77% here, and rooting the tests is worth a further ~40% on top of that (23.08s to ~13s). The timeout lever is free and belongs in its own change; I did not include it here because it is a test-harness policy decision, not a refactor. It did **not** reproduce on workspace (153.86s vs 145.32s), connection (39.08 vs 37.08) or execution (42.77 vs 43.53) — this is specific to the refresh path.

## Ambient leaks fixed (correctness, not speed)
Rooted entry points were silently falling back to ambient resolution and discarding injected roots. The worst one: **refresh tests were reading the host machine's real promotion lease store**, so they failed with `RuntimePromotionContended ... operation "controller upgrade"` whenever the developer machine held a live lease. Now rooted:

- `create_in_roots`, `merge_in_roots`
- `refresh_homeboy_binary`, `plan_homeboy_binary_refresh`, `plan_runner_dev_sync`, `promote_verified_runner_binary` (now `with_config_lock_at`), `refresh_promotion_authorities`, `sync_extension_overlays`, `restore_runner_homeboy_path_if_selected`, `defer_reconnect_after_promotion_race`, `probe_reconnected_admission_readiness`
- `session_path`, `read_session_for_controller`, `read_session_for_status_until`, `read_session_or_live_peer`, `status`, `reconcile_status`, `status_for_admission`, `connect`, `disconnect_with_session`, `rotate_daemon_generation`, `active_jobs_before_daemon_replacement`
- `exec_with_status_snapshot` — it hardcoded `runner: None`, forcing `prepare_runner_process` to re-resolve ambiently
- `runtime_promotion::acquire_in_root` / `acquire_waiting_for_compatible_key_in_root`

Six ambient wrappers became dead once production stopped calling them and were deleted; their remaining callers were tests, which now pass roots explicitly.

## Not converted
`blocked_connect_preserves_successful_promotion_with_one_continuation` converted cleanly and passes in isolation, but flaked roughly 1 run in 3 under parallelism — it asserts an exact phase sequence that shifts with connect timing. Left on `with_isolated_home` rather than shipped flaky. Four SSH-bootstrap tests stay on the lock because `merge_server_runner` and the server registry are still ambient.

## AI Assistance
OpenAI GPT-5.6 Sol through OpenCode did the rooting across all four layers, used a temporary backtrace probe on `load_in_roots` to locate each ambient escape, and measured every claim against a baseline worktree. Chris Huber directed the work and remains responsible for acceptance.