### PR TITLE
fix(review): surface apply-ready candidates

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -573,7 +573,10 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         .and_then(|_| usize_value(payload, &["aggregate_review", "summary", "failed"]))
         .unwrap_or(0);
     let metrics = code_production_metrics(payload);
-    let promotable = metrics.candidate_state.is_available();
+    let promotable = matches!(
+        metrics.candidate_state,
+        CandidateState::ApplyReady | CandidateState::PatchAvailable
+    );
     let patch = promotable
         .then(|| string_value(payload, &["promotion_candidates", "0", "artifact_id"]))
         .flatten();

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -573,7 +573,7 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         .and_then(|_| usize_value(payload, &["aggregate_review", "summary", "failed"]))
         .unwrap_or(0);
     let metrics = code_production_metrics(payload);
-    let promotable = metrics.candidate_state == CandidateState::PatchAvailable;
+    let promotable = metrics.candidate_state.is_available();
     let patch = promotable
         .then(|| string_value(payload, &["promotion_candidates", "0", "artifact_id"]))
         .flatten();
@@ -1299,11 +1299,17 @@ mod tests {
                 "state": "apply_ready",
                 "counts": { "patch_available": 1 }, "scan": { "degraded": false }
             },
-            "selected_candidate": { "status": "verification_pending" },
+            "selected_candidate": {
+                "status": "verification_pending",
+                "artifact": { "id": "candidate", "kind": "patch" },
+                "size_bytes": 7635,
+                "changed_files": ["a.rs", "b.rs", "c.rs"]
+            },
             "execution_states": {
                 "promotion": {
                     "state": "verification_pending",
                     "patch_promoted": false,
+                    "verified": false,
                     "verification_phase": "pre_apply",
                     "target": { "state": "not_applied", "worktree": "fixture@clean-target", "candidate_fingerprint_matches": false }
                 }


### PR DESCRIPTION
## Summary
- classify `apply_ready` candidates as promotable in review summaries
- cover the pre-apply, not-yet-promoted outcome with a substantive selected patch fixture

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-cli review_summary_keeps_a_pre_apply_candidate_out_of_the_promoted_outcome -- --nocapture`
- `cargo test -p homeboy-cli` was started; it exceeded 10 minutes with unrelated existing dispatch/lifecycle failures.

Fixes #13297

AI assistance disclosure: GPT-6 Astra via OpenCode investigated CI artifacts and logs, isolated the candidate-state rendering defect, implemented the focused fix, and ran the listed verification.