### PR TITLE
Fix temp checkout Cargo target cleanup safety

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1208,6 +1208,32 @@ mod tests {
     }
 
     #[test]
+    fn registered_cleanup_artifacts_parse_preserves_global_placement() {
+        let matches = Cli::command_with_scoped_lab_args()
+            .try_get_matches_from([
+                "homeboy",
+                "cleanup",
+                "artifacts",
+                "--placement",
+                "local",
+                "--path",
+                "/tmp/homeboy-cleanup-fixture",
+            ])
+            .expect("cleanup artifacts accepts global placement after its subcommand");
+        let (cli, _) =
+            Cli::from_registered_arg_matches(&matches).expect("registered cleanup parse succeeds");
+
+        assert_eq!(cli.placement, Placement::Local);
+        assert!(matches!(
+            cli.command,
+            Commands::Cleanup(crate::commands::cleanup::CleanupArgs {
+                command: Some(crate::commands::cleanup::CleanupCommand::Artifacts(_)),
+                ..
+            })
+        ));
+    }
+
+    #[test]
     fn placement_exposes_explicit_lab_or_local_fallback() {
         let cli =
             Cli::try_parse_from(["homeboy", "bench", "example", "--placement", "lab-or-local"])

--- a/crates/homeboy-cli/src/command_contract/lab.rs
+++ b/crates/homeboy-cli/src/command_contract/lab.rs
@@ -176,18 +176,6 @@ fn scope_lab_cli_arguments_at_path(
                 command.arg(arg.clone().hide(false))
             }
         })
-    } else if path.iter().map(String::as_str).eq(["cleanup"]) {
-        // Cleanup is controller-owned, not Lab-portable. It still honors the
-        // shared explicit-local execution primitive for bounded synchronous apply.
-        command.arg(
-            lab_args
-                .iter()
-                .find(|arg| arg.get_id() == "placement")
-                .expect("global placement argument")
-                .clone()
-                .global(false)
-                .hide(false),
-        )
     } else {
         command
     };

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -1118,15 +1118,17 @@ fn collect_worktree_candidates(
             USAGE_MEASURED
         };
         let age_seconds = usage.age_seconds();
-        let effective_min_age_days = automatic_policy
+        let declaration_min_age_days = automatic_policy
             .map(|policy| {
                 declaration
                     .min_age_days
                     .unwrap_or(0)
                     .max(policy.min_age_days)
             })
-            .or_else(|| effective_min_age_days(options, &declaration));
-        if let Some(min_age_days) = effective_min_age_days {
+            .or(declaration.min_age_days);
+        if let Some(min_age_days) =
+            effective_min_age_days(options.min_age_days, declaration_min_age_days)
+        {
             if !pressure_eligible && !meets_age_gate(age_seconds, min_age_days) {
                 skipped.push(skip_row(
                     worktree,
@@ -1166,17 +1168,58 @@ fn collect_worktree_candidates(
     })
 }
 
-/// The strictest age floor in play: the caller's gate and the declaration
-/// owner's gate both have to pass.
+/// The caller's age gate can only make a declaration stricter; neither source
+/// may relax the other.
 fn effective_min_age_days(
-    options: &ArtifactCleanupOptions,
-    declaration: &ArtifactDeclaration,
+    caller_min_age_days: Option<u64>,
+    declaration_min_age_days: Option<u64>,
 ) -> Option<u64> {
-    match (options.min_age_days, declaration.min_age_days) {
+    match (caller_min_age_days, declaration_min_age_days) {
         (Some(left), Some(right)) => Some(left.max(right)),
         (Some(value), None) | (None, Some(value)) => Some(value),
         (None, None) => None,
     }
+}
+
+/// Apply the invocation's common eligibility rules after every candidate source
+/// has contributed. Temp artifacts are discovered outside a Git worktree scan,
+/// so filtering only during that scan left them outside the caller's age gate.
+fn retain_commonly_eligible_candidates(
+    candidates: &mut Vec<ArtifactCleanupCandidate>,
+    skipped: &mut Vec<ArtifactCleanupSkipped>,
+    options: &ArtifactCleanupOptions,
+    active: &ActiveWorktrees,
+) {
+    candidates.retain(|candidate| {
+        let liveness = active.liveness(Path::new(&candidate.worktree));
+        if candidate.declared_by == "self_temp_root"
+            && (candidate.liveness != LIVENESS_IDLE || liveness != LIVENESS_IDLE)
+        {
+            let reason = if liveness == LIVENESS_ACTIVE_BUILD
+                || candidate.liveness == LIVENESS_ACTIVE_BUILD
+            {
+                format!(
+                    "active_build: a Cargo build holds the target lock in {}",
+                    candidate.worktree
+                )
+            } else {
+                "checkout is active or its liveness could not be determined".to_string()
+            };
+            skipped.push(candidate_skip_row(candidate, reason));
+            return false;
+        }
+        if let Some(min_age_days) = options.min_age_days {
+            if candidate.pressure_eligible || meets_age_gate(candidate.age_seconds, min_age_days) {
+                return true;
+            }
+            skipped.push(candidate_skip_row(
+                candidate,
+                format!("artifact was modified within the {min_age_days}-day age gate"),
+            ));
+            return false;
+        }
+        true
+    });
 }
 
 /// An artifact whose age cannot be read fails the gate. An unreadable timestamp
@@ -1284,6 +1327,7 @@ fn cleanup_artifacts_in_worktrees(
             candidates.push(candidate);
         }
     }
+    retain_commonly_eligible_candidates(&mut candidates, &mut skipped, options, &active);
 
     // Several workspace roots can resolve to the same linked worktree. Count
     // each canonical artifact once before the global largest-first cap.
@@ -1728,15 +1772,26 @@ fn apply_artifact_candidate_with_before_remove(
         .then(|| filesystem_available_bytes(path.parent().unwrap_or(path)))
         .flatten();
     before_remove();
-    // Git and controller probes above can take long enough for a Cargo build to
-    // start after the initial liveness check.
-    if candidate.kind == "rust_target"
-        && active.liveness(Path::new(&candidate.worktree)) == LIVENESS_ACTIVE_BUILD
-    {
-        return ArtifactCleanupCandidateApplyOutcome::Skipped(format!(
-            "active_build: a Cargo build holds the target lock in {} — deleting it now would be regenerated immediately",
-            candidate.worktree
-        ));
+    // Git and controller probes above can take long enough for a checkout to
+    // become active. Recheck every candidate that was idle at discovery: temp
+    // Homeboy targets are not `rust_target` declarations but use Cargo's lock
+    // protocol just the same.
+    if candidate.kind == "rust_target" || candidate.liveness == LIVENESS_IDLE {
+        match active.liveness(Path::new(&candidate.worktree)) {
+            LIVENESS_IDLE => {}
+            LIVENESS_ACTIVE_BUILD => {
+                return ArtifactCleanupCandidateApplyOutcome::Skipped(format!(
+                    "active_build: a Cargo build holds the target lock in {} — deleting it now would be regenerated immediately",
+                    candidate.worktree
+                ));
+            }
+            _ => {
+                return ArtifactCleanupCandidateApplyOutcome::Skipped(
+                    "checkout became active or its liveness became unknown before removal"
+                        .to_string(),
+                );
+            }
+        }
     }
     match remove_artifact_path(path) {
         Ok(()) => ArtifactCleanupCandidateApplyOutcome::Applied(Box::new(applied_row(
@@ -3166,6 +3221,51 @@ mod tests {
         });
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn apply_rechecks_active_build_for_an_opted_in_active_rust_target() {
+        crate::test_support::with_isolated_home(|_| {
+            let repo = git_repo();
+            let lock = repo.path().join("target/debug/.cargo-lock");
+            write_file(&repo.path().join("target/debug/app"), "artifact");
+            write_file(&lock, "");
+            let scan = collect_worktree_candidates(
+                &WorktreeInfo {
+                    path: repo.path().to_path_buf(),
+                },
+                &ArtifactCleanupOptions {
+                    include_active_worktrees: true,
+                    ..Default::default()
+                },
+                &ActiveWorktrees::default(),
+                &ProtectedControllerExecutables::default(),
+                None,
+                None,
+                None,
+            )
+            .expect("candidate discovery");
+            let mut candidate = scan
+                .candidates
+                .into_iter()
+                .find(|candidate| candidate.relative_path == "target")
+                .expect("target candidate");
+            // The candidate was admitted with active-worktree cleanup opted in.
+            // A build beginning afterward must still veto the final removal.
+            candidate.liveness = LIVENESS_ACTIVE.to_string();
+            let _held = active_build_lock_tests::hold(&lock);
+
+            let outcome =
+                apply_artifact_candidate(&candidate, &ActiveWorktrees::default(), "test-run");
+
+            assert!(matches!(
+                outcome,
+                ArtifactCleanupCandidateApplyOutcome::Skipped(reason)
+                    if reason.starts_with("active_build:")
+            ));
+            assert!(repo.path().join("target").exists());
+        });
+    }
+
     #[test]
     fn apply_fails_closed_when_git_can_no_longer_be_inspected() {
         crate::test_support::with_isolated_home(|_| {
@@ -3613,6 +3713,129 @@ mod tests {
             fs::read_to_string(checkout.join("src/lib.rs")).expect("read source"),
             "changed source"
         );
+    }
+
+    #[test]
+    fn temp_homeboy_checkout_target_honors_the_caller_age_gate() {
+        let repo = git_repo();
+        let temp_root = TempDir::new().expect("temp root");
+        let checkout = temp_homeboy_checkout(temp_root.path(), "homeboy-main-14394-age-gate");
+        let target = checkout.join("target/debug/homeboy");
+        write_file(&target, "binary");
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: true,
+            temp_roots: vec![temp_root.path().to_path_buf()],
+            min_age_days: Some(1),
+            ..Default::default()
+        })
+        .expect("apply cleanup");
+
+        assert!(target.exists(), "a recent temp target must be retained");
+        assert!(output
+            .candidates
+            .iter()
+            .all(|candidate| candidate.path != checkout.join("target").to_string_lossy()));
+        assert!(output.skipped.iter().any(|row| {
+            row.path == checkout.join("target").to_string_lossy()
+                && row.reason.contains("1-day age gate")
+        }));
+    }
+
+    #[test]
+    fn aged_idle_temp_homeboy_checkout_target_is_removed_after_the_caller_age_gate() {
+        let repo = git_repo();
+        let temp_root = TempDir::new().expect("temp root");
+        let checkout = temp_homeboy_checkout(temp_root.path(), "homeboy-main-14394-aged-target");
+        let target = checkout.join("target");
+        let binary = target.join("debug/homeboy");
+        let debug = target.join("debug");
+        write_file(&binary, "binary");
+        let old = SystemTime::now() - Duration::from_secs(2 * SECONDS_PER_DAY);
+        for path in [&target, &debug, &binary] {
+            fs::File::open(path)
+                .expect("open target entry")
+                .set_times(fs::FileTimes::new().set_modified(old))
+                .expect("age target entry");
+        }
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: true,
+            temp_roots: vec![temp_root.path().to_path_buf()],
+            min_age_days: Some(1),
+            ..Default::default()
+        })
+        .expect("apply cleanup");
+
+        assert!(!target.exists(), "an aged idle temp target must be removed");
+        assert!(output
+            .applied
+            .iter()
+            .any(|row| row.path == target.to_string_lossy()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temp_homeboy_checkout_target_with_a_held_lock_is_not_eligible_or_removed() {
+        let repo = git_repo();
+        let temp_root = TempDir::new().expect("temp root");
+        let checkout = temp_homeboy_checkout(temp_root.path(), "homeboy-main-14394-held-lock");
+        let target = checkout.join("target");
+        let lock = target.join("debug/.cargo-lock");
+        write_file(&target.join("debug/homeboy"), "binary");
+        write_file(&lock, "");
+        let _held = active_build_lock_tests::hold(&lock);
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: true,
+            temp_roots: vec![temp_root.path().to_path_buf()],
+            ..Default::default()
+        })
+        .expect("apply cleanup");
+
+        assert!(target.exists(), "a locked temp target must survive cleanup");
+        assert!(output
+            .skipped
+            .iter()
+            .any(|row| row.path == target.to_string_lossy()
+                && row.reason.starts_with("active_build:")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_rechecks_a_late_cargo_lock_for_temp_homeboy_checkout_target() {
+        let temp_root = TempDir::new().expect("temp root");
+        let checkout = temp_homeboy_checkout(temp_root.path(), "homeboy-main-14394-late-lock");
+        let target = checkout.join("target");
+        let lock = target.join("debug/.cargo-lock");
+        write_file(&target.join("debug/homeboy"), "binary");
+        write_file(&lock, "");
+        let candidate = self_temp_artifact_candidates(&ArtifactCleanupOptions {
+            temp_roots: vec![temp_root.path().to_path_buf()],
+            ..Default::default()
+        })
+        .expect("candidate discovery")
+        .into_iter()
+        .find(|candidate| candidate.kind == "temp_homeboy_checkout_target")
+        .expect("temp target candidate");
+        let mut held = None;
+
+        let outcome = apply_artifact_candidate_with_before_remove(
+            &candidate,
+            &ActiveWorktrees::default(),
+            "test-run",
+            || held = Some(active_build_lock_tests::hold(&lock)),
+        );
+
+        assert!(matches!(
+            outcome,
+            ArtifactCleanupCandidateApplyOutcome::Skipped(reason) if reason.starts_with("active_build:")
+        ));
+        assert!(target.exists(), "a late lock must veto deletion");
+        drop(held);
     }
 
     #[test]
@@ -4792,52 +5015,18 @@ mod tests {
     }
 
     #[test]
-    fn declaration_age_floor_composes_with_the_caller_gate() {
-        let declaration = ArtifactDeclaration {
-            relative_path: "deps".to_string(),
-            kind: "dependency-tree".to_string(),
-            declared_by: "extension:fixture".to_string(),
-            category: "dependencies".to_string(),
-            reconstructable: true,
-            rehydrate_command: None,
-            min_age_days: Some(3),
-            liveness_protected: true,
-        };
-
-        assert_eq!(
-            effective_min_age_days(&ArtifactCleanupOptions::default(), &declaration),
-            Some(3)
-        );
-        assert_eq!(
-            effective_min_age_days(
-                &ArtifactCleanupOptions {
-                    min_age_days: Some(9),
-                    ..Default::default()
-                },
-                &declaration,
-            ),
-            Some(9),
-            "the stricter of the two gates wins"
-        );
-        assert_eq!(
-            effective_min_age_days(
-                &ArtifactCleanupOptions {
-                    min_age_days: Some(1),
-                    ..Default::default()
-                },
-                &declaration,
-            ),
-            Some(3),
-            "a looser caller gate cannot relax a declared floor"
-        );
-    }
-
-    #[test]
     fn unreadable_artifact_age_fails_the_gate() {
         assert!(!meets_age_gate(None, 1));
         assert!(!meets_age_gate(Some(SECONDS_PER_DAY - 1), 1));
         assert!(meets_age_gate(Some(SECONDS_PER_DAY), 1));
         assert!(meets_age_gate(Some(0), 0));
+    }
+
+    #[test]
+    fn declaration_age_floor_composes_with_the_caller_gate() {
+        assert_eq!(effective_min_age_days(None, Some(3)), Some(3));
+        assert_eq!(effective_min_age_days(Some(9), Some(3)), Some(9));
+        assert_eq!(effective_min_age_days(Some(1), Some(3)), Some(3));
     }
 
     #[test]
@@ -5047,6 +5236,32 @@ mod tests {
 
             assert!(output.applied.iter().any(|row| row.relative_path == "deps"));
             assert!(!repo.path().join("deps").exists());
+        });
+    }
+
+    #[test]
+    fn opted_in_active_worktree_still_preserves_rust_target() {
+        crate::test_support::with_isolated_home(|_| {
+            let repo = repo_with_ignored_artifacts();
+            let target = repo.path().join("target");
+            write_file(&target.join("debug/app"), "artifact");
+            register_active_task_worktree(repo.path());
+
+            let output = cleanup_artifacts(ArtifactCleanupOptions {
+                path: Some(repo.path().to_path_buf()),
+                apply: true,
+                include_active_worktrees: true,
+                ..Default::default()
+            })
+            .expect("apply cleanup");
+
+            assert!(
+                target.exists(),
+                "an active worktree's Rust target must survive"
+            );
+            assert!(output.skipped.iter().any(|row| {
+                row.relative_path == "target" && row.reason.contains("active task worktree")
+            }));
         });
     }
 

--- a/crates/homeboy-core/src/cleanup/self_artifacts.rs
+++ b/crates/homeboy-core/src/cleanup/self_artifacts.rs
@@ -13,9 +13,9 @@ use std::path::{Path, PathBuf};
 use crate::{git, Error, Result};
 
 use super::{
-    git_safety, has_tracked_changes_under, path_usage, ArtifactCleanupCandidate,
-    ArtifactCleanupOptions, SELF_TEMP_ARTIFACT_CATEGORY, SELF_TEMP_ARTIFACT_LIVENESS,
-    SELF_TEMP_ARTIFACT_READINESS,
+    cargo_target_lock_is_held, git_safety, has_tracked_changes_under, path_usage,
+    ArtifactCleanupCandidate, ArtifactCleanupOptions, LIVENESS_ACTIVE_BUILD,
+    SELF_TEMP_ARTIFACT_CATEGORY, SELF_TEMP_ARTIFACT_LIVENESS, SELF_TEMP_ARTIFACT_READINESS,
 };
 
 pub(super) fn homeboy_source_checkout() -> Result<PathBuf> {
@@ -329,7 +329,13 @@ fn temp_homeboy_checkout_target_candidate(
         allocated_bytes: usage.allocated_bytes,
         usage_measurement: super::USAGE_MEASURED.to_string(),
         age_seconds: usage.age_seconds(),
-        liveness: SELF_TEMP_ARTIFACT_LIVENESS.to_string(),
+        // A temp checkout is not in the task-worktree registry, but its Cargo
+        // target still has the same live-build lock as any other checkout.
+        liveness: if cargo_target_lock_is_held(&target) {
+            LIVENESS_ACTIVE_BUILD.to_string()
+        } else {
+            SELF_TEMP_ARTIFACT_LIVENESS.to_string()
+        },
         readiness: SELF_TEMP_ARTIFACT_READINESS.to_string(),
         rehydrate_command: None,
         source_dirty: safety.source_dirty,


### PR DESCRIPTION
## Summary
- apply the caller age floor and active-build gate to temporary Homeboy checkout targets
- recheck Cargo lock liveness at deletion time and preserve active worktree targets
- keep cleanup placement parsing global and cover the safety paths

Closes #14394

## Verification
- `cargo test -p homeboy-core cleanup::tests::<six focused safety tests> -- --exact`
- `cargo test -p homeboy-cli registered_cleanup_artifacts_parse_preserves_global_placement`
- `cargo fmt --check`
- read-only local `cleanup artifacts` dry run with `--min-age-days 1 --placement local`

## AI assistance
OpenAI gpt-6-astra via OpenCode was used for delegated implementation, review, and focused testing at Chris Huber's direction.