### PR TITLE
fix(agent-task): route selected credentials to Lab runners

### DIFF
--- a/crates/contracts/homeboy-runner-contract/src/claim.rs
+++ b/crates/contracts/homeboy-runner-contract/src/claim.rs
@@ -7,6 +7,15 @@ use crate::{
     WorkspaceClaimProtocol, WorkspaceOwnerLease, WorkspaceOwnerLeaseProtocol,
 };
 
+/// Reference to controller-owned credentials held only in broker memory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerCredentialDeliveryDescriptor {
+    pub delivery_id: String,
+    pub env_names: Vec<String>,
+    pub expires_at_ms: u64,
+}
+
 pub const RUNNER_API_CLAIM_REQUEST_SCHEMA: &str = "homeboy/runner-api-claim-request/v1";
 pub const RUNNER_API_CLAIM_RESPONSE_SCHEMA: &str = "homeboy/runner-api-claim-response/v1";
 
@@ -71,6 +80,8 @@ pub struct RunnerApiClaimedExecution {
     pub workspace_claim_protocol: Option<WorkspaceClaimProtocol>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_owner_lease_protocol: Option<WorkspaceOwnerLeaseProtocol>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_delivery: Option<RunnerCredentialDeliveryDescriptor>,
 }
 
 #[cfg(test)]
@@ -121,6 +132,7 @@ mod tests {
                     execution_protocol: Some(RunnerJobExecutionProtocol::current()),
                     workspace_claim_protocol: None,
                     workspace_owner_lease_protocol: None,
+                    credential_delivery: None,
                 },
             },
         };

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -26,7 +26,8 @@ pub use capability::{
 };
 pub use claim::{
     RunnerApiClaimOutcome, RunnerApiClaimRequest, RunnerApiClaimResponse,
-    RunnerApiClaimedExecution, RUNNER_API_CLAIM_REQUEST_SCHEMA, RUNNER_API_CLAIM_RESPONSE_SCHEMA,
+    RunnerApiClaimedExecution, RunnerCredentialDeliveryDescriptor, RUNNER_API_CLAIM_REQUEST_SCHEMA,
+    RUNNER_API_CLAIM_RESPONSE_SCHEMA,
 };
 pub use discovery::{
     RunnerApiCapabilitiesRequest, RunnerApiCapabilitiesResponse, RunnerApiCompatibility,
@@ -59,7 +60,7 @@ pub use session::{
 };
 pub use submission::{
     RunnerApiSubmitOutcome, RunnerApiSubmitRequest, RunnerApiSubmitResponse,
-    RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_SUBMIT_RESPONSE_SCHEMA,
+    RunnerCredentialDelivery, RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_SUBMIT_RESPONSE_SCHEMA,
 };
 pub use workspace::{
     ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceLease, RunnerWorkspaceSyncMode,

--- a/crates/contracts/homeboy-runner-contract/src/submission.rs
+++ b/crates/contracts/homeboy-runner-contract/src/submission.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -7,6 +9,16 @@ use crate::{
 
 pub const RUNNER_API_SUBMIT_REQUEST_SCHEMA: &str = "homeboy/runner-api-submit-request/v1";
 pub const RUNNER_API_SUBMIT_RESPONSE_SCHEMA: &str = "homeboy/runner-api-submit-response/v1";
+
+/// Values supplied over the authenticated submission transport for a single
+/// claimed execution. This is deliberately not part of the durable envelope.
+/// The broker must retain it only in memory and make it available once to the
+/// runner that owns the live claim.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerCredentialDelivery {
+    pub env: BTreeMap<String, String>,
+}
 
 /// The transport-neutral admission request for one canonical runner execution.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -20,6 +32,10 @@ pub struct RunnerApiSubmitRequest {
     pub workspace_claim_binding: Option<WorkspaceClaimBinding>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_owner_lease: Option<WorkspaceOwnerLease>,
+    /// Ephemeral controller-owned credentials. Never persist this value or
+    /// include it in a replay fingerprint, event, or response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_delivery: Option<RunnerCredentialDelivery>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -55,6 +71,7 @@ mod tests {
             envelope: RunnerExecutionEnvelope::planned("run-1", "test"),
             workspace_claim_binding: None,
             workspace_owner_lease: None,
+            credential_delivery: None,
         };
         let value = serde_json::to_value(&request).expect("submit request JSON");
         assert_eq!(value["schema"], RUNNER_API_SUBMIT_REQUEST_SCHEMA);
@@ -91,6 +108,7 @@ mod tests {
                     expires_at_ms: 100,
                 }),
             }),
+            credential_delivery: None,
             workspace_owner_lease: Some(crate::WorkspaceOwnerLease {
                 schema: WORKSPACE_OWNER_LEASE_SCHEMA.to_string(),
                 protocol: WorkspaceOwnerLeaseProtocol::current(),

--- a/crates/contracts/homeboy-runner-contract/src/submission.rs
+++ b/crates/contracts/homeboy-runner-contract/src/submission.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
@@ -14,10 +15,19 @@ pub const RUNNER_API_SUBMIT_RESPONSE_SCHEMA: &str = "homeboy/runner-api-submit-r
 /// claimed execution. This is deliberately not part of the durable envelope.
 /// The broker must retain it only in memory and make it available once to the
 /// runner that owns the live claim.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct RunnerCredentialDelivery {
     pub env: BTreeMap<String, String>,
+}
+
+impl fmt::Debug for RunnerCredentialDelivery {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RunnerCredentialDelivery")
+            .field("env_names", &self.env.keys().collect::<Vec<_>>())
+            .finish()
+    }
 }
 
 /// The transport-neutral admission request for one canonical runner execution.
@@ -131,6 +141,17 @@ mod tests {
             encoded["workspace_owner_lease"]["protocol"],
             serde_json::json!({ "capability": "workspace-owner-lease", "version": 2 })
         );
+    }
+
+    #[test]
+    fn credential_delivery_debug_redacts_values() {
+        let delivery = RunnerCredentialDelivery {
+            env: BTreeMap::from([("PROVIDER_TOKEN".to_string(), "secret-value".to_string())]),
+        };
+
+        let debug = format!("{delivery:?}");
+        assert!(debug.contains("PROVIDER_TOKEN"));
+        assert!(!debug.contains("secret-value"));
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_provider/secrets.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/secrets.rs
@@ -292,6 +292,18 @@ fn effective_provider_default<'a>(
     {
         return provider.provider_defaults.get(name);
     }
+    // A concrete provider/model route is more specific than a provider's sole
+    // fallback account. Do not require credentials for an unrelated fallback
+    // merely because this executor happens to declare only one default.
+    if let Some(model_provider) = request
+        .executor
+        .model
+        .as_deref()
+        .and_then(|model| model.split_once('/').map(|(provider, _)| provider))
+        .filter(|provider| !provider.trim().is_empty())
+    {
+        return provider.provider_defaults.get(model_provider);
+    }
     (provider.provider_defaults.len() == 1)
         .then(|| provider.provider_defaults.values().next())
         .flatten()
@@ -393,6 +405,43 @@ mod tests {
         assert_eq!(
             provider_secret_env(&provider, Some(&request(Value::Null))),
             vec!["ONLY_ACCOUNT_TOKEN"]
+        );
+    }
+
+    #[test]
+    fn selected_model_route_does_not_inherit_an_unrelated_sole_default() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "test.provider",
+            "backend": "test",
+            "provider_defaults": {
+                "codex": { "required_secret_env": ["CODEX_TOKEN"] }
+            }
+        }))
+        .expect("provider");
+        let mut request = request(Value::Null);
+        request.executor.model = Some("xai/grok-4.6".to_string());
+
+        assert!(provider_secret_env(&provider, Some(&request)).is_empty());
+        assert!(provider_secret_sources(&provider, Some(&request)).is_empty());
+    }
+
+    #[test]
+    fn selected_model_route_uses_its_matching_provider_default() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "test.provider",
+            "backend": "test",
+            "provider_defaults": {
+                "xai": { "required_secret_env": ["XAI_TOKEN"] },
+                "codex": { "required_secret_env": ["CODEX_TOKEN"] }
+            }
+        }))
+        .expect("provider");
+        let mut request = request(Value::Null);
+        request.executor.model = Some("xai/grok-4.6".to_string());
+
+        assert_eq!(
+            provider_secret_env(&provider, Some(&request)),
+            vec!["XAI_TOKEN".to_string()]
         );
     }
 

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -42,13 +42,26 @@ const CREDENTIAL_DELIVERY_TTL_MS: u64 = 60_000;
 
 /// Plaintext is accepted only over the authenticated submission transport and
 /// retained in process memory until the matching live claim consumes it.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(super) struct EphemeralCredentialDelivery {
     id: String,
     env: std::collections::BTreeMap<String, String>,
     claim_id: Option<String>,
     expires_at_ms: u64,
     consumed: bool,
+}
+
+impl std::fmt::Debug for EphemeralCredentialDelivery {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("EphemeralCredentialDelivery")
+            .field("id", &self.id)
+            .field("env_names", &self.env.keys().collect::<Vec<_>>())
+            .field("claim_id", &self.claim_id)
+            .field("expires_at_ms", &self.expires_at_ms)
+            .field("consumed", &self.consumed)
+            .finish()
+    }
 }
 
 pub use homeboy_api_jobs_contract::metadata::{JobArtifactMetadata, RunnerJobLifecycleMetadata};

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -1672,12 +1672,28 @@ impl JobStore {
                     .map(controller_owned_secret_env_names)
                     .unwrap_or_default();
                 if !controller_owned.is_empty() && !deliveries.contains_key(&job_id) {
-                    return Err(Error::validation_invalid_argument(
-                        "credential_delivery",
-                        "controller credential delivery is unavailable after broker restart or revocation",
-                        Some(job_id.to_string()),
-                        None,
-                    ));
+                    Self::append_event_already_locked(
+                        self,
+                        inner,
+                        job_id,
+                        JobEventKind::Error,
+                        Some(
+                            "controller credential delivery is unavailable after broker restart or revocation"
+                                .to_string(),
+                        ),
+                        Some(serde_json::json!({
+                            "status": JobStatus::Failed,
+                            "reason": "controller_credential_delivery_unavailable",
+                            "controller_owned_env_names": controller_owned,
+                        })),
+                    )?;
+                    let stored = inner.jobs.get_mut(&job_id).expect("candidate exists");
+                    stored.job.status = JobStatus::Failed;
+                    stored.job.updated_at_ms = now;
+                    stored.job.finished_at_ms = Some(now);
+                    // A lost sidecar is terminal for this job, but must not
+                    // poison later independent work for the same runner.
+                    return Ok(None);
                 }
                 match execution_protocol {
                     Some(protocol) => {

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -40,6 +40,19 @@ const MAX_COMMAND_ASSETS_BASE64_BYTES: usize = 4_200_000;
 const MAX_CREDENTIAL_DELIVERY_BYTES: usize = 65_536;
 const CREDENTIAL_DELIVERY_TTL_MS: u64 = 60_000;
 
+fn controller_owned_secret_env_names(plan: &SecretEnvPlan) -> std::collections::BTreeSet<String> {
+    plan.env_materialization
+        .as_ref()
+        .map(|plan| {
+            plan.secret_refs
+                .iter()
+                .filter(|secret| secret.owner.as_deref() == Some("controller"))
+                .map(|secret| secret.name.clone())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Plaintext is accepted only over the authenticated submission transport and
 /// retained in process memory until the matching live claim consumes it.
 #[derive(Clone)]
@@ -47,7 +60,9 @@ pub(super) struct EphemeralCredentialDelivery {
     id: String,
     env: std::collections::BTreeMap<String, String>,
     claim_id: Option<String>,
-    expires_at_ms: u64,
+    // Queued work has no delivery expiry. The short lifetime starts only once a
+    // live claim binds the value to its intended runner.
+    expires_at_ms: Option<u64>,
     consumed: bool,
 }
 
@@ -772,6 +787,7 @@ impl<'de> Deserialize<'de> for StoredRemoteRunnerJob {
 }
 
 struct RemoteRunnerAdmission {
+    job_id: Option<Uuid>,
     operation: String,
     runner_id: String,
     project_id: Option<String>,
@@ -1109,9 +1125,17 @@ impl JobStore {
                     Some("decode envelope path materialization plan".to_string()),
                 )
             })?;
+        let provisional_delivery = credential_delivery
+            .map(|delivery| {
+                let job_id = Uuid::new_v4();
+                self.attach_ephemeral_credential_delivery(job_id, delivery, &secret_env_plan)?;
+                Ok::<_, Error>(job_id)
+            })
+            .transpose()?;
         let now = timestamp_ms();
         let job = self.admit_remote_runner_job(
             RemoteRunnerAdmission {
+                job_id: provisional_delivery,
                 operation: dispatch.operation.clone(),
                 runner_id: dispatch.runner_id.clone(),
                 project_id: dispatch.project_id.clone(),
@@ -1132,11 +1156,17 @@ impl JobStore {
                 },
             },
             now,
-        )?;
-        if let Some(delivery) = credential_delivery {
-            self.attach_ephemeral_credential_delivery(job.id, delivery, &secret_env_plan)?;
+        );
+        if let Some(provisional_delivery) = provisional_delivery {
+            if job
+                .as_ref()
+                .map(|job| job.id != provisional_delivery)
+                .unwrap_or(true)
+            {
+                self.discard_ephemeral_credential_delivery(provisional_delivery);
+            }
         }
-        Ok(job)
+        job
     }
 
     fn attach_ephemeral_credential_delivery(
@@ -1156,7 +1186,7 @@ impl JobStore {
                 id: Uuid::new_v4().to_string(),
                 env: delivery.env,
                 claim_id: None,
-                expires_at_ms: timestamp_ms().saturating_add(CREDENTIAL_DELIVERY_TTL_MS),
+                expires_at_ms: None,
                 consumed: false,
             });
         Ok(())
@@ -1167,8 +1197,13 @@ impl JobStore {
         plan: &SecretEnvPlan,
     ) -> Result<()> {
         let names = plan.secret_env_names();
+        let controller_owned = controller_owned_secret_env_names(plan);
         if delivery.env.is_empty()
             || delivery.env.keys().any(|name| !names.contains(name))
+            || delivery
+                .env
+                .keys()
+                .any(|name| !controller_owned.contains(name))
             || delivery
                 .env
                 .iter()
@@ -1182,7 +1217,7 @@ impl JobStore {
         {
             return Err(Error::validation_invalid_argument(
                 "credential_delivery",
-                "credential delivery must contain only planned, bounded non-empty secret values",
+                "credential delivery must contain only controller-owned planned, bounded non-empty secret values",
                 None,
                 None,
             ));
@@ -1213,7 +1248,9 @@ impl JobStore {
         if delivery.id != delivery_id
             || delivery.claim_id.as_deref() != Some(claim_id)
             || delivery.consumed
-            || delivery.expires_at_ms <= timestamp_ms()
+            || delivery
+                .expires_at_ms
+                .is_some_and(|expires_at_ms| expires_at_ms <= timestamp_ms())
         {
             return Err(Error::validation_invalid_argument(
                 "credential_delivery",
@@ -1282,6 +1319,7 @@ impl JobStore {
             .transpose()?;
         let envelope = public_request.execution_envelope();
         let admission = RemoteRunnerAdmission {
+            job_id: None,
             operation: request.operation.clone(),
             runner_id: request.runner_id.clone(),
             project_id: request.project_id.clone(),
@@ -1312,6 +1350,7 @@ impl JobStore {
             submission_key,
             submission_fingerprint,
             stored_remote_runner,
+            job_id,
         } = admission;
         self.durable_transaction(|inner| {
         if let Some(submission_key) = submission_key.as_deref() {
@@ -1400,7 +1439,7 @@ impl JobStore {
             }
         }
         let mut job = Job {
-            id: Uuid::new_v4(),
+            id: job_id.unwrap_or_else(Uuid::new_v4),
             operation,
             status: JobStatus::Queued,
             created_at_ms: now,
@@ -1556,6 +1595,14 @@ impl JobStore {
 
         let now = timestamp_ms();
         let lease_ms = lease_ms.max(1);
+        // Hold the sidecar registry lock through durable claim admission. A
+        // controller installs the entry before publishing the job, so a worker
+        // observes either a complete claim or no claim, never a claim missing
+        // its controller-owned capability.
+        let mut deliveries = self
+            .credential_deliveries
+            .lock()
+            .expect("credential delivery mutex poisoned");
         let claimed = self.durable_transaction(|inner| {
             if let Some(limit) = concurrency_limit {
                 let running = inner
@@ -1619,6 +1666,19 @@ impl JobStore {
                         workspace_owner_lease,
                     )
                 };
+                let controller_owned = envelope
+                    .secret_env
+                    .as_ref()
+                    .map(controller_owned_secret_env_names)
+                    .unwrap_or_default();
+                if !controller_owned.is_empty() && !deliveries.contains_key(&job_id) {
+                    return Err(Error::validation_invalid_argument(
+                        "credential_delivery",
+                        "controller credential delivery is unavailable after broker restart or revocation",
+                        Some(job_id.to_string()),
+                        None,
+                    ));
+                }
                 match execution_protocol {
                     Some(protocol) => {
                         if !protocol.is_supported() {
@@ -1731,21 +1791,23 @@ impl JobStore {
             .is_some()
             .then(crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current);
         let credential_delivery = {
-            let mut deliveries = self
-                .credential_deliveries
-                .lock()
-                .expect("credential delivery mutex poisoned");
             deliveries.get_mut(&job.id).and_then(|delivery| {
-                if delivery.expires_at_ms <= timestamp_ms() || delivery.consumed {
+                if delivery
+                    .expires_at_ms
+                    .is_some_and(|expires_at_ms| expires_at_ms <= timestamp_ms())
+                    || delivery.consumed
+                {
                     return None;
                 }
                 delivery.claim_id = job.claim_id.clone();
+                let expires_at_ms = timestamp_ms()
+                    .saturating_add(CREDENTIAL_DELIVERY_TTL_MS)
+                    .min(job.claim_expires_at_ms.unwrap_or_default());
+                delivery.expires_at_ms = Some(expires_at_ms);
                 Some(RunnerCredentialDeliveryDescriptor {
                     delivery_id: delivery.id.clone(),
                     env_names: delivery.env.keys().cloned().collect(),
-                    expires_at_ms: delivery
-                        .expires_at_ms
-                        .min(job.claim_expires_at_ms.unwrap_or_default()),
+                    expires_at_ms,
                 })
             })
         };

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -28,8 +28,8 @@ use homeboy_lab_contract::lab::execution_envelope::{
 };
 use homeboy_runner_contract::{
     is_internal_control_env, RunnerApiClaimedExecution, RunnerApiSubmitRequest,
-    RunnerMutationArtifacts, RunnerResourceMetrics, RUNNER_API_SUBMIT_REQUEST_SCHEMA,
-    RUNNER_API_V1,
+    RunnerCredentialDelivery, RunnerCredentialDeliveryDescriptor, RunnerMutationArtifacts,
+    RunnerResourceMetrics, RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_V1,
 };
 
 /// Broker metadata is durable queue input. Keep command-file payloads bounded
@@ -37,6 +37,19 @@ use homeboy_runner_contract::{
 const MAX_COMMAND_ASSET_COUNT: usize = 16;
 const MAX_COMMAND_ASSET_BASE64_BYTES: usize = 1_400_000;
 const MAX_COMMAND_ASSETS_BASE64_BYTES: usize = 4_200_000;
+const MAX_CREDENTIAL_DELIVERY_BYTES: usize = 65_536;
+const CREDENTIAL_DELIVERY_TTL_MS: u64 = 60_000;
+
+/// Plaintext is accepted only over the authenticated submission transport and
+/// retained in process memory until the matching live claim consumes it.
+#[derive(Debug, Clone)]
+pub(super) struct EphemeralCredentialDelivery {
+    id: String,
+    env: std::collections::BTreeMap<String, String>,
+    claim_id: Option<String>,
+    expires_at_ms: u64,
+    consumed: bool,
+}
 
 pub use homeboy_api_jobs_contract::metadata::{JobArtifactMetadata, RunnerJobLifecycleMetadata};
 
@@ -494,6 +507,8 @@ pub struct RemoteRunnerJobClaim {
     pub workspace_claim_protocol: Option<crate::workspace_claim::WorkspaceClaimProtocol>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_owner_lease_protocol: Option<crate::workspace_claim::WorkspaceOwnerLeaseProtocol>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_delivery: Option<RunnerCredentialDeliveryDescriptor>,
 }
 
 impl RemoteRunnerJobClaim {
@@ -529,6 +544,7 @@ impl RemoteRunnerJobClaim {
             execution_protocol: self.execution_protocol.clone(),
             workspace_claim_protocol: self.workspace_claim_protocol.clone(),
             workspace_owner_lease_protocol: self.workspace_owner_lease_protocol.clone(),
+            credential_delivery: self.credential_delivery.clone(),
         })
     }
 }
@@ -993,6 +1009,7 @@ impl JobStore {
             envelope: request.execution_envelope(),
             workspace_claim_binding: request.workspace_claim_binding,
             workspace_owner_lease: request.workspace_owner_lease,
+            credential_delivery: None,
         })
     }
 
@@ -1016,6 +1033,7 @@ impl JobStore {
             ));
         }
         let fingerprint = runner_api_submission_payload_fingerprint(&submission)?;
+        let credential_delivery = submission.credential_delivery.clone();
         let envelope = redacted_envelope_for_durable_replay(submission.envelope);
         let dispatch = envelope.dispatch.as_ref().ok_or_else(|| {
             Error::validation_invalid_argument(
@@ -1051,6 +1069,9 @@ impl JobStore {
             lease.verify_shape(timestamp_ms())?;
         }
         let secret_env_plan = envelope.secret_env.clone().unwrap_or_default();
+        if let Some(delivery) = credential_delivery.as_ref() {
+            Self::validate_ephemeral_credential_delivery(delivery, &secret_env_plan)?;
+        }
         reject_inline_durable_secret_env(&dispatch.env, &secret_env_plan)?;
         let lab_runner_workload = lab_runner_workload_from_execution_envelope(&envelope)?;
         super::with_runner_job_preparation(|preparation| {
@@ -1076,7 +1097,7 @@ impl JobStore {
                 )
             })?;
         let now = timestamp_ms();
-        self.admit_remote_runner_job(
+        let job = self.admit_remote_runner_job(
             RemoteRunnerAdmission {
                 operation: dispatch.operation.clone(),
                 runner_id: dispatch.runner_id.clone(),
@@ -1098,7 +1119,105 @@ impl JobStore {
                 },
             },
             now,
-        )
+        )?;
+        if let Some(delivery) = credential_delivery {
+            self.attach_ephemeral_credential_delivery(job.id, delivery, &secret_env_plan)?;
+        }
+        Ok(job)
+    }
+
+    fn attach_ephemeral_credential_delivery(
+        &self,
+        job_id: Uuid,
+        delivery: RunnerCredentialDelivery,
+        plan: &SecretEnvPlan,
+    ) -> Result<()> {
+        Self::validate_ephemeral_credential_delivery(&delivery, plan)?;
+        let mut deliveries = self
+            .credential_deliveries
+            .lock()
+            .expect("credential delivery mutex poisoned");
+        deliveries
+            .entry(job_id)
+            .or_insert_with(|| EphemeralCredentialDelivery {
+                id: Uuid::new_v4().to_string(),
+                env: delivery.env,
+                claim_id: None,
+                expires_at_ms: timestamp_ms().saturating_add(CREDENTIAL_DELIVERY_TTL_MS),
+                consumed: false,
+            });
+        Ok(())
+    }
+
+    fn validate_ephemeral_credential_delivery(
+        delivery: &RunnerCredentialDelivery,
+        plan: &SecretEnvPlan,
+    ) -> Result<()> {
+        let names = plan.secret_env_names();
+        if delivery.env.is_empty()
+            || delivery.env.keys().any(|name| !names.contains(name))
+            || delivery
+                .env
+                .iter()
+                .any(|(name, value)| name.trim().is_empty() || value.is_empty())
+            || delivery
+                .env
+                .iter()
+                .map(|(name, value)| name.len() + value.len())
+                .sum::<usize>()
+                > MAX_CREDENTIAL_DELIVERY_BYTES
+        {
+            return Err(Error::validation_invalid_argument(
+                "credential_delivery",
+                "credential delivery must contain only planned, bounded non-empty secret values",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn consume_ephemeral_credential_delivery(
+        &self,
+        job_id: Uuid,
+        runner_id: &str,
+        claim_id: &str,
+        delivery_id: &str,
+    ) -> Result<std::collections::BTreeMap<String, String>> {
+        self.ensure_remote_runner_claim(job_id, runner_id, claim_id)?;
+        let mut deliveries = self
+            .credential_deliveries
+            .lock()
+            .expect("credential delivery mutex poisoned");
+        let delivery = deliveries.get_mut(&job_id).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "credential_delivery",
+                "controller credential delivery is unavailable",
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+        if delivery.id != delivery_id
+            || delivery.claim_id.as_deref() != Some(claim_id)
+            || delivery.consumed
+            || delivery.expires_at_ms <= timestamp_ms()
+        {
+            return Err(Error::validation_invalid_argument(
+                "credential_delivery",
+                "controller credential delivery is expired, revoked, or already consumed",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        delivery.consumed = true;
+        Ok(std::mem::take(&mut delivery.env))
+    }
+
+    pub fn discard_ephemeral_credential_delivery(&self, job_id: Uuid) {
+        self.credential_deliveries
+            .lock()
+            .expect("credential delivery mutex poisoned")
+            .remove(&job_id);
     }
 
     pub(crate) fn submit_legacy_remote_runner_job(
@@ -1598,6 +1717,25 @@ impl JobStore {
         let workspace_owner_lease_protocol = workspace_owner_lease
             .is_some()
             .then(crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current);
+        let credential_delivery = {
+            let mut deliveries = self
+                .credential_deliveries
+                .lock()
+                .expect("credential delivery mutex poisoned");
+            deliveries.get_mut(&job.id).and_then(|delivery| {
+                if delivery.expires_at_ms <= timestamp_ms() || delivery.consumed {
+                    return None;
+                }
+                delivery.claim_id = job.claim_id.clone();
+                Some(RunnerCredentialDeliveryDescriptor {
+                    delivery_id: delivery.id.clone(),
+                    env_names: delivery.env.keys().cloned().collect(),
+                    expires_at_ms: delivery
+                        .expires_at_ms
+                        .min(job.claim_expires_at_ms.unwrap_or_default()),
+                })
+            })
+        };
         Ok(Some(RemoteRunnerJobClaim {
             job,
             envelope,
@@ -1608,6 +1746,7 @@ impl JobStore {
             execution_protocol,
             workspace_claim_protocol,
             workspace_owner_lease_protocol,
+            credential_delivery,
         }))
     }
 
@@ -1873,7 +2012,9 @@ impl JobStore {
                 ));
             }
         }
-        self.cancel(job_id, reason)
+        let job = self.cancel(job_id, reason)?;
+        self.discard_ephemeral_credential_delivery(job_id);
+        Ok(job)
     }
 
     /// Cancel exactly one daemon-local runner job after proving its durable
@@ -2015,6 +2156,7 @@ impl JobStore {
         let mut reconciled = Vec::new();
         for job_id in expired_ids {
             reconciled.push(self.fail(job_id, "remote runner claim expired")?);
+            self.discard_ephemeral_credential_delivery(job_id);
         }
         Ok(reconciled)
     }

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -61,6 +61,10 @@ pub struct JobStore {
     pub(super) next_event_sequence: Arc<AtomicU64>,
     pub(super) persistence: Option<Arc<JobStorePersistence>>,
     pub(super) daemon_lease_id: Option<String>,
+    /// Controller-supplied credentials are intentionally process-local. They
+    /// never enter the durable queue snapshot or its event stream.
+    pub(super) credential_deliveries:
+        Arc<Mutex<HashMap<uuid::Uuid, super::remote_runner::EphemeralCredentialDelivery>>>,
     #[cfg(test)]
     terminal_write_failures: Arc<AtomicU64>,
     #[cfg(test)]
@@ -610,6 +614,7 @@ impl JobStore {
                 terminal_job_retention_bytes,
             })),
             daemon_lease_id: None,
+            credential_deliveries: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(test)]
             terminal_write_failures: Arc::new(AtomicU64::new(0)),
             #[cfg(test)]
@@ -771,6 +776,7 @@ impl JobStore {
                 terminal_job_retention_bytes,
             })),
             daemon_lease_id: None,
+            credential_deliveries: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(test)]
             terminal_write_failures: Arc::new(AtomicU64::new(0)),
             #[cfg(test)]

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -1502,6 +1502,7 @@ fn envelope_submission_replays_and_persists_no_legacy_execution_request() {
         envelope,
         workspace_claim_binding: None,
         workspace_owner_lease: None,
+        credential_delivery: None,
     };
     let accepted = store
         .submit_runner_api_request(submission.clone())

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -161,12 +161,26 @@ fn controller_delivery_requires_explicit_controller_ownership_and_fails_after_lo
     // This models a controller restart: durable ownership survives while the
     // process-local plaintext registry is intentionally lost.
     store.discard_ephemeral_credential_delivery(job.id);
-    let error = store
+    let independent = store
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
+        .expect("queue independent runner-owned job");
+    assert!(store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
-        .expect_err("missing controller sidecar must reject the claim");
-    assert!(error
-        .message
-        .contains("controller credential delivery is unavailable"));
+        .expect("missing sidecar transitions its job")
+        .is_none());
+    assert_eq!(
+        store.get(job.id).expect("lost-sidecar job").status,
+        JobStatus::Failed
+    );
+    assert_eq!(
+        store
+            .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+            .expect("independent job remains claimable")
+            .expect("independent claim")
+            .job
+            .id,
+        independent.id
+    );
 }
 
 #[test]

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -9,13 +9,28 @@ use super::*;
 use crate::observation::{ArtifactRecord, RunRecord};
 use crate::secret_env_plan::SecretEnvPlan;
 
+fn controller_owned_secret_plan(name: &str) -> SecretEnvPlan {
+    let mut plan = SecretEnvPlan::from_secret_env_names(vec![name.to_string()]);
+    plan.env_materialization = Some(
+        homeboy_runner_contract::env_materialization_plan::EnvMaterializationPlan {
+            secret_refs: vec![
+                homeboy_runner_contract::env_materialization_plan::EnvSecretRef {
+                    name: name.to_string(),
+                    owner: Some("controller".to_string()),
+                },
+            ],
+            ..Default::default()
+        },
+    );
+    plan
+}
+
 #[test]
 fn controller_credential_delivery_is_claim_bound_one_time_and_not_durable() {
     let store = JobStore::default();
     let sentinel = "controller-secret-sentinel-do-not-persist";
     let mut request = remote_runner_request("homeboy-lab", None);
-    request.secret_env_plan =
-        SecretEnvPlan::from_secret_env_names(vec!["PROVIDER_TOKEN".to_string()]);
+    request.secret_env_plan = controller_owned_secret_plan("PROVIDER_TOKEN");
     let job = store
         .submit_runner_api_request(homeboy_runner_contract::RunnerApiSubmitRequest {
             schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
@@ -77,8 +92,7 @@ fn controller_credential_delivery_is_claim_bound_one_time_and_not_durable() {
         .is_err());
 
     let mut cancelled_request = remote_runner_request("homeboy-lab", None);
-    cancelled_request.secret_env_plan =
-        SecretEnvPlan::from_secret_env_names(vec!["PROVIDER_TOKEN".to_string()]);
+    cancelled_request.secret_env_plan = controller_owned_secret_plan("PROVIDER_TOKEN");
     let cancelled = store
         .submit_runner_api_request(homeboy_runner_contract::RunnerApiSubmitRequest {
             schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
@@ -110,6 +124,49 @@ fn controller_credential_delivery_is_claim_bound_one_time_and_not_durable() {
             &cancelled_delivery.delivery_id,
         )
         .is_err());
+}
+
+#[test]
+fn controller_delivery_requires_explicit_controller_ownership_and_fails_after_loss() {
+    let store = JobStore::default();
+    let mut request = remote_runner_request("homeboy-lab", None);
+    request.secret_env_plan = controller_owned_secret_plan("PROVIDER_TOKEN");
+    let submit = |plan: SecretEnvPlan, key: &str| {
+        store.submit_runner_api_request(homeboy_runner_contract::RunnerApiSubmitRequest {
+            schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: homeboy_runner_contract::RUNNER_API_V1,
+            submission_key: key.to_string(),
+            envelope: {
+                let mut request = request.clone();
+                request.secret_env_plan = plan;
+                request.execution_envelope()
+            },
+            workspace_claim_binding: None,
+            workspace_owner_lease: None,
+            credential_delivery: Some(homeboy_runner_contract::RunnerCredentialDelivery {
+                env: BTreeMap::from([("PROVIDER_TOKEN".to_string(), "sentinel".to_string())]),
+            }),
+        })
+    };
+    let mut runner_owned = controller_owned_secret_plan("PROVIDER_TOKEN");
+    runner_owned
+        .env_materialization
+        .as_mut()
+        .unwrap()
+        .secret_refs[0]
+        .owner = Some("runner".to_string());
+    assert!(submit(runner_owned, "runner-owned-delivery").is_err());
+
+    let job = submit(request.secret_env_plan.clone(), "controller-delivery").expect("submit");
+    // This models a controller restart: durable ownership survives while the
+    // process-local plaintext registry is intentionally lost.
+    store.discard_ephemeral_credential_delivery(job.id);
+    let error = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect_err("missing controller sidecar must reject the claim");
+    assert!(error
+        .message
+        .contains("controller credential delivery is unavailable"));
 }
 
 #[test]

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -1,11 +1,116 @@
 #![cfg(test)]
 
+use std::collections::BTreeMap;
 use std::fs;
 
 use serde_json::json;
 
 use super::*;
 use crate::observation::{ArtifactRecord, RunRecord};
+use crate::secret_env_plan::SecretEnvPlan;
+
+#[test]
+fn controller_credential_delivery_is_claim_bound_one_time_and_not_durable() {
+    let store = JobStore::default();
+    let sentinel = "controller-secret-sentinel-do-not-persist";
+    let mut request = remote_runner_request("homeboy-lab", None);
+    request.secret_env_plan =
+        SecretEnvPlan::from_secret_env_names(vec!["PROVIDER_TOKEN".to_string()]);
+    let job = store
+        .submit_runner_api_request(homeboy_runner_contract::RunnerApiSubmitRequest {
+            schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: homeboy_runner_contract::RUNNER_API_V1,
+            submission_key: "controller-credential-delivery".to_string(),
+            envelope: request.execution_envelope(),
+            workspace_claim_binding: None,
+            workspace_owner_lease: None,
+            credential_delivery: Some(homeboy_runner_contract::RunnerCredentialDelivery {
+                env: BTreeMap::from([("PROVIDER_TOKEN".to_string(), sentinel.to_string())]),
+            }),
+        })
+        .expect("credential delivery queues");
+    assert!(!serde_json::to_string(&store.get(job.id).unwrap())
+        .unwrap()
+        .contains(sentinel));
+    assert!(!serde_json::to_string(&store.events(job.id).unwrap())
+        .unwrap()
+        .contains(sentinel));
+
+    let claim = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("claim succeeds")
+        .expect("job is claimed");
+    let delivery = claim
+        .credential_delivery
+        .clone()
+        .expect("claim references delivery");
+    assert_eq!(delivery.env_names, vec!["PROVIDER_TOKEN"]);
+    assert!(!serde_json::to_string(&claim).unwrap().contains(sentinel));
+    let claim_id = claim.job.claim_id.as_deref().unwrap();
+    assert!(store
+        .consume_ephemeral_credential_delivery(
+            job.id,
+            "other-runner",
+            claim_id,
+            &delivery.delivery_id
+        )
+        .is_err());
+    assert_eq!(
+        store
+            .consume_ephemeral_credential_delivery(
+                job.id,
+                "homeboy-lab",
+                claim_id,
+                &delivery.delivery_id
+            )
+            .expect("matching claim consumes delivery")
+            .get("PROVIDER_TOKEN"),
+        Some(&sentinel.to_string())
+    );
+    assert!(store
+        .consume_ephemeral_credential_delivery(
+            job.id,
+            "homeboy-lab",
+            claim_id,
+            &delivery.delivery_id
+        )
+        .is_err());
+
+    let mut cancelled_request = remote_runner_request("homeboy-lab", None);
+    cancelled_request.secret_env_plan =
+        SecretEnvPlan::from_secret_env_names(vec!["PROVIDER_TOKEN".to_string()]);
+    let cancelled = store
+        .submit_runner_api_request(homeboy_runner_contract::RunnerApiSubmitRequest {
+            schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: homeboy_runner_contract::RUNNER_API_V1,
+            submission_key: "cancelled-controller-credential-delivery".to_string(),
+            envelope: cancelled_request.execution_envelope(),
+            workspace_claim_binding: None,
+            workspace_owner_lease: None,
+            credential_delivery: Some(homeboy_runner_contract::RunnerCredentialDelivery {
+                env: BTreeMap::from([("PROVIDER_TOKEN".to_string(), sentinel.to_string())]),
+            }),
+        })
+        .expect("credential delivery queues");
+    let cancelled_claim = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("claim succeeds")
+        .expect("job is claimed");
+    let cancelled_delivery = cancelled_claim
+        .credential_delivery
+        .expect("delivery reference");
+    store
+        .cancel_remote_runner_job(cancelled.id, "test cancellation")
+        .expect("cancel succeeds");
+    assert!(store
+        .consume_ephemeral_credential_delivery(
+            cancelled.id,
+            "homeboy-lab",
+            cancelled_claim.job.claim_id.as_deref().unwrap(),
+            &cancelled_delivery.delivery_id,
+        )
+        .is_err());
+}
 
 #[test]
 fn remote_runner_job_claim_returns_oldest_matching_job() {
@@ -545,6 +650,7 @@ fn remote_runner_protocol_v1_claim_retains_legacy_request_projection() {
             envelope: request.execution_envelope(),
             workspace_claim_binding: None,
             workspace_owner_lease: None,
+            credential_delivery: None,
         })
         .expect("runner API request queues");
     let protocol = crate::runner_job_execution_context::RunnerJobExecutionProtocol {
@@ -606,6 +712,7 @@ fn runner_api_legacy_json_claim_sidecars_match_across_v2_and_v1_projections() {
             envelope: request.execution_envelope(),
             workspace_claim_binding: Some(binding.clone()),
             workspace_owner_lease: Some(owner_lease.clone()),
+            credential_delivery: None,
         })
         .expect("legacy Runner API JSON");
         let submission =

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -6920,7 +6920,7 @@ fn write_http_response(mut stream: TcpStream, response: &HttpResponse) -> std::i
     };
     write!(
         stream,
-        "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nCache-Control: no-store\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
         response.status_code,
         status_text,
         body.len(),

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -127,6 +127,12 @@ struct ConsumeRequest {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+struct CredentialDeliveryConsumeRequest {
+    runner_id: String,
+    claim_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 struct OwnerValidationRequest {
     runner_id: String,
     claim_id: String,
@@ -845,6 +851,12 @@ fn update(
             Ok(body) => daemon_endpoint_response("runner.jobs.consume", body),
             Err(err) => auth_or_bad_request(err),
         },
+        operation if operation.starts_with("credentials/") => {
+            match consume_credential_delivery(job_id, operation, body, job_store, auth) {
+                Ok(body) => daemon_endpoint_response("runner.jobs.credentials.consume", body),
+                Err(err) => auth_or_bad_request(err),
+            }
+        }
         "validate-owner" => match validate_owner(job_id, body, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.owner.validate", body),
             Err(err) => auth_or_bad_request(err),
@@ -953,6 +965,7 @@ fn finish(
         &request.claim_id,
         request.result,
     )?;
+    job_store.discard_ephemeral_credential_delivery(job_id);
     release_terminal_workspace_owner(job_store, job_id);
     Ok(json!({
         "command": "api.runner.jobs.finish",
@@ -1050,6 +1063,37 @@ fn consume(
         "job": job,
         "context_id": request.context_id,
     }))
+}
+
+fn consume_credential_delivery(
+    job_id: Uuid,
+    operation: &str,
+    body: Option<Value>,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
+    let delivery_id = operation
+        .strip_prefix("credentials/")
+        .filter(|id| !id.is_empty())
+        .filter(|id| !id.contains('/'))
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "path",
+                "invalid credential delivery path",
+                None,
+                None,
+            )
+        })?;
+    let request: CredentialDeliveryConsumeRequest =
+        parse_body(body, "remote runner credential delivery consume request")?;
+    auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
+    let env = job_store.consume_ephemeral_credential_delivery(
+        job_id,
+        &request.runner_id,
+        &request.claim_id,
+        delivery_id,
+    )?;
+    Ok(json!({ "env": env }))
 }
 
 /// This is deliberately separate from consume: the worker uses it immediately

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -63,10 +63,23 @@ pub(super) fn exec_via_reverse_broker(
     let redaction_env = env.clone();
     let redaction_secret_env_names = secret_env_names.clone();
     let controller_credential_delivery = {
-        let planned = secret_env_plan.secret_env_names();
+        // SecretEnvPlan is intentionally name-only. The materialization plan is
+        // the durable ownership authority, so an ambient controller value never
+        // overrides a runner-owned reference with the same name.
+        let controller_owned = secret_env_plan
+            .env_materialization
+            .as_ref()
+            .map(|plan| {
+                plan.secret_refs
+                    .iter()
+                    .filter(|secret| secret.owner.as_deref() == Some("controller"))
+                    .map(|secret| secret.name.as_str())
+                    .collect::<std::collections::BTreeSet<_>>()
+            })
+            .unwrap_or_default();
         let env: BTreeMap<_, _> = redaction_env
             .iter()
-            .filter(|(name, _)| planned.contains(*name))
+            .filter(|(name, _)| controller_owned.contains(name.as_str()))
             .map(|(name, value)| (name.clone(), value.clone()))
             .collect();
         (!env.is_empty()).then_some(homeboy_runner_contract::RunnerCredentialDelivery { env })

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -1,4 +1,5 @@
 use homeboy_engine_primitives::content_hash;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
@@ -61,6 +62,15 @@ pub(super) fn exec_via_reverse_broker(
     });
     let redaction_env = env.clone();
     let redaction_secret_env_names = secret_env_names.clone();
+    let controller_credential_delivery = {
+        let planned = secret_env_plan.secret_env_names();
+        let env: BTreeMap<_, _> = redaction_env
+            .iter()
+            .filter(|(name, _)| planned.contains(*name))
+            .map(|(name, value)| (name.clone(), value.clone()))
+            .collect();
+        (!env.is_empty()).then_some(homeboy_runner_contract::RunnerCredentialDelivery { env })
+    };
     // Durable reverse-runner jobs cannot persist inline secret values
     // (`reject_inline_durable_secret_env`). Strip every planned secret name —
     // including provider credential requirements and env-name aliases — so the
@@ -172,12 +182,15 @@ pub(super) fn exec_via_reverse_broker(
         envelope,
         workspace_claim_binding: None,
         workspace_owner_lease: workspace_owner_lease.clone(),
+        credential_delivery: controller_credential_delivery,
     };
     if detach_after_handoff {
         if let Some(run_id) = run_id.as_deref() {
+            let mut durable_submission = submission.clone();
+            durable_submission.credential_delivery = None;
             homeboy_agents::agent_task_lifecycle::record_lab_offload_submission_envelope(
                 run_id,
-                &submission,
+                &durable_submission,
             )?;
         }
     }

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -137,6 +137,7 @@ pub(super) fn exec_via_daemon(
         envelope,
         workspace_claim_binding: None,
         workspace_owner_lease: None,
+        credential_delivery: None,
     };
     let payload = serde_json::to_value(DirectDaemonExecSubmitRequest {
         submission,

--- a/crates/homeboy-lab-runner/src/execution/tests/daemon_exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/daemon_exec.rs
@@ -91,6 +91,7 @@ fn direct_submission(command: Vec<&str>, submission_key: &str) -> serde_json::Va
             envelope: request.execution_envelope(),
             workspace_claim_binding: None,
             workspace_owner_lease: None,
+            credential_delivery: None,
         },
         runner: None,
         raw_exec: false,

--- a/crates/homeboy-lab-runner/src/lab/secrets.rs
+++ b/crates/homeboy-lab-runner/src/lab/secrets.rs
@@ -23,6 +23,7 @@ use homeboy_core::secret_env_plan::{
     SecretEnvHandoffEntry, SecretEnvPlan, SecretEnvPlanMaterializeRequest,
 };
 use homeboy_core::{config, Error, Result};
+use homeboy_runner_contract::env_materialization_plan::{EnvMaterializationPlan, EnvSecretRef};
 
 use super::super::Runner;
 use super::args_util::{non_empty_arg, subcommand_index};
@@ -79,7 +80,8 @@ pub(crate) fn build_lab_secret_env_handoff_plan(
         .into_iter()
         .filter(|(name, _)| !secret_env_names.contains(name))
         .collect::<BTreeMap<_, _>>();
-    let secret_env_plan = materialized_lab_secret_env_plan(public_env, secret_env_names.clone())?;
+    let mut secret_env_plan =
+        materialized_lab_secret_env_plan(public_env, secret_env_names.clone())?;
     let resolved_secret_env_names = secret_env_plan.secret_env_names();
     let secret_values = env_delta
         .iter()
@@ -96,6 +98,26 @@ pub(crate) fn build_lab_secret_env_handoff_plan(
     runner_deferred_secret_env.extend(runner_deferred_secret_env_names(&tunnel_secret_env));
     runner_deferred_secret_env.sort();
     runner_deferred_secret_env.dedup();
+    // Preserve authority with the durable name-only plan. Only values resolved
+    // by this controller are eligible for the transient broker sidecar.
+    secret_env_plan.env_materialization = Some(EnvMaterializationPlan {
+        secret_refs: secret_env_plan
+            .secret_env_names()
+            .into_iter()
+            .map(|name| EnvSecretRef {
+                owner: Some(
+                    if runner_deferred_secret_env.contains(&name) {
+                        "runner"
+                    } else {
+                        "controller"
+                    }
+                    .to_string(),
+                ),
+                name,
+            })
+            .collect(),
+        ..EnvMaterializationPlan::default()
+    });
     let entries = lab_secret_env_handoff_entries(
         &env_delta,
         &runner_deferred_secret_env,

--- a/crates/homeboy-lab-runner/src/lab/secrets/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/lab/secrets/tests/part_b.rs
@@ -279,6 +279,35 @@ fn declared_agent_task_cook_provider_defaults_include_controller_sources() {
 }
 
 #[test]
+fn lab_dispatch_model_route_does_not_require_an_unrelated_sole_provider_default() {
+    let provider = fixture_provider_with_example_defaults();
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--backend".to_string(),
+        "sample-runtime".to_string(),
+        "--model".to_string(),
+        "xai/grok-4.6".to_string(),
+    ];
+
+    let names = declared_agent_task_controller_secret_env_with_providers(
+        &args,
+        std::slice::from_ref(&provider),
+    )
+    .expect("model route secret discovery");
+    let sources = declared_agent_task_controller_secret_sources_with_providers(
+        &args,
+        1,
+        std::slice::from_ref(&provider),
+    )
+    .expect("model route source discovery");
+
+    assert!(names.is_empty());
+    assert!(sources.is_empty());
+}
+
+#[test]
 fn declared_agent_task_providers_still_include_provider_default_sources() {
     let provider = fixture_provider_with_example_defaults();
     let args = vec![

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -1062,6 +1062,7 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
                         envelope: execution,
                         workspace_claim_binding: None,
                         workspace_owner_lease: None,
+                        credential_delivery: None,
                     },
                 )?;
                 Ok(job.id.to_string())

--- a/crates/homeboy-lab-runner/src/worker/broker.rs
+++ b/crates/homeboy-lab-runner/src/worker/broker.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use reqwest::blocking::Client;
 use serde_json::json;
+use std::collections::BTreeMap;
 
 use homeboy_core::api_jobs::{Job, JobStatus, RemoteRunnerJobResult};
 use homeboy_core::error::{Error, Result};
@@ -169,6 +170,37 @@ pub(super) fn consume_execution(
         )
     })?;
     Ok(job)
+}
+
+/// Fetch controller-owned credentials only after the worker has verified the
+/// claim. The broker atomically consumes this capability before returning it.
+pub(super) fn consume_credential_delivery(
+    client: &Client,
+    broker_url: &str,
+    token: Option<&str>,
+    runner_id: &str,
+    claim: &RunnerApiClaimedExecution,
+) -> Result<BTreeMap<String, String>> {
+    let Some(delivery) = claim.credential_delivery.as_ref() else {
+        return Ok(BTreeMap::new());
+    };
+    let data = broker_http::post_json(
+        client,
+        broker_url,
+        &format!(
+            "/runner/jobs/{}/credentials/{}",
+            claim.job_id, delivery.delivery_id
+        ),
+        json!({ "runner_id": runner_id, "claim_id": remote_runner_claim_id(claim) }),
+        "consume controller credential delivery",
+        token,
+    )?;
+    serde_json::from_value(data["env"].clone()).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse controller credential delivery".to_string()),
+        )
+    })
 }
 
 /// Check the exact durable owner lease without consuming the execution receipt.

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -387,6 +387,16 @@ fn run_once_output(
             lease,
         )?;
     }
+    // Bind the controller capability while the live claim is freshly verified,
+    // before potentially slow source preparation. The values remain only in
+    // this worker process until they are projected into the execution child.
+    let controller_credentials = consume_credential_delivery(
+        &client,
+        &options.broker_url,
+        options.broker_token.as_deref(),
+        &options.runner_id,
+        &claim,
+    )?;
     let _command_assets = materialize_command_assets(&claim.job_id, &mut execution_envelope)?;
     let _private_at_files = verify_private_at_files(&mut execution_envelope)?;
     let _staged_workspace = materialize_staged_source_artifact(
@@ -442,15 +452,7 @@ fn run_once_output(
         execution_context.clone(),
         claim.job_id.clone(),
     )?;
-    // Keep controller-owned values out of the envelope; they exist only between
-    // this claimed fetch and the direct provider child environment projection.
-    exec_options.env.extend(consume_credential_delivery(
-        &client,
-        &options.broker_url,
-        options.broker_token.as_deref(),
-        &options.runner_id,
-        &claim,
-    )?);
+    exec_options.env.extend(controller_credentials);
     let exec_result = exec_worker_local_until_cancelled_with_progress(
         &options.runner_id,
         exec_options,

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -25,8 +25,8 @@ use homeboy_lab_contract::lab::execution_envelope::lab_runner_workload_from_exec
 
 use super::super::execution::{exec_worker_local_until_cancelled_with_progress, RunnerExecOptions};
 use super::broker::{
-    append_progress_data, cancelled_job_snapshot, claim_job, consume_execution, finish_job,
-    start_claim_heartbeat, validate_workspace_owner,
+    append_progress_data, cancelled_job_snapshot, claim_job, consume_credential_delivery,
+    consume_execution, finish_job, start_claim_heartbeat, validate_workspace_owner,
 };
 use super::result::{
     cancelled_output, claimed_output, log_worker_event, remote_runner_result_from_exec_output,
@@ -435,15 +435,25 @@ fn run_once_output(
                 .as_ref(),
         )
     });
+    let mut exec_options = runner_exec_options_from_envelope(
+        execution_envelope.clone(),
+        capability_preflight,
+        claimed_run_id,
+        execution_context.clone(),
+        claim.job_id.clone(),
+    )?;
+    // Keep controller-owned values out of the envelope; they exist only between
+    // this claimed fetch and the direct provider child environment projection.
+    exec_options.env.extend(consume_credential_delivery(
+        &client,
+        &options.broker_url,
+        options.broker_token.as_deref(),
+        &options.runner_id,
+        &claim,
+    )?);
     let exec_result = exec_worker_local_until_cancelled_with_progress(
         &options.runner_id,
-        runner_exec_options_from_envelope(
-            execution_envelope.clone(),
-            capability_preflight,
-            claimed_run_id,
-            execution_context.clone(),
-            claim.job_id.clone(),
-        )?,
+        exec_options,
         || {
             verify_staged_workspace_before_execution(
                 &options.runner_id,

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -244,14 +244,8 @@ fn reverse_worker_receives_controller_credential_over_authenticated_broker_witho
         assert_eq!(exit_code, 0);
         assert_eq!(output.job.as_ref().expect("finished job").id, job.id);
         assert_eq!(
-            output
-                .job
-                .as_ref()
-                .expect("finished job")
-                .result
-                .as_ref()
-                .and_then(|result| result.stdout.as_deref()),
-            Some("controller-credential-ok")
+            result_event_data(&broker.store, job.id)["stdout"],
+            serde_json::json!("controller-credential-ok")
         );
         for value in [
             serde_json::to_string(&output).expect("serialize worker output"),

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -200,7 +200,20 @@ fn reverse_worker_receives_controller_credential_over_authenticated_broker_witho
             cwd: Some("/tmp".to_string()),
             env: Default::default(),
             secret_env_names: vec!["PROVIDER_TOKEN".to_string()],
-            secret_env_plan: SecretEnvPlan::from_secret_env_names(["PROVIDER_TOKEN".to_string()]),
+            secret_env_plan: SecretEnvPlan {
+                env_materialization: Some(
+                    homeboy_runner_contract::env_materialization_plan::EnvMaterializationPlan {
+                        secret_refs: vec![
+                            homeboy_runner_contract::env_materialization_plan::EnvSecretRef {
+                                name: "PROVIDER_TOKEN".to_string(),
+                                owner: Some("controller".to_string()),
+                            },
+                        ],
+                        ..Default::default()
+                    },
+                ),
+                ..SecretEnvPlan::from_secret_env_names(["PROVIDER_TOKEN".to_string()])
+            },
             env_materialization: None,
             capture_patch: false,
             source_snapshot: None,

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -5,8 +6,9 @@ use std::sync::{
 use std::time::Duration;
 
 use homeboy_core::api_jobs::{
-    JobEventKind, JobStatus, JobStore, RemoteRunnerJobRequest, RunnerJobLifecycleMetadata,
+    Job, JobEventKind, JobStatus, JobStore, RemoteRunnerJobRequest, RunnerJobLifecycleMetadata,
 };
+use homeboy_core::broker_auth::BROKER_TOKEN_HEADER;
 use homeboy_core::secret_env_plan::SecretEnvPlan;
 use homeboy_core::server::{RunnerPolicy, RunnerSecretEnvRef};
 use homeboy_core::test_support;
@@ -158,6 +160,107 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
                 serde_json::json!("linux_procfs_process_tree")
             );
             assert!(result["metrics"]["sample_count"].as_u64().is_some());
+        }
+    });
+}
+
+#[test]
+fn reverse_worker_receives_controller_credential_over_authenticated_broker_without_persistence() {
+    test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+            false,
+        )
+        .expect("create runner");
+        crate::merge(
+            Some("lab"),
+            &serde_json::json!({
+                "policy": RunnerPolicy {
+                    allow_raw_exec: Some(true),
+                    workspace_roots: vec!["/tmp".to_string()],
+                    allowed_commands: vec!["sh".to_string()],
+                    ..Default::default()
+                }
+            })
+            .to_string(),
+            &[],
+        )
+        .expect("set policy");
+        let broker = test_support::AuthenticatedReverseBrokerFixture::start("lab");
+        let sentinel = "controller-secret-sentinel-do-not-persist";
+        let request = RemoteRunnerJobRequest {
+            runner_id: "lab".to_string(),
+            project_id: None,
+            operation: "runner.exec".to_string(),
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "test -n \"$PROVIDER_TOKEN\" && printf controller-credential-ok".to_string(),
+            ],
+            cwd: Some("/tmp".to_string()),
+            env: Default::default(),
+            secret_env_names: vec!["PROVIDER_TOKEN".to_string()],
+            secret_env_plan: SecretEnvPlan::from_secret_env_names(["PROVIDER_TOKEN".to_string()]),
+            env_materialization: None,
+            capture_patch: false,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            require_paths: Vec::new(),
+            extension_env_providers: Vec::new(),
+            lab_runner_workload: None,
+            lifecycle: None,
+            workspace_claim_binding: None,
+            workspace_owner_lease: None,
+            metadata: None,
+        };
+        let submission = homeboy_runner_contract::RunnerApiSubmitRequest {
+            schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: homeboy_runner_contract::RUNNER_API_V1,
+            submission_key: "controller-credential-worker-e2e".to_string(),
+            envelope: request.execution_envelope(),
+            workspace_claim_binding: None,
+            workspace_owner_lease: None,
+            credential_delivery: Some(homeboy_runner_contract::RunnerCredentialDelivery {
+                env: BTreeMap::from([("PROVIDER_TOKEN".to_string(), sentinel.to_string())]),
+            }),
+        };
+        let response: serde_json::Value = reqwest::blocking::Client::new()
+            .post(format!("{}/runner/jobs", broker.url()))
+            .header(BROKER_TOKEN_HEADER, broker.token())
+            .json(&submission)
+            .send()
+            .expect("submit controller credential job")
+            .error_for_status()
+            .expect("accept controller credential job")
+            .json()
+            .expect("decode controller submission response");
+        let job: Job = serde_json::from_value(response["data"]["body"]["job"].clone())
+            .expect("decode submitted job");
+
+        let mut options = worker_options(broker.url().to_string());
+        options.broker_token = Some(broker.token().to_string());
+        let (output, exit_code) = run_reverse_worker(options).expect("run worker");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.job.as_ref().expect("finished job").id, job.id);
+        assert_eq!(
+            output
+                .job
+                .as_ref()
+                .expect("finished job")
+                .result
+                .as_ref()
+                .and_then(|result| result.stdout.as_deref()),
+            Some("controller-credential-ok")
+        );
+        for value in [
+            serde_json::to_string(&output).expect("serialize worker output"),
+            serde_json::to_string(&broker.store.get(job.id).expect("stored job"))
+                .expect("serialize stored job"),
+            serde_json::to_string(&broker.store.events(job.id).expect("stored events"))
+                .expect("serialize stored events"),
+        ] {
+            assert!(!value.contains(sentinel));
         }
     });
 }


### PR DESCRIPTION
Summary: combines selected-model routing, targeted explicit-runner admission, and controller-owned credential delivery for reverse-runner jobs. Explicit Lab selection is authoritative: admission probes the selected runner and never substitutes another ready runner. Controller values are delivered only for durable EnvMaterializationPlan refs marked owner=controller; runner-owned refs remain runner-owned.

Credential lifecycle: sidecars are allocated before durable admission; claim holds the registry lock; queue time does not consume the claim-bound TTL; and the worker consumes immediately after authenticated owner validation, before command/source/Git preparation. A lost sidecar writes an actionable error and terminalizes only its job, allowing later independent work to claim. Durable payloads, logs, events, artifacts, and results remain reference-only.

Combined head: 646c0a6421b9eca552ffffd45eb3bdbbfde5b27f (normal merge of origin/main 3ee8a6cdda80d74f1b239ebe8332494706d7a254).

Verification on isolated homeboy-lab with CARGO_BUILD_JOBS=2 and two test threads: cargo fmt --check; 8 parsed-command targeted-admission tests; selected CLI targeted-runner test; Lab readiness-state test; focused credential lifecycle and queue-isolation tests; authenticated controller POST to broker to worker test; and full homeboy-lab-runner worker suite, 42 passed. The first combined CLI command exceeded the 120-second compile window; its warmed-cache rerun passed. No shared runtime, deployment, provider invocation, release, or PR merge occurred.

AI Assistance: OpenAI GPT-5.6 Terra (openai/gpt-5.6-terra) via OpenCode inspected #14452, merged and verified the combined candidate, and updated this evidence. No credential values were inspected or included.