### PR TITLE
fix(lab): retain snapshot staging ownership

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -2255,15 +2255,28 @@ pub(super) fn snapshot_input_manifest(
 }
 
 /// Materialize every required manifest entry into one private staging tree.
-/// The returned directory is kept alive through transfer, making the staging
-/// output the sole tar input after validation succeeds.
+/// The returned guard keeps the staging output and its cleanup owner alive
+/// through transfer, making it the sole tar input after validation succeeds.
+#[derive(Debug)]
+pub(super) struct SnapshotStage {
+    path: PathBuf,
+    _scratch_stage: Option<tempfile::TempDir>,
+    _runtime_owner: Option<homeboy_core::engine::temp::RuntimeTempOwner>,
+}
+
+impl SnapshotStage {
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn materialize_snapshot_stage(
     local_path: &Path,
     excludes: &[String],
     manifest: &SnapshotInputManifest,
     scratch: Option<&Path>,
-) -> Result<tempfile::TempDir> {
+) -> Result<SnapshotStage> {
     materialize_snapshot_stage_before(local_path, excludes, manifest, scratch, None)
 }
 
@@ -2273,16 +2286,36 @@ fn materialize_snapshot_stage_before(
     manifest: &SnapshotInputManifest,
     scratch: Option<&Path>,
     deadline: Option<Instant>,
-) -> Result<tempfile::TempDir> {
-    let stage = scratch
-        .map_or_else(tempfile::tempdir, |path| {
-            tempfile::Builder::new()
+) -> Result<SnapshotStage> {
+    let stage = match scratch {
+        Some(path) => {
+            let scratch_stage = tempfile::Builder::new()
                 .prefix("homeboy-snapshot-stage-")
                 .tempdir_in(path)
-        })
-        .map_err(|error| {
-            snapshot_construction_failure("staging", local_path, None, &error.to_string())
-        })?;
+                .map_err(|error| {
+                    snapshot_construction_failure("staging", local_path, None, &error.to_string())
+                })?;
+            SnapshotStage {
+                path: scratch_stage.path().to_path_buf(),
+                _scratch_stage: Some(scratch_stage),
+                _runtime_owner: None,
+            }
+        }
+        None => {
+            let runtime_owner = homeboy_core::engine::temp::RuntimeTempOwner::allocate(
+                "homeboy-snapshot-stage",
+                "workspace_snapshot",
+            )
+            .map_err(|error| {
+                snapshot_construction_failure("staging", local_path, None, &error.to_string())
+            })?;
+            SnapshotStage {
+                path: runtime_owner.path().to_path_buf(),
+                _scratch_stage: None,
+                _runtime_owner: Some(runtime_owner),
+            }
+        }
+    };
     let stage_source = stage.path().join("source");
     fs::create_dir_all(&stage_source).map_err(|error| {
         snapshot_construction_failure(

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1777,6 +1777,88 @@ fn snapshot_staging_rejects_a_disappearing_runtime_overlay_before_ssh() {
 }
 
 #[test]
+fn snapshot_staging_runtime_owner_fixture() {
+    let Some(source) = std::env::var_os("HOMEBOY_SNAPSHOT_STAGE_FIXTURE_SOURCE") else {
+        return;
+    };
+    let ready = std::path::PathBuf::from(
+        std::env::var_os("HOMEBOY_SNAPSHOT_STAGE_FIXTURE_READY").expect("fixture ready path"),
+    );
+    let source = std::path::PathBuf::from(source);
+    let manifest = snapshot_input_manifest(&source, &[]).expect("fixture input manifest");
+    let stage = materialize_snapshot_stage(&source, &[], &manifest, None).expect("fixture stage");
+    fs::write(&ready, stage.path().display().to_string()).expect("publish fixture stage path");
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+
+#[test]
+fn snapshot_staging_runtime_owner_protects_live_stage_and_reclaims_killed_stage() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source");
+        let input = source.path().join("input.txt");
+        fs::write(&input, "source bytes").expect("write source");
+        let manifest = snapshot_input_manifest(source.path(), &[]).expect("input manifest");
+        let live = materialize_snapshot_stage(source.path(), &[], &manifest, None)
+            .expect("stage with runtime owner");
+        let live_path = live.path().to_path_buf();
+
+        let active = homeboy_core::engine::temp::cleanup_runtime_tmp(
+            true,
+            0,
+            Some("homeboy-snapshot-stage"),
+            10,
+        )
+        .expect("clean active runtime stage");
+        assert_eq!(active.removed_count, 0);
+        assert!(live_path.exists(), "live owner must protect its stage");
+        assert_eq!(
+            fs::read_to_string(&input).expect("read source"),
+            "source bytes"
+        );
+        drop(live);
+
+        let ready = source.path().join("stage-ready");
+        let mut child =
+            std::process::Command::new(std::env::current_exe().expect("current test executable"))
+                .arg("snapshot_staging_runtime_owner_fixture")
+                .env("HOMEBOY_SNAPSHOT_STAGE_FIXTURE_SOURCE", source.path())
+                .env("HOMEBOY_SNAPSHOT_STAGE_FIXTURE_READY", &ready)
+                .spawn()
+                .expect("start stage owner fixture");
+        for _ in 0..100 {
+            if ready.exists() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        let abandoned = std::path::PathBuf::from(
+            fs::read_to_string(&ready).expect("fixture must publish its stage path"),
+        );
+        child.kill().expect("SIGKILL stage owner fixture");
+        child.wait().expect("reap killed stage owner fixture");
+
+        let reclaimed = homeboy_core::engine::temp::cleanup_runtime_tmp(
+            true,
+            0,
+            Some("homeboy-snapshot-stage"),
+            10,
+        )
+        .expect("clean abandoned runtime stage");
+        assert!(reclaimed.removed_count >= 1);
+        assert!(
+            !abandoned.exists(),
+            "killed owner stage must be reclaimable"
+        );
+        assert_eq!(
+            fs::read_to_string(&input).expect("read source"),
+            "source bytes"
+        );
+    });
+}
+
+#[test]
 fn snapshot_transport_archives_only_the_admitted_scratch_stage() {
     let source = tempfile::tempdir().expect("source");
     let scratch = tempfile::tempdir().expect("admitted scratch");


### PR DESCRIPTION
## Summary
- Allocate default snapshot staging directories through the runtime temporary-owner lifecycle.
- Preserve caller-provided scratch staging behavior while keeping each stage path alive for transfer.
- Cover active ownership and SIGKILL-abandoned-stage reclamation end to end.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-lab-runner snapshot_staging_runtime_owner -- --nocapture`

## Limits
- Verification is scoped to snapshot-stage formatting and ownership/reclamation behavior; the full workspace test suite was not run.
- The focused test completed with pre-existing dead-code warnings from `homeboy-core`.

Refs #10522

## AI Assistance
Implementation used OpenAI gpt-5.6-terra with opencode run directly in parallel at Chris direction. Review and orchestration used OpenAI gpt-6-astra via OpenCode.