### PR TITLE
Bind adoption promotion reuse to candidate identity

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -497,7 +497,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
     let attempt_dispatcher =
         reconstruct_dispatcher(&recipe.promotion_transport["attempt_dispatch"])?;
     options.provider_transport.attempt_dispatcher = attempt_dispatcher;
-    lifecycle_store.start_candidate_adoption_with_policy(
+    let record = lifecycle_store.start_candidate_adoption_with_policy(
         &record.run_id,
         &candidate_sha,
         &adoption_ai_model,
@@ -986,6 +986,22 @@ fn project_execution_placement(finalization: &mut Value, metadata: &Value) {
     }
 }
 
+fn applied_adoption_promotion_candidate_sha(promotion: &AgentTaskPromotionReport) -> Option<&str> {
+    [
+        "/adoption/candidate_ref",
+        "/resume_contract/inputs/candidate_ref",
+        "/resume_inputs/candidate_ref",
+    ]
+    .into_iter()
+    .find_map(|pointer| {
+        promotion
+            .provenance
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+    })
+}
+
 fn reusable_applied_adoption_promotion(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     record: &agent_task_lifecycle::AgentTaskRunRecord,
@@ -1002,11 +1018,7 @@ fn reusable_applied_adoption_promotion(
         Ok(_) => return None,
         Err(error) => return Some(Err(error)),
     };
-    if record
-        .candidate_adoption
-        .as_ref()
-        .is_none_or(|adoption| adoption.candidate_sha != candidate_sha)
-    {
+    if applied_adoption_promotion_candidate_sha(&promotion) != Some(candidate_sha) {
         return None;
     }
     let Some(worktree_path) = promotion.target.path.as_deref() else {
@@ -1574,6 +1586,201 @@ mod projection_tests {
         assert_ne!(
             adoption_gate_identity(&first).unwrap(),
             adoption_gate_identity(&changed_deadline).unwrap()
+        );
+    }
+}
+
+#[cfg(test)]
+mod reuse_tests {
+    use super::*;
+    use crate::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
+    use crate::agent_task_scheduler::AgentTaskPlan;
+    use serde_json::json;
+    use std::path::Path;
+    use std::process::Command;
+
+    fn fixture_plan() -> AgentTaskPlan {
+        AgentTaskPlan::new(
+            "plan-adoption-reuse",
+            vec![AgentTaskRequest {
+                schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+                task_id: "task-a".to_string(),
+                group_key: None,
+                parent_plan_id: None,
+                executor: AgentTaskExecutor {
+                    backend: "test".to_string(),
+                    selector: Some("fixture".to_string()),
+                    runtime_selection: None,
+                    required_capabilities: Vec::new(),
+                    secret_env: Vec::new(),
+                    model: None,
+                    config: Value::Null,
+                },
+                instructions: "run".to_string(),
+                inputs: Value::Null,
+                source_refs: Vec::new(),
+                workspace: AgentTaskWorkspace::default(),
+                component_contracts: Vec::new(),
+                policy: AgentTaskPolicy::default(),
+                limits: AgentTaskLimits::default(),
+                expected_artifacts: Vec::new(),
+                artifact_declarations: Vec::new(),
+                output_declarations: Vec::new(),
+                runtime_tools: Vec::new(),
+                metadata: Value::Null,
+            }],
+        )
+    }
+
+    fn git(cwd: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    }
+
+    fn applied_promotion(run_id: &str, candidate_sha: &str, worktree: &Path) -> Value {
+        json!({
+            "schema": "homeboy/agent-task-promotion-report/v1",
+            "status": "applied",
+            "source": {"kind": "aggregate", "task_id": "task-a", "run_id": run_id},
+            "to_worktree": "fixture@adoption-reuse",
+            "target": {"worktree": "fixture@adoption-reuse", "path": worktree},
+            "patch_artifact": {
+                "id": "patch",
+                "kind": "patch",
+                "path": "patch",
+                "sha256": "fixture-patch-sha"
+            },
+            "operator_notification": {"status": "completed", "message": "complete"},
+            "provenance": {
+                "gate_feedback_baseline": {"current_diff": ""},
+                "adoption": {"candidate_ref": candidate_sha},
+                "resume_contract": {"inputs": {"candidate_ref": candidate_sha}},
+                "resume_inputs": {"candidate_ref": candidate_sha}
+            }
+        })
+    }
+
+    #[test]
+    fn reusable_applied_adoption_promotion_rejects_a_replaced_candidate_sha() {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let lifecycle_store =
+            crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+        let run_id = "cook-adoption-replacement";
+        lifecycle_store
+            .submit_plan_with_runtime_admission(&fixture_plan(), run_id, |_| Ok(json!({})))
+            .expect("submit");
+        let original = "a3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
+        let replacement = "b3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
+        lifecycle_store
+            .start_candidate_adoption_with_policy(
+                run_id,
+                original,
+                "openai/gpt-5.6-terra",
+                "verification",
+                false,
+                false,
+            )
+            .expect("start original adoption");
+        lifecycle_store
+            .record_promotion(
+                run_id,
+                applied_promotion(run_id, original, Path::new("/tmp")),
+            )
+            .expect("persist applied promotion for the original candidate");
+        lifecycle_store
+            .mutate_record(run_id, |record| {
+                record
+                    .candidate_adoption
+                    .as_mut()
+                    .expect("original adoption")
+                    .owner_pid = u32::MAX;
+                true
+            })
+            .expect("stale original owner");
+        crate::agent_task_lifecycle::reconcile_status_in_store(
+            &lifecycle_store,
+            run_id,
+            crate::agent_task_lifecycle::AgentTaskStatusOptions::default(),
+            false,
+        )
+        .expect("interrupt original adoption");
+        let replaced = lifecycle_store
+            .start_candidate_adoption_with_policy(
+                run_id,
+                replacement,
+                "openai/gpt-5.6-sol",
+                "verification",
+                false,
+                true,
+            )
+            .expect("replace interrupted adoption");
+        assert_eq!(
+            replaced
+                .candidate_adoption
+                .as_ref()
+                .expect("replacement claim")
+                .candidate_sha,
+            replacement
+        );
+        assert!(
+            reusable_applied_adoption_promotion(&lifecycle_store, &replaced, replacement).is_none()
+        );
+    }
+
+    #[test]
+    fn reusable_applied_adoption_promotion_reuses_the_requested_immutable_candidate() {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let lifecycle_store =
+            crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+        let worktree = tempfile::tempdir().expect("candidate worktree");
+        git(worktree.path(), &["init", "--initial-branch=main"]);
+        git(
+            worktree.path(),
+            &["config", "user.email", "agent@example.test"],
+        );
+        git(worktree.path(), &["config", "user.name", "Agent"]);
+        std::fs::write(worktree.path().join("lib.rs"), "candidate\n").unwrap();
+        git(worktree.path(), &["add", "lib.rs"]);
+        git(worktree.path(), &["commit", "-m", "candidate"]);
+        let candidate = git(worktree.path(), &["rev-parse", "HEAD"]);
+        let run_id = "cook-adoption-reuse";
+        lifecycle_store
+            .submit_plan_with_runtime_admission(&fixture_plan(), run_id, |_| Ok(json!({})))
+            .expect("submit");
+        let record = lifecycle_store
+            .start_candidate_adoption_with_policy(
+                run_id,
+                &candidate,
+                "openai/gpt-5.6-terra",
+                "verification",
+                false,
+                false,
+            )
+            .expect("claim requested candidate");
+        lifecycle_store
+            .record_promotion(
+                run_id,
+                applied_promotion(run_id, &candidate, worktree.path()),
+            )
+            .expect("persist applied promotion for the requested candidate");
+        let reused = reusable_applied_adoption_promotion(&lifecycle_store, &record, &candidate)
+            .expect("requested candidate reuses the applied promotion")
+            .expect("reused promotion is valid");
+        assert_eq!(
+            applied_adoption_promotion_candidate_sha(&reused),
+            Some(candidate.as_str())
         );
     }
 }


### PR DESCRIPTION
## Summary
Prevent replacement adoption candidates from inheriting applied promotion and gate evidence belonging to an older candidate.

## What changed
- Refresh the lifecycle record returned when candidate adoption ownership is claimed.
- Require reusable applied adoption promotion provenance to identify the requested immutable candidate SHA.
- Cover replaced-candidate rejection and same-candidate reuse with deterministic lifecycle-store tests.

## How to test
1. Run `cargo test -p homeboy-agents agent_task_service::cook_adoption::reuse_tests::reusable_applied_adoption_promotion_rejects_a_replaced_candidate_sha -- --exact`; expect passes as recorded by Homeboy's deterministic gate.
2. Run `cargo test -p homeboy-agents agent_task_service::cook_adoption::reuse_tests::reusable_applied_adoption_promotion_reuses_the_requested_immutable_candidate -- --exact`; expect passes as recorded by Homeboy's deterministic gate.

## Compatibility
Same-candidate resume behavior is preserved; mismatched or unauthenticated promotion checkpoints run fresh gates instead of being reused.

## Evidence
- Base unchanged since verification: main remains at 15dc18d0c62a2a1ddcb2b10f0007b272c37ab8cd.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/14424
- Verified finalization base: main at 15dc18d0c62a2a1ddcb2b10f0007b272c37ab8cd
- manual-verify-1: passed (cargo test -p homeboy-agents agent\_task\_service::cook\_adoption::reuse\_tests::reusable\_applied\_adoption\_promotion\_rejects\_a\_replaced\_candidate\_sha -- --exact) (Passed)
- manual-verify-2: passed (cargo test -p homeboy-agents agent\_task\_service::cook\_adoption::reuse\_tests::reusable\_applied\_adoption\_promotion\_reuses\_the\_requested\_immutable\_candidate -- --exact) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** xai/grok-4.6
- **Used for:** OpenCode used xAI Grok 4.6 to implement the fix and regression coverage; OpenAI GPT-5.6 Sol reviewed the state transition and verified the exact tests.

## Source relationships
- Closes #14424
