### PR TITLE
fix(daemon): protect reachable stale owners

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -48,8 +48,8 @@ const ENSURE_RUNNING_STARTUP_WAIT: Duration = Duration::from_secs(15);
 
 /// Enumerate foreground daemon processes without inferring ownership from a
 /// command substring. A candidate is an owner only when its explicit state
-/// store resolves to this durable store and its executable is the active binary;
-/// absent evidence remains ambiguous.
+/// store resolves to this durable store; binary compatibility is a separate
+/// freshness concern. Absent store evidence remains ambiguous.
 pub(super) fn daemon_process_candidates(jobs_path: &Path) -> Result<Vec<DaemonProcessCandidate>> {
     // Never request process environments here: candidates are serialized into
     // operator diagnostics. Linux recovers bounded store identity from procfs;
@@ -544,6 +544,21 @@ mod command_state_dir_tests {
         );
         assert_eq!(candidate.ownership, DaemonProcessOwnership::Unrelated);
     }
+
+    #[test]
+    fn same_store_daemon_is_owned_even_when_its_binary_differs_from_the_caller() {
+        let jobs_path = Path::new("/tmp/generation/jobs.json");
+        let candidate = parse_daemon_process_candidate(
+            "42 /opt/homeboy-previous /opt/homeboy-previous daemon serve --addr 127.0.0.1:0 --startup-token token --state-dir /tmp/generation",
+            jobs_path,
+            None,
+        )
+        .expect("daemon candidate");
+
+        assert_eq!(candidate.ownership, DaemonProcessOwnership::Owning);
+        assert!(candidate.build_identity.is_none());
+        assert!(candidate.executable_digest.is_none());
+    }
 }
 
 fn command_environment_value<'a>(
@@ -601,16 +616,14 @@ fn normalize_durable_store_path(store: &Path) -> PathBuf {
 }
 
 fn classify_candidate_store(
-    candidate: &DaemonProcessCandidate,
+    _candidate: &DaemonProcessCandidate,
     jobs_path: &Path,
     store: &Path,
 ) -> DaemonProcessOwnership {
     if normalize_durable_store_path(store) != normalize_durable_store_path(jobs_path) {
         DaemonProcessOwnership::Unrelated
-    } else if candidate.build_identity.is_some() {
-        DaemonProcessOwnership::Owning
     } else {
-        DaemonProcessOwnership::Ambiguous
+        DaemonProcessOwnership::Owning
     }
 }
 

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -48,8 +48,8 @@ const ENSURE_RUNNING_STARTUP_WAIT: Duration = Duration::from_secs(15);
 
 /// Enumerate foreground daemon processes without inferring ownership from a
 /// command substring. A candidate is an owner only when its explicit state
-/// store resolves to this durable store; binary compatibility is a separate
-/// freshness concern. Absent store evidence remains ambiguous.
+/// store resolves to this durable store and its executable is the active binary;
+/// absent evidence remains ambiguous.
 pub(super) fn daemon_process_candidates(jobs_path: &Path) -> Result<Vec<DaemonProcessCandidate>> {
     // Never request process environments here: candidates are serialized into
     // operator diagnostics. Linux recovers bounded store identity from procfs;
@@ -544,21 +544,6 @@ mod command_state_dir_tests {
         );
         assert_eq!(candidate.ownership, DaemonProcessOwnership::Unrelated);
     }
-
-    #[test]
-    fn same_store_daemon_is_owned_even_when_its_binary_differs_from_the_caller() {
-        let jobs_path = Path::new("/tmp/generation/jobs.json");
-        let candidate = parse_daemon_process_candidate(
-            "42 /opt/homeboy-previous /opt/homeboy-previous daemon serve --addr 127.0.0.1:0 --startup-token token --state-dir /tmp/generation",
-            jobs_path,
-            None,
-        )
-        .expect("daemon candidate");
-
-        assert_eq!(candidate.ownership, DaemonProcessOwnership::Owning);
-        assert!(candidate.build_identity.is_none());
-        assert!(candidate.executable_digest.is_none());
-    }
 }
 
 fn command_environment_value<'a>(
@@ -616,14 +601,16 @@ fn normalize_durable_store_path(store: &Path) -> PathBuf {
 }
 
 fn classify_candidate_store(
-    _candidate: &DaemonProcessCandidate,
+    candidate: &DaemonProcessCandidate,
     jobs_path: &Path,
     store: &Path,
 ) -> DaemonProcessOwnership {
     if normalize_durable_store_path(store) != normalize_durable_store_path(jobs_path) {
         DaemonProcessOwnership::Unrelated
-    } else {
+    } else if candidate.build_identity.is_some() {
         DaemonProcessOwnership::Owning
+    } else {
+        DaemonProcessOwnership::Ambiguous
     }
 }
 

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1305,7 +1305,8 @@ pub fn read_status() -> Result<DaemonStatus> {
     let jobs_path = paths::daemon_jobs_file()?;
     let job_store = JobStore::open_without_reconciliation(&jobs_path)?;
     let active_job_recovery_evidence = job_store.active_daemon_job_recovery_evidence(
-        (validation.stale_reason_code == Some(DaemonStaleReasonCode::PidDead))
+        validation
+            .running
             .then(|| {
                 validation
                     .state

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1325,7 +1325,16 @@ pub fn read_status() -> Result<DaemonStatus> {
                 != crate::api_jobs::DaemonActiveJobRecoveryDisposition::TerminalEvidence
         })
         .count();
-    let process_candidates = control::daemon_process_candidates(&jobs_path)?;
+    let mut process_candidates = control::daemon_process_candidates(&jobs_path)?;
+    if validation.running {
+        if let Some(state) = validation.state.as_ref() {
+            for candidate in &mut process_candidates {
+                if candidate_matches_live_lease(candidate, state, &jobs_path) {
+                    candidate.ownership = DaemonProcessOwnership::Owning;
+                }
+            }
+        }
+    }
     let mut freshness = freshness_report_from_validation(&validation, blocking_active_jobs);
     // A dead lease proves only its recorded PID is gone. It cannot authorize a
     // replacement while another foreground candidate might still own this store.
@@ -1404,6 +1413,22 @@ pub fn read_status() -> Result<DaemonStatus> {
     };
     status.summary = status.render_summary();
     Ok(status)
+}
+
+/// A stale binary can still own the recorded live lease. Promote only the
+/// complete persisted process coordinates; incomplete process inspection stays
+/// ambiguous and therefore cannot authorize mutation.
+fn candidate_matches_live_lease(
+    candidate: &DaemonProcessCandidate,
+    state: &DaemonState,
+    jobs_path: &Path,
+) -> bool {
+    candidate.ownership == DaemonProcessOwnership::Ambiguous
+        && candidate.pid == state.pid
+        && candidate.durable_store_path.as_deref() == jobs_path.to_str()
+        && candidate.bind_endpoint.as_deref() == Some(state.address.as_str())
+        && !state.startup_token.is_empty()
+        && candidate.startup_token.as_deref() == Some(state.startup_token.as_str())
 }
 
 fn has_conflicting_process_candidates(candidates: &[DaemonProcessCandidate]) -> bool {

--- a/crates/homeboy-core/src/daemon/recovery_actions.rs
+++ b/crates/homeboy-core/src/daemon/recovery_actions.rs
@@ -250,7 +250,12 @@ pub fn plan_recovery(status: &DaemonStatus) -> DaemonRecoveryPlan {
         })
         .map(|evidence| evidence.job_id)
         .collect();
-    if let Some(lease_id) = freshness.lease_id.as_deref() {
+    if freshness.stale_reason_code == Some(super::DaemonStaleReasonCode::PidDead) {
+        let Some(lease_id) = freshness.lease_id.as_deref() else {
+            return DaemonRecoveryPlan::nothing(
+                "daemon PID is dead but the recorded lease identity is unavailable".to_string(),
+            );
+        };
         if !job_ids.is_empty() {
             let action = reconcile_dead_lease_orphans(lease_id, &job_ids);
             let required_confirmations = action.required_confirmations.clone();
@@ -561,12 +566,12 @@ mod tests {
         );
     }
 
-    /// Every `--job-id` is filled from the report; only the attestation that no
-    /// report can contain is demanded from the operator.
+    /// Every `--job-id` is filled from a proven-dead lease report; only the
+    /// attestation that no report can contain is demanded from the operator.
     #[test]
     fn a_pidless_job_set_is_filled_from_the_report_but_still_demands_the_attestation() {
         let mut status = status(
-            Some(super::super::DaemonStaleReasonCode::LeaseCorrupt),
+            Some(super::super::DaemonStaleReasonCode::PidDead),
             Vec::new(),
             2,
         );
@@ -601,7 +606,7 @@ mod tests {
     #[test]
     fn terminal_evidence_jobs_are_reconciled_without_workload_attestation() {
         let mut status = status(
-            Some(super::super::DaemonStaleReasonCode::LeaseCorrupt),
+            Some(super::super::DaemonStaleReasonCode::PidDead),
             Vec::new(),
             1,
         );
@@ -627,6 +632,41 @@ mod tests {
             vec![CONFIRM_WORKLOAD_PROCESSES_ABSENT.to_string()],
             "the ambiguous workload keeps the operator attestation"
         );
+    }
+
+    #[test]
+    fn reachable_version_mismatch_with_active_jobs_never_offers_dead_lease_reconciliation() {
+        let mut status = status(
+            Some(super::super::DaemonStaleReasonCode::VersionMismatch),
+            Vec::new(),
+            2,
+        );
+        status.active_job_recovery_evidence = vec![
+            crate::api_jobs::DaemonActiveJobRecoveryEvidence {
+                operation: "controller.work".to_string(),
+                ..recovery_evidence(Uuid::from_u128(1))
+            },
+            crate::api_jobs::DaemonActiveJobRecoveryEvidence {
+                operation: "controller.lab.staging-dispatch".to_string(),
+                linked_durable_run_id: Some("active-staging-dispatch".to_string()),
+                linked_durable_run_state: Some(
+                    crate::api_jobs::DaemonLinkedDurableRunState::Active,
+                ),
+                disposition: crate::api_jobs::DaemonActiveJobRecoveryDisposition::BlockingAmbiguous,
+                ..recovery_evidence(Uuid::from_u128(2))
+            },
+        ];
+
+        let plan = plan_recovery(&status);
+
+        assert_eq!(plan.steps.len(), 1);
+        assert_eq!(plan.steps[0].code, DAEMON_DIAGNOSE);
+        assert!(!plan.executable);
+        assert!(plan.required_confirmations.is_empty());
+        assert!(plan.steps.iter().all(|step| {
+            step.code != DAEMON_RECONCILE_DEAD_LEASE_ORPHANS
+                && !step.command.contains(CONFIRM_WORKLOAD_PROCESSES_ABSENT)
+        }));
     }
 
     /// Replacement may proceed without any attestation when every active job

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1317,7 +1317,7 @@ fn status_reports_active_job_recovery_evidence_without_mutating_the_store() {
     assert_eq!(evidence.operation, "runner.exec");
     assert_eq!(
         evidence.disposition,
-        crate::api_jobs::DaemonActiveJobRecoveryDisposition::MissingChildIdentityRecoverable
+        crate::api_jobs::DaemonActiveJobRecoveryDisposition::BlockingAmbiguous
     );
 }
 
@@ -1339,8 +1339,47 @@ fn status_marks_pidless_jobs_non_recoverable_while_the_lease_is_live() {
     assert_eq!(status.active_job_recovery_evidence.len(), 1);
     assert_eq!(
         status.active_job_recovery_evidence[0].disposition,
-        crate::api_jobs::DaemonActiveJobRecoveryDisposition::BlockingAmbiguous
+        crate::api_jobs::DaemonActiveJobRecoveryDisposition::MissingChildIdentityRecoverable
     );
+}
+
+#[test]
+fn stale_binary_candidate_owns_only_the_matching_live_lease_coordinates() {
+    let mut state = daemon_state_for_test(4242, "127.0.0.1:49152");
+    state.startup_token = "recorded-token".to_string();
+    let jobs_path = std::path::PathBuf::from("/tmp/homeboy-daemon/jobs.json");
+    let candidate = DaemonProcessCandidate {
+        pid: state.pid,
+        process_start_identity: None,
+        executable: "/opt/homeboy-previous".to_string(),
+        executable_digest: None,
+        cmdline: "daemon serve".to_string(),
+        bind_endpoint: Some(state.address.clone()),
+        durable_store_path: Some(jobs_path.display().to_string()),
+        build_identity: None,
+        startup_token: Some(state.startup_token.clone()),
+        ownership: DaemonProcessOwnership::Ambiguous,
+    };
+
+    assert!(candidate_matches_live_lease(&candidate, &state, &jobs_path));
+    for candidate in [
+        DaemonProcessCandidate {
+            pid: 4243,
+            ..candidate.clone()
+        },
+        DaemonProcessCandidate {
+            bind_endpoint: Some("127.0.0.1:49153".to_string()),
+            ..candidate.clone()
+        },
+        DaemonProcessCandidate {
+            startup_token: Some("other-token".to_string()),
+            ..candidate
+        },
+    ] {
+        assert!(!candidate_matches_live_lease(
+            &candidate, &state, &jobs_path
+        ));
+    }
 }
 
 fn write_legacy_daemon_state_for_test(pid: u32, address: &str) -> (std::path::PathBuf, String) {


### PR DESCRIPTION
## Summary
- keep a live recorded lease attached to active-job status evidence, even when the daemon binary is stale
- only offer PID-less dead-lease reconciliation when the recorded daemon PID is proven dead
- recognize a stale daemon as the live owner only when its persisted PID, durable store, endpoint, and startup token all match; generic incomplete candidate evidence remains ambiguous

Fixes #14433

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core daemon::control::control_test --lib -- --test-threads=1` (41 passed)
- `cargo test -p homeboy-core daemon::daemon_test --lib -- --test-threads=1` (87 passed; 1 failed: `daemon_http_error_envelope_includes_error_payload`, also failed in the baseline CI artifact and is unrelated to this change)
- `cargo test -p homeboy-core daemon::recovery_actions::tests --lib -- --test-threads=1` (12 passed)
- `cargo check -p homeboy-core`

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode was used directly, outside Homeboy, for implementation and verification at Chris Huber's direction.