### PR TITLE
Fix admission retry status projection

### DIFF
--- a/crates/contracts/homeboy-control-plane-contract/src/lib.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/lib.rs
@@ -42,10 +42,11 @@ pub use identity::{
 pub use resolve::{resolve, IdentityKind, ResolveError, ResolvedIdentities};
 pub use resource::{
     ControlPlaneAction, ControlPlaneActionAvailability, ControlPlaneActionConfirmation,
-    ControlPlaneActionEligibility, ControlPlaneActionEligibilityReport, ControlPlaneBlocker,
-    ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEvidenceRef, ControlPlaneLiveness,
-    ControlPlaneLocation, ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneResult,
-    ControlPlaneRun, ControlPlaneRunState, ControlPlaneRuntime, ControlPlaneStateSummary,
+    ControlPlaneActionEligibility, ControlPlaneActionEligibilityReport, ControlPlaneAdmissionRetry,
+    ControlPlaneAdmissionRetryDisposition, ControlPlaneBlocker, ControlPlaneError,
+    ControlPlaneErrorClass, ControlPlaneEvidenceRef, ControlPlaneLiveness, ControlPlaneLocation,
+    ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneResult, ControlPlaneRun,
+    ControlPlaneRunState, ControlPlaneRuntime, ControlPlaneStateSummary,
     CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA, CONTROL_PLANE_RESULT_SCHEMA, CONTROL_PLANE_RUN_SCHEMA,
 };
 pub use review::{

--- a/crates/contracts/homeboy-control-plane-contract/src/resource.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/resource.rs
@@ -205,6 +205,34 @@ pub struct ControlPlaneBlocker {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
     pub message: String,
+    /// Typed durable state when this blocker is an admission decision.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    /// Bounded, redacted durable reason when it differs from the legacy message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry: Option<ControlPlaneAdmissionRetry>,
+}
+
+/// Bounded automatic reconciliation state for a durable admission blocker.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControlPlaneAdmissionRetry {
+    pub policy: String,
+    pub attempts: u64,
+    pub max_attempts: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_attempt_at: Option<String>,
+    pub disposition: ControlPlaneAdmissionRetryDisposition,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlPlaneAdmissionRetryDisposition {
+    AutomaticReconciliationScheduled,
+    AutomaticReconciliationDue,
+    Exhausted,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -376,6 +404,9 @@ mod tests {
         resource.blocker = Some(ControlPlaneBlocker {
             code: Some("stale".to_string()),
             message: "runner_disconnected".to_string(),
+            state: None,
+            reason: None,
+            retry: None,
         });
         resource.owner = Some(ControlPlaneOwner {
             kind: "runner".to_string(),

--- a/crates/homeboy-agents/src/agent_task_lifecycle/action_eligibility.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/action_eligibility.rs
@@ -121,6 +121,11 @@ fn resume_availability(record: &AgentTaskRunRecord) -> (ControlPlaneActionAvaila
     if record.metadata.get("queue_quarantine").is_some() {
         return unavailable("run is quarantined and must be re-armed before resume");
     }
+    if let Some(next_attempt_at) = scheduled_unmaterialized_admission_retry(record) {
+        return available(format!(
+            "resume is legal but explicitly re-arms this admission; automatic reconciliation is scheduled for {next_attempt_at}, so waiting is the recommended next action"
+        ));
+    }
     match record.state {
         AgentTaskRunState::Queued => available("queued run can re-enter execution"),
         AgentTaskRunState::Running => match record.local_owner_liveness() {
@@ -134,6 +139,18 @@ fn resume_availability(record: &AgentTaskRunRecord) -> (ControlPlaneActionAvaila
         },
         _ => unavailable("terminal runs cannot be resumed"),
     }
+}
+
+fn scheduled_unmaterialized_admission_retry(record: &AgentTaskRunRecord) -> Option<String> {
+    let admission = record.metadata.get("unmaterialized_cook_admission")?;
+    if !admission.is_object() || record.state.is_terminal() {
+        return None;
+    }
+    let next_attempt_at = admission.pointer("/retry/next_attempt_at")?.as_str()?;
+    let next_attempt_at = chrono::DateTime::parse_from_rfc3339(next_attempt_at)
+        .ok()?
+        .with_timezone(&chrono::Utc);
+    (next_attempt_at > chrono::Utc::now()).then(|| next_attempt_at.to_rfc3339())
 }
 
 fn retry_availability(
@@ -273,5 +290,28 @@ mod tests {
             resume.availability,
             ControlPlaneActionAvailability::Available
         );
+    }
+
+    #[test]
+    fn scheduled_unmaterialized_retry_describes_resume_as_a_manual_rearm() {
+        let mut record = record(AgentTaskRunState::Queued, false);
+        record.metadata["unmaterialized_cook_admission"] = serde_json::json!({
+            "state": "blocked_runner_stale",
+            "retry": { "next_attempt_at": "2099-01-01T00:00:00Z" },
+        });
+
+        let report = lifecycle_action_eligibility(&record, None);
+        let resume = report
+            .actions
+            .iter()
+            .find(|action| action.action == ControlPlaneAction::Resume)
+            .expect("resume action");
+
+        assert_eq!(
+            resume.availability,
+            ControlPlaneActionAvailability::Available
+        );
+        assert!(resume.reason.contains("explicitly re-arms"));
+        assert!(resume.reason.contains("recommended next action"));
     }
 }

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -9,18 +9,19 @@ use chrono::{DateTime, Utc};
 use homeboy_control_plane_contract::ControlPlaneRetryParameters;
 use homeboy_control_plane_contract::{
     ControlPlaneAction, ControlPlaneActionAcknowledgement, ControlPlaneActionOutcome,
-    ControlPlaneActionPayload, ControlPlaneActionRequest, ControlPlaneBlocker,
-    ControlPlaneCancelDisposition, ControlPlaneCancelParameters, ControlPlaneCancelResult,
-    ControlPlaneCapabilities, ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEvidenceRef,
-    ControlPlaneLiveness, ControlPlaneLocation, ControlPlaneOperation, ControlPlaneOwner,
-    ControlPlaneProviderSummary, ControlPlaneResource, ControlPlaneRun, ControlPlaneRunReview,
-    ControlPlaneRunReviewRequest, ControlPlaneRunState, ControlPlaneRuntime,
-    ControlPlaneStateSummary, ExecutionId, ProviderSessionId, RunId,
-    CONTROL_PLANE_ACTION_ACKNOWLEDGEMENT_SCHEMA, CONTROL_PLANE_ACTION_REQUEST_SCHEMA,
-    CONTROL_PLANE_CANCEL_PARAMETERS_SCHEMA, CONTROL_PLANE_CANCEL_RESULT_SCHEMA,
-    CONTROL_PLANE_EMPTY_ACTION_PAYLOAD_SCHEMA, CONTROL_PLANE_PROMOTE_PARAMETERS_SCHEMA,
-    CONTROL_PLANE_PROMOTE_RESULT_SCHEMA, CONTROL_PLANE_RESUME_RESULT_SCHEMA,
-    CONTROL_PLANE_RETRY_PARAMETERS_SCHEMA, CONTROL_PLANE_RETRY_RESULT_SCHEMA,
+    ControlPlaneActionPayload, ControlPlaneActionRequest, ControlPlaneAdmissionRetry,
+    ControlPlaneAdmissionRetryDisposition, ControlPlaneBlocker, ControlPlaneCancelDisposition,
+    ControlPlaneCancelParameters, ControlPlaneCancelResult, ControlPlaneCapabilities,
+    ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEvidenceRef, ControlPlaneLiveness,
+    ControlPlaneLocation, ControlPlaneOperation, ControlPlaneOwner, ControlPlaneProviderSummary,
+    ControlPlaneResource, ControlPlaneRun, ControlPlaneRunReview, ControlPlaneRunReviewRequest,
+    ControlPlaneRunState, ControlPlaneRuntime, ControlPlaneStateSummary, ExecutionId,
+    ProviderSessionId, RunId, CONTROL_PLANE_ACTION_ACKNOWLEDGEMENT_SCHEMA,
+    CONTROL_PLANE_ACTION_REQUEST_SCHEMA, CONTROL_PLANE_CANCEL_PARAMETERS_SCHEMA,
+    CONTROL_PLANE_CANCEL_RESULT_SCHEMA, CONTROL_PLANE_EMPTY_ACTION_PAYLOAD_SCHEMA,
+    CONTROL_PLANE_PROMOTE_PARAMETERS_SCHEMA, CONTROL_PLANE_PROMOTE_RESULT_SCHEMA,
+    CONTROL_PLANE_RESUME_RESULT_SCHEMA, CONTROL_PLANE_RETRY_PARAMETERS_SCHEMA,
+    CONTROL_PLANE_RETRY_RESULT_SCHEMA,
 };
 use homeboy_core::control_plane::{register_control_plane_provider, ControlPlaneProvider};
 use serde_json::Value;
@@ -1961,24 +1962,30 @@ fn blocker(record: &AgentTaskRunRecord) -> Option<ControlPlaneBlocker> {
         return Some(ControlPlaneBlocker {
             code: Some("quarantine".to_string()),
             message: redacted_bounded(message, MESSAGE_BOUND),
+            state: None,
+            reason: None,
+            retry: None,
         });
     }
     if let Some(reason) = record.stale_running_reason() {
         return Some(ControlPlaneBlocker {
             code: Some("stale".to_string()),
             message: redacted_bounded(reason, MESSAGE_BOUND),
+            state: None,
+            reason: None,
+            retry: None,
         });
     }
-    if let Some(state) = record
-        .metadata
-        .pointer("/unmaterialized_cook_admission/state")
-        .and_then(|value| value.as_str())
-        .filter(|value| !value.trim().is_empty())
-    {
-        return Some(ControlPlaneBlocker {
-            code: Some("unmaterialized".to_string()),
-            message: redacted_bounded(state, MESSAGE_BOUND),
-        });
+    if let Some(admission) = record.metadata.get("unmaterialized_cook_admission") {
+        if let Some((state, reason, retry)) = unmaterialized_admission_blocker(admission) {
+            return Some(ControlPlaneBlocker {
+                code: Some(state.clone()),
+                message: reason.clone(),
+                state: Some(state),
+                reason: Some(reason),
+                retry,
+            });
+        }
     }
     if let Some(message) = record
         .metadata
@@ -1990,6 +1997,9 @@ fn blocker(record: &AgentTaskRunRecord) -> Option<ControlPlaneBlocker> {
         return Some(ControlPlaneBlocker {
             code: Some("controller_failure".to_string()),
             message: redacted_bounded(message, MESSAGE_BOUND),
+            state: None,
+            reason: None,
+            retry: None,
         });
     }
     record
@@ -2000,7 +2010,68 @@ fn blocker(record: &AgentTaskRunRecord) -> Option<ControlPlaneBlocker> {
         .map(|message| ControlPlaneBlocker {
             code: Some("adoption".to_string()),
             message: redacted_bounded(message, MESSAGE_BOUND),
+            state: None,
+            reason: None,
+            retry: None,
         })
+}
+
+fn unmaterialized_admission_blocker(
+    admission: &Value,
+) -> Option<(String, String, Option<ControlPlaneAdmissionRetry>)> {
+    let state = admission.get("state")?.as_str()?.trim();
+    if !matches!(
+        state,
+        "queued" | "blocked_runner_unavailable" | "blocked_runner_stale" | "exhausted"
+    ) {
+        return None;
+    }
+    let reason = admission
+        .get("reason")
+        .and_then(Value::as_str)
+        .filter(|reason| !reason.trim().is_empty())
+        .map(|reason| redacted_bounded(reason, MESSAGE_BOUND))
+        .unwrap_or_else(|| redacted_bounded(state, MESSAGE_BOUND));
+    let Some(retry) = admission.get("retry") else {
+        return Some((state.to_string(), reason, None));
+    };
+    if retry.get("policy").and_then(Value::as_str) != Some("bounded_exponential") {
+        return Some((state.to_string(), reason, None));
+    }
+    let Some(max_attempts) = retry.get("max_attempts").and_then(Value::as_u64) else {
+        return Some((state.to_string(), reason, None));
+    };
+    let attempts = admission
+        .get("admission_attempts")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    let next_attempt_at = retry
+        .get("next_attempt_at")
+        .and_then(Value::as_str)
+        .and_then(parse_timestamp)
+        .map(|timestamp| timestamp.to_rfc3339());
+    let disposition = if state == "exhausted" || attempts >= max_attempts {
+        ControlPlaneAdmissionRetryDisposition::Exhausted
+    } else if next_attempt_at
+        .as_deref()
+        .and_then(parse_timestamp)
+        .is_some_and(|timestamp| timestamp > Utc::now())
+    {
+        ControlPlaneAdmissionRetryDisposition::AutomaticReconciliationScheduled
+    } else {
+        ControlPlaneAdmissionRetryDisposition::AutomaticReconciliationDue
+    };
+    Some((
+        state.to_string(),
+        reason,
+        Some(ControlPlaneAdmissionRetry {
+            policy: "bounded_exponential".to_string(),
+            attempts,
+            max_attempts,
+            next_attempt_at,
+            disposition,
+        }),
+    ))
 }
 
 fn owner(record: &AgentTaskRunRecord) -> ControlPlaneOwner {
@@ -2318,7 +2389,8 @@ mod tests {
     use crate::agent_task_schedule::AgentTaskPlan;
     use homeboy_control_plane_contract::{
         ControlPlaneAction, ControlPlaneActionAvailability, ControlPlaneActionOutcome,
-        ControlPlaneActionPayload, ControlPlaneActionRequest, ControlPlaneCancelDisposition,
+        ControlPlaneActionPayload, ControlPlaneActionRequest,
+        ControlPlaneAdmissionRetryDisposition, ControlPlaneCancelDisposition,
         ControlPlaneCancelResult, ControlPlaneErrorClass, ControlPlaneEvent,
         ControlPlaneEventSource, ControlPlaneOperation, ControlPlaneRunReviewRequest,
         ControlPlaneRunState, EventCursor, EventId, RunId, CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA,
@@ -3254,6 +3326,90 @@ mod tests {
         assert_eq!(
             eligibility(&with_plan, ControlPlaneAction::Retry),
             ControlPlaneActionAvailability::Unavailable
+        );
+    }
+
+    #[test]
+    fn queued_unmaterialized_admission_projects_reason_retry_and_manual_rearm_presentation() {
+        let mut record = record(AGENT_TASK_RUN);
+        record.state = AgentTaskRunState::Queued;
+        record.metadata["unmaterialized_cook_admission"] = json!({
+            "schema": "homeboy/unmaterialized-cook-admission/v1",
+            "state": "queued",
+            "reason": "Lab admission predicate controller_version != job_command_binary_version failed token=secret-value",
+            "admission_attempts": 3,
+            "retry": {
+                "policy": "bounded_exponential",
+                "next_attempt_at": "2099-01-01T00:00:00Z",
+                "max_attempts": 20,
+            },
+        });
+
+        let resource = project_record(&record, None).expect("project admission");
+        let blocker = resource.blocker.expect("admission blocker");
+        assert_eq!(blocker.code.as_deref(), Some("queued"));
+        assert_eq!(blocker.state.as_deref(), Some("queued"));
+        assert_eq!(
+            blocker.reason.as_deref(),
+            Some("Lab admission predicate controller_version != job_command_binary_version failed token=[REDACTED]")
+        );
+        assert_eq!(
+            blocker.message,
+            "Lab admission predicate controller_version != job_command_binary_version failed token=[REDACTED]"
+        );
+        let retry = blocker.retry.expect("bounded retry");
+        assert_eq!(retry.policy, "bounded_exponential");
+        assert_eq!(retry.attempts, 3);
+        assert_eq!(retry.max_attempts, 20);
+        assert_eq!(
+            retry.next_attempt_at.as_deref(),
+            Some("2099-01-01T00:00:00+00:00")
+        );
+        assert_eq!(
+            retry.disposition,
+            ControlPlaneAdmissionRetryDisposition::AutomaticReconciliationScheduled
+        );
+        let resume = resource
+            .action_eligibility
+            .expect("action eligibility")
+            .actions
+            .into_iter()
+            .find(|action| action.action == ControlPlaneAction::Resume)
+            .expect("resume action");
+        assert_eq!(
+            resume.availability,
+            ControlPlaneActionAvailability::Available
+        );
+        assert!(resume.reason.contains("explicitly re-arms"));
+        assert!(resume.reason.contains("recommended next action"));
+    }
+
+    #[test]
+    fn exhausted_unmaterialized_admission_projects_its_bounded_terminal_disposition() {
+        let mut record = record(AGENT_TASK_RUN);
+        record.state = AgentTaskRunState::Failed;
+        record.metadata["unmaterialized_cook_admission"] = json!({
+            "schema": "homeboy/unmaterialized-cook-admission/v1",
+            "state": "exhausted",
+            "reason": "bounded Lab admission retry budget exhausted",
+            "admission_attempts": 20,
+            "retry": {
+                "policy": "bounded_exponential",
+                "next_attempt_at": "2026-09-08T03:14:05.251948+00:00",
+                "max_attempts": 20,
+            },
+        });
+
+        let resource = project_record(&record, None).expect("project exhausted admission");
+        let blocker = resource.blocker.expect("admission blocker");
+        assert_eq!(blocker.code.as_deref(), Some("exhausted"));
+        assert_eq!(
+            blocker.reason.as_deref(),
+            Some("bounded Lab admission retry budget exhausted")
+        );
+        assert_eq!(
+            blocker.retry.expect("bounded retry").disposition,
+            ControlPlaneAdmissionRetryDisposition::Exhausted
         );
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -490,6 +490,15 @@ fn render_status_summary(payload: &Value) -> Option<String> {
     if let Some(blocker) = string_value(payload, &["blocker", "message"]) {
         lines.push(format!("Blocker: {blocker}"));
     }
+    if string_value(payload, &["blocker", "retry", "disposition"])
+        == Some("automatic_reconciliation_scheduled")
+    {
+        let next_attempt_at = string_value(payload, &["blocker", "retry", "next_attempt_at"])
+            .unwrap_or("the recorded retry time");
+        lines.push(format!(
+            "Retry: automatic reconciliation scheduled for {next_attempt_at}; waiting is recommended"
+        ));
+    }
     lines.push(format!(
         "Artifacts: {}",
         array_len(payload, &["artifacts"]).unwrap_or(0)
@@ -507,6 +516,11 @@ fn control_plane_next_action(payload: &Value, run_id: &str) -> String {
     {
         let cook_id = string_value(payload, &["mission"]).unwrap_or(run_id);
         return format!("homeboy agent-task cook-continue {cook_id}");
+    }
+    if string_value(payload, &["blocker", "retry", "disposition"])
+        == Some("automatic_reconciliation_scheduled")
+    {
+        return format!("homeboy agent-task status {run_id} --watch");
     }
     const PREFERRED: [&str; 5] = ["reconcile", "resume", "retry", "review", "promote"];
     let Some(actions) = payload
@@ -1713,6 +1727,45 @@ mod tests {
         let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
         assert!(summary.contains("Next: homeboy agent-task resume unmaterialized-cook\n"));
         assert!(!summary.contains("homeboy agent-task run unmaterialized-cook"));
+    }
+
+    #[test]
+    fn status_summary_waits_for_a_scheduled_unmaterialized_admission_retry() {
+        let payload = json!({
+            "schema": "homeboy/control-plane-run/v1",
+            "run": "unmaterialized-cook",
+            "state": "queued",
+            "blocker": {
+                "code": "queued",
+                "state": "queued",
+                "message": "Lab admission is waiting for runner reconciliation",
+                "reason": "Lab admission is waiting for runner reconciliation",
+                "retry": {
+                    "policy": "bounded_exponential",
+                    "attempts": 3,
+                    "max_attempts": 20,
+                    "next_attempt_at": "2099-01-01T00:00:00+00:00",
+                    "disposition": "automatic_reconciliation_scheduled"
+                }
+            },
+            "action_eligibility": {
+                "actions": [{
+                    "action": "resume",
+                    "availability": "available",
+                    "reason": "resume is legal but explicitly re-arms this admission",
+                    "confirmation": "none",
+                    "idempotent": true,
+                    "requires_revalidation": true,
+                    "result_resource_type": "agent_task_run"
+                }]
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.contains("Retry: automatic reconciliation scheduled"));
+        assert!(summary.contains("Next: homeboy agent-task status unmaterialized-cook --watch\n"));
+        assert!(!summary.contains("Next: homeboy agent-task resume unmaterialized-cook\n"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #14417.

Projects durable unmaterialized Cook admission state, redacted reason, and bounded retry schedule through the control-plane status contract. When automatic reconciliation is scheduled, the CLI recommends `homeboy agent-task status <run> --watch` rather than a blind Resume; Resume remains explicitly described as a manual rearm.

## Reproduction and Evidence

1. Create a queued unmaterialized admission with a supported blocked state, a bounded exponential retry policy, and a future `next_attempt_at`.
2. Read it through the agent-task control-plane status projection.
3. Verify that the blocker preserves the typed state, redacted reason, retry policy/counts/timestamp, and `automatic_reconciliation_scheduled` disposition.
4. Verify that the status summary recommends `homeboy agent-task status <run> --watch`, not Resume.

Validated with:

- `cargo fmt --check`
- `cargo test -p homeboy-control-plane-contract`
- `cargo test -p homeboy-agents scheduled_unmaterialized_retry_describes_resume_as_a_manual_rearm`
- `cargo test -p homeboy-agents queued_unmaterialized_admission_projects_reason_retry_and_manual_rearm_presentation`
- `cargo test -p homeboy-agents exhausted_unmaterialized_admission_projects_its_bounded_terminal_disposition`
- `cargo test -p homeboy-cli status_summary_waits_for_a_scheduled_unmaterialized_admission_retry`

The full affected-crate library suites exceeded the two-minute local command budget; the focused tests and contract suite above pass.

## AI Assistance

openai/gpt-5.6-terra through direct OpenCode implemented the typed projection, CLI recommendation, tests, and verification. GPT-6 Astra through OpenCode orchestrated and reviewed the lifecycle/control-plane scope. Chris Huber directed the work and remains responsible for acceptance.