### PR TITLE
fix(runner): prioritize explicit lease adoption

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1344,17 +1344,30 @@ impl CliRuntime {
             return std::process::ExitCode::from(exit_code_to_u8(exit_code));
         }
         if crate::core::parsed_command_preflight::captured_result().is_none() {
-            let lab_readiness = matches!(
+            let lab_readiness = if matches!(
+                preflight_input.lab_route,
+                crate::core::parsed_command_preflight::LabRouteIntent::Supported { .. }
+            ) {
+                cli.runner
+                    .as_deref()
+                    .map(crate::runner::lab_runner_readiness_for_admission)
+                    .unwrap_or_else(|| crate::runner::lab_runner_readiness())
+                    .ok()
+            } else {
+                None
+            };
+            let selected_runner_id = matches!(
                 preflight_input.lab_route,
                 crate::core::parsed_command_preflight::LabRouteIntent::Supported { .. }
             )
-            .then(|| crate::runner::lab_runner_readiness().ok())
+            .then(|| {
+                cli.runner.clone().or_else(|| {
+                    lab_readiness
+                        .as_ref()
+                        .and_then(|readiness| readiness.selected_runner_id.clone())
+                })
+            })
             .flatten();
-            let selected_runner_id = cli.runner.clone().or_else(|| {
-                lab_readiness
-                    .as_ref()
-                    .and_then(|readiness| readiness.selected_runner_id.clone())
-            });
             let result = match crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
                 normalized.clone(),
                 preflight_input.clone(),
@@ -1368,7 +1381,13 @@ impl CliRuntime {
                     selected_runner_id: selected_runner_id.clone(),
                     generic_route: generic_route_policy_snapshot(&cli, selected_runner_id.clone()),
                     deferred_pressure_refusal: false,
-                    runner_admitted: selected_runner_id.is_some() && lab_readiness.as_ref().is_some_and(|readiness| readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady),
+                    runner_admitted: selected_runner_id.as_ref().is_some_and(|runner_id| {
+                        lab_readiness.as_ref().is_some_and(|readiness| {
+                            readiness.state
+                                == crate::runner::runners::LabRunnerReadinessState::ConnectedReady
+                                && readiness.available_runner_ids.contains(runner_id)
+                        })
+                    }),
                     runner_incompatible: false,
                     auto_local_capacity_fallback: false,
                 },
@@ -2720,10 +2739,15 @@ fn preflight_composed_lab_route(
     let Ok((resources, _)) = crate::commands::resources::run_preflight() else {
         return None;
     };
-    let mut readiness = hot_command
-        .lab_offload_supported
-        .then(|| crate::runner::lab_runner_readiness().ok())
-        .flatten();
+    let mut readiness = if hot_command.lab_offload_supported {
+        options
+            .runner
+            .map(crate::runner::lab_runner_readiness_for_admission)
+            .unwrap_or_else(|| crate::runner::lab_runner_readiness())
+            .ok()
+    } else {
+        None
+    };
     let observed_at_ms = unix_timestamp_ms();
     if hot_command.lab_offload_supported
         && options.runner.is_none()
@@ -2742,11 +2766,13 @@ fn preflight_composed_lab_route(
     let warning =
         resource_policy::evaluate_with_runner_hint(hot_command, &resources, readiness.as_ref());
     let runner_hosted = resource_policy::is_runner_hosted_exec();
-    let runner_admits_offload = options.runner.is_some()
-        || readiness.as_ref().is_some_and(|readiness| {
-            readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady
-                && readiness.selected_runner_id.is_some()
-        });
+    let runner_admits_offload = readiness.as_ref().is_some_and(|readiness| {
+        readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady
+            && readiness
+                .selected_runner_id
+                .as_ref()
+                .is_some_and(|runner| readiness.available_runner_ids.contains(runner))
+    });
     let auto_local_capacity_fallback = resource_policy::admits_auto_local_capacity_fallback(
         hot_command,
         &resources,
@@ -2927,7 +2953,11 @@ fn preflight_hot_command_with_input(
     if let Some(hot_command) = resource_policy::hot_command_for_cli(cli) {
         if let Ok((resources, _)) = preflight() {
             let mut lab_readiness = if hot_command.lab_offload_supported {
-                crate::runner::lab_runner_readiness().ok()
+                cli.runner
+                    .as_deref()
+                    .map(crate::runner::lab_runner_readiness_for_admission)
+                    .unwrap_or_else(|| crate::runner::lab_runner_readiness())
+                    .ok()
             } else {
                 None
             };
@@ -2958,9 +2988,8 @@ fn preflight_hot_command_with_input(
                     lab_inventory_diagnostic = Some(diagnostic);
                 }
             }
-            // An explicit runner is a routing decision, not a default-runner
-            // fallback. Let Lab offload report any runner-specific readiness or
-            // capability failure rather than blocking it at controller preflight.
+            // An explicit runner is a routing decision, so its targeted snapshot
+            // is the sole readiness evidence used for controller admission.
             let selected_lab_runner = resource_policy_runner_hint(
                 cli,
                 lab_readiness

--- a/crates/homeboy-core/src/parsed_command_preflight.rs
+++ b/crates/homeboy-core/src/parsed_command_preflight.rs
@@ -737,4 +737,85 @@ mod tests {
         )
         .is_err());
     }
+
+    #[test]
+    fn resolver_accepts_an_explicit_runner_from_its_authoritative_ready_snapshot() {
+        let input = explicit_runner_input();
+        let policy = explicit_runner_policy("connected_ready", vec!["lab-b".into()], true);
+
+        assert!(resolve_parsed_command_preflight(vec!["fixture".into()], input, policy).is_ok());
+    }
+
+    #[test]
+    fn resolver_rejects_an_explicit_runner_without_ready_inventory_evidence() {
+        let input = explicit_runner_input();
+        let policy = explicit_runner_policy("stale", Vec::new(), false);
+
+        let error = resolve_parsed_command_preflight(vec!["fixture".into()], input, policy)
+            .expect_err("stale runner evidence must fail closed");
+        assert_eq!(error.details["field"], "selected_runner_id");
+    }
+
+    #[test]
+    fn resolver_does_not_admit_a_runner_for_an_unsupported_local_route() {
+        let mut input = explicit_runner_input();
+        input.lab_route = LabRouteIntent::Unsupported;
+        input.placement = PlacementIntent::Auto;
+        let mut policy = explicit_runner_policy("connected_ready", vec!["lab-b".into()], false);
+        policy.lab_readiness = None;
+        policy.selected_runner_id = None;
+        policy.generic_route = GenericRoutePolicySnapshot {
+            command_supports_lab: false,
+            automatic_authorized: false,
+            selected_runner_id: None,
+        };
+
+        assert!(resolve_parsed_command_preflight(vec!["fixture".into()], input, policy).is_ok());
+    }
+
+    fn explicit_runner_input() -> ParsedCommandPreflightInput {
+        ParsedCommandPreflightInput {
+            identity: ParsedCommandIdentity {
+                family: "fixture".into(),
+                operation: vec!["run".into()],
+            },
+            resource_admission: ResourceAdmissionRequirement::Exempt,
+            controller_execution: ControllerExecution::Ordinary,
+            deferred_workload: DeferredWorkloadPolicy::Eligible,
+            placement: PlacementIntent::Lab,
+            runner: RunnerIntent::Explicit("lab-b".into()),
+            runner_normalization: RunnerNormalization::None,
+            lab_route: LabRouteIntent::Supported { automatic: true },
+            provenance: ProvenanceRequirement::None,
+        }
+    }
+
+    fn explicit_runner_policy(
+        state: &str,
+        available_runner_ids: Vec<String>,
+        runner_admitted: bool,
+    ) -> ParsedCommandPolicySnapshot {
+        ParsedCommandPolicySnapshot {
+            resource_admission_evidence: ResourceAdmissionEvidence::Unavailable,
+            resource_policy: None,
+            lab_readiness: Some(LabReadinessSnapshot {
+                state: state.into(),
+                selected_runner_id: Some("lab-b".into()),
+                available_runner_ids,
+                reasons: Vec::new(),
+                remediation_commands: Vec::new(),
+                repair_admitted_runner_ids: Vec::new(),
+            }),
+            selected_runner_id: Some("lab-b".into()),
+            generic_route: GenericRoutePolicySnapshot {
+                command_supports_lab: true,
+                automatic_authorized: true,
+                selected_runner_id: Some("lab-b".into()),
+            },
+            deferred_pressure_refusal: false,
+            runner_admitted,
+            runner_incompatible: false,
+            auto_local_capacity_fallback: false,
+        }
+    }
 }

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -826,12 +826,16 @@ fn connect_with_orphan_adoption_and_live_lease(
     // inspecting A or selecting any ordinary replacement path.
     if recovery_daemon.is_none() {
         let replay = super::generation_store::replacement_operation_replay(runner_id)?;
-        // Explicit candidate reconciliation is the authority selected to
-        // resolve an unleased process conflict. Replaying a prior
-        // ensure-running command first can only reproduce that conflict; the
-        // reconciliation block below durably records the typed supersession.
-        let replay =
-            replay.filter(|(kind, _)| !(reconcile_unleased_candidates && kind == "ensure-running"));
+        // An explicit recovery intent is authoritative over the stale automatic
+        // ensure-running replay it is meant to resolve. Its exact validation
+        // still runs below before the replay is terminalized.
+        let replay = replay.filter(|(kind, _)| {
+            should_replay_pending_replacement(
+                kind,
+                reconcile_unleased_candidates,
+                live_lease_expectation.is_some(),
+            )
+        });
         if let Some((kind, command)) = replay {
             let command = if kind == "ensure-running" {
                 if let Err(error) = negotiate_ensure_running_operation_id(
@@ -1411,6 +1415,11 @@ fn connect_with_orphan_adoption_and_live_lease(
             tunnel_process_start_identity.as_ref(),
         ));
     }
+    if live_lease_expectation.is_some() {
+        super::generation_store::terminalize_ensure_running_replay_for_live_lease_adoption(
+            runner_id,
+        )?;
+    }
     let connection_warning = daemon
         .inspected_freshness
         .as_ref()
@@ -1638,6 +1647,14 @@ fn verify_live_lease_adoption(
         ));
     }
     Ok(())
+}
+
+fn should_replay_pending_replacement(
+    kind: &str,
+    reconcile_unleased_candidates: bool,
+    adopt_live_lease: bool,
+) -> bool {
+    kind != "ensure-running" || (!reconcile_unleased_candidates && !adopt_live_lease)
 }
 
 fn remote_leaseless_recovery_command(

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -128,6 +128,26 @@ fn explicit_live_lease_adoption_requires_the_exact_current_lease_and_pid() {
 }
 
 #[test]
+fn explicit_live_lease_adoption_precedes_only_stale_ensure_running_replay() {
+    assert!(!should_replay_pending_replacement(
+        "ensure-running",
+        false,
+        true
+    ));
+    assert!(!should_replay_pending_replacement(
+        "ensure-running",
+        true,
+        false
+    ));
+    assert!(should_replay_pending_replacement(
+        "ensure-running",
+        false,
+        false
+    ));
+    assert!(should_replay_pending_replacement("state-loss", false, true));
+}
+
+#[test]
 fn explicit_live_lease_adoption_accepts_an_exact_reachable_stale_daemon() {
     let session = direct_ssh_session("lease-recorded");
     let mut status = remote_daemon_status_for_test(false, true, 1, "lease-live", 4646);

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -921,6 +921,45 @@ pub(crate) fn terminalize_unleased_candidate_reconciliation(runner_id: &str) -> 
     })
 }
 
+/// An exact live-lease adoption rechecks the observed daemon after its tunnel
+/// health probe. Once that succeeds, an older automatic start replay cannot
+/// safely add information and is terminalized with its replacement evidence.
+pub(crate) fn terminalize_ensure_running_replay_for_live_lease_adoption(
+    runner_id: &str,
+) -> Result<()> {
+    with_rooted_registry_lock(runner_id, |config_root| {
+        let path = replacement_operation_path_in_root(config_root, runner_id);
+        let mut operation: ReplacementOperation =
+            serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+            })?)
+            .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+        let Some(previous_command) = operation.replay_command.as_deref() else {
+            return Ok(());
+        };
+        if operation.kind.as_deref() != Some("ensure-running") {
+            return Ok(());
+        }
+        write_durable_json(
+            &superseded_replacement_path_in_root(config_root, runner_id),
+            &SupersededReplacementEvidence {
+                schema: "homeboy/runner-replacement-operation-supersession/v1",
+                runner_id,
+                operation_id: &operation.operation_id,
+                previous_kind: "ensure-running",
+                previous_replay_command: previous_command,
+                replacement_kind: "live-lease-adoption",
+                replacement_replay_command: "verified exact live-lease adoption",
+                superseded_at: Utc::now().to_rfc3339(),
+            },
+        )?;
+        operation.operation_id = uuid::Uuid::new_v4().to_string();
+        operation.replay_command = None;
+        operation.kind = None;
+        write_durable_json(&path, &operation)
+    })
+}
+
 /// Update an operation journal while the caller holds this runner's registry
 /// lock through [`with_admission_fence`].
 pub(crate) fn record_replacement_operation_replay_locked(
@@ -2376,6 +2415,46 @@ mod tests {
             assert_eq!(evidence["operation_id"], operation_id);
             assert_eq!(evidence["previous_kind"], "ensure-running");
             assert_eq!(evidence["replacement_kind"], "unleased-candidates");
+        });
+    }
+
+    #[test]
+    fn verified_live_lease_adoption_terminalizes_ensure_running_with_evidence() {
+        test_support::with_isolated_home(|_| {
+            let operation_id = replacement_operation("runner-a").expect("operation");
+            record_replacement_operation_replay(
+                "runner-a",
+                "ensure-running",
+                "homeboy daemon ensure-running --replacement-operation-id operation-a",
+            )
+            .expect("ensure-running replay");
+
+            terminalize_ensure_running_replay_for_live_lease_adoption("runner-a")
+                .expect("verified adoption terminalizes stale replay");
+
+            assert!(replacement_operation_replay("runner-a")
+                .expect("replacement replay")
+                .is_none());
+            assert_ne!(
+                replacement_operation("runner-a").expect("replacement operation"),
+                operation_id
+            );
+            let evidence_dir = paths::runner_sessions_dir()
+                .expect("runner sessions")
+                .join("runner-a")
+                .join("superseded-replacements");
+            let evidence = std::fs::read_dir(evidence_dir)
+                .expect("supersession evidence")
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .expect("evidence entries");
+            assert_eq!(evidence.len(), 1);
+            let evidence: serde_json::Value = serde_json::from_slice(
+                &std::fs::read(evidence[0].path()).expect("read supersession evidence"),
+            )
+            .expect("supersession evidence JSON");
+            assert_eq!(evidence["operation_id"], operation_id);
+            assert_eq!(evidence["previous_kind"], "ensure-running");
+            assert_eq!(evidence["replacement_kind"], "live-lease-adoption");
         });
     }
 

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -959,6 +959,33 @@ pub fn refresh_lab_runner_readiness_for_admission() -> Result<LabRunnerReadiness
     lab_runner_readiness_from_refresh_observations(preferred.as_deref(), observations)
 }
 
+/// Read one explicitly selected runner for immediate workload admission. Unlike
+/// the bounded inventory refresh, this never substitutes another runner.
+pub fn lab_runner_readiness_for_admission(runner_id: &str) -> Result<LabRunnerReadiness> {
+    let runner = load(runner_id)?;
+    runner_probe_gate::invalidate_runner_probes(runner_id);
+    let status = runner_admission_snapshot(runner_id)?.status;
+    let capabilities_ready = !runner_capability_inventory(runner_id)?
+        .runtime_ids
+        .is_empty();
+    let mode = status
+        .session
+        .as_ref()
+        .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone());
+    let candidate = lab_runner_admission_candidate(
+        runner_id,
+        mode,
+        runner.settings.concurrency_limit,
+        &status,
+        capabilities_ready,
+        lab::offload::metadata::require_exact_runner_version(&runner.settings),
+    );
+    Ok(lab_runner_readiness_from_candidates(
+        Some(runner_id),
+        vec![candidate],
+    ))
+}
+
 fn observe_lab_runner_admission_candidate(
     runner_id: &str,
     deadline: std::time::Instant,
@@ -966,9 +993,9 @@ fn observe_lab_runner_admission_candidate(
     let runner = load(runner_id)?;
     runner_probe_gate::invalidate_runner_probes(runner_id);
     let status = runner_admission_snapshot_until(runner_id, deadline)?.status;
-    let capabilities_ready = runner_capability_inventory_until(runner_id, deadline)?
+    let capabilities_ready = !runner_capability_inventory_until(runner_id, deadline)?
         .runtime_ids
-        .contains("homeboy");
+        .is_empty();
     let mode = status
         .session
         .as_ref()


### PR DESCRIPTION
## Summary

Give exact live-lease adoption precedence over a stale automatic `ensure-running` replay. The stale replay is terminalized only after the existing lease, PID, endpoint, and build-identity validation succeeds, with durable supersession evidence.

Closes #14454

## Safety

- Ordinary replay behavior is unchanged.
- Non-`ensure-running` recovery journals remain replayable.
- Lease/PID mismatches, endpoint failures, build mismatch, and active work continue through the existing fail-closed checks.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner --lib live_lease -- --nocapture`
- Full `cargo test -p homeboy-lab-runner --lib` was started but exceeded the 10-minute command budget in unrelated staging-controller tests.

## AI Assistance

OpenAI GPT-5.6 Terra via OpenCode inspected the recovery ordering, implemented the minimal generic fix, and ran focused regression coverage under Chris Huber's direction.