### PR TITLE
fix(agent-task): retain explicit runner for provider readiness

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -3505,8 +3505,7 @@ fn normalize_agent_task_runner_option(cli: &mut Cli, normalized_args: &[String])
         || !matches!(
             &cli.command,
             Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
-                command:
-                    crate::commands::agent_task::AgentTaskCommand::Cook(_)
+                command: crate::commands::agent_task::AgentTaskCommand::Cook(_)
                     | crate::commands::agent_task::AgentTaskCommand::Providers(_),
             })
         )

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1156,7 +1156,7 @@ impl CliRuntime {
         }
         commands::set_skip_deps_hydration(cli.skip_deps_hydration);
         normalize_runs_runner_options(&mut cli, &normalized);
-        normalize_cook_runner_option(&mut cli, &normalized);
+        normalize_agent_task_runner_option(&mut cli, &normalized);
         if let Commands::AgentTask(agent_task) = &mut cli.command {
             if let crate::commands::agent_task::AgentTaskCommand::Cook(cook) =
                 &mut agent_task.command
@@ -3497,15 +3497,17 @@ fn normalize_runs_runner_options(cli: &mut Cli, normalized_args: &[String]) {
     }
 }
 
-/// Cook is re-executed by a pinned controller binary. Retain an explicit runner
-/// from that exact argv even when a command-scoped Clap argument did not hydrate
-/// the root global field used by admission and placement routing.
-fn normalize_cook_runner_option(cli: &mut Cli, normalized_args: &[String]) {
+/// Runner-scoped agent-task commands retain the explicit selection from their
+/// exact argv when a command-scoped Clap argument did not hydrate the root
+/// global field used by admission and placement routing.
+fn normalize_agent_task_runner_option(cli: &mut Cli, normalized_args: &[String]) {
     if cli.runner.is_some()
         || !matches!(
             &cli.command,
             Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
-                command: crate::commands::agent_task::AgentTaskCommand::Cook(_),
+                command:
+                    crate::commands::agent_task::AgentTaskCommand::Cook(_)
+                    | crate::commands::agent_task::AgentTaskCommand::Providers(_),
             })
         )
     {
@@ -6110,7 +6112,7 @@ mod tests {
     }
 
     #[test]
-    fn pinned_cook_argv_restores_explicit_runner_before_admission() {
+    fn agent_task_argv_restores_explicit_runner_before_admission() {
         let mut cli = Cli::parse_from([
             "homeboy",
             "agent-task",
@@ -6136,7 +6138,7 @@ mod tests {
             "homeboy-lab".to_string(),
         ];
 
-        normalize_cook_runner_option(&mut cli, &pinned_argv);
+        normalize_agent_task_runner_option(&mut cli, &pinned_argv);
 
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
         assert_eq!(
@@ -6144,6 +6146,46 @@ mod tests {
             Some("homeboy-lab"),
             "hot-machine admission must receive the runner selected in pinned argv"
         );
+    }
+
+    #[test]
+    fn provider_readiness_argv_restores_runner_from_both_documented_positions() {
+        for argv in [
+            vec![
+                "homeboy".to_string(),
+                "--runner".to_string(),
+                "homeboy-lab".to_string(),
+                "agent-task".to_string(),
+                "providers".to_string(),
+                "--backend".to_string(),
+                "opencode".to_string(),
+                "--validate-readiness".to_string(),
+            ],
+            vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "providers".to_string(),
+                "--runner".to_string(),
+                "homeboy-lab".to_string(),
+                "--backend".to_string(),
+                "opencode".to_string(),
+                "--validate-readiness".to_string(),
+            ],
+        ] {
+            let mut cli = Cli::parse_from([
+                "homeboy",
+                "agent-task",
+                "providers",
+                "--backend",
+                "opencode",
+                "--validate-readiness",
+            ]);
+
+            normalize_agent_task_runner_option(&mut cli, &argv);
+
+            assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+            assert_eq!(resource_policy_runner_hint(&cli, None), Some("homeboy-lab"));
+        }
     }
 
     #[test]

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1208,6 +1208,53 @@ mod tests {
     }
 
     #[test]
+    fn registered_provider_readiness_parse_preserves_runner_from_both_positions() {
+        for args in [
+            [
+                "homeboy",
+                "--runner",
+                "homeboy-lab",
+                "agent-task",
+                "providers",
+                "--backend",
+                "opencode",
+                "--validate-readiness",
+            ]
+            .as_slice(),
+            [
+                "homeboy",
+                "agent-task",
+                "providers",
+                "--runner",
+                "homeboy-lab",
+                "--backend",
+                "opencode",
+                "--validate-readiness",
+            ]
+            .as_slice(),
+        ] {
+            let matches = Cli::command_with_scoped_lab_args()
+                .try_get_matches_from(args)
+                .expect("provider readiness accepts an explicit runner");
+            let (cli, _) = Cli::from_registered_arg_matches(&matches)
+                .expect("registered provider readiness parse retains runner");
+
+            assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+            let normalized_args = args.iter().map(|arg| (*arg).to_string()).collect::<Vec<_>>();
+            let preflight = crate::commands::utils::resource_policy::parsed_command_preflight_input(
+                &cli,
+                &normalized_args,
+            );
+            assert_eq!(
+                preflight.runner,
+                crate::core::parsed_command_preflight::RunnerIntent::Explicit(
+                    "homeboy-lab".to_string()
+                )
+            );
+        }
+    }
+
+    #[test]
     fn registered_cleanup_artifacts_parse_preserves_global_placement() {
         let matches = Cli::command_with_scoped_lab_args()
             .try_get_matches_from([

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1240,7 +1240,10 @@ mod tests {
                 .expect("registered provider readiness parse retains runner");
 
             assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
-            let normalized_args = args.iter().map(|arg| (*arg).to_string()).collect::<Vec<_>>();
+            let normalized_args = args
+                .iter()
+                .map(|arg| (*arg).to_string())
+                .collect::<Vec<_>>();
             let preflight = crate::commands::utils::resource_policy::parsed_command_preflight_input(
                 &cli,
                 &normalized_args,


### PR DESCRIPTION
## Summary

Address #14429 by retaining an explicitly selected runner before provider-readiness admission and routing.

The runtime already recovers Cook's runner from normalized argv when command-scoped parsing leaves the root runner field unset. Extend that existing normalization to `agent-task providers`, so an explicit runner cannot be treated as unscoped controller-local discovery. Existing runner selection, authentication ownership and runner transport contracts remain intact.

## Verification

Baseline: `cea1565d3fffa9f3c02885c0e11fbde2d3ab719a`.
Candidate: `4a810908496a73b9cbef3cbd73679c40cd301bd2` (runtime fix plus final formatting-only correction).

[Final CI](https://github.com/Extra-Chill/homeboy/actions/runs/34248302552) passed formatting, lint, candidate build, candidate tests, baseline tests and the final Test verdict. The live ready-runner verification limitation below remains explicit.

- Registered parser/preflight coverage verifies both documented positions of `--runner`.
- Runtime normalization coverage begins with a missing root runner field and verifies normalized argv restores the selected runner before admission for both positions.
- Focused Rust tests, formatting and `cargo check -p homeboy-cli` passed on the lab.
- Final `cargo fmt --all --check` passed from the repository root with its pinned toolchain after correcting two CI formatting differences.
- The installed 0.369.6 controller reproduces the issue: explicit runner readiness returns `ready` with controller scope and a null runner ID.
- A source-built candidate on that controller returns an explicit selected-runner admission failure instead of silently reporting controller readiness, for both flag positions.

The ready-runner positive case remains unverified: the configured daemon and candidate builds differ, and shared runner configuration/binaries were deliberately left unchanged. The observed candidate result proves fail-closed admission, not successful remote inference or credential readiness. The initial parser-only candidate was held until the runtime normalization change was added.

## Reproduce

```sh
cargo test -p homeboy-cli registered_provider_readiness_parse_preserves_runner_from_both_positions --lib
cargo test -p homeboy-cli provider_readiness_argv_restores_runner_from_both_documented_positions --lib
cargo test -p homeboy-cli agent_task_argv_restores_explicit_runner_before_admission --lib
cargo fmt --check
cargo check -p homeboy-cli
```

With a configured runner and provider, compare the two public forms using the built CLI:

```sh
homeboy --runner RUNNER agent-task providers --backend BACKEND --model MODEL --validate-readiness
homeboy agent-task providers --runner RUNNER --backend BACKEND --model MODEL --validate-readiness
```

Both must retain the requested runner. Runner admission/readiness failures must remain visible rather than falling through to a controller-local `ready` result. Provider credentials stay at their existing owners; this patch neither copies secrets nor modifies configuration.

## AI Assistance

OpenAI GPT-5.6 Terra via direct OpenCode investigated the live reproduction, implemented the runtime change and ran verification. GPT-6 Astra via OpenCode coordinated and reviewed the work, rejected the initial unsupported already-fixed conclusion, and prepared this PR under Chris Huber's direction. Direct execution was explicitly authorized after control-plane failures; no release or deployment was performed.
