### PR TITLE
fix(test): reap detached descendants on runner cancellation

### DIFF
--- a/scripts/nextest-hermetic-test-environment.sh
+++ b/scripts/nextest-hermetic-test-environment.sh
@@ -123,17 +123,61 @@ exec perl -MPOSIX=setsid,WNOHANG -MTime::HiRes=time -e '
         return unless defined $tmpdir && $tmpdir =~ m{/\.homeboy-test-tmp/run\.[^/]+$};
         system("rm", "-rf", "--", $tmpdir);
     };
-    my $cleanup = sub {
-        # A clean test leaves no process in its private group. Avoid charging
-        # nextest process-per-test execution a grace period in that case.
-        return unless kill 0, -$child;
-        kill "TERM", -$child;
-        # Give actual descendants a bounded chance to exit cleanly before
-        # enforcing the same process-group cleanup guarantee.
-        if (kill 0, -$child) {
-            select undef, undef, undef, 1;
-            kill "KILL", -$child if kill 0, -$child;
+    my $process_snapshot = sub {
+        open my $ps, "-|", "/bin/ps", "-axo", "pid=,ppid=,lstart=" or return {};
+        my %processes;
+        while (my $line = <$ps>) {
+            my ($pid, $parent, $started) = $line =~ /^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/;
+            $processes{$pid} = { pid => $pid, parent => $parent, started => $started }
+                if defined $pid;
         }
+        close $ps;
+        return \%processes;
+    };
+    my $descendants = sub {
+        my ($root, $processes) = @_;
+        my %children;
+        for my $process (values %$processes) {
+            push @{ $children{$process->{parent}} }, $process;
+        }
+        my @tree = grep { defined } ($processes->{$root});
+        my %seen = ($root => 1);
+        for (my $index = 0; $index < @tree; $index++) {
+            for my $process (@{ $children{$tree[$index]{pid}} // [] }) {
+                next if $seen{$process->{pid}}++;
+                push @tree, $process;
+            }
+        }
+        return @tree;
+    };
+    my $signal_owned = sub {
+        my ($signal, $owned) = @_;
+        # A nested Homeboy command can make its own process group. Snapshot the
+        # tree before signaling the test group so those descendants cannot
+        # reparent and escape cleanup when the test binary exits.
+        my $current = $process_snapshot->();
+        for my $pid (keys %$owned) {
+            next unless exists $current->{$pid} && $current->{$pid}{started} eq $owned->{$pid};
+            kill $signal, $pid;
+        }
+        kill $signal, -$child;
+    };
+    my $cleanup = sub {
+        # A clean test leaves no process in its private group. Avoid both the
+        # process-table scan and termination grace period for normal nextest
+        # cases.
+        return unless kill 0, -$child;
+        my $snapshot = $process_snapshot->();
+        my %owned = map { $_->{pid} => $_->{started} } $descendants->($child, $snapshot);
+        $signal_owned->("TERM", \%owned);
+        # Re-discover after the grace period so descendants started while the
+        # first snapshot was taken receive the forced signal too. Retain the
+        # TERM snapshot: a cooperative parent can exit and reparent a detached
+        # TERM-resistant child before escalation.
+        select undef, undef, undef, 1;
+        $snapshot = $process_snapshot->();
+        $owned{$_->{pid}} = $_->{started} for $descendants->($child, $snapshot);
+        $signal_owned->("KILL", \%owned);
         waitpid $child, 0;
         while (waitpid(-1, WNOHANG) > 0) {}
     };

--- a/scripts/test-hermetic-test-runner.sh
+++ b/scripts/test-hermetic-test-runner.sh
@@ -7,7 +7,22 @@ set -eu
 root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 runner="$root/scripts/nextest-hermetic-test-environment.sh"
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-hermetic-runner-test.XXXXXX")"
-trap 'rm -rf "$scratch"' EXIT HUP INT TERM
+
+cleanup_known_descendants() {
+    for pid_file in "$scratch"/*descendant-pid; do
+        [ -f "$pid_file" ] || continue
+        IFS="$(printf '\t')" read -r pid started < "$pid_file" || continue
+        [ -n "$started" ] || continue
+        current="$(/bin/ps -p "$pid" -o lstart= 2>/dev/null || true)"
+        [ "$current" = "$started" ] || continue
+        kill -TERM "$pid" 2>/dev/null || true
+        sleep 1
+        current="$(/bin/ps -p "$pid" -o lstart= 2>/dev/null || true)"
+        [ "$current" = "$started" ] && kill -KILL "$pid" 2>/dev/null || true
+    done
+}
+
+trap 'cleanup_known_descendants; rm -rf "$scratch"' EXIT HUP INT TERM
 
 run_bounded() {
     perl -e 'alarm shift @ARGV; exec @ARGV or die "exec: $!\n"' 8 "$runner" "$@"
@@ -21,13 +36,13 @@ clean_tmp="$(<"$scratch/clean-tmp")"
 [ ! -e "$clean_tmp" ]
 
 set +e
-HOMEBOY_TEST_TIMEOUT_SECONDS=1 run_bounded sh -c 'printf "%s" "$TMPDIR" > "$1"; trap "" TERM; (trap "" TERM; while :; do sleep 1; done) & printf "%s" "$!" > "$2"; while :; do sleep 1; done' sh "$scratch/hung-tmp" "$scratch/descendant-pid" >"$scratch/hung.stdout" 2>"$scratch/hung.stderr"
+HOMEBOY_TEST_TIMEOUT_SECONDS=1 run_bounded sh -c 'printf "%s" "$TMPDIR" > "$1"; trap "" TERM; (trap "" TERM; while :; do sleep 1; done) & pid=$!; printf "%s\t" "$pid" > "$2"; /bin/ps -p "$pid" -o lstart= >> "$2"; while :; do sleep 1; done' sh "$scratch/hung-tmp" "$scratch/descendant-pid" >"$scratch/hung.stdout" 2>"$scratch/hung.stderr"
 status=$?
 set -e
 [ "$status" -eq 124 ]
 hung_tmp="$(<"$scratch/hung-tmp")"
 [ ! -e "$hung_tmp" ]
-descendant="$(<"$scratch/descendant-pid")"
+IFS="$(printf '\t')" read -r descendant _ < "$scratch/descendant-pid"
 if kill -0 "$descendant" 2>/dev/null; then
     echo "TERM-resistant descendant survived runner timeout: $descendant" >&2
     exit 1
@@ -36,6 +51,58 @@ if ! perl -0777 -ne 'exit(/test binary .* exceeded suite deadline 1s/ ? 0 : 1)' 
     echo "timeout diagnostic did not name the binary and deadline" >&2
     exit 1
 fi
+
+run_separate_session_fixture() {
+    output_prefix="$1"
+    timeout_seconds="$2"
+    HOMEBOY_TEST_TIMEOUT_SECONDS="$timeout_seconds" perl -e 'alarm shift @ARGV; exec @ARGV or die "exec: $!\n"' 8 "$runner" sh -c '
+        printf "%s" "$TMPDIR" > "$1"
+        perl -MPOSIX=setsid -e "setsid() or die qq(setsid: \$!\\n); \$SIG{TERM} = q(IGNORE); \$SIG{INT} = q(IGNORE); open my \$pid, q(>), \$ARGV[0] or die qq(pid: \$!\\n); print \$pid qq(\$\$\\t), qx(/bin/ps -p \$\$ -o lstart=); close \$pid; while (1) { sleep 1 }" "$2" &
+        while :; do sleep 1; done
+    ' sh "$scratch/$output_prefix-tmp" "$scratch/$output_prefix-descendant-pid" >"$scratch/$output_prefix.stdout" 2>"$scratch/$output_prefix.stderr" &
+    runner_pid=$!
+    deadline=$(( $(date +%s) + 5 ))
+    while [ ! -f "$scratch/$output_prefix-descendant-pid" ] && [ "$(date +%s)" -lt "$deadline" ]; do
+        sleep 1
+    done
+    if [ ! -f "$scratch/$output_prefix-descendant-pid" ]; then
+        kill -KILL "$runner_pid" 2>/dev/null || true
+        wait "$runner_pid" 2>/dev/null || true
+        echo "separate-session fixture did not publish its PID" >&2
+        exit 1
+    fi
+}
+
+assert_separate_session_reaped() {
+    output_prefix="$1"
+    expected_status="$2"
+    set +e
+    wait "$runner_pid"
+    status=$?
+    set -e
+    [ "$status" -eq "$expected_status" ]
+    tmp="$(<"$scratch/$output_prefix-tmp")"
+    [ ! -e "$tmp" ]
+    IFS="$(printf '\t')" read -r descendant _ < "$scratch/$output_prefix-descendant-pid"
+    if kill -0 "$descendant" 2>/dev/null; then
+        echo "separate-session TERM-resistant descendant survived: $descendant" >&2
+        exit 1
+    fi
+}
+
+run_separate_session_fixture timeout 1
+sleep 2
+assert_separate_session_reaped timeout 124
+if ! perl -0777 -ne 'exit(/test binary .* exceeded suite deadline 1s/ ? 0 : 1)' "$scratch/timeout.stderr"; then
+    echo "timeout cleanup diagnostic did not name the binary and deadline" >&2
+    exit 1
+fi
+
+for signal in TERM INT; do
+    run_separate_session_fixture "$signal" 30
+    kill -"$signal" "$runner_pid"
+    assert_separate_session_reaped "$signal" 143
+done
 
 set +e
 HOMEBOY_TEST_TIMEOUT_SECONDS=0 run_bounded sh -c 'exit 0' >"$scratch/zero.stdout" 2>"$scratch/zero.stderr"


### PR DESCRIPTION
## Summary
Related to #7469.

An orphaned TERM-resistant test fixture was found spinning for nearly eight days, accumulating 180 CPU hours. The hermetic runner signals its original process group, but nested commands can create separate sessions and escape that cleanup.

- Snapshot descendant PIDs and start times before TERM, retaining their identities through KILL escalation even after their parent exits.
- Revalidate retained identities before signaling and discover additional descendants before escalation.
- Preserve the normal clean-exit fast path.
- Add real-process regressions with a cooperative parent and a separate-session TERM-resistant child for deadline, TERM, and INT cancellation. Fixture readiness is published after signal handlers and session setup; failure cleanup checks recorded process identities.

## Verification
Passed locally on macOS:

```sh
scripts/test-hermetic-test-runner.sh
HOMEBOY_TEST_TIMEOUT_SECONDS=60 cargo test --test cleanup_deadline_isolation hanging_category_returns_typed_partial_evidence_and_later_category_completes -- --test-threads=1
HOMEBOY_TEST_TIMEOUT_SECONDS=60 cargo test -p homeboy-engine-primitives controller_loss_reaps_the_release_mutation_process_group -- --test-threads=1
git diff --check
```

Both targeted Rust tests passed. The shell regression verifies dead descendant PIDs, expected exit status, and private temp-root removal. The shell regression was also rerun during final review.

## Scope
This covers cancellation and deadlines while the direct test child/group is live. It does not contain detached descendants that already escaped before cleanup begins, nor untrappable SIGKILL. PID/start-time validation reduces PID reuse risk but inspection and signaling are not atomic. Linux validation remains for CI.

## AI Assistance
OpenAI gpt-6-astra through OpenCode investigated the process evidence, implemented the patch using a delegated coding agent, reviewed and corrected the reparenting edge case, ran verification, and prepared this PR. The human authorized the repair and publication.