### PR TITLE
Fix managed dev-sync snapshot dispatch

### DIFF
--- a/crates/homeboy-core/src/hygiene.rs
+++ b/crates/homeboy-core/src/hygiene.rs
@@ -401,6 +401,7 @@ fn checkout_hygiene_snapshot(
     allowed: bool,
 ) -> Result<CheckoutHygieneSnapshot> {
     let path = checkout.path;
+    let managed_snapshot = is_managed_extension_snapshot(&path);
     let mut head = git_output(&path, &["rev-parse", "HEAD"]);
     let branch = git_output(&path, &["rev-parse", "--abbrev-ref", "HEAD"]);
     let upstream = git_output(&path, &["rev-parse", "--abbrev-ref", "@{upstream}"]);
@@ -409,7 +410,9 @@ fn checkout_hygiene_snapshot(
     }
     let dirty = git_output(&path, &["status", "--porcelain=v1"]).map(|value| !value.is_empty());
     let (mut behind, mut ahead) = git_ahead_behind(&path);
-    let refreshable = !allowed
+    let allowed = allowed || (managed_snapshot && dirty == Some(false) && ahead.unwrap_or(0) == 0);
+    let refreshable = !managed_snapshot
+        && !allowed
         && upstream.is_some()
         && dirty == Some(false)
         && ahead.unwrap_or(0) == 0
@@ -439,7 +442,6 @@ fn checkout_hygiene_snapshot(
 
 /// A non-linked installed extension is controller-managed cache state. It can
 /// advance only when it is clean, follows an upstream, and has no explicit pin.
-/// Linked/dev sources remain developer-owned and are left to normal hygiene.
 fn is_managed_extension_cache(path: &Path) -> bool {
     let Ok(extensions_dir) = crate::paths::extensions() else {
         return false;
@@ -455,6 +457,40 @@ fn is_managed_extension_cache(path: &Path) -> bool {
     std::fs::read_to_string(path.join(".source-requested-ref"))
         .map(|value| value.trim().is_empty())
         .unwrap_or(true)
+}
+
+/// Homeboy refreshes linked local extensions by snapshotting their bytes below
+/// `extension-sources/<id>` before repointing the installed link. That target
+/// is immutable provenance: upstream drift is an available update, not stale
+/// execution input. `extension refresh` owns creating a newer snapshot.
+///
+/// Other links remain developer-owned even when they are clean and behind.
+fn is_managed_extension_snapshot(path: &Path) -> bool {
+    let Ok(extensions_dir) = crate::paths::extensions() else {
+        return false;
+    };
+    let Some(extension_id) = path.file_name() else {
+        return false;
+    };
+    if path.parent() != Some(extensions_dir.as_path())
+        || !std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink())
+    {
+        return false;
+    }
+
+    let Ok(target) = path.canonicalize() else {
+        return false;
+    };
+    let Ok(snapshot_root) = crate::paths::extension_source_root(&extension_id.to_string_lossy())
+        .and_then(|root| {
+            root.canonicalize().map_err(|error| {
+                Error::internal_io(error.to_string(), Some(root.display().to_string()))
+            })
+        })
+    else {
+        return false;
+    };
+    target.starts_with(snapshot_root)
 }
 
 fn lab_source_evidence_from_snapshot(
@@ -1048,6 +1084,119 @@ mod tests {
             assert_ne!(
                 git_output(&extension, &["rev-parse", "HEAD"]),
                 git_output(writer.path(), &["rev-parse", "HEAD"])
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dependency_hygiene_accepts_immutable_managed_extension_snapshot() {
+        crate::test_support::with_isolated_home(|_| {
+            let extensions = crate::paths::extensions().unwrap();
+            let snapshot = crate::paths::extension_source_root("wordpress")
+                .unwrap()
+                .join("wordpress");
+            fs::create_dir_all(&extensions).unwrap();
+            fs::create_dir_all(&snapshot).unwrap();
+            let remote = init_repo_with_upstream(&snapshot);
+            std::os::unix::fs::symlink(&snapshot, extensions.join("wordpress")).unwrap();
+            assert!(is_managed_extension_snapshot(&extensions.join("wordpress")));
+
+            let writer = tempfile::tempdir().unwrap();
+            git(
+                writer.path(),
+                &[
+                    "clone",
+                    "--branch",
+                    "main",
+                    remote.path().to_str().unwrap(),
+                    ".",
+                ],
+            );
+            git(writer.path(), &["config", "user.email", "test@example.com"]);
+            git(writer.path(), &["config", "user.name", "Homeboy Test"]);
+            fs::write(writer.path().join("remote.txt"), "remote\n").unwrap();
+            git(writer.path(), &["add", "."]);
+            git(writer.path(), &["commit", "-m", "remote update"]);
+            git(writer.path(), &["push", "origin", "HEAD:main"]);
+            let snapshot_head = git_output(&snapshot, &["rev-parse", "HEAD"]);
+
+            let snapshots = require_checkout_hygiene_without_lifecycle(
+                vec![DependencyCheckout {
+                    id: "wordpress".to_string(),
+                    role: "extension".to_string(),
+                    path: extensions.join("wordpress"),
+                }],
+                DependencyHygieneOptions { allow_stale: false },
+            )
+            .expect("managed immutable snapshot remains valid when upstream advances");
+
+            assert_eq!(snapshots[0].behind, Some(1));
+            assert_eq!(git_output(&snapshot, &["rev-parse", "HEAD"]), snapshot_head);
+
+            fs::write(snapshot.join("dirty.txt"), "dirty\n").unwrap();
+            let err = require_checkout_hygiene_without_lifecycle(
+                vec![DependencyCheckout {
+                    id: "wordpress".to_string(),
+                    role: "extension".to_string(),
+                    path: extensions.join("wordpress"),
+                }],
+                DependencyHygieneOptions { allow_stale: false },
+            )
+            .expect_err("dirty managed snapshot must be repaired through its owning lifecycle");
+
+            assert_eq!(err.details["checkouts"][0]["dirty"].as_bool(), Some(true));
+            assert_eq!(git_output(&snapshot, &["rev-parse", "HEAD"]), snapshot_head);
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dependency_hygiene_rejects_stale_developer_extension_link() {
+        crate::test_support::with_isolated_home(|_| {
+            let extensions = crate::paths::extensions().unwrap();
+            let developer_source = tempfile::tempdir().unwrap();
+            let remote = init_repo_with_upstream(developer_source.path());
+            fs::create_dir_all(&extensions).unwrap();
+            std::os::unix::fs::symlink(developer_source.path(), extensions.join("wordpress"))
+                .unwrap();
+            assert!(!is_managed_extension_snapshot(
+                &extensions.join("wordpress")
+            ));
+
+            let writer = tempfile::tempdir().unwrap();
+            git(
+                writer.path(),
+                &[
+                    "clone",
+                    "--branch",
+                    "main",
+                    remote.path().to_str().unwrap(),
+                    ".",
+                ],
+            );
+            git(writer.path(), &["config", "user.email", "test@example.com"]);
+            git(writer.path(), &["config", "user.name", "Homeboy Test"]);
+            fs::write(writer.path().join("remote.txt"), "remote\n").unwrap();
+            git(writer.path(), &["add", "."]);
+            git(writer.path(), &["commit", "-m", "remote update"]);
+            git(writer.path(), &["push", "origin", "HEAD:main"]);
+            let source_head = git_output(developer_source.path(), &["rev-parse", "HEAD"]);
+
+            let err = require_checkout_hygiene_without_lifecycle(
+                vec![DependencyCheckout {
+                    id: "wordpress".to_string(),
+                    role: "extension".to_string(),
+                    path: extensions.join("wordpress"),
+                }],
+                DependencyHygieneOptions { allow_stale: false },
+            )
+            .expect_err("developer-owned link remains subject to stale hygiene");
+
+            assert_eq!(err.details["checkouts"][0]["behind"].as_u64(), Some(1));
+            assert_eq!(
+                git_output(developer_source.path(), &["rev-parse", "HEAD"]),
+                source_head
             );
         });
     }

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -427,6 +427,20 @@ fn lab_runner_exec_options(
     mut env: std::collections::HashMap<String, String>,
     secret_env_names: Vec<String>,
 ) -> RunnerExecOptions {
+    let mut command = context.command.clone();
+    let executable = context
+        .lab_metadata
+        .pointer("/execution_bundle/binary/path")
+        .and_then(serde_json::Value::as_str)
+        .filter(|path| !path.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            command
+                .first()
+                .expect("Lab dispatch command has an admitted executable")
+                .clone()
+        });
+    command[0] = executable.clone();
     env.insert(
         super::super::super::RUNNER_PLACEMENT_RESOLVED_ENV.to_string(),
         "1".to_string(),
@@ -453,12 +467,12 @@ fn lab_runner_exec_options(
     env.extend(lab_rig_registry_env(context.rig_registry_root.as_deref()));
     RunnerExecOptions {
         execution_context:
-            homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local("homeboy"),
+            homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(executable),
         cwd: Some(context.remote_cwd.clone()),
         project_id: None,
         allow_diagnostic_ssh: false,
         diagnostic_ssh_timeout: None,
-        command: context.command.clone(),
+        command,
         env,
         secret_env_names,
         secret_env_plan: Some(context.secret_env_handoff.secret_env_plan.clone()),
@@ -3443,6 +3457,14 @@ mod tests {
         assert_eq!(
             options.env.get("HOME"),
             Some(&"/runner/job/home".to_string())
+        );
+        assert_eq!(
+            options.command,
+            vec!["/runner/admitted-homeboy".to_string(), "bench".to_string()]
+        );
+        assert_eq!(
+            options.execution_context.runtime_id(),
+            "/runner/admitted-homeboy"
         );
         assert!(crate::execution_bundle::validate_bundle_env(
             &options.env,


### PR DESCRIPTION
Fixes #14444.

The prior repair excluded all extension symlinks from the managed-cache path. This follow-up recognizes only Homeboy-owned durable snapshot links below `extension-sources/<extension-id>/`: clean, non-diverged captures remain valid when their upstream advances, while developer links and dirty captures remain under normal hygiene.

Lab dispatch now derives both argv[0] and the execution context runtime ID from the admitted execution-bundle binary, preserving resolved local placement.

Tests:
- `cargo test -p homeboy-core hygiene::tests::dependency_hygiene_`
- `cargo test -p homeboy-lab-runner final_dispatch_reasserts_the_admitted_rig_registry_root`

AI assistance disclosure: OpenAI gpt-5.6-terra via OpenCode was used to inspect the existing lifecycle contracts, implement this focused repair, and run the listed tests. No private data is included.