### PR TITLE
fix(agent-task): admit exhausted Cook retries

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/action_eligibility.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/action_eligibility.rs
@@ -155,6 +155,19 @@ fn retry_availability(
     }) {
         return unavailable("acceptance rejection repair budget is exhausted for this lineage");
     }
+    if super::is_unmaterialized_cook_admission(record) {
+        if !record.metadata["unmaterialized_cook_admission"]["binding"]["replay_intent"]
+            .as_object()
+            .is_some_and(|intent| intent.get("argv").is_some_and(serde_json::Value::is_array))
+        {
+            return unavailable(
+                "terminal unmaterialized Cook admission lacks its durable replay intent",
+            );
+        }
+        return available(
+            "terminal unmaterialized Cook admission retains its immutable replay binding; retry will reserve a new admission and revalidate runner readiness",
+        );
+    }
     if record.metadata["cook_id"].is_string() {
         match crate::agent_task_service::retry_admission_for_projection(&record.run_id) {
             Ok(crate::agent_task_service::RetryProjectionAdmission::DurableCook) => {
@@ -271,6 +284,28 @@ mod tests {
         assert!(resume.idempotent);
         assert_eq!(
             resume.availability,
+            ControlPlaneActionAvailability::Available
+        );
+    }
+
+    #[test]
+    fn exhausted_unmaterialized_cook_retry_uses_its_replay_binding_not_plan_identity() {
+        let mut record = record(AgentTaskRunState::Failed, false);
+        record.metadata["unmaterialized_cook_admission"] = serde_json::json!({
+            "state": "exhausted",
+            "binding": {
+                "replay_intent": {
+                    "cook_id": "run",
+                    "argv": ["agent-task", "cook", "--run-id", "run"]
+                }
+            }
+        });
+
+        let report =
+            lifecycle_action_eligibility(&record, Some(&AgentTaskPlan::new("empty", vec![])));
+
+        assert_eq!(
+            decision(&report, ControlPlaneAction::Retry),
             ControlPlaneActionAvailability::Available
         );
     }

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -2401,4 +2401,100 @@ mod tests {
             assert!(terminal.metadata.get("provider_execution").is_none());
         });
     }
+
+    #[test]
+    fn exhausted_unmaterialized_admission_retries_its_original_binding_once_after_runner_recovers()
+    {
+        with_isolated_home(|_| {
+            let cook_id = "reconcile-unmaterialized-retry-after-exhaustion";
+            let binding = serde_json::json!({
+                "schema": "homeboy/unmaterialized-cook-binding/v1",
+                "request_ref": "sha256:original-submission",
+                "worktree_ref": "homeboy@fix-unmaterialized-admission-retry",
+                "task": { "prompt_ref": "sha256:exact-task-prompt" },
+                "gates": { "verify": ["cargo test -p homeboy-agents"] },
+                "retry": { "max_attempts": 3, "provider_rotations": 0 },
+                "provider_runtime_refs": { "backend": "opencode", "model": "gpt-5.6" },
+                "placement": { "candidate_runner_refs": ["lab"], "local_fallback": false },
+                "replay_intent": {
+                    "cook_id": cook_id,
+                    "argv": ["agent-task", "cook", "--run-id", cook_id]
+                }
+            });
+            agent_task_lifecycle::record_unmaterialized_cook_admission_in_store(
+                &test_lifecycle_store(),
+                cook_id,
+                binding.clone(),
+                "blocked_runner_stale",
+                "runner stale",
+            )
+            .expect("admit original Cook");
+            agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
+                record.metadata["unmaterialized_cook_admission"]["retry"]["max_attempts"] =
+                    serde_json::json!(1);
+                record.metadata["unmaterialized_cook_admission"]["retry"]["next_attempt_at"] =
+                    serde_json::json!("2000-01-01T00:00:00+00:00");
+            })
+            .expect("make original admission exhaust");
+
+            let exhausted = reconcile_unmaterialized_cook_admissions_with(
+                Some(cook_id),
+                |_| Ok(serde_json::json!({ "state": "blocked_runner_stale" })),
+                |_| panic!("exhausted admission must not replay"),
+            )
+            .expect("exhaust admission");
+            assert_eq!(exhausted["exhausted"], 1);
+            let source = agent_task_lifecycle::exact_record(cook_id).expect("failed source");
+            assert_eq!(
+                source.state,
+                agent_task_lifecycle::AgentTaskRunState::Failed
+            );
+
+            let retry = crate::agent_task_service::retry(cook_id, None, false, false)
+                .expect("native retry reserves a successor admission");
+            assert!(retry.created);
+            assert!(retry.record.tasks.is_empty());
+            let admission = &retry.record.metadata["unmaterialized_cook_admission"];
+            assert_eq!(retry.record.metadata["retry_of"], cook_id);
+            assert_eq!(admission["binding"]["task"], binding["task"]);
+            assert_eq!(admission["binding"]["gates"], binding["gates"]);
+            assert_eq!(
+                admission["binding"]["worktree_ref"],
+                binding["worktree_ref"]
+            );
+            assert_eq!(admission["binding"]["retry"], binding["retry"]);
+            assert_eq!(
+                admission["binding"]["replay_intent"]["cook_id"],
+                retry.record.run_id
+            );
+
+            agent_task_lifecycle::rearm_unmaterialized_cook_admission(&retry.record.run_id)
+                .expect("runner readiness repair rearms the successor admission");
+            let replay_requests = std::cell::RefCell::new(Vec::new());
+            let recovered = reconcile_unmaterialized_cook_admissions_with(
+                Some(&retry.record.run_id),
+                |_| Ok(serde_json::json!({ "state": "eligible", "runner_id": "repaired-lab" })),
+                |request| {
+                    replay_requests.borrow_mut().push(request.clone());
+                    Ok(serde_json::json!({ "worker_id": "repaired-worker" }))
+                },
+            )
+            .expect("repaired runner replays successor");
+            assert_eq!(recovered["replayed"], 1);
+            assert_eq!(replay_requests.borrow().len(), 1);
+            assert_eq!(
+                replay_requests.borrow()[0]["intent"]["argv"],
+                serde_json::json!(["agent-task", "cook", "--run-id", retry.record.run_id])
+            );
+
+            let duplicate = reconcile_unmaterialized_cook_admissions_with(
+                Some(&retry.record.run_id),
+                |_| panic!("active replay lease must prevent a duplicate runner selection"),
+                |_| panic!("active replay lease must prevent duplicate materialization"),
+            )
+            .expect("duplicate pass is inert");
+            assert_eq!(duplicate["replayed"], 0);
+            assert_eq!(replay_requests.borrow().len(), 1);
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- Make terminal unmaterialized Cook admissions with an exhausted runner-admission budget eligible for retry when their durable replay intent is complete.
- Reserve a fresh admission while retaining the original task, gates, worktree, and retry policy; only the successor Cook identity changes.

## Context
No dedicated issue was found. This addresses observed exhausted admission reports that said retry was unavailable despite a durable replay binding. Related to #14404.

## Testing
- `cargo test -p homeboy-agents --lib exhausted_unmaterialized --jobs 2`
- `cargo fmt --all`
- `git diff --check`

## AI Assistance
- Implementation: gpt-5.6-terra via OpenCode, direct implementation and verification run in parallel.
- Orchestration review: gpt-6-astra via OpenCode, user-directed.