### PR TITLE
fix(runner): require targeted runner admission

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1344,17 +1344,30 @@ impl CliRuntime {
             return std::process::ExitCode::from(exit_code_to_u8(exit_code));
         }
         if crate::core::parsed_command_preflight::captured_result().is_none() {
-            let lab_readiness = matches!(
+            let lab_readiness = if matches!(
+                preflight_input.lab_route,
+                crate::core::parsed_command_preflight::LabRouteIntent::Supported { .. }
+            ) {
+                cli.runner
+                    .as_deref()
+                    .map(crate::runner::lab_runner_readiness_for_admission)
+                    .unwrap_or_else(|| crate::runner::lab_runner_readiness())
+                    .ok()
+            } else {
+                None
+            };
+            let selected_runner_id = matches!(
                 preflight_input.lab_route,
                 crate::core::parsed_command_preflight::LabRouteIntent::Supported { .. }
             )
-            .then(|| crate::runner::lab_runner_readiness().ok())
+            .then(|| {
+                cli.runner.clone().or_else(|| {
+                    lab_readiness
+                        .as_ref()
+                        .and_then(|readiness| readiness.selected_runner_id.clone())
+                })
+            })
             .flatten();
-            let selected_runner_id = cli.runner.clone().or_else(|| {
-                lab_readiness
-                    .as_ref()
-                    .and_then(|readiness| readiness.selected_runner_id.clone())
-            });
             let result = match crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
                 normalized.clone(),
                 preflight_input.clone(),
@@ -1368,7 +1381,13 @@ impl CliRuntime {
                     selected_runner_id: selected_runner_id.clone(),
                     generic_route: generic_route_policy_snapshot(&cli, selected_runner_id.clone()),
                     deferred_pressure_refusal: false,
-                    runner_admitted: selected_runner_id.is_some() && lab_readiness.as_ref().is_some_and(|readiness| readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady),
+                    runner_admitted: selected_runner_id.as_ref().is_some_and(|runner_id| {
+                        lab_readiness.as_ref().is_some_and(|readiness| {
+                            readiness.state
+                                == crate::runner::runners::LabRunnerReadinessState::ConnectedReady
+                                && readiness.available_runner_ids.contains(runner_id)
+                        })
+                    }),
                     runner_incompatible: false,
                     auto_local_capacity_fallback: false,
                 },
@@ -2720,10 +2739,15 @@ fn preflight_composed_lab_route(
     let Ok((resources, _)) = crate::commands::resources::run_preflight() else {
         return None;
     };
-    let mut readiness = hot_command
-        .lab_offload_supported
-        .then(|| crate::runner::lab_runner_readiness().ok())
-        .flatten();
+    let mut readiness = if hot_command.lab_offload_supported {
+        options
+            .runner
+            .map(crate::runner::lab_runner_readiness_for_admission)
+            .unwrap_or_else(|| crate::runner::lab_runner_readiness())
+            .ok()
+    } else {
+        None
+    };
     let observed_at_ms = unix_timestamp_ms();
     if hot_command.lab_offload_supported
         && options.runner.is_none()
@@ -2742,11 +2766,13 @@ fn preflight_composed_lab_route(
     let warning =
         resource_policy::evaluate_with_runner_hint(hot_command, &resources, readiness.as_ref());
     let runner_hosted = resource_policy::is_runner_hosted_exec();
-    let runner_admits_offload = options.runner.is_some()
-        || readiness.as_ref().is_some_and(|readiness| {
-            readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady
-                && readiness.selected_runner_id.is_some()
-        });
+    let runner_admits_offload = readiness.as_ref().is_some_and(|readiness| {
+        readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady
+            && readiness
+                .selected_runner_id
+                .as_ref()
+                .is_some_and(|runner| readiness.available_runner_ids.contains(runner))
+    });
     let auto_local_capacity_fallback = resource_policy::admits_auto_local_capacity_fallback(
         hot_command,
         &resources,
@@ -2927,7 +2953,11 @@ fn preflight_hot_command_with_input(
     if let Some(hot_command) = resource_policy::hot_command_for_cli(cli) {
         if let Ok((resources, _)) = preflight() {
             let mut lab_readiness = if hot_command.lab_offload_supported {
-                crate::runner::lab_runner_readiness().ok()
+                cli.runner
+                    .as_deref()
+                    .map(crate::runner::lab_runner_readiness_for_admission)
+                    .unwrap_or_else(|| crate::runner::lab_runner_readiness())
+                    .ok()
             } else {
                 None
             };
@@ -2958,9 +2988,8 @@ fn preflight_hot_command_with_input(
                     lab_inventory_diagnostic = Some(diagnostic);
                 }
             }
-            // An explicit runner is a routing decision, not a default-runner
-            // fallback. Let Lab offload report any runner-specific readiness or
-            // capability failure rather than blocking it at controller preflight.
+            // An explicit runner is a routing decision, so its targeted snapshot
+            // is the sole readiness evidence used for controller admission.
             let selected_lab_runner = resource_policy_runner_hint(
                 cli,
                 lab_readiness

--- a/crates/homeboy-core/src/parsed_command_preflight.rs
+++ b/crates/homeboy-core/src/parsed_command_preflight.rs
@@ -737,4 +737,85 @@ mod tests {
         )
         .is_err());
     }
+
+    #[test]
+    fn resolver_accepts_an_explicit_runner_from_its_authoritative_ready_snapshot() {
+        let input = explicit_runner_input();
+        let policy = explicit_runner_policy("connected_ready", vec!["lab-b".into()], true);
+
+        assert!(resolve_parsed_command_preflight(vec!["fixture".into()], input, policy).is_ok());
+    }
+
+    #[test]
+    fn resolver_rejects_an_explicit_runner_without_ready_inventory_evidence() {
+        let input = explicit_runner_input();
+        let policy = explicit_runner_policy("stale", Vec::new(), false);
+
+        let error = resolve_parsed_command_preflight(vec!["fixture".into()], input, policy)
+            .expect_err("stale runner evidence must fail closed");
+        assert_eq!(error.details["field"], "selected_runner_id");
+    }
+
+    #[test]
+    fn resolver_does_not_admit_a_runner_for_an_unsupported_local_route() {
+        let mut input = explicit_runner_input();
+        input.lab_route = LabRouteIntent::Unsupported;
+        input.placement = PlacementIntent::Auto;
+        let mut policy = explicit_runner_policy("connected_ready", vec!["lab-b".into()], false);
+        policy.lab_readiness = None;
+        policy.selected_runner_id = None;
+        policy.generic_route = GenericRoutePolicySnapshot {
+            command_supports_lab: false,
+            automatic_authorized: false,
+            selected_runner_id: None,
+        };
+
+        assert!(resolve_parsed_command_preflight(vec!["fixture".into()], input, policy).is_ok());
+    }
+
+    fn explicit_runner_input() -> ParsedCommandPreflightInput {
+        ParsedCommandPreflightInput {
+            identity: ParsedCommandIdentity {
+                family: "fixture".into(),
+                operation: vec!["run".into()],
+            },
+            resource_admission: ResourceAdmissionRequirement::Exempt,
+            controller_execution: ControllerExecution::Ordinary,
+            deferred_workload: DeferredWorkloadPolicy::Eligible,
+            placement: PlacementIntent::Lab,
+            runner: RunnerIntent::Explicit("lab-b".into()),
+            runner_normalization: RunnerNormalization::None,
+            lab_route: LabRouteIntent::Supported { automatic: true },
+            provenance: ProvenanceRequirement::None,
+        }
+    }
+
+    fn explicit_runner_policy(
+        state: &str,
+        available_runner_ids: Vec<String>,
+        runner_admitted: bool,
+    ) -> ParsedCommandPolicySnapshot {
+        ParsedCommandPolicySnapshot {
+            resource_admission_evidence: ResourceAdmissionEvidence::Unavailable,
+            resource_policy: None,
+            lab_readiness: Some(LabReadinessSnapshot {
+                state: state.into(),
+                selected_runner_id: Some("lab-b".into()),
+                available_runner_ids,
+                reasons: Vec::new(),
+                remediation_commands: Vec::new(),
+                repair_admitted_runner_ids: Vec::new(),
+            }),
+            selected_runner_id: Some("lab-b".into()),
+            generic_route: GenericRoutePolicySnapshot {
+                command_supports_lab: true,
+                automatic_authorized: true,
+                selected_runner_id: Some("lab-b".into()),
+            },
+            deferred_pressure_refusal: false,
+            runner_admitted,
+            runner_incompatible: false,
+            auto_local_capacity_fallback: false,
+        }
+    }
 }

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -959,6 +959,33 @@ pub fn refresh_lab_runner_readiness_for_admission() -> Result<LabRunnerReadiness
     lab_runner_readiness_from_refresh_observations(preferred.as_deref(), observations)
 }
 
+/// Read one explicitly selected runner for immediate workload admission. Unlike
+/// the bounded inventory refresh, this never substitutes another runner.
+pub fn lab_runner_readiness_for_admission(runner_id: &str) -> Result<LabRunnerReadiness> {
+    let runner = load(runner_id)?;
+    runner_probe_gate::invalidate_runner_probes(runner_id);
+    let status = runner_admission_snapshot(runner_id)?.status;
+    let capabilities_ready = !runner_capability_inventory(runner_id)?
+        .runtime_ids
+        .is_empty();
+    let mode = status
+        .session
+        .as_ref()
+        .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone());
+    let candidate = lab_runner_admission_candidate(
+        runner_id,
+        mode,
+        runner.settings.concurrency_limit,
+        &status,
+        capabilities_ready,
+        lab::offload::metadata::require_exact_runner_version(&runner.settings),
+    );
+    Ok(lab_runner_readiness_from_candidates(
+        Some(runner_id),
+        vec![candidate],
+    ))
+}
+
 fn observe_lab_runner_admission_candidate(
     runner_id: &str,
     deadline: std::time::Instant,
@@ -966,9 +993,9 @@ fn observe_lab_runner_admission_candidate(
     let runner = load(runner_id)?;
     runner_probe_gate::invalidate_runner_probes(runner_id);
     let status = runner_admission_snapshot_until(runner_id, deadline)?.status;
-    let capabilities_ready = runner_capability_inventory_until(runner_id, deadline)?
+    let capabilities_ready = !runner_capability_inventory_until(runner_id, deadline)?
         .runtime_ids
-        .contains("homeboy");
+        .is_empty();
     let mode = status
         .session
         .as_ref()


### PR DESCRIPTION
## Summary
Make explicit Lab runner selection authoritative for admission.

## What changed
- Probe the explicitly selected runner without substituting a default runner.
- Require the selected runner to appear in ready inventory before admission.
- Keep unsupported local routes outside Lab admission.

## How to test
1. Run `cargo fmt --check`; expect passes as recorded by Homeboy's deterministic gate.
2. Run `cargo test -p homeboy-core parsed_command_preflight`; expect passes as recorded by Homeboy's deterministic gate.
3. Run `cargo test -p homeboy-cli --lib explicit_runner_preserves_lab_routing_for_hot_cook_and_review_commands`; expect passes as recorded by Homeboy's deterministic gate.
4. Run `cargo test -p homeboy-cli --lib bench_list_rig_discovers_scenarios_without_preflight_or_bench_prepare`; expect passes as recorded by Homeboy's deterministic gate.
5. Run `cargo test -p homeboy-lab-runner --lib lab_runner_readiness_distinguishes_absent_ready_ineligible_stale_and_capacity`; expect passes as recorded by Homeboy's deterministic gate.

## Compatibility
No public CLI contract changes.

## Evidence
- Base unchanged since verification: main remains at 1aaec23a538bcefdca1cac54dc91b2f237371bb6.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/14450
- Verified finalization base: main at 1aaec23a538bcefdca1cac54dc91b2f237371bb6
- manual-verify-1: passed (cargo fmt --check) (Passed)
- manual-verify-2: passed (cargo test -p homeboy-core parsed\_command\_preflight) (Passed)
- manual-verify-3: passed (cargo test -p homeboy-cli --lib explicit\_runner\_preserves\_lab\_routing\_for\_hot\_cook\_and\_review\_commands) (Passed)
- manual-verify-4: passed (cargo test -p homeboy-cli --lib bench\_list\_rig\_discovers\_scenarios\_without\_preflight\_or\_bench\_prepare) (Passed)
- manual-verify-5: passed (cargo test -p homeboy-lab-runner --lib lab\_runner\_readiness\_distinguishes\_absent\_ready\_ineligible\_stale\_and\_capacity) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Models:** OpenAI GPT-6 Astra via OpenCode orchestrated the work; the delegated finalization agent reported openai/gpt-5.6-terra.
- **Used for:** Inspected the admission paths, implemented and reviewed the targeted readiness fix, and ran deterministic verification.

## Source relationships
- Closes #14450