### PR TITLE
Distinguish unverified provider authentication in runner doctor

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/checks.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/checks.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::commands::runner::controller_ancestry::{commits_are_ancestral, CommitAncestry};
+use std::collections::BTreeSet;
 use types::{RunnerCheck, RunnerDoctorStatus, RunnerRepairAction, ToolProbe};
 
 pub(crate) fn tool_check(spec: RunnerToolSpec, probe: &ToolProbe) -> RunnerCheck {
@@ -361,8 +362,8 @@ pub(crate) fn lab_offload_status(
     checks: &[RunnerCheck],
     eligible_provider_ids: &[String],
 ) -> (RunnerDoctorStatus, types::RunnerDoctorProviderReadiness) {
-    let mut ready_for = eligible_provider_ids.to_vec();
-    let mut blocked_for = Vec::new();
+    let mut live_auth_ready = BTreeSet::new();
+    let mut blocked = BTreeSet::new();
     let mut has_runner_error = false;
     let mut has_warning = false;
 
@@ -371,6 +372,15 @@ pub(crate) fn lab_offload_status(
             has_warning = true;
         }
         if check.status != RunnerDoctorStatus::Error {
+            if check.status == RunnerDoctorStatus::Ok
+                && check.details.get("readiness_scope").map(String::as_str) == Some("live_auth")
+                && check
+                    .details
+                    .get("provider_id")
+                    .is_some_and(|provider_id| eligible_provider_ids.contains(provider_id))
+            {
+                live_auth_ready.insert(check.details["provider_id"].clone());
+            }
             continue;
         }
         let Some(provider_id) = check.details.get("provider_id") else {
@@ -378,22 +388,38 @@ pub(crate) fn lab_offload_status(
             continue;
         };
         if eligible_provider_ids.iter().any(|id| id == provider_id) {
-            ready_for.retain(|id| id != provider_id);
-            if !blocked_for.contains(provider_id) {
-                blocked_for.push(provider_id.clone());
-            }
+            blocked.insert(provider_id.clone());
         }
     }
 
     if has_runner_error {
-        ready_for.clear();
-        blocked_for = eligible_provider_ids.to_vec();
+        blocked.extend(eligible_provider_ids.iter().cloned());
     }
 
-    let status = if has_runner_error || (!eligible_provider_ids.is_empty() && ready_for.is_empty())
-    {
+    // A failed substrate or auth observation always dominates a successful
+    // probe, including when independently bounded probes complete out of order.
+    let ready_for = eligible_provider_ids
+        .iter()
+        .filter(|id| live_auth_ready.contains(*id) && !blocked.contains(*id))
+        .cloned()
+        .collect::<Vec<_>>();
+    let blocked_for = eligible_provider_ids
+        .iter()
+        .filter(|id| blocked.contains(*id))
+        .cloned()
+        .collect::<Vec<_>>();
+    let unverified_for = eligible_provider_ids
+        .iter()
+        .filter(|id| !live_auth_ready.contains(*id) && !blocked.contains(*id))
+        .cloned()
+        .collect::<Vec<_>>();
+    let unverified_remediation = (!unverified_for.is_empty()).then(|| {
+        "Provider authentication is unverified because runner doctor cannot select a model. Run the selected task's normal preflight; doctor never changes credentials.".to_string()
+    });
+
+    let status = if has_runner_error || (!blocked_for.is_empty() && ready_for.is_empty()) {
         RunnerDoctorStatus::Error
-    } else if has_warning {
+    } else if has_warning || !unverified_for.is_empty() {
         RunnerDoctorStatus::Warning
     } else {
         RunnerDoctorStatus::Ok
@@ -403,6 +429,8 @@ pub(crate) fn lab_offload_status(
         types::RunnerDoctorProviderReadiness {
             ready_for,
             blocked_for,
+            unverified_for,
+            unverified_remediation,
         },
     )
 }

--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -208,9 +208,7 @@ fn compact_projection(report: &RunnerDoctorOutput) -> serde_json::Value {
             },
         );
     let provider_total = report.provider_readiness.as_ref().map_or(0, |readiness| {
-        readiness.ready_for.len()
-            + readiness.blocked_for.len()
-            + readiness.unverified_for.len()
+        readiness.ready_for.len() + readiness.blocked_for.len() + readiness.unverified_for.len()
     });
     let runner_id = bounded_text(&report.runner_id);
     let failed_repairs = report

--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -177,27 +177,40 @@ fn compact_projection(report: &RunnerDoctorOutput) -> serde_json::Value {
             })
         })
         .collect::<Vec<_>>();
-    let (ready_for, blocked_for) = report.provider_readiness.as_ref().map_or_else(
-        || (Vec::new(), Vec::new()),
-        |readiness| {
-            (
-                readiness
-                    .ready_for
-                    .iter()
-                    .take(COMPACT_PROVIDER_LIMIT)
-                    .map(|value| bounded_text(value))
-                    .collect::<Vec<_>>(),
-                readiness
-                    .blocked_for
-                    .iter()
-                    .take(COMPACT_PROVIDER_LIMIT)
-                    .map(|value| bounded_text(value))
-                    .collect::<Vec<_>>(),
-            )
-        },
-    );
+    let (ready_for, blocked_for, unverified_for, unverified_remediation) =
+        report.provider_readiness.as_ref().map_or_else(
+            || (Vec::new(), Vec::new(), Vec::new(), None),
+            |readiness| {
+                (
+                    readiness
+                        .ready_for
+                        .iter()
+                        .take(COMPACT_PROVIDER_LIMIT)
+                        .map(|value| bounded_text(value))
+                        .collect::<Vec<_>>(),
+                    readiness
+                        .blocked_for
+                        .iter()
+                        .take(COMPACT_PROVIDER_LIMIT)
+                        .map(|value| bounded_text(value))
+                        .collect::<Vec<_>>(),
+                    readiness
+                        .unverified_for
+                        .iter()
+                        .take(COMPACT_PROVIDER_LIMIT)
+                        .map(|value| bounded_text(value))
+                        .collect::<Vec<_>>(),
+                    readiness
+                        .unverified_remediation
+                        .as_deref()
+                        .map(bounded_text),
+                )
+            },
+        );
     let provider_total = report.provider_readiness.as_ref().map_or(0, |readiness| {
-        readiness.ready_for.len() + readiness.blocked_for.len()
+        readiness.ready_for.len()
+            + readiness.blocked_for.len()
+            + readiness.unverified_for.len()
     });
     let runner_id = bounded_text(&report.runner_id);
     let failed_repairs = report
@@ -231,10 +244,10 @@ fn compact_projection(report: &RunnerDoctorOutput) -> serde_json::Value {
         },
         "checks": checks,
         "repairs": failed_repairs,
-        "provider_readiness": if provider_total == 0 { serde_json::Value::Null } else { serde_json::json!({ "ready_for": ready_for, "blocked_for": blocked_for }) },
+        "provider_readiness": if provider_total == 0 { serde_json::Value::Null } else { serde_json::json!({ "ready_for": ready_for, "blocked_for": blocked_for, "unverified_for": unverified_for, "guidance": unverified_remediation }) },
         "truncation": {
             "checks": { "shown": checks.len(), "omitted": report.checks.len().saturating_sub(checks.len()), "evidence_ref": "runner:doctor:checks", "full_command": format!("homeboy runner doctor {runner_id} --full") },
-            "provider_readiness": { "shown": ready_for.len() + blocked_for.len(), "omitted": provider_total.saturating_sub(ready_for.len() + blocked_for.len()), "evidence_ref": "runner:doctor:provider-readiness", "full_command": format!("homeboy runner doctor {runner_id} --full") },
+            "provider_readiness": { "shown": ready_for.len() + blocked_for.len() + unverified_for.len(), "omitted": provider_total.saturating_sub(ready_for.len() + blocked_for.len() + unverified_for.len()), "evidence_ref": "runner:doctor:provider-readiness", "full_command": format!("homeboy runner doctor {runner_id} --full") },
             "omitted_sections": ["resource_maps", "probe_details", "diagnostics", "secret_env_migration", "daemon_recovery", "admission_summary"],
         }
     });

--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -439,6 +439,18 @@ pub(crate) fn provider_readiness_checks(
         .collect()
 }
 
+pub(crate) fn selected_provider_readiness_contracts(
+    contracts: Vec<
+        homeboy::agents::agent_tasks::provider::AgentTaskProviderRunnerReadinessContract,
+    >,
+    provider_ids: &[String],
+) -> Vec<homeboy::agents::agent_tasks::provider::AgentTaskProviderRunnerReadinessContract> {
+    contracts
+        .into_iter()
+        .filter(|contract| provider_ids.contains(&contract.provider_id))
+        .collect()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct LabOffloadExtensionDependency {
     pub extension_id: String,

--- a/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
@@ -313,11 +313,18 @@ pub fn report(
             .collect::<BTreeSet<_>>();
         checks.extend(parity_checks);
         if !global_parity_blocked {
-            let readiness_contracts =
-                homeboy::agents::agent_tasks::provider::provider_runner_readiness_contracts()
-                    .into_iter()
-                    .filter(|contract| !blocked_providers.contains(&contract.provider_id))
-                    .collect::<Vec<_>>();
+            let selected_provider_ids = probes::eligible_provider_ids(
+                catalog.providers(),
+                options.agent_backend.as_deref(),
+                options.agent_selector.as_deref(),
+            );
+            let readiness_contracts = probes::selected_provider_readiness_contracts(
+                homeboy::agents::agent_tasks::provider::provider_runner_readiness_contracts(),
+                &selected_provider_ids,
+            )
+            .into_iter()
+            .filter(|contract| !blocked_providers.contains(&contract.provider_id))
+            .collect::<Vec<_>>();
             checks.extend(probes::provider_readiness_checks(
                 client,
                 &readiness_contracts,

--- a/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
@@ -271,9 +271,18 @@ fn repair_extension_parity(
     report.checks.retain(|check| check.id != "extension.parity");
     report.checks.extend(parity_checks);
     if parity_ready {
+        let catalog = homeboy::agents::agent_tasks::provider::AgentTaskProviderCatalog::discover();
+        let selected_provider_ids = probes::eligible_provider_ids(
+            catalog.providers(),
+            options.agent_backend.as_deref(),
+            options.agent_selector.as_deref(),
+        );
         report.checks.extend(probes::provider_readiness_checks(
             client,
-            &homeboy::agents::agent_tasks::provider::provider_runner_readiness_contracts(),
+            &probes::selected_provider_readiness_contracts(
+                homeboy::agents::agent_tasks::provider::provider_runner_readiness_contracts(),
+                &selected_provider_ids,
+            ),
         ));
     }
     report.repairs.push(RunnerRepair {

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/provider.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/provider.rs
@@ -1,6 +1,7 @@
 use super::super::*;
 use homeboy::agents::agent_tasks::provider::{
     AgentTaskExecutorProvider, AgentTaskProviderEnvPathReadiness, AgentTaskProviderRunnerReadiness,
+    AgentTaskProviderRunnerReadinessContract,
 };
 use homeboy::core::command_invocation::CommandInvocation;
 use serde_json::json;
@@ -191,6 +192,41 @@ fn local_provider_executor_resolution_check_filters_to_selected_provider() {
         checks[0].details.get("provider_id").map(String::as_str),
         Some("selected.provider")
     );
+}
+
+#[test]
+fn selected_provider_readiness_contracts_do_not_probe_unselected_providers() {
+    let contracts = ["selected.provider", "unselected.provider"]
+        .into_iter()
+        .map(|provider_id| AgentTaskProviderRunnerReadinessContract {
+            provider_id: provider_id.to_string(),
+            backend: "test".to_string(),
+            runtime_id: Some("test-runtime".to_string()),
+            runtime_path: Some("/runtime".to_string()),
+            readiness: AgentTaskProviderRunnerReadiness {
+                id: format!("agent_task.provider_auth.{provider_id}"),
+                label: "Provider live authentication".to_string(),
+                required_extensions: Vec::new(),
+                invocation: Some(CommandInvocation {
+                    argv: vec!["node".to_string(), "readiness.cjs".to_string()],
+                    ..CommandInvocation::default()
+                }),
+                secret_env: Vec::new(),
+                env_path: None,
+                executable: None,
+                remediation: None,
+                extra: BTreeMap::new(),
+            },
+        })
+        .collect();
+
+    let selected = probes::selected_provider_readiness_contracts(
+        contracts,
+        &["selected.provider".to_string()],
+    );
+
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].provider_id, "selected.provider");
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
@@ -80,6 +80,80 @@ fn compact_doctor_projection_bounds_evidence_and_renders_action() {
 }
 
 #[test]
+fn compact_doctor_projection_retains_provider_readiness() {
+    let (mut report, _) = run("local").expect("local doctor report");
+    report.provider_readiness = Some(types::RunnerDoctorProviderReadiness {
+        ready_for: vec!["ready.provider".to_string()],
+        blocked_for: vec!["blocked.provider".to_string()],
+        unverified_for: vec!["unverified.provider".to_string()],
+        unverified_remediation: Some("Authentication has not been verified.".to_string()),
+    });
+
+    let compact = output_projection(report, false);
+
+    assert_eq!(
+        compact["provider_readiness"]["ready_for"],
+        serde_json::json!(["ready.provider"])
+    );
+    assert_eq!(
+        compact["provider_readiness"]["blocked_for"],
+        serde_json::json!(["blocked.provider"])
+    );
+    assert_eq!(
+        compact["provider_readiness"]["unverified_for"],
+        serde_json::json!(["unverified.provider"])
+    );
+    assert_eq!(
+        compact["provider_readiness"]["guidance"],
+        "Authentication has not been verified."
+    );
+}
+
+#[test]
+fn compact_doctor_projection_retains_all_unverified_provider_readiness() {
+    let (mut report, _) = run("local").expect("local doctor report");
+    report.provider_readiness = Some(types::RunnerDoctorProviderReadiness {
+        ready_for: Vec::new(),
+        blocked_for: Vec::new(),
+        unverified_for: vec!["opencode.agent-task-executor".to_string()],
+        unverified_remediation: Some(
+            "Provider authentication is unverified because runner doctor cannot select a model."
+                .to_string(),
+        ),
+    });
+
+    let compact = output_projection(report, false);
+
+    assert_eq!(
+        compact["provider_readiness"]["unverified_for"],
+        serde_json::json!(["opencode.agent-task-executor"])
+    );
+    assert_eq!(
+        compact["provider_readiness"]["guidance"],
+        "Provider authentication is unverified because runner doctor cannot select a model."
+    );
+    assert_eq!(compact["truncation"]["provider_readiness"]["shown"], 1);
+}
+
+#[test]
+fn full_doctor_projection_retains_nonsecret_unverified_provider_ids() {
+    let (mut report, _) = run("local").expect("local doctor report");
+    report.provider_readiness = Some(types::RunnerDoctorProviderReadiness {
+        ready_for: Vec::new(),
+        blocked_for: Vec::new(),
+        unverified_for: vec!["opencode.agent-task-executor".to_string()],
+        unverified_remediation: None,
+    });
+
+    let full = output_projection(report, true);
+
+    assert_eq!(
+        full["provider_readiness"]["unverified_for"],
+        serde_json::json!(["opencode.agent-task-executor"])
+    );
+}
+
+#[test]
 fn compact_doctor_puts_blockers_and_remediation_before_informational_checks() {
     let (mut report, _) = run("local").expect("local doctor report");
     report.checks = (0..COMPACT_CHECK_LIMIT)
@@ -320,7 +394,7 @@ fn overall_status_promotes_errors_over_warnings() {
 #[test]
 fn lab_offload_readiness_keeps_a_healthy_eligible_provider_ready() {
     let checks = vec![
-        provider_check("selected.provider", RunnerDoctorStatus::Ok),
+        live_auth_provider_check("selected.provider", RunnerDoctorStatus::Ok),
         provider_check("optional.provider", RunnerDoctorStatus::Error),
     ];
     let eligible = vec![
@@ -333,12 +407,13 @@ fn lab_offload_readiness_keeps_a_healthy_eligible_provider_ready() {
     assert_eq!(status, RunnerDoctorStatus::Ok);
     assert_eq!(readiness.ready_for, vec!["selected.provider"]);
     assert_eq!(readiness.blocked_for, vec!["optional.provider"]);
+    assert!(readiness.unverified_for.is_empty());
 }
 
 #[test]
 fn lab_offload_readiness_blocks_a_failed_selected_provider() {
     let checks = vec![
-        provider_check("selected.provider", RunnerDoctorStatus::Error),
+        live_auth_provider_check("selected.provider", RunnerDoctorStatus::Error),
         provider_check("optional.provider", RunnerDoctorStatus::Ok),
     ];
     let eligible = vec!["selected.provider".to_string()];
@@ -348,6 +423,45 @@ fn lab_offload_readiness_blocks_a_failed_selected_provider() {
     assert_eq!(status, RunnerDoctorStatus::Error);
     assert!(readiness.ready_for.is_empty());
     assert_eq!(readiness.blocked_for, vec!["selected.provider"]);
+    assert!(readiness.unverified_for.is_empty());
+}
+
+#[test]
+fn lab_offload_readiness_error_dominates_live_auth_in_any_order() {
+    let eligible = vec!["selected.provider".to_string()];
+    for checks in [
+        vec![
+            provider_check("selected.provider", RunnerDoctorStatus::Error),
+            live_auth_provider_check("selected.provider", RunnerDoctorStatus::Ok),
+        ],
+        vec![
+            live_auth_provider_check("selected.provider", RunnerDoctorStatus::Ok),
+            provider_check("selected.provider", RunnerDoctorStatus::Error),
+            live_auth_provider_check("selected.provider", RunnerDoctorStatus::Ok),
+        ],
+    ] {
+        let (status, readiness) = checks::lab_offload_status(&checks, &eligible);
+        assert_eq!(status, RunnerDoctorStatus::Error);
+        assert!(readiness.ready_for.is_empty());
+        assert_eq!(readiness.blocked_for, eligible);
+    }
+}
+
+#[test]
+fn lab_offload_readiness_does_not_treat_a_resolved_require_graph_as_live_auth() {
+    let checks = vec![provider_check("selected.provider", RunnerDoctorStatus::Ok)];
+    let eligible = vec!["selected.provider".to_string()];
+
+    let (status, readiness) = checks::lab_offload_status(&checks, &eligible);
+
+    assert_eq!(status, RunnerDoctorStatus::Warning);
+    assert!(readiness.ready_for.is_empty());
+    assert!(readiness.blocked_for.is_empty());
+    assert_eq!(readiness.unverified_for, eligible);
+    assert_eq!(
+        readiness.unverified_remediation.as_deref(),
+        Some("Provider authentication is unverified because runner doctor cannot select a model. Run the selected task's normal preflight; doctor never changes credentials.")
+    );
 }
 
 #[test]
@@ -368,6 +482,7 @@ fn lab_offload_readiness_blocks_all_providers_on_a_runner_prerequisite_error() {
     assert_eq!(status, RunnerDoctorStatus::Error);
     assert!(readiness.ready_for.is_empty());
     assert_eq!(readiness.blocked_for, eligible);
+    assert!(readiness.unverified_for.is_empty());
 }
 
 fn provider_check(provider_id: &str, status: RunnerDoctorStatus) -> types::RunnerCheck {
@@ -379,6 +494,14 @@ fn provider_check(provider_id: &str, status: RunnerDoctorStatus) -> types::Runne
         remediation_action: None,
         details: BTreeMap::from([("provider_id".to_string(), provider_id.to_string())]),
     }
+}
+
+fn live_auth_provider_check(provider_id: &str, status: RunnerDoctorStatus) -> types::RunnerCheck {
+    let mut check = provider_check(provider_id, status);
+    check
+        .details
+        .insert("readiness_scope".to_string(), "live_auth".to_string());
+    check
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/runner/doctor/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/types.rs
@@ -58,8 +58,15 @@ pub struct RunnerDoctorDiagnostics {
 
 #[derive(Debug, Serialize)]
 pub struct RunnerDoctorProviderReadiness {
+    /// Providers with a selected, successful provider-owned live auth check.
     pub ready_for: Vec<String>,
+    /// Providers whose selected live auth check failed or whose runner substrate failed.
     pub blocked_for: Vec<String>,
+    /// Providers whose runtime/load checks may have passed but did not run a
+    /// provider-owned live auth check, so they are not dispatch-ready.
+    pub unverified_for: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unverified_remediation: Option<String>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary

- Keep runtime/executor load checks distinct from selected-model authentication.
- Report a healthy graph with unverified model auth as a warning, not a false ready verdict or a universal runner error.
- Retain bounded nonsecret `unverified_for` identifiers and guidance through normal compact/full redaction.
- Make provider errors dominate successful observations regardless of order, and retain provider-scoped checks during repair.
- Keep live model-aware authentication in the existing selected-task preflight and canonical provider readiness contract; doctor does not change credentials.

Addresses the misleading provider-readiness slice of #7014. The broader automatic environment-convergence workflow remains outside this change.

## Verification

- `cargo test -p homeboy-cli runner::doctor::tests::shape --lib`: 22 pass on the lab.
- `cargo test -p homeboy-cli runner::doctor::tests::provider --lib`: 13 pass on the lab.
- Formatting passes.
- A bounded canonical selected-model provider request reaches the runtime and returns the expected non-retryable `auth_failure` / `authentication_rejected` verdict with credential-refresh guidance. No credentials were changed.
- The publication commit has the same complete source tree as the tested candidate; local evidence-only history is excluded.

The installed lab CLI also exposed a stale runtime-manifest schema mismatch. That installation state is distinct from the source correction and is not represented as fixed here.

## AI Assistance

OpenAI GPT-5.6 Terra via OpenCode implemented and tested the candidate. GPT-6 Astra via OpenCode reviewed error precedence, output/redaction behavior and the false-error regression, requested corrections, and prepared the public-safe candidate under Chris Huber’s direction.