### PR TITLE
fix(worktree): bound reconciliation authority

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -96,6 +96,7 @@ pub trait RunnerContinuationProvider: Send + Sync {
         _runner_id: &str,
         _workspace: WorkspaceIdentity,
         _lifecycle_revision: u64,
+        _deadline: std::time::Instant,
     ) -> Result<WorkspaceClaim> {
         Err(Error::validation_invalid_argument(
             "workspace_claim",
@@ -105,11 +106,21 @@ pub trait RunnerContinuationProvider: Send + Sync {
         ))
     }
 
-    fn validate_workspace_claim(&self, _runner_id: &str, _claim: &WorkspaceClaim) -> Result<bool> {
+    fn validate_workspace_claim(
+        &self,
+        _runner_id: &str,
+        _claim: &WorkspaceClaim,
+        _deadline: std::time::Instant,
+    ) -> Result<bool> {
         Ok(false)
     }
 
-    fn release_workspace_claim(&self, _runner_id: &str, _claim: &WorkspaceClaim) -> Result<()> {
+    fn release_workspace_claim(
+        &self,
+        _runner_id: &str,
+        _claim: &WorkspaceClaim,
+        _deadline: std::time::Instant,
+    ) -> Result<()> {
         Err(Error::validation_invalid_argument(
             "workspace_claim",
             "runner does not advertise workspace claim capability",

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -289,6 +289,67 @@ fn configured_terminal_authorities() -> std::result::Result<Vec<String>, String>
     Ok(authorities)
 }
 
+/// Validate only durable/configured authority identity. This deliberately avoids
+/// live runner probes; bounded claim acquisition supplies that liveness fence.
+pub fn cached_terminal_workspace_authority(
+    record: &TaskWorktreeRecord,
+) -> std::result::Result<Option<Box<TerminalWorkspaceAuthorityProof>>, String> {
+    let Some(proof) = record.terminal_workspace_authority.as_ref() else {
+        return Ok(None);
+    };
+    let runner_ids = with_runner_continuation(|provider| {
+        let ids = provider.terminal_workspace_authority_runner_ids()?;
+        if !ids.is_empty() && !provider.supports_terminal_workspace_authority() {
+            return Err(Error::validation_invalid_argument(
+                "terminal_workspace_authority",
+                "configured runner does not support terminal workspace authority",
+                None,
+                None,
+            ));
+        }
+        if ids.iter().any(|id| {
+            id.trim().is_empty()
+                || id == "controller"
+                || !provider.runner_authority(id).is_configured()
+        }) {
+            return Err(Error::validation_invalid_argument(
+                "terminal_workspace_authority",
+                "configured terminal workspace authority is missing",
+                None,
+                None,
+            ));
+        }
+        Ok(ids)
+    })
+    .map_err(|error| error.message)?;
+    let mut authority_set = vec!["controller".to_string()];
+    authority_set.extend(runner_ids);
+    authority_set.sort();
+    // A cached remote receipt cannot establish that its accepted runner job is
+    // still terminal without the same bounded reconciliation used at issuance.
+    // Keep local-only proofs usable; fail closed for remote authority until a
+    // deadline-aware refresh protocol exists.
+    if authority_set.len() != 1 {
+        return Ok(None);
+    }
+    Ok((proof.exact_for(record, record.run_id.as_deref())
+        && proof.authority_set == authority_set
+        && proof.authority_set_fingerprint == authority_set_fingerprint(&authority_set))
+    .then(|| Box::new(proof.clone())))
+}
+
+/// Bounded worktree inventory currently supports controller-local evidence
+/// only. A remote authority needs a durable release receipt that survives the
+/// page deadline before it can participate in destructive reconciliation.
+pub fn bounded_inventory_requires_remote_claims() -> bool {
+    with_runner_continuation(|provider| {
+        let claims = provider.workspace_claim_runner_ids()?;
+        let terminal = provider.terminal_workspace_authority_runner_ids()?;
+        Ok::<bool, Error>(!claims.is_empty() || !terminal.is_empty())
+    })
+    .unwrap_or(true)
+}
+
 /// The complete authority set for a workspace mutation. Each remote component
 /// has its own opaque token; callers must validate and release every component.
 #[derive(Debug, Clone)]
@@ -476,7 +537,11 @@ impl CompositeWorkspaceClaimAcquisitionGuard {
         }
     }
 
-    fn fail(mut self, mut primary: Error) -> CompositeWorkspaceClaimAcquisitionFailure {
+    fn fail(
+        mut self,
+        mut primary: Error,
+        deadline: std::time::Instant,
+    ) -> CompositeWorkspaceClaimAcquisitionFailure {
         let mut rollback_failures = Vec::new();
         if let Err(error) = release_local_workspace_claim(&self.local) {
             rollback_failures.push(CompositeWorkspaceClaimRollbackFailure {
@@ -493,7 +558,7 @@ impl CompositeWorkspaceClaimAcquisitionGuard {
             .all(|failure| failure.component != "local");
         for component in &mut self.runners {
             if let Err(error) = with_runner_continuation(|provider| {
-                provider.release_workspace_claim(&component.runner_id, &component.claim)
+                provider.release_workspace_claim(&component.runner_id, &component.claim, deadline)
             }) {
                 rollback_failures.push(CompositeWorkspaceClaimRollbackFailure {
                     component: component.runner_id.clone(),
@@ -538,9 +603,27 @@ pub fn acquire_composite_workspace_claim(
     workspace: WorkspaceIdentity,
     generation: u64,
 ) -> std::result::Result<CompositeWorkspaceClaim, CompositeWorkspaceClaimAcquisitionFailure> {
-    // Recovery is bounded and does not let an unrelated unreachable authority
-    // prevent a distinct workspace from being reconciled.
-    let _ = retry_pending_composite_workspace_cleanups(32);
+    acquire_composite_workspace_claim_until(
+        workspace,
+        generation,
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+    )
+}
+
+#[expect(
+    clippy::result_large_err,
+    reason = "failure retains all acquired authority receipts for deterministic rollback"
+)]
+pub fn acquire_composite_workspace_claim_until(
+    workspace: WorkspaceIdentity,
+    generation: u64,
+    deadline: std::time::Instant,
+) -> std::result::Result<CompositeWorkspaceClaim, CompositeWorkspaceClaimAcquisitionFailure> {
+    if std::time::Instant::now() >= deadline {
+        return Err(CompositeWorkspaceClaimAcquisitionFailure::from(
+            composite_error("workspace claim acquisition deadline exhausted", Vec::new()),
+        ));
+    }
     if let Some(status) = composite_acquisition_intent_for_workspace(&workspace) {
         let mut failure = CompositeWorkspaceClaimAcquisitionFailure::from(composite_error(
             "workspace has unresolved composite acquisition intent",
@@ -573,19 +656,20 @@ pub fn acquire_composite_workspace_claim(
         requested_ttl_ms: LOCAL_WORKSPACE_CLAIM_TTL_MS,
         state: "acquiring".into(),
     };
-    if let Err(error) =
-        homeboy_core::config::with_config_lock(|| write_composite_acquisition_intent(&intent))
-    {
+    if let Err(error) = homeboy_core::config::with_config_lock_until(deadline, || {
+        write_composite_acquisition_intent(&intent)
+    }) {
         return Err(CompositeWorkspaceClaimAcquisitionFailure::from(error));
     }
-    match acquire_composite_workspace_claim_unrecovered(workspace, generation) {
+    match acquire_composite_workspace_claim_unrecovered(workspace, generation, deadline) {
         Ok(claim) => {
             let mut active = intent;
             active.state = "active".into();
-            if let Err(error) = homeboy_core::config::with_config_lock(|| {
+            if let Err(error) = homeboy_core::config::with_config_lock_until(deadline, || {
                 write_composite_acquisition_intent(&active)
             }) {
-                let status = persist_and_retry_composite_workspace_cleanup(claim, &error);
+                let status =
+                    persist_and_retry_composite_workspace_cleanup_until(claim, &error, deadline);
                 let mut failure = CompositeWorkspaceClaimAcquisitionFailure::from(error);
                 failure.primary.retryable = Some(true);
                 failure.primary.details["workspace_claim_composite_cleanup"] = serde_json::json!({
@@ -598,8 +682,11 @@ pub fn acquire_composite_workspace_claim(
         }
         Err(mut failure) => {
             if let Some(cleanup) = failure.cleanup.take() {
-                let status =
-                    persist_and_retry_composite_workspace_cleanup(cleanup, &failure.primary);
+                let status = persist_and_retry_composite_workspace_cleanup_until(
+                    cleanup,
+                    &failure.primary,
+                    deadline,
+                );
                 failure.primary.retryable = Some(true);
                 failure.primary.details["workspace_claim_composite_cleanup"] = serde_json::json!({
                     "status": status.public_summary(),
@@ -608,7 +695,7 @@ pub fn acquire_composite_workspace_claim(
             } else {
                 // Every acquired component was released, so the intent is no
                 // longer a crash-recovery obligation.
-                let _ = homeboy_core::config::with_config_lock(|| {
+                let _ = homeboy_core::config::with_config_lock_until(deadline, || {
                     remove_composite_acquisition_intent(&intent.workspace)
                 });
             }
@@ -624,6 +711,7 @@ pub fn acquire_composite_workspace_claim(
 fn acquire_composite_workspace_claim_unrecovered(
     workspace: WorkspaceIdentity,
     generation: u64,
+    deadline: std::time::Instant,
 ) -> std::result::Result<CompositeWorkspaceClaim, CompositeWorkspaceClaimAcquisitionFailure> {
     workspace.verify()?;
     let local = acquire_local_workspace_claim(workspace.clone(), generation)?;
@@ -632,42 +720,51 @@ fn acquire_composite_workspace_claim_unrecovered(
     let runner_ids =
         match with_runner_continuation(|provider| provider.workspace_claim_runner_ids()) {
             Ok(runner_ids) => runner_ids,
-            Err(error) => return Err(guard.fail(error)),
+            Err(error) => return Err(guard.fail(error, deadline)),
         };
     let mut unique_runner_ids = std::collections::BTreeSet::new();
     for runner_id in &runner_ids {
         if runner_id.trim().is_empty() || runner_id != runner_id.trim() || runner_id == "controller"
         {
-            return Err(guard.fail(Error::validation_invalid_argument(
-                "workspace_claim_runner_ids",
-                "configured workspace claim runner id is malformed",
-                Some(runner_id.clone()),
-                None,
-            )));
+            return Err(guard.fail(
+                Error::validation_invalid_argument(
+                    "workspace_claim_runner_ids",
+                    "configured workspace claim runner id is malformed",
+                    Some(runner_id.clone()),
+                    None,
+                ),
+                deadline,
+            ));
         }
         if !unique_runner_ids.insert(runner_id) {
-            return Err(guard.fail(Error::validation_invalid_argument(
-                "workspace_claim_runner_ids",
-                "configured workspace claim runner ids are not unique",
-                Some(runner_id.clone()),
-                None,
-            )));
+            return Err(guard.fail(
+                Error::validation_invalid_argument(
+                    "workspace_claim_runner_ids",
+                    "configured workspace claim runner ids are not unique",
+                    Some(runner_id.clone()),
+                    None,
+                ),
+                deadline,
+            ));
         }
     }
     if !runner_ids.is_empty()
         && !with_runner_continuation(|provider| provider.supports_workspace_claims())
     {
-        return Err(guard.fail(composite_error(
-            "workspace claim provider does not support configured remote authorities",
-            Vec::new(),
-        )));
+        return Err(guard.fail(
+            composite_error(
+                "workspace claim provider does not support configured remote authorities",
+                Vec::new(),
+            ),
+            deadline,
+        ));
     }
     for runner_id in runner_ids {
         let acquired = match with_runner_continuation(|provider| {
-            provider.acquire_workspace_claim(&runner_id, workspace.clone(), generation)
+            provider.acquire_workspace_claim(&runner_id, workspace.clone(), generation, deadline)
         }) {
             Ok(claim) => claim,
-            Err(error) => return Err(guard.fail(error)),
+            Err(error) => return Err(guard.fail(error, deadline)),
         };
         match acquired {
             claim if claim.workspace == workspace => {
@@ -678,12 +775,15 @@ fn acquire_composite_workspace_claim_unrecovered(
                 });
             }
             _ => {
-                return Err(guard.fail(Error::validation_invalid_argument(
-                    "workspace_claim",
-                    "runner returned a workspace claim for another workspace",
-                    Some(runner_id),
-                    None,
-                )));
+                return Err(guard.fail(
+                    Error::validation_invalid_argument(
+                        "workspace_claim",
+                        "runner returned a workspace claim for another workspace",
+                        Some(runner_id),
+                        None,
+                    ),
+                    deadline,
+                ));
             }
         }
     }
@@ -708,6 +808,16 @@ pub fn composite_workspace_claim_ready_to_commit(claim: &CompositeWorkspaceClaim
 }
 
 pub fn validate_composite_workspace_claim(claim: &CompositeWorkspaceClaim) -> Result<bool> {
+    validate_composite_workspace_claim_until(
+        claim,
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+    )
+}
+
+pub fn validate_composite_workspace_claim_until(
+    claim: &CompositeWorkspaceClaim,
+    deadline: std::time::Instant,
+) -> Result<bool> {
     claim.workspace.verify()?;
     if claim.local.workspace != claim.workspace || !validate_local_workspace_claim(&claim.local)? {
         return Ok(false);
@@ -716,7 +826,7 @@ pub fn validate_composite_workspace_claim(claim: &CompositeWorkspaceClaim) -> Re
         if component.runner_id.trim().is_empty()
             || component.claim.workspace != claim.workspace
             || !with_runner_continuation(|provider| {
-                provider.validate_workspace_claim(&component.runner_id, &component.claim)
+                provider.validate_workspace_claim(&component.runner_id, &component.claim, deadline)
             })?
         {
             return Ok(false);
@@ -733,6 +843,16 @@ pub enum CompositeWorkspaceClaimRelease {
 pub fn release_composite_workspace_claim(
     claim: &mut CompositeWorkspaceClaim,
 ) -> Result<CompositeWorkspaceClaimRelease> {
+    release_composite_workspace_claim_until(
+        claim,
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+    )
+}
+
+pub fn release_composite_workspace_claim_until(
+    claim: &mut CompositeWorkspaceClaim,
+    deadline: std::time::Instant,
+) -> Result<CompositeWorkspaceClaimRelease> {
     let mut failures = Vec::new();
     // Release the primary inventory authority first; retries skip evidence of a
     // successful release and fan out only to unresolved remote components.
@@ -747,7 +867,7 @@ pub fn release_composite_workspace_claim(
             continue;
         }
         if let Err(error) = with_runner_continuation(|provider| {
-            provider.release_workspace_claim(&component.runner_id, &component.claim)
+            provider.release_workspace_claim(&component.runner_id, &component.claim, deadline)
         }) {
             failures.push(format!("{}: {}", component.runner_id, error.message));
         } else {
@@ -755,7 +875,7 @@ pub fn release_composite_workspace_claim(
         }
     }
     if failures.is_empty() {
-        homeboy_core::config::with_config_lock(|| {
+        homeboy_core::config::with_config_lock_until(deadline, || {
             remove_composite_acquisition_intent(&claim.workspace)
         })?;
         Ok(CompositeWorkspaceClaimRelease::Released)
@@ -823,6 +943,53 @@ pub fn persist_and_retry_composite_workspace_cleanup(
             failures: vec![error.message],
         }
     })
+}
+
+/// Persist a cleanup receipt while respecting a caller-owned operation budget.
+/// An expired apply page leaves the receipt for the normal recovery worker
+/// rather than starting a fresh remote release window.
+pub fn persist_and_retry_composite_workspace_cleanup_until(
+    claim: CompositeWorkspaceClaim,
+    error: &Error,
+    deadline: std::time::Instant,
+) -> CompositeWorkspaceCleanupStatus {
+    let pending = PendingCompositeWorkspaceCleanup {
+        schema: PENDING_COMPOSITE_WORKSPACE_CLEANUP_SCHEMA.into(),
+        recovery_id: uuid::Uuid::new_v4().to_string(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        workspace: claim.workspace,
+        generation: claim.generation,
+        local: claim.local,
+        local_released: claim.local_released,
+        runners: claim
+            .runners
+            .into_iter()
+            .map(|component| PendingCompositeWorkspaceCleanupComponent {
+                runner_id: component.runner_id,
+                claim: component.claim,
+                released: component.released,
+            })
+            .collect(),
+        attempt_count: 0,
+        last_error: PendingCompositeWorkspaceCleanupError {
+            code: error.code.as_str().into(),
+            message: error.message.clone(),
+        },
+    };
+    let recovery_id = pending.recovery_id.clone();
+    match homeboy_core::config::with_config_lock_until(deadline, || {
+        write_pending_composite_cleanup(&pending)
+    }) {
+        Ok(()) => CompositeWorkspaceCleanupStatus::Pending {
+            recovery_id,
+            attempt_count: 0,
+            failures: vec!["reconciliation deadline exhausted before release".into()],
+        },
+        Err(error) => CompositeWorkspaceCleanupStatus::Quarantined {
+            recovery_id,
+            reason: format!("could not persist cleanup receipt: {}", error.message),
+        },
+    }
 }
 
 /// Explicit lifecycle recovery API. Every pending receipt is replayed at most
@@ -1418,6 +1585,7 @@ mod tests {
             runner_id: &str,
             workspace: WorkspaceIdentity,
             _lifecycle_revision: u64,
+            _deadline: std::time::Instant,
         ) -> Result<WorkspaceClaim> {
             if self.fail_acquire_for.as_deref() == Some(runner_id)
                 && workspace.locator == "workspace-claim-rollback"
@@ -1433,7 +1601,12 @@ mod tests {
             Ok(Self::claim(workspace, runner_id))
         }
 
-        fn release_workspace_claim(&self, runner_id: &str, _claim: &WorkspaceClaim) -> Result<()> {
+        fn release_workspace_claim(
+            &self,
+            runner_id: &str,
+            _claim: &WorkspaceClaim,
+            _deadline: std::time::Instant,
+        ) -> Result<()> {
             self.released
                 .lock()
                 .expect("release log")
@@ -1536,6 +1709,48 @@ mod tests {
             commit_budget_ms(10_000, [310_000, 12_500].into_iter()),
             1_500
         );
+    }
+
+    #[test]
+    fn cached_terminal_authority_refuses_a_stale_authority_set_fingerprint() {
+        let workspace = workspace();
+        let record = TaskWorktreeRecord {
+            id: "fixture@task".into(),
+            component_id: "fixture".into(),
+            source_checkout: "/tmp/source".into(),
+            worktree_path: "/tmp/worktree".into(),
+            branch: "task".into(),
+            base_ref: "HEAD".into(),
+            workspace_identity: Some(workspace.clone()),
+            task_url: None,
+            run_id: None,
+            cleanup_policy: homeboy_core::worktree::CleanupPolicy::RemoveWhenSafe,
+            terminal_disposition: Some("succeeded".into()),
+            branch_cleanup_intent: homeboy_core::worktree::BranchCleanupIntent::DeleteWhenMerged,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            state: homeboy_core::worktree::TaskWorktreeState::Active,
+            lifecycle_revision: 0,
+            terminal_workspace_authority: Some(TerminalWorkspaceAuthorityProof {
+                schema: TERMINAL_WORKSPACE_AUTHORITY_SCHEMA.into(),
+                capability: TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY.into(),
+                capability_version: 1,
+                workspace,
+                task_worktree_id: "fixture@task".into(),
+                manifest_revision: 0,
+                run_id: None,
+                controller_state: "Succeeded".into(),
+                controller_version: 0,
+                accepted_runner_id: None,
+                accepted_runner_job_id: None,
+                authority_set: vec!["retired-runner".into()],
+                authority_set_fingerprint: authority_set_fingerprint(&["retired-runner".into()]),
+                observations: Vec::new(),
+                issued_evidence: Vec::new(),
+            }),
+        };
+        assert!(cached_terminal_workspace_authority(&record)
+            .expect("local current-authority validation")
+            .is_none());
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1988,7 +1988,10 @@ fn cleanup_inventory_with_deadline(
             &args,
             deadline,
             CleanupCategoryCommandOverrides::default(),
-            || repo_artifacts_category(apply, deadline).map(|category| vec![category]),
+            || {
+                repo_artifacts_category(apply, cleanup_category_action_deadline(deadline))
+                    .map(|category| vec![category])
+            },
         );
     }
 
@@ -2001,11 +2004,26 @@ fn cleanup_inventory_with_deadline(
             deadline,
             CleanupCategoryCommandOverrides::default(),
             || {
-                let output = worktree::cleanup(WorktreeCleanupOptions {
-                    force: false,
-                    dry_run: !apply,
-                    cleanup_branches: apply,
-                    allow_unmerged_branches: false,
+                let category_deadline = cleanup_category_action_deadline(deadline);
+                let remaining = category_deadline
+                    .map(|deadline| {
+                        deadline.duration_since(SystemTime::now()).map_err(|_| {
+                            homeboy::core::Error::internal_unexpected(
+                                "cleanup category deadline exhausted before task-worktree cleanup",
+                            )
+                        })
+                    })
+                    .transpose()?;
+                let output = worktree::cleanup_page(worktree::WorktreeCleanupPageOptions {
+                    cleanup: WorktreeCleanupOptions {
+                        force: false,
+                        dry_run: !apply,
+                        cleanup_branches: apply,
+                        allow_unmerged_branches: false,
+                    },
+                    limit: args.limit.unwrap_or(500).max(1) as usize,
+                    cursor: args.cursor.clone(),
+                    deadline: remaining.and_then(|remaining| Instant::now().checked_add(remaining)),
                 })?;
                 task_worktrees_category(output, apply).map(|category| vec![category])
             },
@@ -2456,7 +2474,7 @@ fn cleanup_inventory_with_deadline(
                         cursor: args.cursor.clone(),
                         now: std::time::SystemTime::now(),
                         lease_ttl: policy.shared_store_lease_ttl(),
-                        deadline: None,
+                        deadline: cleanup_category_action_deadline(deadline),
                     })?;
                 category_from_output(
                     SHARED_CARGO_TARGETS_METADATA,
@@ -2500,11 +2518,7 @@ fn cleanup_inventory_with_deadline(
                         } else {
                             OutputBudget::COLLECTION.max_items
                         },
-                        deadline: deadline.or_else(|| {
-                            SystemTime::now().checked_add(Duration::from_secs(
-                                config.retention.automatic_retention_max_run_seconds,
-                            ))
-                        }),
+                        deadline: cleanup_category_action_deadline(deadline),
                     },
                 )?;
                 category_from_output(
@@ -3039,6 +3053,27 @@ fn cleanup_category_timeout(required: Duration, deadline: Option<SystemTime>) ->
                 .unwrap_or(Duration::ZERO),
         )
     })
+}
+
+/// Bound direct category work to the child process's inherited allowance, not
+/// merely the parent aggregate wall. Reserve time for the child to serialize
+/// evidence before its supervisor reaps it.
+fn cleanup_category_action_deadline(deadline: Option<SystemTime>) -> Option<SystemTime> {
+    let child_deadline = std::env::var(CLEANUP_CATEGORY_CHILD_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .and_then(|milliseconds| {
+            SystemTime::now().checked_add(
+                Duration::from_millis(milliseconds)
+                    .saturating_sub(CLEANUP_CHILD_TERMINATION_ALLOWANCE),
+            )
+        });
+    match (deadline, child_deadline) {
+        (Some(parent), Some(child)) => Some(parent.min(child)),
+        (Some(parent), None) => Some(parent),
+        (None, Some(child)) => Some(child),
+        (None, None) => None,
+    }
 }
 
 fn cleanup_category_heartbeat() -> Duration {
@@ -3772,6 +3807,10 @@ fn task_worktrees_category(
         output,
     )?;
     category.reconciliation_blocker_count = reconciliation_blocker_count;
+    if let Some(continuation) = category.output.get("continuation").and_then(Value::as_str) {
+        category.inventory_completeness = "partial".to_string();
+        category.continuation_command = continuation.to_string();
+    }
     Ok(category)
 }
 
@@ -5988,6 +6027,8 @@ mod tests {
                 candidates: Vec::new(),
                 removed: Vec::new(),
                 skipped: Vec::new(),
+                next_cursor: None,
+                continuation: None,
             },
             false,
         )
@@ -6016,6 +6057,8 @@ mod tests {
                 candidates: Vec::new(),
                 removed: Vec::new(),
                 skipped: Vec::new(),
+                next_cursor: None,
+                continuation: None,
             },
             false,
         )

--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -288,10 +288,31 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
         >,
     );
     impl worktree::WorktreeReconciliationAuthority for AgentTaskAuthority {
+        fn bounded_inventory_apply_refusal(
+            &self,
+        ) -> Option<worktree::WorktreeInventoryApplyRefusal> {
+            homeboy::agents::agent_task_lifecycle::bounded_inventory_requires_remote_claims()
+                .then_some(worktree::WorktreeInventoryApplyRefusal {
+                    code: "remote_workspace_reconciliation_unsupported",
+                    mutated_records: 0,
+                    mutation_provenance: "none",
+                    required_primitive: "durable remote claim release receipt and retry protocol",
+                    message: "worktree inventory --apply is local-only while remote workspace claim authorities are configured; no reconciliation claims were acquired",
+                })
+        }
+
         fn acquire(
             &self,
             record: &worktree::TaskWorktreeRecord,
+            deadline: std::time::Instant,
         ) -> homeboy::core::Result<worktree::WorktreeLivenessAuthority> {
+            const CLAIM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+            let deadline = deadline.min(std::time::Instant::now() + CLAIM_TIMEOUT);
+            if std::time::Instant::now() >= deadline {
+                return Ok(worktree::WorktreeLivenessAuthority::Incomplete {
+                    reason: "worktree inventory apply authority deadline exhausted".to_string(),
+                });
+            }
             let workspace = match record.effective_workspace_identity() {
                 Ok(workspace) => workspace,
                 Err(error) => {
@@ -300,12 +321,22 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
                     })
                 }
             };
-            let proof = match homeboy::agents::agent_task_lifecycle::resolve_terminal_workspace_authority(record)? {
-                homeboy::agents::agent_task_lifecycle::TerminalWorkspaceAuthorityResolution::Proven(proof) => proof,
-                homeboy::agents::agent_task_lifecycle::TerminalWorkspaceAuthorityResolution::Refused { reason, .. } => {
-                    return Ok(worktree::WorktreeLivenessAuthority::Incomplete { reason });
-                }
-            };
+            // The terminal proof is local durable evidence. Remote liveness is
+            // established only by the claim calls below, all under `deadline`.
+            let proof =
+                match homeboy::agents::agent_task_lifecycle::cached_terminal_workspace_authority(
+                    record,
+                )
+                .map_err(homeboy::core::Error::internal_unexpected)?
+                {
+                    Some(proof) => proof,
+                    None => {
+                        return Ok(worktree::WorktreeLivenessAuthority::Incomplete {
+                            reason: "missing or stale terminal workspace authority proof"
+                                .to_string(),
+                        });
+                    }
+                };
             // Persist before acquiring the fence. A no-run-id record can only
             // ever reach this point through a previously exact cached proof.
             homeboy::core::worktree::persist_terminal_workspace_authority(
@@ -313,9 +344,10 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
                 record.lifecycle_revision,
                 *proof,
             )?;
-            match homeboy::agents::agent_task_lifecycle::acquire_composite_workspace_claim(
+            match homeboy::agents::agent_task_lifecycle::acquire_composite_workspace_claim_until(
                 workspace,
                 record.lifecycle_revision,
+                deadline,
             ) {
                 Ok(composite) => {
                     let claim = composite.local.clone();
@@ -354,13 +386,21 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
             &self,
             _: &worktree::TaskWorktreeRecord,
             claim: &homeboy::core::workspace_claim::WorkspaceClaim,
+            deadline: std::time::Instant,
         ) -> homeboy::core::Result<bool> {
+            if std::time::Instant::now() >= deadline {
+                return Ok(false);
+            }
             let claims = self.0.lock().map_err(|_| {
                 homeboy::core::Error::internal_unexpected("workspace claim adapter lock poisoned")
             })?;
             claims
                 .get(&claim.token)
-                .map(homeboy::agents::agent_task_lifecycle::validate_composite_workspace_claim)
+                .map(|claim| {
+                    homeboy::agents::agent_task_lifecycle::validate_composite_workspace_claim_until(
+                        claim, deadline,
+                    )
+                })
                 .transpose()
                 .map(|valid| valid.unwrap_or(false))
         }
@@ -383,6 +423,7 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
         fn release(
             &self,
             claim: &homeboy::core::workspace_claim::WorkspaceClaim,
+            _deadline: std::time::Instant,
         ) -> homeboy::core::Result<()> {
             let mut claims = self.0.lock().map_err(|_| {
                 homeboy::core::Error::internal_unexpected("workspace claim adapter lock poisoned")
@@ -395,7 +436,7 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
                     None,
                 ));
             };
-            match homeboy::agents::agent_task_lifecycle::release_composite_workspace_claim(&mut composite)? {
+            match homeboy::agents::agent_task_lifecycle::release_composite_workspace_claim_until(&mut composite, _deadline)? {
                 homeboy::agents::agent_task_lifecycle::CompositeWorkspaceClaimRelease::Released => {
                     Ok(())
                 }
@@ -406,7 +447,7 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
                         None,
                         Some(failures),
                     );
-                    let status = homeboy::agents::agent_task_lifecycle::persist_and_retry_composite_workspace_cleanup(composite, &error);
+                    let status = homeboy::agents::agent_task_lifecycle::persist_and_retry_composite_workspace_cleanup_until(composite, &error, _deadline);
                     Err(homeboy::core::Error::validation_invalid_argument(
                         "workspace_claim_composite",
                         format!("workspace composite release incomplete: {}", status.public_summary()),
@@ -525,6 +566,7 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
                 cursor,
                 adopted_cursor,
                 apply,
+                apply_deadline: None,
             },
             &AgentTaskAuthority(std::sync::Mutex::new(std::collections::HashMap::new())),
         )?),
@@ -938,6 +980,8 @@ mod tests {
             candidates: Vec::new(),
             removed: Vec::new(),
             skipped: Vec::new(),
+            next_cursor: None,
+            continuation: None,
         };
 
         let actions = super::worktree_cleanup_actionable(&output, true);
@@ -962,6 +1006,8 @@ mod tests {
             candidates: Vec::new(),
             removed: Vec::new(),
             skipped: Vec::new(),
+            next_cursor: None,
+            continuation: None,
         };
 
         let without_branches = super::worktree_cleanup_actionable(&output, false);
@@ -988,6 +1034,8 @@ mod tests {
             candidates: Vec::new(),
             removed: Vec::new(),
             skipped: Vec::new(),
+            next_cursor: None,
+            continuation: None,
         };
 
         assert!(super::worktree_cleanup_actionable(&output, true)

--- a/crates/homeboy-core/src/config.rs
+++ b/crates/homeboy-core/src/config.rs
@@ -136,6 +136,42 @@ pub fn with_config_lock<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
     with_config_lock_for("config mutation", operation)
 }
 
+/// Run a short mutation under the caller's monotonic deadline.
+pub fn with_config_lock_until<T>(
+    deadline: std::time::Instant,
+    operation: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    let lock_path = paths::homeboy()?.join("config.lock");
+    if config_lock_is_held(&lock_path) {
+        return operation();
+    }
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("create config lock directory".to_string()),
+            )
+        })?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some("open config lock".to_string()))
+        })?;
+    let _guard = ConfigLockGuard::lock_until(
+        file,
+        &lock_path,
+        "bounded workspace reconciliation",
+        deadline,
+    )?;
+    let _depth = ConfigLockPathGuard::enter(&lock_path);
+    operation()
+}
+
 /// Run `operation` while holding the exclusive config lock under `config_root`.
 pub fn with_config_lock_at<T>(
     config_root: &Path,
@@ -399,6 +435,47 @@ fn config_lock_timeout_error(
 impl ConfigLockGuard {
     fn lock(mut file: File, lock_path: &Path, operation: &str) -> Result<Self> {
         lock_exclusive_bounded(&file, lock_path, operation)?;
+        let owner = ConfigLockOwner {
+            pid: std::process::id(),
+            operation: operation.to_string(),
+        };
+        let owner = serde_json::to_vec(&owner).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize config lock owner".to_string()),
+            )
+        })?;
+        file.set_len(0)
+            .and_then(|_| file.seek(SeekFrom::Start(0)).map(|_| ()))
+            .and_then(|_| file.write_all(&owner))
+            .and_then(|_| file.sync_data())
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("write config lock owner".to_string()),
+                )
+            })?;
+        Ok(Self { file })
+    }
+
+    fn lock_until(
+        mut file: File,
+        lock_path: &Path,
+        operation: &str,
+        deadline: std::time::Instant,
+    ) -> Result<Self> {
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .ok_or_else(|| {
+                Error::internal_io(
+                    "config lock deadline exhausted",
+                    Some(operation.to_string()),
+                )
+            })?;
+        #[cfg(unix)]
+        lock_bounded(&file, lock_path, operation, libc::LOCK_EX, Some(remaining))?;
+        #[cfg(not(unix))]
+        let _ = remaining;
         let owner = ConfigLockOwner {
             pid: std::process::id(),
             operation: operation.to_string(),
@@ -1831,6 +1908,29 @@ mod tests {
                 "timeout must respect the configured bound: {:?}",
                 error.details
             );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deadline_scoped_config_lock_respects_the_supplied_deadline() {
+        crate::test_support::with_isolated_home(|_home| {
+            let lock_path = paths::homeboy().expect("config root").join("config.lock");
+            std::fs::create_dir_all(lock_path.parent().expect("lock parent")).expect("config dir");
+            let holder = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .expect("holder handle");
+            let _holder = ConfigLockGuard::lock(holder, &lock_path, "test holder")
+                .expect("holder acquires the lock");
+            let started = std::time::Instant::now();
+            let error =
+                with_config_lock_until(started + std::time::Duration::from_millis(40), || Ok(()))
+                    .expect_err("contended deadline-scoped lock must time out");
+            assert_eq!(error.details["kind"], "config_lock_timeout");
+            assert!(started.elapsed() < std::time::Duration::from_secs(1));
         });
     }
 

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -25,18 +25,18 @@ pub use types::{
     TerminalWorkspaceAuthorityObservation, TerminalWorkspaceAuthorityProof, WorkspaceRefRecord,
     WorktreeAdoptOptions, WorktreeAdoptOutput, WorktreeAdoptedInventoryPage,
     WorktreeBranchCleanupReport, WorktreeCleanupCandidate, WorktreeCleanupCounts,
-    WorktreeCleanupOptions, WorktreeCleanupOutput, WorktreeCleanupSkipped, WorktreeCreateAction,
-    WorktreeCreateEvidence, WorktreeCreateOptions, WorktreeCreateOutput,
-    WorktreeCreateReconciliation, WorktreeHandoffFreshness, WorktreeHandoffFreshnessProof,
-    WorktreeImportOptions, WorktreeImportOutput, WorktreeInventoryApplyRefusal,
-    WorktreeInventoryAuthorization, WorktreeInventoryCrossTab, WorktreeInventoryLocalEvidence,
-    WorktreeInventoryOptions, WorktreeInventoryOutput, WorktreeInventoryRecord,
-    WorktreeLeaseActivity, WorktreeListDiagnostic, WorktreeListOutput, WorktreeLivenessAuthority,
-    WorktreeOwnershipProbe, WorktreeQueueCreateFailure, WorktreeQueueCreateOptions,
-    WorktreeQueueCreateOutput, WorktreeQueueCreateRequest, WorktreeQueueCreateRow,
-    WorktreeQueueCreateStatus, WorktreeQueueLockHolder, WorktreeReconciliationAction,
-    WorktreeReconciliationAuthority, WorktreeReconciliationResult, WorktreeRemoveOptions,
-    WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
+    WorktreeCleanupOptions, WorktreeCleanupOutput, WorktreeCleanupPageOptions,
+    WorktreeCleanupSkipped, WorktreeCreateAction, WorktreeCreateEvidence, WorktreeCreateOptions,
+    WorktreeCreateOutput, WorktreeCreateReconciliation, WorktreeHandoffFreshness,
+    WorktreeHandoffFreshnessProof, WorktreeImportOptions, WorktreeImportOutput,
+    WorktreeInventoryApplyRefusal, WorktreeInventoryAuthorization, WorktreeInventoryCrossTab,
+    WorktreeInventoryLocalEvidence, WorktreeInventoryOptions, WorktreeInventoryOutput,
+    WorktreeInventoryRecord, WorktreeLeaseActivity, WorktreeListDiagnostic, WorktreeListOutput,
+    WorktreeLivenessAuthority, WorktreeOwnershipProbe, WorktreeQueueCreateFailure,
+    WorktreeQueueCreateOptions, WorktreeQueueCreateOutput, WorktreeQueueCreateRequest,
+    WorktreeQueueCreateRow, WorktreeQueueCreateStatus, WorktreeQueueLockHolder,
+    WorktreeReconciliationAction, WorktreeReconciliationAuthority, WorktreeReconciliationResult,
+    WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
     TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY, TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
 };
 
@@ -555,6 +555,57 @@ pub(super) fn with_task_worktree_registry_write_lock<T>(
     operation()
 }
 
+pub(super) fn with_task_worktree_registry_write_lock_until<T>(
+    deadline: std::time::Instant,
+    operation: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    loop {
+        if std::time::Instant::now() >= deadline {
+            return Err(Error::internal_io(
+                "task-worktree registry lease deadline exhausted",
+                Some("lock task worktree registry".into()),
+            ));
+        }
+        if let Ok(gate) = TASK_WORKTREE_REGISTRY_GATE
+            .get_or_init(|| RwLock::new(()))
+            .try_write()
+        {
+            if std::time::Instant::now() >= deadline {
+                return Err(Error::internal_io(
+                    "task-worktree registry lease deadline exhausted",
+                    Some("lock task worktree registry".into()),
+                ));
+            }
+            let lock = open_task_worktree_registry_lock()?;
+            while lock.try_lock_exclusive().is_err() {
+                if std::time::Instant::now() >= deadline {
+                    return Err(Error::internal_io(
+                        "task-worktree registry lease deadline exhausted",
+                        Some("lock task worktree registry".into()),
+                    ));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(Error::internal_io(
+                    "task-worktree registry lease deadline exhausted",
+                    Some("lock task worktree registry".into()),
+                ));
+            }
+            let result = operation();
+            drop(gate);
+            return result;
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(Error::internal_io(
+                "task-worktree registry lease deadline exhausted",
+                Some("lock task worktree registry".into()),
+            ));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
 fn open_task_worktree_registry_lock() -> Result<std::fs::File> {
     let store = metadata_dir()?;
     let parent = store.parent().ok_or_else(|| {
@@ -635,7 +686,20 @@ pub fn remove(options: WorktreeRemoveOptions) -> Result<WorktreeRemoveOutput> {
 
 pub fn cleanup(options: WorktreeCleanupOptions) -> Result<WorktreeCleanupOutput> {
     let store = metadata_dir()?;
-    cleanup_with_store(options, &store)
+    cleanup_with_store_page(
+        WorktreeCleanupPageOptions {
+            cleanup: options,
+            limit: usize::MAX,
+            cursor: None,
+            deadline: None,
+        },
+        &store,
+    )
+}
+
+pub fn cleanup_page(options: WorktreeCleanupPageOptions) -> Result<WorktreeCleanupOutput> {
+    let store = metadata_dir()?;
+    cleanup_with_store_page(options, &store)
 }
 
 /// Register an active task-worktree record against the current test home.

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -192,30 +192,88 @@ pub(super) fn cleanup_with_store(
     options: WorktreeCleanupOptions,
     store: &Path,
 ) -> Result<WorktreeCleanupOutput> {
+    cleanup_with_store_page(
+        WorktreeCleanupPageOptions {
+            cleanup: options,
+            limit: usize::MAX,
+            cursor: None,
+            deadline: None,
+        },
+        store,
+    )
+}
+
+pub(super) fn cleanup_with_store_page(
+    page: WorktreeCleanupPageOptions,
+    store: &Path,
+) -> Result<WorktreeCleanupOutput> {
+    let options = page.cleanup.clone();
     let mut candidates = Vec::new();
     let mut removed = Vec::new();
     let mut skipped = Vec::new();
-    for record in list_with_store(store)?.worktrees {
+    let mut records = list_with_store(store)?
+        .worktrees
+        .into_iter()
+        .filter(|record| {
+            page.cursor
+                .as_ref()
+                .is_none_or(|cursor| record.id > *cursor)
+        });
+    let mut next_cursor = None;
+    let mut continuation = None;
+    // Only advance the cursor after a record has been fully inspected. If the
+    // deadline interrupts an inspection, resuming after that record would drop
+    // it from every subsequent page.
+    let mut last_id = None;
+    for record in records.by_ref().take(page.limit.max(1)) {
+        if page
+            .deadline
+            .is_some_and(|deadline| std::time::Instant::now() >= deadline)
+        {
+            next_cursor = last_id.clone().or_else(|| page.cursor.clone());
+            continuation = Some(cleanup_continuation(&page, next_cursor.as_deref()));
+            break;
+        }
         if record.state != TaskWorktreeState::Active {
+            last_id = Some(record.id.clone());
             continue;
         }
         if record.cleanup_policy == CleanupPolicy::PreserveOnFailure {
+            last_id = Some(record.id.clone());
             continue;
         }
-        let safety = match safety_report(&record) {
+        let safety = match safety_report_until(&record, page.deadline) {
             Ok(safety) => safety,
             Err(error) => {
+                if deadline_exhausted(page.deadline) {
+                    next_cursor = last_id.clone().or_else(|| page.cursor.clone());
+                    continuation = Some(cleanup_continuation(&page, next_cursor.as_deref()));
+                    break;
+                }
                 skipped.push(WorktreeCleanupSkipped {
-                    record,
+                    record: record.clone(),
                     safety: None,
                     reasons: vec![error.message],
                 });
+                last_id = Some(record.id.clone());
                 continue;
             }
         };
-        let branch_cleanup = branch_cleanup_report(&record)
-            .unwrap_or_else(|error| branch_cleanup_unknown(&record, error.message));
+        let branch_cleanup = match branch_cleanup_report_until(&record, page.deadline) {
+            Ok(report) => report,
+            Err(_error) if deadline_exhausted(page.deadline) => {
+                next_cursor = last_id.clone().or_else(|| page.cursor.clone());
+                continuation = Some(cleanup_continuation(&page, next_cursor.as_deref()));
+                break;
+            }
+            Err(error) => branch_cleanup_unknown(&record, error.message),
+        };
         let live_owner_count = live_workspace_owner_count(&record, store)?;
+        if deadline_exhausted(page.deadline) {
+            next_cursor = last_id.clone().or_else(|| page.cursor.clone());
+            continuation = Some(cleanup_continuation(&page, next_cursor.as_deref()));
+            break;
+        }
         let skip_reasons = cleanup_skip_reasons(&record, &safety, options.force, live_owner_count);
         if !skip_reasons.is_empty() {
             skipped.push(WorktreeCleanupSkipped {
@@ -233,7 +291,15 @@ pub(super) fn cleanup_with_store(
         });
 
         if !options.dry_run {
-            match remove_with_store(
+            if page
+                .deadline
+                .is_some_and(|deadline| std::time::Instant::now() >= deadline)
+            {
+                next_cursor = last_id.clone();
+                continuation = Some(cleanup_continuation(&page, next_cursor.as_deref()));
+                break;
+            }
+            match remove_with_store_until(
                 WorktreeRemoveOptions {
                     id: record.id.clone(),
                     force: options.force,
@@ -241,15 +307,21 @@ pub(super) fn cleanup_with_store(
                     allow_unmerged_branch: options.allow_unmerged_branches,
                 },
                 store,
+                page.deadline,
             ) {
                 Ok(output) => removed.push(output),
                 Err(error) => skipped.push(WorktreeCleanupSkipped {
-                    record,
+                    record: record.clone(),
                     safety: Some(safety),
                     reasons: vec![error.message],
                 }),
             }
         }
+        last_id = Some(record.id.clone());
+    }
+    if next_cursor.is_none() && records.next().is_some() {
+        next_cursor = last_id;
+        continuation = Some(cleanup_continuation(&page, next_cursor.as_deref()));
     }
     let branch_delete_candidates = candidates
         .iter()
@@ -287,7 +359,26 @@ pub(super) fn cleanup_with_store(
         candidates,
         removed,
         skipped,
+        next_cursor,
+        continuation,
     })
+}
+
+fn cleanup_continuation(page: &WorktreeCleanupPageOptions, cursor: Option<&str>) -> String {
+    let cursor = cursor
+        .map(|cursor| format!(" --cursor {}", shell_arg(cursor)))
+        .unwrap_or_default();
+    let apply = (!page.cleanup.dry_run)
+        .then_some(" --apply")
+        .unwrap_or_default();
+    format!(
+        "homeboy cleanup --include task-worktrees --limit {}{apply}{cursor}",
+        page.limit.max(1)
+    )
+}
+
+fn deadline_exhausted(deadline: Option<std::time::Instant>) -> bool {
+    deadline.is_some_and(|deadline| std::time::Instant::now() >= deadline)
 }
 
 fn cleanup_skip_reasons(
@@ -845,7 +936,16 @@ fn remove_exact_stale_worktree_registration(source: &Path, worktree: &Path) -> R
 }
 
 fn git_common_dir(source: &Path) -> Result<PathBuf> {
-    let raw = git::run_git(source, &["rev-parse", "--git-common-dir"], "git common dir")?;
+    git_common_dir_until(source, None)
+}
+
+fn git_common_dir_until(source: &Path, deadline: Option<std::time::Instant>) -> Result<PathBuf> {
+    let raw = run_inventory_git_until(
+        source,
+        &["rev-parse", "--git-common-dir"],
+        "git common dir",
+        deadline,
+    )?;
     let path = PathBuf::from(raw.trim());
     let path = if path.is_absolute() {
         path
@@ -962,7 +1062,18 @@ pub(super) fn inventory_with_store_and_authority(
     adopted_store_dir: &Path,
     authority: &dyn WorktreeReconciliationAuthority,
 ) -> Result<WorktreeInventoryOutput> {
+    const APPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(25);
     let limit = options.limit.max(1);
+    let apply_refusal = options
+        .apply
+        .then(|| authority.bounded_inventory_apply_refusal())
+        .flatten();
+    let apply = options.apply && apply_refusal.is_none();
+    let apply_deadline = apply.then(|| {
+        options
+            .apply_deadline
+            .unwrap_or_else(|| std::time::Instant::now() + APPLY_TIMEOUT)
+    });
     let worktrees = list_with_store(store_dir)?.worktrees;
     let total = worktrees.len();
     let mut worktrees = worktrees.into_iter().filter(|record| {
@@ -972,35 +1083,83 @@ pub(super) fn inventory_with_store_and_authority(
             .is_none_or(|cursor| record.id.as_str() > cursor.as_str())
     });
     let records_page: Vec<_> = worktrees.by_ref().take(limit).collect();
-    let next_cursor = worktrees.next().map(|_| {
+    let mut next_cursor = worktrees.next().map(|_| {
         records_page
             .last()
             .expect("a page with a following record is non-empty")
             .id
             .clone()
     });
-    let truncated = next_cursor.is_some();
+    let mut truncated = next_cursor.is_some();
     let mut records = Vec::new();
+    let mut apply_continuation = None;
 
     for mut record in records_page {
+        if apply_deadline.is_some_and(|deadline| std::time::Instant::now() >= deadline) {
+            let cursor = records
+                .last()
+                .map(|item: &WorktreeInventoryRecord| item.record.id.clone())
+                .or_else(|| options.cursor.clone());
+            apply_continuation = Some(inventory_apply_continuation(limit, cursor.as_deref()));
+            next_cursor = cursor;
+            truncated = true;
+            break;
+        }
         let mut path_exists = Path::new(&record.worktree_path).exists();
         let mut missing_active = if record.state == TaskWorktreeState::Active && !path_exists {
-            Some(missing_active_worktree(&record))
+            Some(missing_active_worktree(&record, apply_deadline))
         } else {
             None
         };
-        let reconciliation = if options.apply && missing_active.is_some() {
-            let authority_snapshot = authority.acquire(&record)?;
+        if apply_deadline.is_some_and(|deadline| std::time::Instant::now() >= deadline) {
+            let cursor = records
+                .last()
+                .map(|item: &WorktreeInventoryRecord| item.record.id.clone())
+                .or_else(|| options.cursor.clone());
+            apply_continuation = Some(inventory_apply_continuation(limit, cursor.as_deref()));
+            next_cursor = cursor;
+            truncated = true;
+            break;
+        }
+        let reconciliation = if apply
+            && missing_active.as_ref().is_some_and(|missing| {
+                missing.reason == MissingActiveWorktreeReason::RequiresAuthoritativeLiveness
+            }) {
+            let deadline = apply_deadline.expect("apply has an authority deadline");
+            if std::time::Instant::now() >= deadline {
+                let cursor = records
+                    .last()
+                    .map(|item: &WorktreeInventoryRecord| item.record.id.clone())
+                    .or_else(|| options.cursor.clone());
+                apply_continuation = Some(inventory_apply_continuation(limit, cursor.as_deref()));
+                next_cursor = cursor;
+                truncated = true;
+                break;
+            }
+            let authority_snapshot = authority.acquire(&record, deadline)?;
+            if std::time::Instant::now() >= deadline {
+                if let WorktreeLivenessAuthority::Terminal { claim, .. } = &authority_snapshot {
+                    let _ = authority.release(claim, deadline);
+                }
+                let cursor = records
+                    .last()
+                    .map(|item: &WorktreeInventoryRecord| item.record.id.clone())
+                    .or_else(|| options.cursor.clone());
+                apply_continuation = Some(inventory_apply_continuation(limit, cursor.as_deref()));
+                next_cursor = cursor;
+                truncated = true;
+                break;
+            }
             if let WorktreeLivenessAuthority::Terminal { claim, .. } = &authority_snapshot {
                 let validation = claim
                     .verify_shape(chrono::Utc::now().timestamp_millis().max(0) as u64)
-                    .and_then(|_| authority.validate(&record, claim));
+                    .and_then(|_| authority.validate(&record, claim, deadline));
                 let valid = match validation {
                     Ok(valid) => valid,
                     Err(error) => {
                         // A validation transport failure still owns a fence.
                         // Release it before returning a typed, non-mutating refusal.
-                        let release = authority.release(claim);
+                        let release = authority.release(claim, deadline);
                         records.push(WorktreeInventoryRecord {
                             record,
                             path_exists,
@@ -1011,12 +1170,19 @@ pub(super) fn inventory_with_store_and_authority(
                                 reason: Some(error.message),
                             }),
                         });
-                        release?;
+                        if release.is_err() && std::time::Instant::now() >= deadline {
+                            let cursor = records.last().map(|item| item.record.id.clone());
+                            apply_continuation =
+                                Some(inventory_apply_continuation(limit, cursor.as_deref()));
+                            next_cursor = cursor;
+                            truncated = true;
+                            break;
+                        }
                         continue;
                     }
                 };
                 if !valid {
-                    let release = authority.release(claim);
+                    let release = authority.release(claim, deadline);
                     records.push(WorktreeInventoryRecord {
                         record,
                         path_exists,
@@ -1027,24 +1193,51 @@ pub(super) fn inventory_with_store_and_authority(
                             reason: Some("workspace owner rejected, expired, or does not support the reconciliation claim".to_string()),
                         }),
                     });
-                    release?;
+                    if release.is_err() && std::time::Instant::now() >= deadline {
+                        let cursor = records.last().map(|item| item.record.id.clone());
+                        apply_continuation =
+                            Some(inventory_apply_continuation(limit, cursor.as_deref()));
+                        next_cursor = cursor;
+                        truncated = true;
+                        break;
+                    }
                     continue;
                 }
+            }
+            if std::time::Instant::now() >= deadline {
+                if let WorktreeLivenessAuthority::Terminal { claim, .. } = &authority_snapshot {
+                    let _ = authority.release(claim, deadline);
+                }
+                let cursor = records
+                    .last()
+                    .map(|item: &WorktreeInventoryRecord| item.record.id.clone())
+                    .or_else(|| options.cursor.clone());
+                apply_continuation = Some(inventory_apply_continuation(limit, cursor.as_deref()));
+                next_cursor = cursor;
+                truncated = true;
+                break;
             }
             let reconciliation = reconcile_missing_record_with_store(
                 store_dir,
                 &record,
                 &authority_snapshot,
                 authority,
+                deadline,
             );
-            if let WorktreeLivenessAuthority::Terminal { claim, .. } = &authority_snapshot {
-                authority.release(claim)?;
-            }
+            let release = match &authority_snapshot {
+                WorktreeLivenessAuthority::Terminal { claim, .. } => {
+                    authority.release(claim, deadline)
+                }
+                _ => Ok(()),
+            };
+            // Reconciliation may have committed a state transition, so a
+            // failed release is never safe to hide from the caller.
             let (reread, reread_path_exists, result) = reconciliation?;
+            release?;
             record = reread;
             path_exists = reread_path_exists;
             missing_active = (record.state == TaskWorktreeState::Active && !path_exists)
-                .then(|| missing_active_worktree(&record));
+                .then(|| missing_active_worktree(&record, apply_deadline));
             Some(result)
         } else {
             None
@@ -1103,12 +1296,15 @@ pub(super) fn inventory_with_store_and_authority(
 
     Ok(WorktreeInventoryOutput {
         schema: "homeboy/worktree-inventory/v1",
-        authorization: if options.apply {
+        authorization: if apply {
             WorktreeInventoryAuthorization::ExplicitApply
+        } else if options.apply {
+            WorktreeInventoryAuthorization::ApplyRefused
         } else {
             WorktreeInventoryAuthorization::Preview
         },
-        apply_refusal: None,
+        apply_refusal,
+        apply_continuation,
         cursor: options.cursor,
         next_cursor,
         limit,
@@ -1127,18 +1323,28 @@ pub(super) fn inventory_with_store_and_authority(
     })
 }
 
-fn missing_active_worktree(record: &TaskWorktreeRecord) -> MissingActiveWorktree {
+fn inventory_apply_continuation(limit: usize, cursor: Option<&str>) -> String {
+    let cursor = cursor
+        .map(|cursor| format!(" --cursor {}", shell_arg(cursor)))
+        .unwrap_or_default();
+    format!("homeboy worktree inventory --apply --limit {limit}{cursor}")
+}
+
+fn missing_active_worktree(
+    record: &TaskWorktreeRecord,
+    deadline: Option<std::time::Instant>,
+) -> MissingActiveWorktree {
     if record.cleanup_policy == CleanupPolicy::PreserveOnFailure {
         return MissingActiveWorktree {
             reason: MissingActiveWorktreeReason::PreserveOnFailure,
-            local_evidence: local_inventory_evidence(record),
+            local_evidence: local_inventory_evidence(record, deadline),
             continuation: format!(
                 "Inspect preserved task worktree `{}` and explicitly remove it when terminal.",
                 record.id
             ),
         };
     }
-    let evidence = local_inventory_evidence(record);
+    let evidence = local_inventory_evidence(record, deadline);
     let reason = if !evidence.source_checkout_exists {
         MissingActiveWorktreeReason::SourceCheckoutUnavailable
     } else if evidence.source_dirty == Some(true) {
@@ -1168,8 +1374,9 @@ fn reconcile_missing_record_with_store(
     expected: &TaskWorktreeRecord,
     authority_snapshot: &WorktreeLivenessAuthority,
     authority: &dyn WorktreeReconciliationAuthority,
+    deadline: std::time::Instant,
 ) -> Result<(TaskWorktreeRecord, bool, WorktreeReconciliationResult)> {
-    with_task_worktree_registry_write_lock(|| {
+    with_task_worktree_registry_write_lock_until(deadline, || {
         // Re-read under the exclusive registry lease. Any concurrent publisher must
         // finish before this snapshot is evaluated and conditionally written.
         let mut record = read_record(store_dir, &expected.id)?;
@@ -1194,7 +1401,7 @@ fn reconcile_missing_record_with_store(
                 },
             ));
         }
-        let evidence = local_inventory_evidence(&record);
+        let evidence = local_inventory_evidence(&record, Some(deadline));
         let shared_active_owner = list_with_store(store_dir)?
             .worktrees
             .into_iter()
@@ -1239,6 +1446,7 @@ fn reconcile_missing_record_with_store(
             WorktreeLivenessAuthority::Terminal { claim, provenance } => {
                 let identity = record.effective_workspace_identity()?;
                 if claim.workspace != identity
+                    || std::time::Instant::now() >= deadline
                     || (authority.requires_terminal_workspace_authority_proof()
                         && !record
                             .terminal_workspace_authority
@@ -1251,7 +1459,7 @@ fn reconcile_missing_record_with_store(
                     return Ok((record, false, WorktreeReconciliationResult {
                         action: WorktreeReconciliationAction::Refused,
                         provenance: "leased manifest re-read".to_string(),
-                        reason: Some("workspace identity changed or the local reconciliation claim budget expired before commit".to_string()),
+                        reason: Some("workspace identity changed or the reconciliation authority budget expired before commit".to_string()),
                     }));
                 }
                 record.state = TaskWorktreeState::Removed;
@@ -1297,7 +1505,10 @@ fn reconcile_missing_record_with_store(
     })
 }
 
-fn local_inventory_evidence(record: &TaskWorktreeRecord) -> WorktreeInventoryLocalEvidence {
+fn local_inventory_evidence(
+    record: &TaskWorktreeRecord,
+    deadline: Option<std::time::Instant>,
+) -> WorktreeInventoryLocalEvidence {
     let source = Path::new(&record.source_checkout);
     if !source.is_dir() {
         return WorktreeInventoryLocalEvidence {
@@ -1307,9 +1518,9 @@ fn local_inventory_evidence(record: &TaskWorktreeRecord) -> WorktreeInventoryLoc
             unavailable_reason: Some("recorded source checkout is unavailable".to_string()),
         };
     }
-    let source_dirty = is_dirty(source).ok();
+    let source_dirty = is_dirty_until(source, deadline).ok();
     let unpushed_branch_commits =
-        unpushed_branch_commit_count(source, &record.branch, &record.base_ref).ok();
+        unpushed_branch_commit_count_until(source, &record.branch, &record.base_ref, deadline).ok();
     let unavailable_reason = match (&source_dirty, &unpushed_branch_commits) {
         (None, _) => Some("could not inspect source checkout dirtiness".to_string()),
         (_, None) => Some("could not inspect task branch push state".to_string()),
@@ -1323,8 +1534,13 @@ fn local_inventory_evidence(record: &TaskWorktreeRecord) -> WorktreeInventoryLoc
     }
 }
 
-fn unpushed_branch_commit_count(source: &Path, branch: &str, base_ref: &str) -> Result<u32> {
-    git::run_git(
+fn unpushed_branch_commit_count_until(
+    source: &Path,
+    branch: &str,
+    base_ref: &str,
+    deadline: Option<std::time::Instant>,
+) -> Result<u32> {
+    run_inventory_git_until(
         source,
         &[
             "show-ref",
@@ -1333,8 +1549,9 @@ fn unpushed_branch_commit_count(source: &Path, branch: &str, base_ref: &str) -> 
             &format!("refs/heads/{branch}"),
         ],
         "git show-ref task branch",
+        deadline,
     )?;
-    let upstream = git::run_git(
+    let upstream = run_inventory_git_until(
         source,
         &[
             "rev-parse",
@@ -1342,19 +1559,42 @@ fn unpushed_branch_commit_count(source: &Path, branch: &str, base_ref: &str) -> 
             &format!("{branch}@{{upstream}}"),
         ],
         "git task branch upstream",
+        deadline,
     );
     let range = match upstream {
         Ok(upstream) if !upstream.trim().is_empty() => format!("{}..{branch}", upstream.trim()),
         _ => format!("{base_ref}..{branch}"),
     };
-    let count = git::run_git(
+    let count = run_inventory_git_until(
         source,
         &["rev-list", "--count", &range],
         "git task branch rev-list",
+        deadline,
     )?;
     count.trim().parse::<u32>().map_err(|error| {
         Error::internal_unexpected(format!("invalid task branch commit count: {error}"))
     })
+}
+
+fn run_inventory_git_until(
+    source: &Path,
+    args: &[&str],
+    context: &str,
+    deadline: Option<std::time::Instant>,
+) -> Result<String> {
+    match deadline {
+        Some(deadline) => {
+            let remaining = deadline
+                .checked_duration_since(std::time::Instant::now())
+                .ok_or_else(|| {
+                    Error::internal_unexpected(
+                        "worktree inventory apply deadline exhausted during local git preflight",
+                    )
+                })?;
+            git::run_git_with_env_timeout(source, args, context, &[], remaining)
+        }
+        None => git::run_git(source, args, context),
+    }
 }
 
 pub(super) fn list_adopted_with_store(store_dir: &Path) -> Result<Vec<AdoptedWorkspaceRecord>> {
@@ -1385,12 +1625,35 @@ pub(super) fn remove_with_store(
     options: WorktreeRemoveOptions,
     store_dir: &Path,
 ) -> Result<WorktreeRemoveOutput> {
-    with_task_worktree_registry_write_lock(|| remove_with_store_unlocked(options, store_dir))
+    remove_with_store_until(options, store_dir, None)
+}
+
+fn remove_with_store_until(
+    options: WorktreeRemoveOptions,
+    store_dir: &Path,
+    deadline: Option<std::time::Instant>,
+) -> Result<WorktreeRemoveOutput> {
+    match deadline {
+        Some(deadline) => with_task_worktree_registry_write_lock_until(deadline, || {
+            remove_with_store_unlocked_until(options, store_dir, Some(deadline))
+        }),
+        None => with_task_worktree_registry_write_lock(|| {
+            remove_with_store_unlocked_until(options, store_dir, None)
+        }),
+    }
 }
 
 fn remove_with_store_unlocked(
     options: WorktreeRemoveOptions,
     store_dir: &Path,
+) -> Result<WorktreeRemoveOutput> {
+    remove_with_store_unlocked_until(options, store_dir, None)
+}
+
+fn remove_with_store_unlocked_until(
+    options: WorktreeRemoveOptions,
+    store_dir: &Path,
+    deadline: Option<std::time::Instant>,
 ) -> Result<WorktreeRemoveOutput> {
     // The registry lease fences the complete decision and Git mutation. Always
     // re-read under it so finalization that won the lease first is preserved.
@@ -1400,7 +1663,7 @@ fn remove_with_store_unlocked(
             .to_string_lossy()
             .to_string();
     }
-    let safety = safety_report(&record)?;
+    let safety = safety_report_until(&record, deadline)?;
     if !options.force && !safety.safe {
         return Err(Error::validation_invalid_argument(
             "worktree",
@@ -1448,7 +1711,7 @@ fn remove_with_store_unlocked(
     let worktree_parent = Path::new(&record.worktree_path)
         .parent()
         .map(Path::to_path_buf);
-    let git_common_dir = git_common_dir(Path::new(&record.source_checkout))?;
+    let git_common_dir = git_common_dir_until(Path::new(&record.source_checkout), deadline)?;
     let result = claims.with_reconciliation_fence(&claim, || {
         if !safety.worktree_missing {
             let mut args = vec!["worktree", "remove"];
@@ -1456,10 +1719,11 @@ fn remove_with_store_unlocked(
                 args.push("--force");
             }
             args.push(&record.worktree_path);
-            git::run_git(
+            run_inventory_git_until(
                 Path::new(&record.source_checkout),
                 &args,
                 "git worktree remove",
+                deadline,
             )?;
         }
         if let Some(parent) = &worktree_parent {
@@ -1483,12 +1747,11 @@ fn remove_with_store_unlocked(
                     Some(git_metadata_parent.display().to_string()),
                 )
             })?;
-        let mut branch_cleanup = branch_cleanup_report(&record)
+        let mut branch_cleanup = branch_cleanup_report_until(&record, deadline)
             .unwrap_or_else(|error| branch_cleanup_unknown(&record, error.message));
-        if options.cleanup_branch {
-            branch_cleanup =
-                apply_branch_cleanup(&record, branch_cleanup, options.allow_unmerged_branch)?;
-        }
+        // The worktree is physically gone at this point. Publish that durable
+        // fact before optional branch cleanup so a branch-delete failure cannot
+        // leave an active manifest pointing at a removed checkout.
         record.state = TaskWorktreeState::Removed;
         record.lifecycle_revision = record.lifecycle_revision.checked_add(1).ok_or_else(|| {
             Error::validation_invalid_argument(
@@ -1499,6 +1762,15 @@ fn remove_with_store_unlocked(
             )
         })?;
         write_record_unlocked(store_dir, &record)?;
+        if options.cleanup_branch {
+            branch_cleanup = apply_branch_cleanup_until(
+                &record,
+                branch_cleanup,
+                options.allow_unmerged_branch,
+                deadline,
+            )
+            .unwrap_or_else(|error| branch_cleanup_unknown(&record, error.message));
+        }
         Ok(WorktreeRemoveOutput {
             record,
             safety,
@@ -1540,6 +1812,13 @@ fn workspace_claim_store_for_worktrees(
 pub(super) fn branch_cleanup_report(
     record: &TaskWorktreeRecord,
 ) -> Result<WorktreeBranchCleanupReport> {
+    branch_cleanup_report_until(record, None)
+}
+
+fn branch_cleanup_report_until(
+    record: &TaskWorktreeRecord,
+    deadline: Option<std::time::Instant>,
+) -> Result<WorktreeBranchCleanupReport> {
     let cleanup_command = format!(
         "homeboy worktree remove {} --cleanup-branch",
         shell_arg(&record.id)
@@ -1558,7 +1837,7 @@ pub(super) fn branch_cleanup_report(
     }
     let source = resolved_source_checkout(record)?;
     let branch = record.branch.as_str();
-    let exists = git::run_git(
+    let exists = run_inventory_git_until(
         &source,
         &[
             "show-ref",
@@ -1567,6 +1846,7 @@ pub(super) fn branch_cleanup_report(
             &format!("refs/heads/{branch}"),
         ],
         "git show-ref branch",
+        deadline,
     )
     .is_ok();
     if !exists {
@@ -1582,10 +1862,11 @@ pub(super) fn branch_cleanup_report(
         });
     }
     let base_ref = branch_cleanup_base_ref(record);
-    let merged = git::run_git(
+    let merged = run_inventory_git_until(
         &source,
         &["merge-base", "--is-ancestor", branch, &base_ref],
         "git merge-base branch cleanup",
+        deadline,
     )
     .is_ok();
     Ok(WorktreeBranchCleanupReport {
@@ -1610,8 +1891,17 @@ pub(super) fn branch_cleanup_report(
 
 fn apply_branch_cleanup(
     record: &TaskWorktreeRecord,
+    report: WorktreeBranchCleanupReport,
+    allow_unmerged_branch: bool,
+) -> Result<WorktreeBranchCleanupReport> {
+    apply_branch_cleanup_until(record, report, allow_unmerged_branch, None)
+}
+
+fn apply_branch_cleanup_until(
+    record: &TaskWorktreeRecord,
     mut report: WorktreeBranchCleanupReport,
     allow_unmerged_branch: bool,
+    deadline: Option<std::time::Instant>,
 ) -> Result<WorktreeBranchCleanupReport> {
     if report.status == BranchCleanupStatus::Missing || report.deleted {
         return Ok(report);
@@ -1623,10 +1913,11 @@ fn apply_branch_cleanup(
     // Homeboy has already verified this branch is contained in its configured cleanup base.
     // Use that proof instead of Git's separate upstream-based `-d` heuristic.
     let delete_flag = "-D";
-    git::run_git(
+    run_inventory_git_until(
         &source,
         &["branch", delete_flag, &record.branch],
         "git branch delete task worktree branch",
+        deadline,
     )?;
     report.deleted = true;
     report.status = BranchCleanupStatus::Deleted;
@@ -1680,6 +1971,13 @@ fn shell_arg(value: &str) -> String {
 }
 
 pub(super) fn safety_report(record: &TaskWorktreeRecord) -> Result<WorktreeSafetyReport> {
+    safety_report_until(record, None)
+}
+
+fn safety_report_until(
+    record: &TaskWorktreeRecord,
+    deadline: Option<std::time::Instant>,
+) -> Result<WorktreeSafetyReport> {
     let source = resolved_source_checkout(record)?;
     let parent = source.parent().ok_or_else(|| {
         Error::internal_unexpected(format!(
@@ -1708,11 +2006,11 @@ pub(super) fn safety_report(record: &TaskWorktreeRecord) -> Result<WorktreeSafet
     let caller_cwd = normalize_missing_path(&caller_cwd);
     let live_caller_cwd =
         !worktree_missing && (caller_cwd == worktree || caller_cwd.starts_with(&worktree));
-    let dirty = !worktree_missing && is_dirty(&worktree)?;
+    let dirty = !worktree_missing && is_dirty_until(&worktree, deadline)?;
     let unpushed_commits = if worktree_missing {
         0
     } else {
-        unpushed_commit_count(&worktree, &record.base_ref)?
+        unpushed_commit_count_until(&worktree, &record.base_ref, deadline)?
     };
     let mut reasons = Vec::new();
     if dirty {
@@ -1752,8 +2050,29 @@ pub(super) fn is_dirty(path: &Path) -> Result<bool> {
     )
 }
 
+fn is_dirty_until(path: &Path, deadline: Option<std::time::Instant>) -> Result<bool> {
+    Ok(
+        !run_inventory_git_until(path, &["status", "--porcelain=v1"], "git status", deadline)?
+            .trim()
+            .is_empty(),
+    )
+}
+
 pub(super) fn unpushed_commit_count(path: &Path, base_ref: &str) -> Result<u32> {
-    let upstream = git::run_git(path, &["rev-parse", "--abbrev-ref", "@{u}"], "git upstream");
+    unpushed_commit_count_until(path, base_ref, None)
+}
+
+fn unpushed_commit_count_until(
+    path: &Path,
+    base_ref: &str,
+    deadline: Option<std::time::Instant>,
+) -> Result<u32> {
+    let upstream = run_inventory_git_until(
+        path,
+        &["rev-parse", "--abbrev-ref", "@{u}"],
+        "git upstream",
+        deadline,
+    );
     let range = if let Ok(upstream) = upstream {
         let upstream = upstream.trim();
         if upstream.is_empty() {
@@ -1764,7 +2083,12 @@ pub(super) fn unpushed_commit_count(path: &Path, base_ref: &str) -> Result<u32> 
     } else {
         format!("{base_ref}..HEAD")
     };
-    let count = git::run_git(path, &["rev-list", "--count", &range], "git rev-list")?;
+    let count = run_inventory_git_until(
+        path,
+        &["rev-list", "--count", &range],
+        "git rev-list",
+        deadline,
+    )?;
     Ok(count.trim().parse::<u32>().unwrap_or(0))
 }
 

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -170,7 +170,11 @@ fn terminal_claim() -> crate::workspace_claim::WorkspaceClaim {
 struct FixedLivenessAuthority(WorktreeLivenessAuthority);
 
 impl WorktreeReconciliationAuthority for FixedLivenessAuthority {
-    fn acquire(&self, _: &TaskWorktreeRecord) -> Result<WorktreeLivenessAuthority> {
+    fn acquire(
+        &self,
+        _: &TaskWorktreeRecord,
+        _: std::time::Instant,
+    ) -> Result<WorktreeLivenessAuthority> {
         Ok(self.0.clone())
     }
 
@@ -178,6 +182,7 @@ impl WorktreeReconciliationAuthority for FixedLivenessAuthority {
         &self,
         _: &TaskWorktreeRecord,
         _: &crate::workspace_claim::WorkspaceClaim,
+        _: std::time::Instant,
     ) -> Result<bool> {
         Ok(true)
     }
@@ -187,10 +192,68 @@ impl WorktreeReconciliationAuthority for FixedLivenessAuthority {
     }
 }
 
+struct FailingReleaseAuthority;
+
+impl WorktreeReconciliationAuthority for FailingReleaseAuthority {
+    fn acquire(
+        &self,
+        _: &TaskWorktreeRecord,
+        _: std::time::Instant,
+    ) -> Result<WorktreeLivenessAuthority> {
+        Ok(WorktreeLivenessAuthority::Terminal {
+            claim: terminal_claim(),
+            provenance: "terminal claim with failed release".to_string(),
+        })
+    }
+
+    fn validate(
+        &self,
+        _: &TaskWorktreeRecord,
+        _: &crate::workspace_claim::WorkspaceClaim,
+        _: std::time::Instant,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn release(
+        &self,
+        _: &crate::workspace_claim::WorkspaceClaim,
+        _: std::time::Instant,
+    ) -> Result<()> {
+        Err(Error::internal_unexpected("test authority release failed"))
+    }
+}
+
+struct RefusingAuthority;
+
+impl WorktreeReconciliationAuthority for RefusingAuthority {
+    fn bounded_inventory_apply_refusal(&self) -> Option<WorktreeInventoryApplyRefusal> {
+        Some(WorktreeInventoryApplyRefusal {
+            code: "remote_workspace_reconciliation_unsupported",
+            mutated_records: 0,
+            mutation_provenance: "none",
+            required_primitive: "durable remote claim release receipt and retry protocol",
+            message: "remote reconciliation is not available",
+        })
+    }
+
+    fn acquire(
+        &self,
+        _: &TaskWorktreeRecord,
+        _: std::time::Instant,
+    ) -> Result<WorktreeLivenessAuthority> {
+        panic!("refused inventory must not acquire an authority claim")
+    }
+}
+
 struct RestoreAuthority(PathBuf);
 
 impl WorktreeReconciliationAuthority for RestoreAuthority {
-    fn acquire(&self, _: &TaskWorktreeRecord) -> Result<WorktreeLivenessAuthority> {
+    fn acquire(
+        &self,
+        _: &TaskWorktreeRecord,
+        _: std::time::Instant,
+    ) -> Result<WorktreeLivenessAuthority> {
         fs::create_dir_all(&self.0).unwrap();
         Ok(WorktreeLivenessAuthority::Terminal {
             claim: terminal_claim(),
@@ -202,6 +265,7 @@ impl WorktreeReconciliationAuthority for RestoreAuthority {
         &self,
         _: &TaskWorktreeRecord,
         _: &crate::workspace_claim::WorkspaceClaim,
+        _: std::time::Instant,
     ) -> Result<bool> {
         Ok(true)
     }
@@ -212,8 +276,53 @@ struct SlowAuthority {
     release: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
 }
 
+struct CountingAuthority(std::sync::atomic::AtomicUsize);
+
+impl WorktreeReconciliationAuthority for CountingAuthority {
+    fn acquire(
+        &self,
+        _: &TaskWorktreeRecord,
+        _: std::time::Instant,
+    ) -> Result<WorktreeLivenessAuthority> {
+        self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(WorktreeLivenessAuthority::Incomplete {
+            reason: "test authority must not be called".to_string(),
+        })
+    }
+}
+
+struct DeadlineAuthority;
+
+impl WorktreeReconciliationAuthority for DeadlineAuthority {
+    fn acquire(
+        &self,
+        _: &TaskWorktreeRecord,
+        deadline: std::time::Instant,
+    ) -> Result<WorktreeLivenessAuthority> {
+        while std::time::Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        Ok(WorktreeLivenessAuthority::Terminal {
+            claim: terminal_claim(),
+            provenance: "authority observed the supplied deadline".to_string(),
+        })
+    }
+
+    fn release(
+        &self,
+        _: &crate::workspace_claim::WorkspaceClaim,
+        _: std::time::Instant,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
 impl WorktreeReconciliationAuthority for SlowAuthority {
-    fn acquire(&self, _: &TaskWorktreeRecord) -> Result<WorktreeLivenessAuthority> {
+    fn acquire(
+        &self,
+        _: &TaskWorktreeRecord,
+        _: std::time::Instant,
+    ) -> Result<WorktreeLivenessAuthority> {
         self.started.send(()).unwrap();
         self.release.lock().unwrap().recv().unwrap();
         Ok(WorktreeLivenessAuthority::Terminal {
@@ -226,6 +335,7 @@ impl WorktreeReconciliationAuthority for SlowAuthority {
         &self,
         _: &TaskWorktreeRecord,
         _: &crate::workspace_claim::WorkspaceClaim,
+        _: std::time::Instant,
     ) -> Result<bool> {
         Ok(true)
     }
@@ -1485,6 +1595,174 @@ fn inventory_reconciles_only_a_leased_terminal_clean_snapshot() {
 }
 
 #[test]
+fn inventory_does_not_hide_a_failed_authority_release() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = git_repo();
+    let store = dir.path().join("store");
+    run_git(source.path(), &["branch", "task"]);
+    let record = fixture_record(source.path(), &sibling_worktree_path(source.path(), "gone"));
+    write_record(&store, &record).unwrap();
+
+    let error = inventory_with_store_and_authority(
+        WorktreeInventoryOptions {
+            limit: 10,
+            apply: true,
+            ..Default::default()
+        },
+        &store,
+        &dir.path().join("adopted"),
+        &FailingReleaseAuthority,
+    )
+    .expect_err("a completed reconciliation must surface an unreleased authority claim");
+
+    assert!(error.message.contains("test authority release failed"));
+}
+
+#[test]
+fn inventory_skips_authority_for_locally_blocked_missing_records() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = git_repo();
+    let store = dir.path().join("store");
+    let mut preserve = fixture_record(
+        source.path(),
+        &sibling_worktree_path(source.path(), "preserve"),
+    );
+    preserve.cleanup_policy = CleanupPolicy::PreserveOnFailure;
+    preserve.id = "fixture@preserve".to_string();
+    write_record(&store, &preserve).unwrap();
+
+    let mut unavailable = fixture_record(
+        dir.path().join("missing-source").as_path(),
+        &dir.path().join("gone"),
+    );
+    unavailable.id = "fixture@unavailable".to_string();
+    write_record(&store, &unavailable).unwrap();
+
+    let dirty_source = git_repo();
+    run_git(dirty_source.path(), &["branch", "task"]);
+    fs::write(dirty_source.path().join("dirty-source.txt"), "dirty\n").unwrap();
+    let mut dirty = fixture_record(
+        dirty_source.path(),
+        &sibling_worktree_path(dirty_source.path(), "dirty"),
+    );
+    dirty.id = "fixture@dirty".to_string();
+    write_record(&store, &dirty).unwrap();
+
+    let unpushed_source = git_repo();
+    let unpushed_path = sibling_worktree_path(unpushed_source.path(), "unpushed");
+    merged_task_branch_with_stale_upstream(unpushed_source.path(), &unpushed_path);
+    let mut unpushed = fixture_record(unpushed_source.path(), &unpushed_path);
+    unpushed.id = "fixture@unpushed".to_string();
+    write_record(&store, &unpushed).unwrap();
+
+    let authority = CountingAuthority(std::sync::atomic::AtomicUsize::new(0));
+    let output = inventory_with_store_and_authority(
+        WorktreeInventoryOptions {
+            limit: 10,
+            apply: true,
+            ..Default::default()
+        },
+        &store,
+        &dir.path().join("adopted"),
+        &authority,
+    )
+    .unwrap();
+
+    assert_eq!(authority.0.load(std::sync::atomic::Ordering::SeqCst), 0);
+    let reasons = output
+        .records
+        .iter()
+        .map(|item| item.missing_active.as_ref().unwrap().reason.clone())
+        .collect::<Vec<_>>();
+    assert!(reasons.contains(&MissingActiveWorktreeReason::PreserveOnFailure));
+    assert!(reasons.contains(&MissingActiveWorktreeReason::SourceCheckoutUnavailable));
+    assert!(reasons.contains(&MissingActiveWorktreeReason::SourceDirty));
+    assert!(reasons.contains(&MissingActiveWorktreeReason::UnpushedBranch));
+}
+
+#[test]
+fn inventory_apply_deadline_returns_a_retry_without_mutating_the_missing_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = git_repo();
+    let store = dir.path().join("store");
+    run_git(source.path(), &["branch", "task"]);
+    let record = fixture_record(
+        source.path(),
+        &sibling_worktree_path(source.path(), "deadline"),
+    );
+    write_record(&store, &record).unwrap();
+
+    let output = inventory_with_store_and_authority(
+        WorktreeInventoryOptions {
+            limit: 10,
+            cursor: Some("fixture@before".to_string()),
+            apply: true,
+            apply_deadline: Some(std::time::Instant::now() + std::time::Duration::from_millis(10)),
+            ..Default::default()
+        },
+        &store,
+        &dir.path().join("adopted"),
+        &DeadlineAuthority,
+    )
+    .unwrap();
+
+    assert_eq!(output.records.len(), 0);
+    assert_eq!(
+        output.apply_continuation.as_deref(),
+        Some("homeboy worktree inventory --apply --limit 10 --cursor fixture@before")
+    );
+    assert!(output.truncated);
+    assert_eq!(
+        read_record(&store, &record.id).unwrap().state,
+        TaskWorktreeState::Active
+    );
+}
+
+#[test]
+fn inventory_apply_refusal_preserves_local_missing_diagnostics_without_acquiring() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = git_repo();
+    let store = dir.path().join("store");
+    run_git(source.path(), &["branch", "task"]);
+    let record = fixture_record(source.path(), &sibling_worktree_path(source.path(), "gone"));
+    write_record(&store, &record).unwrap();
+
+    let output = inventory_with_store_and_authority(
+        WorktreeInventoryOptions {
+            limit: 10,
+            apply: true,
+            ..Default::default()
+        },
+        &store,
+        &dir.path().join("adopted"),
+        &RefusingAuthority,
+    )
+    .unwrap();
+
+    assert_eq!(
+        output.authorization,
+        WorktreeInventoryAuthorization::ApplyRefused
+    );
+    assert_eq!(
+        output.apply_refusal.as_ref().map(|refusal| refusal.code),
+        Some("remote_workspace_reconciliation_unsupported")
+    );
+    assert_eq!(output.records.len(), 1);
+    assert_eq!(
+        output.records[0]
+            .missing_active
+            .as_ref()
+            .map(|missing| &missing.reason),
+        Some(&MissingActiveWorktreeReason::RequiresAuthoritativeLiveness)
+    );
+    assert!(output.records[0].reconciliation.is_none());
+    assert_eq!(
+        read_record(&store, &record.id).unwrap().state,
+        TaskWorktreeState::Active
+    );
+}
+
+#[test]
 fn inventory_refuses_expired_workspace_claims() {
     let dir = tempfile::tempdir().unwrap();
     let source = git_repo();
@@ -2145,6 +2423,136 @@ fn cleanup_dry_run_reports_safe_candidate_without_removing() {
     assert_eq!(output.candidates[0].record.id, record.id);
     assert!(!output.candidates[0].safety.worktree_missing);
     assert_eq!(updated.state, TaskWorktreeState::Active);
+    assert!(worktree.exists());
+}
+
+#[test]
+fn cleanup_page_paginates_real_candidates_and_preserves_page_options_in_continuation() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = git_repo();
+    let first_path = sibling_worktree_path(source.path(), "page-first");
+    let second_path = sibling_worktree_path(source.path(), "page-second");
+    run_git(
+        source.path(),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "page-first",
+            &first_path.to_string_lossy(),
+        ],
+    );
+    run_git(
+        source.path(),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "page-second",
+            &second_path.to_string_lossy(),
+        ],
+    );
+    let store = dir.path().join("store");
+    let mut first = succeeded_record(source.path(), &first_path);
+    first.id = "fixture@page-first".to_string();
+    first.branch = "page-first".to_string();
+    let mut second = succeeded_record(source.path(), &second_path);
+    second.id = "fixture@page-second".to_string();
+    second.branch = "page-second".to_string();
+    write_record(&store, &first).unwrap();
+    write_record(&store, &second).unwrap();
+
+    let first_page = cleanup_with_store_page(
+        WorktreeCleanupPageOptions {
+            cleanup: WorktreeCleanupOptions {
+                force: false,
+                dry_run: true,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
+            },
+            limit: 1,
+            cursor: None,
+            deadline: None,
+        },
+        &store,
+    )
+    .unwrap();
+    assert_eq!(first_page.candidates.len(), 1);
+    assert_eq!(
+        first_page.next_cursor.as_deref(),
+        Some("fixture@page-first")
+    );
+    assert_eq!(
+        first_page.continuation.as_deref(),
+        Some("homeboy cleanup --include task-worktrees --limit 1 --cursor fixture@page-first")
+    );
+
+    let second_page = cleanup_with_store_page(
+        WorktreeCleanupPageOptions {
+            cleanup: WorktreeCleanupOptions {
+                force: false,
+                dry_run: true,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
+            },
+            limit: 1,
+            cursor: first_page.next_cursor,
+            deadline: None,
+        },
+        &store,
+    )
+    .unwrap();
+    assert_eq!(second_page.candidates.len(), 1);
+    assert_eq!(second_page.candidates[0].record.id, "fixture@page-second");
+    assert!(second_page.next_cursor.is_none());
+}
+
+#[test]
+fn expired_cleanup_apply_keeps_the_unprocessed_candidate_active_and_replays_apply() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = git_repo();
+    let worktree = sibling_worktree_path(source.path(), "expired-cleanup");
+    run_git(
+        source.path(),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "expired-cleanup",
+            &worktree.to_string_lossy(),
+        ],
+    );
+    let store = dir.path().join("store");
+    let record = succeeded_record(source.path(), &worktree);
+    write_record(&store, &record).unwrap();
+
+    let output = cleanup_with_store_page(
+        WorktreeCleanupPageOptions {
+            cleanup: WorktreeCleanupOptions {
+                force: false,
+                dry_run: false,
+                cleanup_branches: true,
+                allow_unmerged_branches: false,
+            },
+            limit: 7,
+            cursor: None,
+            deadline: Some(std::time::Instant::now()),
+        },
+        &store,
+    )
+    .unwrap();
+
+    assert!(output.candidates.is_empty());
+    assert!(output.removed.is_empty());
+    assert_eq!(output.next_cursor, None);
+    assert_eq!(
+        output.continuation.as_deref(),
+        Some("homeboy cleanup --include task-worktrees --limit 7 --apply")
+    );
+    assert_eq!(
+        read_record(&store, &record.id).unwrap().state,
+        TaskWorktreeState::Active
+    );
     assert!(worktree.exists());
 }
 

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -443,6 +443,9 @@ pub struct WorktreeInventoryOutput {
     pub authorization: WorktreeInventoryAuthorization,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub apply_refusal: Option<WorktreeInventoryApplyRefusal>,
+    /// Exact bounded retry command when apply authority time is exhausted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub apply_continuation: Option<String>,
     /// The task-worktree page starts strictly after this sorted record ID.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
@@ -494,12 +497,28 @@ pub struct WorktreeInventoryRecord {
 }
 
 pub trait WorktreeReconciliationAuthority {
+    /// Refuse apply before any authority acquisition when this implementation
+    /// cannot complete the bounded reconciliation contract safely.
+    fn bounded_inventory_apply_refusal(&self) -> Option<WorktreeInventoryApplyRefusal> {
+        None
+    }
+
     /// Acquires an owner-issued admission fence before the registry write lease.
-    fn acquire(&self, record: &TaskWorktreeRecord) -> Result<WorktreeLivenessAuthority>;
+    /// Implementations must pass this deadline to every remote authority call.
+    fn acquire(
+        &self,
+        record: &TaskWorktreeRecord,
+        deadline: std::time::Instant,
+    ) -> Result<WorktreeLivenessAuthority>;
 
     /// Revalidates the opaque fence at the owner. This is intentionally outside
     /// the task-worktree registry lease because it can be a network operation.
-    fn validate(&self, _record: &TaskWorktreeRecord, _claim: &WorkspaceClaim) -> Result<bool> {
+    fn validate(
+        &self,
+        _record: &TaskWorktreeRecord,
+        _claim: &WorkspaceClaim,
+        _deadline: std::time::Instant,
+    ) -> Result<bool> {
         Ok(false)
     }
 
@@ -514,7 +533,7 @@ pub trait WorktreeReconciliationAuthority {
     }
 
     /// Releases the owner-issued fence after the conditional registry mutation.
-    fn release(&self, _claim: &WorkspaceClaim) -> Result<()> {
+    fn release(&self, _claim: &WorkspaceClaim, _deadline: std::time::Instant) -> Result<()> {
         Ok(())
     }
 }
@@ -603,6 +622,9 @@ pub struct WorktreeInventoryOptions {
     pub cursor: Option<String>,
     pub adopted_cursor: Option<String>,
     pub apply: bool,
+    /// Testable monotonic deadline for the complete apply page. Production
+    /// callers leave this unset and use the bounded default.
+    pub apply_deadline: Option<std::time::Instant>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -626,6 +648,10 @@ pub struct WorktreeCleanupOutput {
     pub candidates: Vec<WorktreeCleanupCandidate>,
     pub removed: Vec<WorktreeRemoveOutput>,
     pub skipped: Vec<WorktreeCleanupSkipped>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Default, PartialEq, Eq)]
@@ -703,6 +729,14 @@ pub struct WorktreeCleanupOptions {
     pub dry_run: bool,
     pub cleanup_branches: bool,
     pub allow_unmerged_branches: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorktreeCleanupPageOptions {
+    pub cleanup: WorktreeCleanupOptions,
+    pub limit: usize,
+    pub cursor: Option<String>,
+    pub deadline: Option<std::time::Instant>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1986,6 +1986,10 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     status_with_admission_projection(runner_id).map(|(status, _, _)| status)
 }
 
+pub(crate) fn status_until(runner_id: &str, deadline: Instant) -> Result<RunnerStatusReport> {
+    status_with_admission_projection_until(runner_id, deadline).map(|(status, _, _)| status)
+}
+
 /// Capture status and the generation ledger together so callers that need an
 /// admission answer cannot observe a second, racing persisted generation state.
 pub(crate) fn status_with_admission_projection(

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -47,6 +47,7 @@ impl RunnerContinuationProvider for RunnerContinuation {
         runner_id: &str,
         workspace: WorkspaceIdentity,
         lifecycle_revision: u64,
+        deadline: std::time::Instant,
     ) -> Result<WorkspaceClaim> {
         let body = workspace_claim_post(
             runner_id,
@@ -56,6 +57,7 @@ impl RunnerContinuationProvider for RunnerContinuation {
                 "lifecycle_revision": lifecycle_revision,
                 "ttl_ms": homeboy_core::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS,
             }),
+            deadline,
         )?;
         let claim: WorkspaceClaim = serde_json::from_value(
             body.get("claim").cloned().unwrap_or(Value::Null),
@@ -73,11 +75,17 @@ impl RunnerContinuationProvider for RunnerContinuation {
         Ok(claim)
     }
 
-    fn validate_workspace_claim(&self, runner_id: &str, claim: &WorkspaceClaim) -> Result<bool> {
+    fn validate_workspace_claim(
+        &self,
+        runner_id: &str,
+        claim: &WorkspaceClaim,
+        deadline: std::time::Instant,
+    ) -> Result<bool> {
         let body = workspace_claim_post(
             runner_id,
             "/workspace-claims/validate",
             json!({ "claim": claim }),
+            deadline,
         )?;
         body.get("valid").and_then(Value::as_bool).ok_or_else(|| {
             workspace_claim_error(
@@ -87,11 +95,17 @@ impl RunnerContinuationProvider for RunnerContinuation {
         })
     }
 
-    fn release_workspace_claim(&self, runner_id: &str, claim: &WorkspaceClaim) -> Result<()> {
+    fn release_workspace_claim(
+        &self,
+        runner_id: &str,
+        claim: &WorkspaceClaim,
+        deadline: std::time::Instant,
+    ) -> Result<()> {
         let body = workspace_claim_post(
             runner_id,
             "/workspace-claims/release",
             json!({ "claim": claim }),
+            deadline,
         )?;
         if body.get("released").and_then(Value::as_bool) != Some(true) {
             return Err(workspace_claim_error(
@@ -114,6 +128,7 @@ impl RunnerContinuationProvider for RunnerContinuation {
             runner_id,
             "/workspace-claims/authority",
             json!({ "workspace": workspace }),
+            std::time::Instant::now() + Duration::from_secs(30),
         )?;
         let status: WorkspaceAuthorityStatus = serde_json::from_value(
             body.get("status").cloned().unwrap_or(Value::Null),
@@ -298,8 +313,13 @@ struct DaemonEnvelope {
     data: Option<Value>,
 }
 
-fn workspace_claim_post(runner_id: &str, path: &str, payload: Value) -> Result<Value> {
-    let report = super::connection::status(runner_id)?;
+fn workspace_claim_post(
+    runner_id: &str,
+    path: &str,
+    payload: Value,
+    deadline: std::time::Instant,
+) -> Result<Value> {
+    let report = super::connection::status_until(runner_id, deadline)?;
     let session = report
         .session
         .filter(|_| report.connected)
@@ -308,7 +328,7 @@ fn workspace_claim_post(runner_id: &str, path: &str, payload: Value) -> Result<V
         let broker_url = session.broker_url.ok_or_else(|| {
             workspace_claim_error(runner_id, "reverse runner session has no broker endpoint")
         })?;
-        return reverse_workspace_claim_post(runner_id, &broker_url, path, payload);
+        return reverse_workspace_claim_post(runner_id, &broker_url, path, payload, deadline);
     }
     if session.mode != super::RunnerTunnelMode::DirectSsh {
         return Err(workspace_claim_error(
@@ -319,14 +339,7 @@ fn workspace_claim_post(runner_id: &str, path: &str, payload: Value) -> Result<V
     let local_url = session.local_url.ok_or_else(|| {
         workspace_claim_error(runner_id, "direct daemon session has no local endpoint")
     })?;
-    let client = Client::builder()
-        .no_proxy()
-        .timeout(Duration::from_secs(10))
-        .build()
-        .map_err(|error| {
-            workspace_claim_error(runner_id, format!("build daemon client: {error}"))
-        })?;
-    let capabilities = daemon_get_json(&client, &local_url, "/capabilities", runner_id)?;
+    let capabilities = daemon_get_json(&local_url, "/capabilities", runner_id, deadline)?;
     let protocols: Vec<WorkspaceClaimProtocol> = serde_json::from_value(
         capabilities
             .get("capabilities")
@@ -344,7 +357,7 @@ fn workspace_claim_post(runner_id: &str, path: &str, payload: Value) -> Result<V
             "daemon does not advertise workspace claim capability v1",
         ));
     }
-    daemon_post_json(&client, &local_url, path, payload, runner_id)
+    daemon_post_json(&local_url, path, payload, runner_id, deadline)
 }
 
 fn reverse_workspace_claim_post(
@@ -352,14 +365,10 @@ fn reverse_workspace_claim_post(
     broker_url: &str,
     daemon_path: &str,
     payload: Value,
+    deadline: std::time::Instant,
 ) -> Result<Value> {
-    let client = Client::builder()
-        .timeout(Duration::from_secs(10))
-        .build()
-        .map_err(|error| {
-            workspace_claim_error(runner_id, format!("build broker client: {error}"))
-        })?;
     let token = homeboy_core::broker_auth::broker_submit_token_for_runner(runner_id)?;
+    let client = workspace_claim_client(deadline, runner_id, false)?;
     let capabilities = client
         .get(format!(
             "{}/runner/workspace-claims/capabilities",
@@ -397,6 +406,7 @@ fn reverse_workspace_claim_post(
         ));
     }
     let operation = daemon_path.trim_start_matches("/workspace-claims/");
+    let client = workspace_claim_client(deadline, runner_id, false)?;
     let response = client
         .post(format!(
             "{}/runner/workspace-claims/{operation}",
@@ -416,7 +426,13 @@ fn reverse_workspace_claim_post(
     )
 }
 
-fn daemon_get_json(client: &Client, url: &str, path: &str, runner_id: &str) -> Result<Value> {
+fn daemon_get_json(
+    url: &str,
+    path: &str,
+    runner_id: &str,
+    deadline: std::time::Instant,
+) -> Result<Value> {
+    let client = workspace_claim_client(deadline, runner_id, true)?;
     let response = client
         .get(format!("{}{}", url.trim_end_matches('/'), path))
         .send()
@@ -430,12 +446,13 @@ fn daemon_get_json(client: &Client, url: &str, path: &str, runner_id: &str) -> R
 }
 
 fn daemon_post_json(
-    client: &Client,
     url: &str,
     path: &str,
     payload: Value,
     runner_id: &str,
+    deadline: std::time::Instant,
 ) -> Result<Value> {
+    let client = workspace_claim_client(deadline, runner_id, true)?;
     let response = client
         .post(format!("{}{}", url.trim_end_matches('/'), path))
         .json(&payload)
@@ -444,6 +461,36 @@ fn daemon_post_json(
             workspace_claim_error(runner_id, format!("daemon claim request failed: {error}"))
         })?;
     daemon_response(response.status().as_u16(), response.text(), path, runner_id)
+}
+
+fn workspace_claim_client(
+    deadline: std::time::Instant,
+    runner_id: &str,
+    no_proxy: bool,
+) -> Result<Client> {
+    let timeout = remaining_workspace_claim_budget(deadline, runner_id)?;
+    let builder = if no_proxy {
+        Client::builder().no_proxy().timeout(timeout)
+    } else {
+        Client::builder().timeout(timeout)
+    };
+    builder.build().map_err(|error| {
+        workspace_claim_error(runner_id, format!("build workspace claim client: {error}"))
+    })
+}
+
+fn remaining_workspace_claim_budget(
+    deadline: std::time::Instant,
+    runner_id: &str,
+) -> Result<Duration> {
+    deadline
+        .checked_duration_since(std::time::Instant::now())
+        .ok_or_else(|| {
+            workspace_claim_error(
+                runner_id,
+                "worktree inventory apply authority deadline exhausted",
+            )
+        })
 }
 
 fn daemon_response(


### PR DESCRIPTION
## Summary

- Evaluate local missing-worktree blockers before reconciliation authority acquisition, and bound cleanup/inventory pages with resumable cursors.
- Propagate a single deadline through registry leases, local Git preflight, runner status, and workspace-claim transport.
- Keep claim ownership fail-closed: an unreleased authority claim is surfaced as an error.

## Remote Authority Status

Remote workspace reconciliation is intentionally incomplete. When remote claim or terminal authorities are configured, `homeboy worktree inventory --apply` returns `remote_workspace_reconciliation_unsupported` before acquiring a claim or mutating a reconciliation record. Local blocker diagnostics and bounded task-worktree cleanup remain available.

Refs #14397

## Verification

```sh
cargo fmt --check
cargo test -p homeboy-core worktree::tests
cargo test -p homeboy-agents workspace_claims
cargo test -p homeboy-lab-runner continuation_provider
cargo test -p homeboy-cli commands::worktree
cargo test -p homeboy-cli commands::cleanup
```

All commands passed. The core worktree suite covers local-first authority skipping, deadline continuation without mutation, release failure visibility, cleanup pagination, and expired cleanup continuation.

## AI Assistance

OpenAI gpt-6-astra via OpenCode was used at Chris Huber's direction for delegated implementation, review, and testing. Chris directed the landing workflow and acceptance scope.