### PR TITLE
Hydrate historical task base for merge adoption

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -2741,8 +2741,16 @@ fn reconstruct_recipe_options(
                 .map_err(recipe_value_error("to_worktree"))?,
             source_worktree_path: serde_json::from_value(field("source_worktree_path")?)
                 .map_err(recipe_value_error("source_worktree_path"))?,
-            task_base_sha: serde_json::from_value(field("task_base_sha")?)
-                .map_err(recipe_value_error("task_base_sha"))?,
+            task_base_sha: serde_json::from_value::<Option<String>>(field("task_base_sha")?)
+                .map_err(recipe_value_error("task_base_sha"))?
+                .or_else(|| {
+                    initial
+                        .plan
+                        .metadata
+                        .pointer("/cook_workspace_base/sha")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                }),
             source_refs: recipe.source_refs.clone(),
         },
         provider_transport: CookProviderTransport {
@@ -3591,6 +3599,29 @@ mod tests {
         assert_eq!(
             error.details["problem"],
             "missing finalization field `to_worktree`"
+        );
+    }
+
+    #[test]
+    fn adoption_reconstruction_hydrates_a_legacy_plan_task_base() {
+        let mut historical = recipe();
+        historical.finalization["task_base_sha"] = Value::Null;
+        historical.attempts[0].plan.metadata["cook_workspace_base"] =
+            serde_json::json!({"sha": "immutable-plan-base"});
+
+        let adoption =
+            reconstruct_adoption_options(&historical).expect("reconstruct historical adoption");
+        assert_eq!(
+            adoption.workspace.task_base_sha.as_deref(),
+            Some("immutable-plan-base")
+        );
+
+        historical.finalization["task_base_sha"] = serde_json::json!("recipe-base");
+        let adoption =
+            reconstruct_adoption_options(&historical).expect("reconstruct current adoption");
+        assert_eq!(
+            adoption.workspace.task_base_sha.as_deref(),
+            Some("recipe-base")
         );
     }
 


### PR DESCRIPTION
## Summary

Hydrate a missing historical adoption task base from the immutable attempt plan so two-parent merge candidates can authenticate both lineages.

## What changed

- Preserve an explicit recipe `finalization.task_base_sha` as authoritative.
- Fall back to `plan.metadata.cook_workspace_base.sha` when a legacy recipe stores a null task base.
- Cover both historical fallback and current-recipe precedence.

## Verification

- `cargo test -p homeboy-agents agent_task_service::cook_recipe::tests::adoption_reconstruction_hydrates_a_legacy_plan_task_base -- --exact`
- `cargo fmt --all -- --check`

Closes #14431

## AI assistance

OpenAI GPT-5.6 Sol was used through OpenCode to trace the durable recipe mismatch, implement the reconstruction fallback, and run the focused regression.