### PR TITLE
feat(daemon): inspect durable jobs

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -1,8 +1,10 @@
 use clap::{Args, CommandFactory, Subcommand};
 use serde::Serialize;
 use std::path::PathBuf;
+use std::time::Instant;
 use uuid::Uuid;
 
+use homeboy::core::api_jobs::{DaemonJobInspection, JobEvent, JobStatus, JobStore};
 use homeboy::core::daemon::{
     self, BrokerConfig, BrokerConfigOptions, DaemonCandidateReconciliationResult,
     DaemonExactOrphanRecoveryResult, DaemonLeaselessRecoveryResult, DaemonOrphanAdoptionResult,
@@ -194,6 +196,57 @@ enum DaemonCommand {
     },
     /// Fetch artifact bytes through the local daemon byte endpoint
     ArtifactGet(DaemonArtifactGetArgs),
+    /// Inspect durable daemon jobs without reading the internal store directly
+    Jobs(DaemonJobsArgs),
+}
+
+#[derive(Args)]
+pub struct DaemonJobsArgs {
+    #[command(subcommand)]
+    command: DaemonJobsCommand,
+}
+
+#[derive(Subcommand)]
+enum DaemonJobsCommand {
+    /// List compact durable daemon-job projections
+    List(DaemonJobsListArgs),
+    /// Show one daemon job; --full includes retained events
+    Show(DaemonJobsShowArgs),
+    /// Wait for one daemon job to reach a terminal state
+    Watch(DaemonJobsWatchArgs),
+}
+
+#[derive(Args)]
+pub struct DaemonJobsListArgs {
+    #[arg(long)]
+    status: Option<String>,
+    #[arg(long)]
+    operation: Option<String>,
+    #[arg(long)]
+    lease: Option<String>,
+    #[arg(long)]
+    run: Option<String>,
+    #[arg(long, default_value_t = 20)]
+    limit: usize,
+}
+
+#[derive(Args)]
+pub struct DaemonJobsShowArgs {
+    pub job_id: Uuid,
+    /// Include retained event payloads and checkpoints; compact output omits them.
+    #[arg(long)]
+    full: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct DaemonJobsWatchArgs {
+    pub job_id: Uuid,
+    #[arg(long, default_value = "5m", conflicts_with = "forever")]
+    timeout: String,
+    #[arg(long, conflicts_with = "timeout")]
+    forever: bool,
+    #[arg(long, default_value = "2s")]
+    interval: String,
 }
 
 #[derive(Args, Clone)]
@@ -227,6 +280,52 @@ pub enum DaemonOutput {
     Status(DaemonStatus),
     BrokerConfig(BrokerConfig),
     ArtifactGet(DaemonArtifactGetOutput),
+    JobsList(DaemonJobsListOutput),
+    JobsShow(DaemonJobsShowOutput),
+    JobsWatch(DaemonJobsWatchOutput),
+}
+
+#[derive(Debug, Serialize)]
+pub struct DaemonJobSummary {
+    pub id: Uuid,
+    pub status: JobStatus,
+    pub operation: String,
+    pub lease_id: Option<String>,
+    pub linked_durable_run_id: Option<String>,
+    pub child_identity: Option<homeboy::core::api_jobs::DaemonJobChildIdentity>,
+    pub age_ms: u64,
+    pub terminal_disposition: Option<String>,
+    pub next_actions: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DaemonJobsListOutput {
+    pub command: &'static str,
+    pub jobs: Vec<DaemonJobSummary>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DaemonJobsShowOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub job: DaemonJobSummary,
+    pub retained_event_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events: Option<Vec<JobEvent>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DaemonJobsWatchOutput {
+    pub command: &'static str,
+    pub job_id: Uuid,
+    pub status: JobStatus,
+    pub terminal: bool,
+    pub timed_out: bool,
+    pub waited_secs: u64,
+    pub poll_count: u64,
+    pub job: DaemonJobSummary,
 }
 
 /// The resolved recovery, and what was done about it.
@@ -447,6 +546,195 @@ pub fn run(args: DaemonArgs) -> CmdResult<DaemonOutput> {
             0,
         )),
         DaemonCommand::ArtifactGet(args) => artifact_get(args),
+        DaemonCommand::Jobs(args) => jobs(args),
+    }
+}
+
+fn jobs(args: DaemonJobsArgs) -> CmdResult<DaemonOutput> {
+    match args.command {
+        DaemonJobsCommand::List(args) => jobs_list(args),
+        DaemonJobsCommand::Show(args) => jobs_show(args),
+        DaemonJobsCommand::Watch(args) => jobs_watch(args),
+    }
+}
+
+fn job_store() -> homeboy::core::Result<JobStore> {
+    JobStore::open_without_reconciliation(homeboy::core::paths::daemon_jobs_file()?)
+}
+
+fn jobs_list(args: DaemonJobsListArgs) -> CmdResult<DaemonOutput> {
+    let status = args.status.as_deref().map(parse_job_status).transpose()?;
+    let store = job_store()?;
+    let mut jobs = store
+        .list()
+        .into_iter()
+        .rev()
+        .filter_map(|job| {
+            if status.is_some_and(|status| job.status != status)
+                || args
+                    .operation
+                    .as_ref()
+                    .is_some_and(|operation| &job.operation != operation)
+                || args
+                    .lease
+                    .as_ref()
+                    .is_some_and(|lease| job.daemon_lease_id.as_ref() != Some(lease))
+            {
+                return None;
+            }
+            let inspection = store.inspection(job.id).ok()?;
+            args.run
+                .as_ref()
+                .is_none_or(|run| inspection.linked_durable_run_id.as_ref() == Some(run))
+                .then(|| job_summary(inspection))
+        })
+        .collect::<Vec<_>>();
+    jobs.truncate(args.limit);
+    Ok((
+        DaemonOutput::JobsList(DaemonJobsListOutput {
+            command: "daemon.jobs.list",
+            jobs,
+        }),
+        0,
+    ))
+}
+
+fn jobs_show(args: DaemonJobsShowArgs) -> CmdResult<DaemonOutput> {
+    let store = job_store()?;
+    let inspection = require_job_inspection(&store, args.job_id)?;
+    let events = store.events(args.job_id)?;
+    let checkpoint = args.full.then(|| inspection.checkpoint.clone()).flatten();
+    Ok((
+        DaemonOutput::JobsShow(DaemonJobsShowOutput {
+            command: "daemon.jobs.show",
+            job: job_summary(inspection),
+            retained_event_count: events.len(),
+            events: args.full.then_some(events),
+            checkpoint,
+        }),
+        0,
+    ))
+}
+
+fn jobs_watch(args: DaemonJobsWatchArgs) -> CmdResult<DaemonOutput> {
+    use crate::commands::utils::watch::{watch_loop, WatchConfig, WatchPoller, TIMEOUT_EXIT_CODE};
+    struct Poller;
+    impl WatchPoller for Poller {
+        type Item = DaemonJobInspection;
+        fn poll(&self, id: &str) -> homeboy::core::Result<Self::Item> {
+            let job_id = Uuid::parse_str(id).map_err(|_| missing_or_pruned_job(Uuid::nil()))?;
+            require_job_inspection(&job_store()?, job_id)
+        }
+        fn is_terminal(&self, item: &Self::Item) -> bool {
+            item.job.status.is_terminal()
+        }
+    }
+    let interval = crate::commands::utils::watch::parse_duration("--interval", &args.interval)?;
+    let timeout = (!args.forever)
+        .then(|| crate::commands::utils::watch::parse_duration("--timeout", &args.timeout))
+        .transpose()?;
+    let started = Instant::now();
+    let result = watch_loop(
+        &Poller,
+        &args.job_id.to_string(),
+        &WatchConfig { interval, timeout },
+        std::thread::sleep,
+        || started.elapsed(),
+        |job, poll| {
+            eprintln!(
+                "homeboy daemon jobs watch {}: poll {poll} status={}",
+                job.job.id,
+                job.job.status.as_str()
+            )
+        },
+    )?;
+    let timed_out = result.timed_out();
+    let exit_code = if timed_out {
+        TIMEOUT_EXIT_CODE
+    } else {
+        exit_code_for_job_status(result.item.job.status)
+    };
+    let status = result.item.job.status;
+    Ok((
+        DaemonOutput::JobsWatch(DaemonJobsWatchOutput {
+            command: "daemon.jobs.watch",
+            job_id: args.job_id,
+            status,
+            terminal: !timed_out,
+            timed_out,
+            waited_secs: result.waited.as_secs(),
+            poll_count: result.poll_count,
+            job: job_summary(result.item),
+        }),
+        exit_code,
+    ))
+}
+
+fn parse_job_status(value: &str) -> homeboy::core::Result<JobStatus> {
+    match value {
+        "queued" => Ok(JobStatus::Queued),
+        "running" => Ok(JobStatus::Running),
+        "succeeded" => Ok(JobStatus::Succeeded),
+        "failed" => Ok(JobStatus::Failed),
+        "cancelled" => Ok(JobStatus::Cancelled),
+        _ => Err(Error::validation_invalid_argument(
+            "status",
+            "expected queued, running, succeeded, failed, or cancelled",
+            Some(value.to_string()),
+            None,
+        )),
+    }
+}
+
+fn exit_code_for_job_status(status: JobStatus) -> i32 {
+    if status == JobStatus::Succeeded {
+        0
+    } else {
+        1
+    }
+}
+
+fn require_job_inspection(
+    store: &JobStore,
+    job_id: Uuid,
+) -> homeboy::core::Result<DaemonJobInspection> {
+    store
+        .inspection(job_id)
+        .map_err(|_| missing_or_pruned_job(job_id))
+}
+
+fn missing_or_pruned_job(job_id: Uuid) -> Error {
+    let mut error = Error::validation_invalid_argument("job_id", "daemon job is missing or its retained terminal record was pruned", Some(job_id.to_string()), Some(vec!["Inspect linked durable evidence with `homeboy runs show <run-id>` or `homeboy agent-task status <run-id>` when a prior job response named one.".to_string()]));
+    error.details["classification"] = serde_json::json!("daemon_job_missing_or_pruned");
+    error.details["retention"] = serde_json::json!(
+        "terminal daemon jobs and events are retained within bounded store limits"
+    );
+    error
+}
+
+fn job_summary(inspection: DaemonJobInspection) -> DaemonJobSummary {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let id = inspection.job.id;
+    let mut next_actions = vec![format!("homeboy daemon jobs show {id}")];
+    if !inspection.job.status.is_terminal() {
+        next_actions.push(format!("homeboy daemon jobs watch {id}"));
+    }
+    if let Some(run_id) = &inspection.linked_durable_run_id {
+        next_actions.push(format!("homeboy runs show {run_id}"));
+    }
+    DaemonJobSummary {
+        id,
+        status: inspection.job.status,
+        operation: inspection.job.operation,
+        lease_id: inspection.job.daemon_lease_id,
+        linked_durable_run_id: inspection.linked_durable_run_id,
+        child_identity: inspection.child_identity,
+        age_ms: now_ms.saturating_sub(inspection.job.created_at_ms),
+        terminal_disposition: inspection.terminal_disposition,
+        next_actions,
     }
 }
 
@@ -816,6 +1104,64 @@ mod tests {
 
     use super::*;
     use crate::cli_surface::{Cli, Commands};
+
+    #[test]
+    fn daemon_job_status_filters_and_watch_exit_semantics_are_stable() {
+        assert!(Cli::try_parse_from([
+            "homeboy", "daemon", "jobs", "list", "--status", "running", "--limit", "1"
+        ])
+        .is_ok());
+        assert!(Cli::try_parse_from([
+            "homeboy",
+            "daemon",
+            "jobs",
+            "show",
+            "00000000-0000-0000-0000-000000000001",
+            "--full"
+        ])
+        .is_ok());
+        assert!(Cli::try_parse_from([
+            "homeboy",
+            "daemon",
+            "jobs",
+            "watch",
+            "00000000-0000-0000-0000-000000000001",
+            "--timeout",
+            "1s"
+        ])
+        .is_ok());
+        assert_eq!(
+            parse_job_status("running").expect("status"),
+            JobStatus::Running
+        );
+        assert!(parse_job_status("pass").is_err());
+        assert_eq!(exit_code_for_job_status(JobStatus::Succeeded), 0);
+        for status in [
+            JobStatus::Queued,
+            JobStatus::Running,
+            JobStatus::Failed,
+            JobStatus::Cancelled,
+        ] {
+            assert_eq!(
+                exit_code_for_job_status(status),
+                1,
+                "{status:?} must not report success"
+            );
+        }
+    }
+
+    #[test]
+    fn pruned_or_unknown_daemon_job_has_a_typed_retention_diagnostic() {
+        let error = missing_or_pruned_job(Uuid::nil());
+        assert_eq!(
+            error.details["classification"],
+            "daemon_job_missing_or_pruned"
+        );
+        assert!(error.details["retention"].as_str().is_some());
+        assert!(error
+            .message
+            .contains("missing or its retained terminal record was pruned"));
+    }
 
     #[test]
     fn legacy_child_recovery_parser_requires_exact_evidence() {

--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -37,5 +37,28 @@ pub use types::{
     LeaselessOrphanJobDiagnostics, RunnerJobLogSnapshot, RunnerJobProjection, RunnerJobSource,
 };
 
+/// Read-only projection for inspecting one durable daemon job without exposing
+/// the store's private request payload or mutating lifecycle state.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DaemonJobInspection {
+    pub job: Job,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub linked_durable_run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub child_identity: Option<DaemonJobChildIdentity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_disposition: Option<String>,
+    /// Driver-owned checkpoint retained for explicit full evidence requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DaemonJobChildIdentity {
+    pub pid: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_group_id: Option<u32>,
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -1518,7 +1518,7 @@ impl JobStore {
         }
     }
 
-    pub(crate) fn list(&self) -> Vec<Job> {
+    pub fn list(&self) -> Vec<Job> {
         let inner = self.inner.lock().expect("job store mutex poisoned");
         let mut jobs: Vec<Job> = inner
             .jobs
@@ -1527,6 +1527,54 @@ impl JobStore {
             .collect();
         jobs.sort_by_key(|job| (job.created_at_ms, job.id));
         jobs
+    }
+
+    /// Return a safe, non-reconciling projection for daemon-job inspection.
+    pub fn inspection(&self, job_id: Uuid) -> Result<super::DaemonJobInspection> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        let linked_durable_run_id = stored
+            .controller_job
+            .as_ref()
+            .and_then(|controller| controller.linked_durable_run_id.clone())
+            .or_else(|| {
+                stored.events.iter().find_map(|event| {
+                    event.data.as_ref().and_then(|data| {
+                        ["durable_run_id", "run_id", "agent_task_run_id"]
+                            .iter()
+                            .find_map(|key| data.get(*key)?.as_str().map(str::to_string))
+                    })
+                })
+            });
+        let child_identity = stored
+            .local_child
+            .as_ref()
+            .and_then(|child| child.process.as_ref())
+            .map(|process| super::DaemonJobChildIdentity {
+                pid: process.pid,
+                process_group_id: process.process_group_id,
+            });
+        let terminal_disposition = stored.job.status.is_terminal().then(|| {
+            stored
+                .job
+                .stale_reason
+                .clone()
+                .unwrap_or_else(|| stored.job.status.as_str().to_string())
+        });
+        let checkpoint = stored
+            .controller_job
+            .as_ref()
+            .and_then(|controller| controller.checkpoint.clone());
+        Ok(super::DaemonJobInspection {
+            job: stored.job.clone(),
+            linked_durable_run_id,
+            child_identity,
+            terminal_disposition,
+            checkpoint,
+        })
     }
 
     pub fn events(&self, job_id: Uuid) -> Result<Vec<JobEvent>> {

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -39,6 +39,29 @@ fn inspection_reuses_the_canonical_job_and_keeps_events_separate() {
 }
 
 #[test]
+fn inspection_projects_linked_durable_run_from_retained_event_metadata() {
+    let store = JobStore::default();
+    let job = store.create("controller.work");
+    store
+        .append_event(
+            job.id,
+            JobEventKind::Progress,
+            None,
+            Some(json!({"durable_run_id": "run-linked-1"})),
+        )
+        .expect("append linked run metadata");
+
+    assert_eq!(
+        store
+            .inspection(job.id)
+            .expect("inspection")
+            .linked_durable_run_id
+            .as_deref(),
+        Some("run-linked-1")
+    );
+}
+
+#[test]
 fn active_count_reads_durable_jobs_without_reconciling_them() {
     let temp = tempfile::tempdir().expect("temp dir");
     let path = temp.path().join("jobs.json");

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -19,6 +19,26 @@ fn test_create() {
 }
 
 #[test]
+fn inspection_reuses_the_canonical_job_and_keeps_events_separate() {
+    let store = JobStore::default();
+    let job = store.create("controller.work");
+    store.start(job.id).expect("start");
+    store
+        .complete(job.id, Some(json!({"exit_code": 0})))
+        .expect("complete");
+
+    let inspection = store.inspection(job.id).expect("inspection");
+    assert_eq!(inspection.job.id, job.id);
+    assert_eq!(inspection.job.status, JobStatus::Succeeded);
+    assert_eq!(
+        inspection.terminal_disposition.as_deref(),
+        Some("succeeded")
+    );
+    assert!(inspection.linked_durable_run_id.is_none());
+    assert!(store.events(job.id).expect("events").len() > 1);
+}
+
+#[test]
 fn active_count_reads_durable_jobs_without_reconciling_them() {
     let temp = tempfile::tempdir().expect("temp dir");
     let path = temp.path().join("jobs.json");


### PR DESCRIPTION
Fixes #14435

## Summary
- Add read-only `homeboy daemon jobs list`, `show`, and `watch` commands over the durable job store.
- Keep list/show compact by default; `show --full` includes retained events and checkpoints.
- Return typed missing-or-pruned retention diagnostics, linked run actions, and success/failure/timeout watch exits.

## Tests
- `cargo test -p homeboy-cli daemon_job_status_filters_and_watch_exit_semantics_are_stable` - passed (1 passed).
- `cargo test -p homeboy-cli pruned_or_unknown_daemon_job_has_a_typed_retention_diagnostic` - passed (1 passed).
- `cargo test -p homeboy-core api_jobs::tests::part_a::inspection_reuses_the_canonical_job_and_keeps_events_separate` - passed (1 passed).
- `cargo test -p homeboy-core api_jobs::tests::part_a::inspection_projects_linked_durable_run_from_retained_event_metadata` - passed (1 passed).
- `cargo check -p homeboy-cli` - passed.
- `cargo fmt --check` - passed.

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode was used directly, outside Homeboy, for implementation and verification at Chris Huber's direction.