### PR TITLE
fix(lab): stage the materialized Cook workspace

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -2559,10 +2559,17 @@ fn decode_cook_dispatch_field<T: serde::de::DeserializeOwned>(
 
 fn cook_attempt_source_path<'a>(
     derived_cook_baseline: Option<&'a DerivedCookBaselineCapability>,
+    plan: &'a homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
     controller_source_path: Option<&'a Path>,
 ) -> Option<&'a Path> {
     derived_cook_baseline
         .map(|capability| capability.canonical_path())
+        .or_else(|| {
+            plan.tasks
+                .first()
+                .and_then(|task| task.workspace.root.as_deref())
+                .map(Path::new)
+        })
         .or(controller_source_path)
 }
 
@@ -2605,7 +2612,8 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
         // continuation, and fanout replay. A derived baseline is the declared
         // pre-staging transition where a changed candidate may replace it.
         let source_path =
-            cook_attempt_source_path(derived_cook_baseline, self.source_path.as_deref());
+            cook_attempt_source_path(derived_cook_baseline, &plan, self.source_path.as_deref())
+                .map(PathBuf::from);
         let task = plan
             .tasks
             .first()
@@ -2617,7 +2625,7 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
             &self.placement_decision,
             &self.runner_id,
             &task,
-            source_path,
+            source_path.as_deref(),
         )?;
         // The capability has already bound the promoted artifact and exact
         // baseline to this retry; only its evidence crosses the Lab boundary.
@@ -2708,7 +2716,7 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
                     // A retry's baseline is controller-owned capability, not plan
                     // data. Stage that exact clean checkout; never substitute the
                     // controller's original workspace during nested Lab dispatch.
-                    source_path,
+                    source_path: source_path.as_deref(),
                     expected_source_snapshot_identity: None,
                     verified_cook_baseline: verified_cook_baseline.as_ref(),
                     job_overrides: self.job_overrides.clone(),

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -2557,22 +2557,6 @@ fn decode_cook_dispatch_field<T: serde::de::DeserializeOwned>(
     })
 }
 
-fn cook_attempt_source_path<'a>(
-    derived_cook_baseline: Option<&'a DerivedCookBaselineCapability>,
-    plan: &'a homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
-    controller_source_path: Option<&'a Path>,
-) -> Option<&'a Path> {
-    derived_cook_baseline
-        .map(|capability| capability.canonical_path())
-        .or_else(|| {
-            plan.tasks
-                .first()
-                .and_then(|task| task.workspace.root.as_deref())
-                .map(Path::new)
-        })
-        .or(controller_source_path)
-}
-
 impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
     for LabCookAttemptDispatcher
 {
@@ -2611,9 +2595,16 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
         // Preserve the controller's canonical decision across ordinary retry,
         // continuation, and fanout replay. A derived baseline is the declared
         // pre-staging transition where a changed candidate may replace it.
-        let source_path =
-            cook_attempt_source_path(derived_cook_baseline, &plan, self.source_path.as_deref())
-                .map(PathBuf::from);
+        let source_path = derived_cook_baseline
+            .map(|capability| capability.canonical_path())
+            .or_else(|| {
+                plan.tasks
+                    .first()
+                    .and_then(|task| task.workspace.root.as_deref())
+                    .map(Path::new)
+            })
+            .or(self.source_path.as_deref())
+            .map(PathBuf::from);
         let task = plan
             .tasks
             .first()

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -858,7 +858,7 @@ fn cook_dispatch_stages_runner_identity_without_starting_handoff_lease() {
         let error =
             crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher::dispatch_attempt(
                 &dispatcher,
-                plan,
+                plan.clone(),
                 "cook-preacceptance-order",
                 None,
             )
@@ -903,6 +903,55 @@ fn cook_dispatch_stages_runner_identity_without_starting_handoff_lease() {
             materialized_workspace.path().display().to_string(),
             "the dispatch plan's post-admission workspace is the ordinary Lab staging source"
         );
+
+        let serialized_plan = serde_json::to_string(&plan).expect("serialize materialized plan");
+        let provider_args = lab_cook_attempt_args(serialized_plan, "cook-preacceptance-order");
+        let provider_cli = Cli::try_parse_from(&provider_args).expect("parse provider attempt");
+        let placement_decision =
+            serde_json::from_value(record.metadata["execution_placement_decision"].clone())
+                .expect("materialized placement decision");
+        let staged_source = PathBuf::from(
+            record.metadata["execution_placement_decision"]["identity"]["workspace"]
+                .as_str()
+                .expect("materialized placement workspace"),
+        );
+        let staging_request = homeboy_lab_runner::LabOffloadRequest {
+            placement_decision,
+            command: Some(
+                lab_offload_command(&provider_cli.command)
+                    .expect("resolve provider Lab command")
+                    .expect("portable provider Lab command"),
+            ),
+            normalized_args: &provider_args,
+            explicit_runner: Some("missing-homeboy-lab"),
+            placement: homeboy::cli_surface::Placement::Lab,
+            allow_local_fallback: false,
+            allow_dirty_lab_workspace: false,
+            skip_deps_hydration: false,
+            preserve_workspace_on_failure: false,
+            capture_patch: false,
+            mutation_flag: None,
+            placement_outcome_target: None,
+            detach_after_handoff: false,
+            output_file_requested: false,
+            read_only_polling: false,
+            local_output_file: None,
+            durable_agent_task_plan: Some(&plan),
+            durable_run_id: None,
+            source_path: Some(&staged_source),
+            expected_source_snapshot_identity: None,
+            verified_cook_baseline: None,
+            require_controller_git_bundle: false,
+            reuse_compatible_snapshot: false,
+            job_overrides: runners::LabJobOverrides::default(),
+        };
+        let recipe = homeboy_lab_runner::LabStagingRecipe::from_request(
+            "cook-preacceptance-order",
+            "missing-homeboy-lab",
+            &staging_request,
+        )
+        .expect("Lab staging recipe accepts the materialized source path");
+        assert_eq!(recipe.source_path, Some(staged_source));
     });
 }
 
@@ -1841,33 +1890,61 @@ fn detached_agent_task_handoffs_do_not_use_trace_dispatch_timeout() {
 
 #[test]
 fn cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace() {
-    let baseline = tempfile::tempdir().expect("baseline");
-    let controller = tempfile::tempdir().expect("controller");
-    let capability = crate::agents::agent_task_service::test_derived_cook_baseline_capability(
-        baseline.path().to_path_buf(),
-        "baseline-commit".to_string(),
-        "baseline-tree".to_string(),
-        "task",
-        Some(serde_json::json!({"workspace_snapshot_identity": "snapshot:parent"})),
-    );
-    let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new("cook-retry", vec![]);
+    crate::test_support::with_isolated_home(|_| {
+        let baseline = tempfile::tempdir().expect("derived baseline");
+        let ordinary_workspace = tempfile::tempdir().expect("materialized workspace");
+        let controller = tempfile::tempdir().expect("controller workspace");
+        let capability = crate::agents::agent_task_service::test_derived_cook_baseline_capability(
+            baseline.path().to_path_buf(),
+            "baseline-commit".to_string(),
+            "baseline-tree".to_string(),
+            "task",
+            Some(serde_json::json!({"workspace_snapshot_identity": "snapshot:parent"})),
+        );
+        let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+            "cook-derived-baseline",
+            vec![serde_json::from_value(serde_json::json!({
+                "task_id": "task",
+                "executor": { "backend": "fixture" },
+                "instructions": "continue from derived baseline",
+                "workspace": { "root": ordinary_workspace.path() }
+            }))
+            .expect("materialized ordinary workspace")],
+        );
+        let dispatcher = LabCookAttemptDispatcher {
+            runner_id: "missing-homeboy-lab".to_string(),
+            placement_decision: fixture_preflight_decision(
+                &Cli::parse_from(["homeboy", "status"]),
+                Some("missing-homeboy-lab"),
+                "task",
+                Some(controller.path()),
+            )
+            .expect("test placement decision"),
+            allow_local_fallback: false,
+            allow_dirty_lab_workspace: false,
+            skip_deps_hydration: false,
+            detach_after_handoff: false,
+            source_path: Some(controller.path().to_path_buf()),
+            job_overrides: runners::LabJobOverrides::default(),
+            progress_reporter: crate::commands::agent_task::CookProgressReporter::new(false),
+        };
 
-    assert_eq!(
-        super::cook_attempt_source_path(Some(&capability), &plan, Some(controller.path())),
-        Some(capability.canonical_path())
-    );
-    assert_eq!(
-        capability.verified_baseline_provenance(),
-        serde_json::json!({
-            "source_run_id": "test-source-run",
-            "source_task_id": "task",
-            "promoted_patch_artifact_sha256": "test-artifact-sha256",
-            "baseline_commit": "baseline-commit",
-            "baseline_tree": "baseline-tree",
-            "parent_snapshot_identity": "snapshot:parent",
-            "preexisting_candidate": false,
-        })
-    );
+        crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher::dispatch_attempt(
+            &dispatcher,
+            plan,
+            "cook-derived-baseline",
+            Some(&capability),
+        )
+        .expect_err("missing Lab target rejects after source selection");
+        let record = agent_task_lifecycle::reconcile_status("cook-derived-baseline")
+            .expect("durable attempt");
+
+        assert_eq!(
+            record.metadata["execution_placement_decision"]["identity"]["workspace"],
+            capability.canonical_path().display().to_string(),
+            "derived baseline takes priority over the materialized plan and controller sources"
+        );
+    });
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -826,12 +826,14 @@ fn lab_cook_child_invocation_consumes_controller_runner_placement() {
 #[test]
 fn cook_dispatch_stages_runner_identity_without_starting_handoff_lease() {
     crate::test_support::with_isolated_home(|_| {
+        let materialized_workspace = tempfile::tempdir().expect("materialized workspace");
         let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
             "cook-preacceptance-order",
             vec![serde_json::from_value(serde_json::json!({
                 "task_id": "task",
                 "executor": { "backend": "fixture" },
-                "instructions": "exercise controller handoff staging"
+                "instructions": "exercise controller handoff staging",
+                "workspace": { "root": materialized_workspace.path() }
             }))
             .expect("task")],
         );
@@ -885,13 +887,21 @@ fn cook_dispatch_stages_runner_identity_without_starting_handoff_lease() {
             record.metadata["pre_execution_failure"]["provider_executions_consumed"],
             0
         );
-        assert!(record
-            .metadata
-            .get("execution_placement_invalidated")
-            .is_none());
+        assert!(
+            record.metadata["execution_placement_invalidated"]["reasons"]
+                .as_array()
+                .expect("placement invalidation reasons")
+                .contains(&serde_json::json!("workspace_changed")),
+            "materializing the planned destination replaces the pre-admission placement identity"
+        );
         assert_eq!(
             record.metadata["execution_placement_decision"]["identity"]["task"],
             "task"
+        );
+        assert_eq!(
+            record.metadata["execution_placement_decision"]["identity"]["workspace"],
+            materialized_workspace.path().display().to_string(),
+            "the dispatch plan's post-admission workspace is the ordinary Lab staging source"
         );
     });
 }
@@ -1840,9 +1850,10 @@ fn cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace() 
         "task",
         Some(serde_json::json!({"workspace_snapshot_identity": "snapshot:parent"})),
     );
+    let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new("cook-retry", vec![]);
 
     assert_eq!(
-        super::cook_attempt_source_path(Some(&capability), Some(controller.path())),
+        super::cook_attempt_source_path(Some(&capability), &plan, Some(controller.path())),
         Some(capability.canonical_path())
     );
     assert_eq!(


### PR DESCRIPTION
## Summary

Repair #14427: Lab staging uses the concrete worktree produced after durable Cook admission instead of the dispatcher's stale pre-admission source path.

Source authority is now selected in the existing dispatcher:

1. A derived Cook baseline, when present.
2. The materialized dispatch-plan task workspace.
3. The persisted controller source as the existing fallback.

The selected path is owned before plan mutation and passed to placement resolution and Lab staging. Worktree creation timing, transport policy, credential ownership and derived-baseline priority remain unchanged.

## Evidence

Baseline: `15dc18d0c62a2a1ddcb2b10f0007b272c37ab8cd`.
Candidate: `da7d7e96f3264cb9c6193c3c2df1c0b7161f82aa`.

[Final CI](https://github.com/Extra-Chill/homeboy/actions/runs/34247090163) passed formatting, lint, candidate build, candidate tests, baseline tests and the final Test verdict. The local baseline failure below remains disclosed separately; a green comparison gate is not a claim that every local baseline test passed.

- The lifecycle regression starts with no captured source and a materialized plan workspace. It checks durable placement identity and validates a real `LabStagingRecipe` with the resulting source path.
- Applying only the changed test file to the immutable baseline fails on the missing materialized placement source; the production fix passes.
- The derived-baseline regression supplies three distinct competing paths and verifies the derived baseline wins.
- The existing service materialization-before-provider-dispatch test passes.
- Formatting, focused regressions and the exact committed candidate build pass on the lab. Shared installed runtimes were not changed.
- The full dispatch module completed with **102 passed, 1 failed** in 975.68 seconds when run single-threaded. The sole failure, `nested_command_targeting_parent_runner_does_not_require_a_second_controller_session`, reproduces on the immutable baseline with the same `detach-after-handoff` validation error. It is not waived or described as a pass.
- Parallel module execution exceeded the available test budget; the completed single-threaded result above is the reported suite evidence.

## Reproduce

```sh
cargo fmt --check
cargo test -p homeboy-cli cook_dispatch_stages_runner_identity_without_starting_handoff_lease --lib
cargo test -p homeboy-cli cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace --lib
cargo test -p homeboy-agents service_materializes_component_worktree_before_provider_dispatch --lib
cargo test -p homeboy-cli commands::infra::route::tests::dispatch --lib -- --test-threads=1
```

For the failing-baseline proof, create an isolated checkout of the baseline, copy only the candidate's `crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs` into that checkout, and run the first lifecycle regression. The test file compiles against both implementations.

The original production Cook failed before any provider execution; this candidate verifies the specific workspace-to-staging boundary. A complete live provider run through the repaired control plane remains separate from these deterministic checks, including runner authentication/readiness.

## AI Assistance

OpenAI GPT-5.6 Terra via direct OpenCode implemented the fix and lab verification. GPT-6 Astra via OpenCode coordinated the work, reviewed source authority and requested stronger staging/baseline regressions, then prepared this PR under Chris Huber's direction. Direct execution was explicitly authorized after control-plane failures. No release, deployment or shared credential/configuration changes were performed.
