### PR TITLE
Remove retired control-plane projections

### DIFF
--- a/crates/contracts/homeboy-lifecycle-contract/src/cook_status.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/cook_status.rs
@@ -46,15 +46,15 @@
 //! a persisted report, has no process exit code to branch on and cannot decide
 //! success, terminality, or retry from the string alone.
 //!
-//! `homeboy_core::run_lifecycle_status::RunLifecycleStatus` is the closed
-//! vocabulary that answers those questions, and `From<&CookStatus>` is the
-//! projection onto it. Reports emit it as an additive `lifecycle_status`
-//! beside the unchanged `status`, so callers that match on the raw string keep
-//! working while a machine consumer gets a decidable classification.
+//! `homeboy_core::run_lifecycle_status::RunLifecycleStatus` is the internal
+//! closed vocabulary that answers those questions, and `From<&CookStatus>` is
+//! the projection onto it. External consumers read canonical lifecycle and
+//! retry eligibility from `homeboy/control-plane-run/v1`.
 //!
 //! That projection is deliberately *not* an authority on terminality. It is
 //! pinned to agree with [`CookStatus::is_in_flight`] for every known variant,
-//! and reports emit `terminal` from the declared [`CookDisposition`] below.
+//! while internal aggregation reads terminality from the declared
+//! [`CookDisposition`] below.
 //! [`CookStatus::Unknown`] projects to an explicit "unknown" rather than a
 //! manufactured failure, for exactly the reason terminality is declared here
 //! rather than inferred.

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -216,8 +216,6 @@ pub struct RunnerExecutionRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agent_task_run_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mirror_run_id: Option<String>,
     /// Flattened runtime view of `path_materialization_plan`, populated only by
     /// [`RunnerExecutionRecord::projection`]. Always empty on a stored record,
@@ -358,7 +356,6 @@ impl RunnerExecutionRecord {
             job_id: None,
             local_run_id: None,
             remote_run_id: None,
-            agent_task_run_id: None,
             mirror_run_id: None,
             materialized_paths: Vec::new(),
             path_materialization_plan: None,
@@ -410,11 +407,6 @@ impl RunnerExecutionRecord {
     pub fn with_mirror_run_id(mut self, mirror_run_id: Option<String>) -> Self {
         self.mirror_run_id = mirror_run_id.clone();
         self.remote_run_id = mirror_run_id;
-        self
-    }
-
-    pub fn with_agent_task_run_id(mut self, agent_task_run_id: impl Into<String>) -> Self {
-        self.agent_task_run_id = Some(agent_task_run_id.into());
         self
     }
 
@@ -725,6 +717,22 @@ mod tests {
         assert_eq!(record.status, "planned");
         assert!(record.job_id.is_none());
         assert!(record.artifact_refs.is_empty());
+    }
+
+    #[test]
+    fn retired_agent_task_run_id_is_accepted_but_not_reemitted() {
+        let record: RunnerExecutionRecord = serde_json::from_value(serde_json::json!({
+            "schema": RUNNER_EXECUTION_RECORD_SCHEMA,
+            "execution_id": "execution-1",
+            "runner_id": "runner-1",
+            "transport": "daemon",
+            "status": "planned",
+            "agent_task_run_id": "legacy-run"
+        }))
+        .expect("legacy runner record");
+
+        let value = serde_json::to_value(record).expect("runner record");
+        assert!(value.get("agent_task_run_id").is_none());
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -1631,8 +1631,15 @@ impl AgentTaskBatchStore {
         batch_id: &str,
         child_run_id: &str,
         finalization: Value,
+        terminal_state: Option<AgentTaskRunState>,
     ) -> Result<()> {
-        record_child_finalization_in_store(self, batch_id, child_run_id, finalization)
+        record_child_finalization_in_store(
+            self,
+            batch_id,
+            child_run_id,
+            finalization,
+            terminal_state,
+        )
     }
 
     /// Read the persisted durable batch record.
@@ -2016,11 +2023,13 @@ pub(crate) fn record_child_finalization(
     batch_id: &str,
     child_run_id: &str,
     finalization: Value,
+    terminal_state: Option<AgentTaskRunState>,
 ) -> Result<()> {
     AgentTaskBatchStore::from_current_data_root()?.record_child_finalization(
         batch_id,
         child_run_id,
         finalization,
+        terminal_state,
     )
 }
 
@@ -2029,38 +2038,9 @@ pub fn record_child_finalization_in_store(
     batch_id: &str,
     child_run_id: &str,
     finalization: Value,
+    terminal_state: Option<AgentTaskRunState>,
 ) -> Result<()> {
     store.mutate_batch(batch_id, |batch| {
-        let terminal_state = finalization
-            .get("terminal")
-            .and_then(Value::as_bool)
-            .filter(|terminal| *terminal)
-            .and_then(|_| finalization.get("lifecycle_status"))
-            .cloned()
-            .and_then(|state| {
-                serde_json::from_value::<homeboy_core::run_lifecycle_status::RunLifecycleStatus>(
-                    state,
-                )
-                .ok()
-            })
-            .and_then(|state| {
-                use homeboy_core::run_lifecycle_status::RunLifecycleStatus;
-                Some(match state {
-                    RunLifecycleStatus::Succeeded => AgentTaskRunState::Succeeded,
-                    RunLifecycleStatus::CandidateRecoverable => {
-                        AgentTaskRunState::CandidateRecoverable
-                    }
-                    RunLifecycleStatus::PartialRecoverable => AgentTaskRunState::PartialRecoverable,
-                    RunLifecycleStatus::PartialFailure => AgentTaskRunState::PartialFailure,
-                    RunLifecycleStatus::Cancelled => AgentTaskRunState::Cancelled,
-                    RunLifecycleStatus::Failed
-                    | RunLifecycleStatus::TimedOut
-                    | RunLifecycleStatus::Stale => AgentTaskRunState::Failed,
-                    RunLifecycleStatus::Queued
-                    | RunLifecycleStatus::Running
-                    | RunLifecycleStatus::Unknown => return None,
-                })
-            });
         let metadata = match &mut batch.metadata {
             Value::Object(map) => map,
             other => {
@@ -2981,6 +2961,7 @@ mod tests {
                 "batch/converge",
                 "batch_converge-a",
                 json!({ "status": "review_ready", "attempt": 1 }),
+                None,
             )
             .expect("first finalization recorded");
         // A repeated resume overwrites the same key rather than accumulating.
@@ -2989,6 +2970,7 @@ mod tests {
                 "batch/converge",
                 "batch_converge-a",
                 json!({ "status": "review_ready", "attempt": 2 }),
+                None,
             )
             .expect("second finalization overwrites");
 
@@ -3875,10 +3857,20 @@ mod tests {
             .expect("persist planning record");
         std::thread::scope(|scope| {
             let first = scope.spawn(|| {
-                store.record_child_finalization("finalize-wave", "a-run", json!({ "attempt": 1 }))
+                store.record_child_finalization(
+                    "finalize-wave",
+                    "a-run",
+                    json!({ "attempt": 1 }),
+                    None,
+                )
             });
             let second = scope.spawn(|| {
-                store.record_child_finalization("finalize-wave", "b-run", json!({ "attempt": 1 }))
+                store.record_child_finalization(
+                    "finalize-wave",
+                    "b-run",
+                    json!({ "attempt": 1 }),
+                    None,
+                )
             });
             first
                 .join()

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -632,8 +632,7 @@ pub(crate) fn expire_unaccepted_lab_handoff_in_store(
                 runner_id,
                 "daemon",
                 1,
-            )
-            .with_agent_task_run_id(record_run_id),
+            ),
         )
         .unwrap_or(Value::Null),
     );
@@ -799,7 +798,6 @@ pub(crate) fn apply_runner_job_terminal_state(
         .runner_id()
         .zip(record.runner_job_id())
         .map(|(runner_id, runner_job_id)| (runner_id.to_string(), runner_job_id.to_string()));
-    let agent_task_run_id = record.run_id.clone();
     let metadata = record.ensure_metadata_object();
     metadata.insert("runner_job_status".to_string(), json!(status));
     metadata.insert("runner_job_events".to_string(), json!(events));
@@ -817,8 +815,7 @@ pub(crate) fn apply_runner_job_terminal_state(
                         1
                     },
                 )
-                .with_job_id(&runner_job_id)
-                .with_agent_task_run_id(agent_task_run_id),
+                .with_job_id(&runner_job_id),
             )
             .unwrap_or(Value::Null),
         );
@@ -840,7 +837,6 @@ pub(crate) fn record_runner_job_terminal_metadata(
         .runner_id()
         .zip(record.runner_job_id())
         .map(|(runner_id, runner_job_id)| (runner_id.to_string(), runner_job_id.to_string()));
-    let agent_task_run_id = record.run_id.clone();
     let metadata = record.ensure_metadata_object();
     metadata.insert("runner_job_status".to_string(), json!(status));
     metadata.insert("runner_job_events".to_string(), json!(events));
@@ -858,8 +854,7 @@ pub(crate) fn record_runner_job_terminal_metadata(
                         1
                     },
                 )
-                .with_job_id(&runner_job_id)
-                .with_agent_task_run_id(agent_task_run_id),
+                .with_job_id(&runner_job_id),
             )
             .unwrap_or(Value::Null),
         );

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -765,8 +765,7 @@ pub(crate) fn record_detached_lab_run_with_submission_in_store(
                 input.runner_id,
                 "daemon",
             )
-            .with_job_id(input.runner_job_id)
-            .with_agent_task_run_id(&run_id),
+            .with_job_id(input.runner_job_id),
         )
         .unwrap_or(Value::Null),
     );
@@ -920,8 +919,7 @@ fn record_lab_offload_proxy_in_store(
             serde_json::to_value(
                 homeboy_core::runner_execution_envelope::RunnerExecutionRecord::planned(
                     &run_id, runner_id, "daemon",
-                )
-                .with_agent_task_run_id(&run_id),
+                ),
             )
             .unwrap_or(Value::Null),
         );

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -392,8 +392,8 @@ pub(crate) fn bind_pending_lab_handoff_snapshot_in_store(
 /// This is the recovery-safe fallback for
 /// [`bind_pending_lab_handoff_snapshot_in_store`]:
 /// it only yields a runner when the execution record is *planned* (not yet
-/// bound to a job id) and names this exact run, so binding a replacement job
-/// cannot latch onto a terminal or mismatched execution record.
+/// bound to a job id), so binding a replacement job cannot latch onto a
+/// terminal execution record. The outer lifecycle record owns run identity.
 fn planned_execution_record_runner_id(record: &AgentTaskRunRecord) -> Option<String> {
     let execution = record
         .metadata
@@ -405,13 +405,6 @@ fn planned_execution_record_runner_id(record: &AgentTaskRunRecord) -> Option<Str
                 .ok()
         })?;
     if execution.job_id.is_some() {
-        return None;
-    }
-    if execution
-        .agent_task_run_id
-        .as_deref()
-        .is_some_and(|run_id| run_id != record.run_id)
-    {
         return None;
     }
     let runner_id = execution.runner_id.trim();

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -943,10 +943,6 @@ impl AgentTaskRunRecord {
             .and_then(Value::as_str)
             == Some("planned")
             && execution
-                .and_then(|value| value.get("agent_task_run_id"))
-                .and_then(Value::as_str)
-                == Some(self.run_id.as_str())
-            && execution
                 .and_then(|value| value.get("runner_id"))
                 .and_then(Value::as_str)
                 .is_some_and(|runner_id| self.runner_id() == Some(runner_id))

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -618,6 +618,7 @@ fn detached_handoff_persists_only_the_runner_api_replay_envelope() {
             envelope: legacy.execution_envelope(),
             workspace_claim_binding: None,
             workspace_owner_lease: None,
+            credential_delivery: None,
         };
 
         let pending = record_lab_offload_submission_envelope(run_id, &submission)

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1278,12 +1278,8 @@ pub struct AgentTaskCandidateAdoptionOptions {
 
 /// A Cook outcome.
 ///
-/// `Serialize` is written by hand rather than derived so the additive
-/// [`RunLifecycleProjection`] is emitted by *every* producer of this type
-/// without each of the ~30 struct literals that build it having to carry three
-/// more fields it would then be free to compute differently. The projection is
-/// derived from `status` and `disposition`, which are already present, so
-/// there is nothing for a call site to supply and nothing for it to get wrong.
+/// `Serialize` is written by hand so the derived completion projection is
+/// emitted by every producer without duplicating it across report constructors.
 #[derive(Debug, Clone)]
 pub struct AgentTaskCookReport {
     pub schema: &'static str,
@@ -1342,8 +1338,7 @@ pub struct AgentTaskCookCompletion {
     pub next_action: Option<AgentTaskCookRecoveryAction>,
 }
 
-/// The closed-vocabulary classification emitted beside an open `status`
-/// string.
+/// Internal closed-vocabulary classification of an open `status` string.
 ///
 /// # Why a report carries this at all
 ///
@@ -1352,7 +1347,9 @@ pub struct AgentTaskCookCompletion {
 /// contract every *process* caller branches on, but a consumer reading a
 /// persisted report or an HTTP response has no exit code. Without this, such a
 /// consumer receiving `{"status": "moving_base"}` cannot decide success,
-/// completion, or retry at all.
+/// completion, or retry from the Cook document. External consumers use the
+/// canonical control-plane run resource; this projection remains internal to
+/// Cook and batch aggregation.
 ///
 /// # Where each field's authority comes from
 ///
@@ -1412,8 +1409,7 @@ impl serde::Serialize for AgentTaskCookReport {
         serializer: S,
     ) -> std::result::Result<S::Ok, S::Error> {
         /// Mirrors [`AgentTaskCookReport`] field for field, in order, with the
-        /// same `skip_serializing_if` rules, plus the three appended
-        /// projection fields. Borrowed so serialization stays
+        /// same `skip_serializing_if` rules. Borrowed so serialization stays
         /// allocation-free.
         #[derive(serde::Serialize)]
         struct Wire<'a> {
@@ -1448,14 +1444,8 @@ impl serde::Serialize for AgentTaskCookReport {
             failure_context: Option<&'a AgentTaskCookFailureContext>,
             #[serde(skip_serializing_if = "Option::is_none")]
             completion: Option<AgentTaskCookCompletion>,
-            // Additive. `status` above is unchanged and remains the field
-            // callers match on.
-            lifecycle_status: RunLifecycleStatus,
-            terminal: bool,
-            retryable: bool,
         }
 
-        let lifecycle = self.lifecycle();
         let completion = self.completion();
         let wire = Wire {
             schema: self.schema,
@@ -1476,9 +1466,6 @@ impl serde::Serialize for AgentTaskCookReport {
             moving_base_recovery: self.moving_base_recovery.as_ref(),
             failure_context: self.failure_context.as_ref(),
             completion,
-            lifecycle_status: lifecycle.lifecycle_status,
-            terminal: lifecycle.terminal,
-            retryable: lifecycle.retryable,
         };
         serde::Serialize::serialize(&wire, serializer)
     }
@@ -1922,10 +1909,7 @@ impl From<&Error> for AgentTaskCookCellError {
 
 /// One child's outcome inside a batch.
 ///
-/// `Serialize` is hand-written for the same reason as [`AgentTaskCookReport`]:
-/// the lifecycle projection is derived from fields already present, so it is
-/// emitted for every producer instead of being a fourth thing a call site can
-/// forget or contradict.
+/// `Serialize` preserves the existing omission rules for optional fields.
 #[derive(Debug, Clone)]
 pub struct AgentTaskCookBatchCellReport {
     pub cook_id: String,
@@ -1970,12 +1954,8 @@ impl serde::Serialize for AgentTaskCookBatchCellReport {
             result: Option<&'a AgentTaskCookReport>,
             #[serde(skip_serializing_if = "Option::is_none")]
             error: Option<&'a AgentTaskCookCellError>,
-            lifecycle_status: RunLifecycleStatus,
-            terminal: bool,
-            retryable: bool,
         }
 
-        let lifecycle = self.lifecycle();
         let wire = Wire {
             cook_id: &self.cook_id,
             initial_run_id: &self.initial_run_id,
@@ -1983,9 +1963,6 @@ impl serde::Serialize for AgentTaskCookBatchCellReport {
             exit_code: self.exit_code,
             result: self.result.as_ref(),
             error: self.error.as_ref(),
-            lifecycle_status: lifecycle.lifecycle_status,
-            terminal: lifecycle.terminal,
-            retryable: lifecycle.retryable,
         };
         serde::Serialize::serialize(&wire, serializer)
     }
@@ -2072,12 +2049,8 @@ impl serde::Serialize for AgentTaskCookBatchReport {
             cancelled: usize,
             timed_out: usize,
             cooks: &'a [AgentTaskCookBatchCellReport],
-            lifecycle_status: RunLifecycleStatus,
-            terminal: bool,
-            retryable: bool,
         }
 
-        let lifecycle = self.lifecycle();
         let wire = Wire {
             schema: self.schema,
             batch_id: &self.batch_id,
@@ -2090,9 +2063,6 @@ impl serde::Serialize for AgentTaskCookBatchReport {
             cancelled: self.cancelled,
             timed_out: self.timed_out,
             cooks: &self.cooks,
-            lifecycle_status: lifecycle.lifecycle_status,
-            terminal: lifecycle.terminal,
-            retryable: lifecycle.retryable,
         };
         serde::Serialize::serialize(&wire, serializer)
     }
@@ -2205,17 +2175,19 @@ mod run_lifecycle_projection_tests {
         }
     }
 
-    /// The whole point: the raw, open status is untouched and the closed
-    /// classification arrives beside it.
     #[test]
-    fn a_cook_report_emits_the_projection_without_changing_status() {
-        let value = serde_json::to_value(report("durable_failure", CookDisposition::Terminal))
-            .expect("serialize");
+    fn a_cook_report_omits_the_retired_lifecycle_projection() {
+        let report = report("durable_failure", CookDisposition::Terminal);
+        let lifecycle = report.lifecycle();
+        let value = serde_json::to_value(report).expect("serialize");
 
         assert_eq!(value["status"], "durable_failure");
-        assert_eq!(value["lifecycle_status"], "failed");
-        assert_eq!(value["terminal"], true);
-        assert_eq!(value["retryable"], true);
+        assert_eq!(lifecycle.lifecycle_status, RunLifecycleStatus::Failed);
+        assert!(lifecycle.terminal);
+        assert!(lifecycle.retryable);
+        assert!(value.get("lifecycle_status").is_none());
+        assert!(value.get("terminal").is_none());
+        assert!(value.get("retryable").is_none());
         // Unchanged fields must still be present and still be skipped when
         // absent, exactly as the derived implementation did.
         assert_eq!(value["schema"], "homeboy/agent-task-cook/v1");
@@ -2230,14 +2202,14 @@ mod run_lifecycle_projection_tests {
     /// however its status string reads.
     #[test]
     fn terminality_follows_the_declared_disposition_not_the_status_string() {
-        let value = serde_json::to_value(report("durable_failure", CookDisposition::InFlight))
-            .expect("serialize");
+        let report = report("durable_failure", CookDisposition::InFlight);
+        let lifecycle = report.lifecycle();
 
-        assert_eq!(value["lifecycle_status"], "failed");
-        assert_eq!(value["terminal"], false);
+        assert_eq!(lifecycle.lifecycle_status, RunLifecycleStatus::Failed);
+        assert!(!lifecycle.terminal);
         assert_eq!(
-            value["retryable"], false,
-            "a Cook a durable owner still carries must never be advertised as retryable"
+            lifecycle.retryable, false,
+            "a Cook a durable owner still carries must never be treated as retryable"
         );
     }
 
@@ -2245,31 +2217,34 @@ mod run_lifecycle_projection_tests {
     /// classification, never a manufactured failure — while `terminal` still
     /// arrives, because the exit declared it.
     #[test]
-    fn an_unreadable_status_reports_unknown_but_still_reports_terminality() {
-        let value = serde_json::to_value(report("moving_base", CookDisposition::Terminal))
-            .expect("serialize");
+    fn an_unreadable_status_classifies_unknown_but_retains_terminality() {
+        let report = report("moving_base", CookDisposition::Terminal);
+        let lifecycle = report.lifecycle();
+        let value = serde_json::to_value(report).expect("serialize");
 
         assert_eq!(value["status"], "moving_base");
-        assert_eq!(value["lifecycle_status"], "unknown");
-        assert_eq!(value["terminal"], true);
-        assert_eq!(value["retryable"], false);
+        assert_eq!(lifecycle.lifecycle_status, RunLifecycleStatus::Unknown);
+        assert!(lifecycle.terminal);
+        assert!(!lifecycle.retryable);
     }
 
     /// A cell that carries a child report defers to that report's declared
     /// disposition rather than re-deriving anything.
     #[test]
     fn a_batch_cell_defers_to_its_childs_declared_disposition() {
-        let value = serde_json::to_value(cell(
+        let cell = cell(
             "durable_failure",
             Some(report("durable_failure", CookDisposition::InFlight)),
-        ))
-        .expect("serialize");
+        );
+        let lifecycle = cell.lifecycle();
+        let value = serde_json::to_value(cell).expect("serialize");
 
         assert_eq!(value["status"], "durable_failure");
         assert_eq!(value["exit_code"], 1);
-        assert_eq!(value["lifecycle_status"], "failed");
-        assert_eq!(value["terminal"], false);
-        assert_eq!(value["result"]["terminal"], false);
+        assert_eq!(lifecycle.lifecycle_status, RunLifecycleStatus::Failed);
+        assert!(!lifecycle.terminal);
+        assert!(value.get("lifecycle_status").is_none());
+        assert!(value["result"].get("terminal").is_none());
     }
 
     /// A child that failed before producing any Cook report has no declared
@@ -2277,11 +2252,14 @@ mod run_lifecycle_projection_tests {
     /// in-flight reading.
     #[test]
     fn a_batch_cell_without_a_child_report_classifies_from_status_alone() {
-        let value = serde_json::to_value(cell("failed", None)).expect("serialize");
+        let cell = cell("failed", None);
+        let lifecycle = cell.lifecycle();
+        let value = serde_json::to_value(cell).expect("serialize");
 
-        assert_eq!(value["lifecycle_status"], "failed");
-        assert_eq!(value["terminal"], true);
-        assert_eq!(value["retryable"], true);
+        assert_eq!(lifecycle.lifecycle_status, RunLifecycleStatus::Failed);
+        assert!(lifecycle.terminal);
+        assert!(lifecycle.retryable);
+        assert!(value.get("lifecycle_status").is_none());
         assert!(value.get("result").is_none());
     }
 
@@ -2325,7 +2303,7 @@ mod run_lifecycle_projection_tests {
     }
 
     #[test]
-    fn a_batch_report_emits_the_projection_beside_its_status() {
+    fn a_batch_report_omits_the_retired_lifecycle_projection() {
         let report = AgentTaskCookBatchReport {
             schema: "homeboy/agent-task-cook-batch/v1",
             batch_id: "batch-projection".to_string(),
@@ -2341,14 +2319,18 @@ mod run_lifecycle_projection_tests {
         };
 
         let value = serde_json::to_value(&report).expect("serialize");
+        let lifecycle = report.lifecycle();
 
         assert_eq!(value["status"], "partial_failure");
-        assert_eq!(value["lifecycle_status"], "partial_failure");
-        assert_eq!(value["terminal"], true);
         assert_eq!(
-            value["retryable"], false,
-            "a partially failed batch must not be advertised as blanket-retryable"
+            lifecycle.lifecycle_status,
+            RunLifecycleStatus::PartialFailure
         );
+        assert!(lifecycle.terminal);
+        assert!(!lifecycle.retryable);
+        assert!(value.get("lifecycle_status").is_none());
+        assert!(value.get("terminal").is_none());
+        assert!(value.get("retryable").is_none());
     }
 
     #[test]
@@ -2899,6 +2881,7 @@ pub fn run_cook_batch_with_control(
                                 &batch_id,
                                 &cell.initial_run_id,
                                 child_finalization_value(&cell),
+                                child_terminal_state(&cell),
                             ) {
                                 // Cleanup cannot consume a successful outcome
                                 // until its batch checkpoint is durable.
@@ -3215,6 +3198,7 @@ where
             batch_id,
             &child.run_id,
             child_finalization_value(&cell),
+            child_terminal_state(&cell),
         )?;
         cells.push(cell);
     }
@@ -3425,19 +3409,37 @@ where
 ///
 /// `error` follows [`AgentTaskCookBatchCellReport::error`] and is therefore now
 /// an object rather than a string; `error.message` carries the text the field
-/// used to hold. `status` and `exit_code` are unchanged, and
-/// `lifecycle_status`/`terminal`/`retryable` are added so an owner reading only
-/// this checkpoint can classify the child without loading its report.
+/// used to hold. `status` and `exit_code` are unchanged. Canonical lifecycle is
+/// persisted directly on the batch child rather than duplicated in this JSON.
 fn child_finalization_value(cell: &AgentTaskCookBatchCellReport) -> Value {
-    let lifecycle = cell.lifecycle();
     serde_json::json!({
         "resumed_at": chrono::Utc::now().to_rfc3339(),
         "exit_code": cell.exit_code,
         "status": cell.status,
-        "lifecycle_status": lifecycle.lifecycle_status,
-        "terminal": lifecycle.terminal,
-        "retryable": lifecycle.retryable,
         "error": cell.error,
+    })
+}
+
+fn child_terminal_state(
+    cell: &AgentTaskCookBatchCellReport,
+) -> Option<crate::agent_task_lifecycle::AgentTaskRunState> {
+    let lifecycle = cell.lifecycle();
+    if !lifecycle.terminal {
+        return None;
+    }
+    use crate::agent_task_lifecycle::AgentTaskRunState;
+    Some(match lifecycle.lifecycle_status {
+        RunLifecycleStatus::Succeeded => AgentTaskRunState::Succeeded,
+        RunLifecycleStatus::CandidateRecoverable => AgentTaskRunState::CandidateRecoverable,
+        RunLifecycleStatus::PartialRecoverable => AgentTaskRunState::PartialRecoverable,
+        RunLifecycleStatus::PartialFailure => AgentTaskRunState::PartialFailure,
+        RunLifecycleStatus::Cancelled => AgentTaskRunState::Cancelled,
+        RunLifecycleStatus::Failed | RunLifecycleStatus::TimedOut | RunLifecycleStatus::Stale => {
+            AgentTaskRunState::Failed
+        }
+        RunLifecycleStatus::Queued | RunLifecycleStatus::Running | RunLifecycleStatus::Unknown => {
+            return None
+        }
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -14017,7 +14017,7 @@ fn terminality_is_declared_by_the_exit_not_read_from_the_status_string() {
 }
 
 #[test]
-fn selection_required_serializes_as_a_known_terminal_partial_failure() {
+fn selection_required_keeps_internal_lifecycle_out_of_the_cook_wire_format() {
     let report = cook_report(CookReportInput {
         cook_id: "cook-selection-lifecycle".to_string(),
         status: "selection_required",
@@ -14031,9 +14031,16 @@ fn selection_required_serializes_as_a_known_terminal_partial_failure() {
 
     let serialized = serde_json::to_value(&report.value).expect("serialize Cook report");
     assert_eq!(serialized["status"], "selection_required");
-    assert_eq!(serialized["lifecycle_status"], "partial_failure");
-    assert_eq!(serialized["terminal"], true);
-    assert_eq!(serialized["retryable"], false);
+    let lifecycle = report.value.lifecycle();
+    assert_eq!(
+        lifecycle.lifecycle_status,
+        RunLifecycleStatus::PartialFailure
+    );
+    assert!(lifecycle.terminal);
+    assert!(!lifecycle.retryable);
+    assert!(serialized.get("lifecycle_status").is_none());
+    assert!(serialized.get("terminal").is_none());
+    assert!(serialized.get("retryable").is_none());
 }
 
 #[test]

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -14,12 +14,12 @@ use homeboy_control_plane_contract::{
     ControlPlaneActionRequest, ControlPlaneAdmissionRetry, ControlPlaneAdmissionRetryDisposition,
     ControlPlaneAttempt, ControlPlaneAttemptListRequest, ControlPlaneAttemptPage,
     ControlPlaneBlocker, ControlPlaneCancelDisposition, ControlPlaneCancelParameters,
-    ControlPlaneCancelResult, ControlPlaneCapabilities, ControlPlaneCompatibilityWindow,
-    ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEventAppendRequest,
-    ControlPlaneEventRetention, ControlPlaneEventSource, ControlPlaneEvidenceRef,
-    ControlPlaneExecution, ControlPlaneExecutionPage, ControlPlaneLiveness, ControlPlaneLocation,
-    ControlPlaneMission, ControlPlaneMissionListRequest, ControlPlaneMissionPage,
-    ControlPlaneOperation, ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneReference,
+    ControlPlaneCancelResult, ControlPlaneCapabilities, ControlPlaneError, ControlPlaneErrorClass,
+    ControlPlaneEventAppendRequest, ControlPlaneEventRetention, ControlPlaneEventSource,
+    ControlPlaneEvidenceRef, ControlPlaneExecution, ControlPlaneExecutionPage,
+    ControlPlaneLiveness, ControlPlaneLocation, ControlPlaneMission,
+    ControlPlaneMissionListRequest, ControlPlaneMissionPage, ControlPlaneOperation,
+    ControlPlaneOwner, ControlPlaneProviderSummary, ControlPlaneReference,
     ControlPlaneReferencePage, ControlPlaneReferenceRegistration, ControlPlaneReferenceType,
     ControlPlaneResource, ControlPlaneRun, ControlPlaneRunListRequest, ControlPlaneRunPage,
     ControlPlaneRunPlacement, ControlPlaneRunPlacementEffective, ControlPlaneRunPlacementRequested,
@@ -1477,20 +1477,6 @@ impl OrchestrationService<LifecycleStoreLookup> {
         capabilities
             .operations
             .push(ControlPlaneOperation::ExecuteRunAction);
-        capabilities.compatibility_windows = vec![
-            ControlPlaneCompatibilityWindow {
-                projection: "homeboy/agent-task-cook/v1#lifecycle_status,terminal,retryable"
-                    .to_string(),
-                replacement_schema: "homeboy/control-plane-run/v1#state,action_eligibility"
-                    .to_string(),
-                remove_in: "0.371.0".to_string(),
-            },
-            ControlPlaneCompatibilityWindow {
-                projection: "homeboy/runner-execution-record/v1#agent_task_run_id".to_string(),
-                replacement_schema: "homeboy/control-plane-run/v1#run".to_string(),
-                remove_in: "0.371.0".to_string(),
-            },
-        ];
         capabilities
     }
 
@@ -5669,20 +5655,7 @@ mod tests {
             ]
         );
         assert!(!capabilities.operations.is_empty());
-        assert_eq!(capabilities.compatibility_windows.len(), 2);
-        assert!(capabilities
-            .compatibility_windows
-            .iter()
-            .all(|window| window.remove_in == "0.371.0"));
-        assert!(capabilities.compatibility_windows.iter().any(|window| {
-            window.projection == "homeboy/agent-task-cook/v1#lifecycle_status,terminal,retryable"
-                && window.replacement_schema
-                    == "homeboy/control-plane-run/v1#state,action_eligibility"
-        }));
-        assert!(capabilities.compatibility_windows.iter().any(|window| {
-            window.projection == "homeboy/runner-execution-record/v1#agent_task_run_id"
-                && window.replacement_schema == "homeboy/control-plane-run/v1#run"
-        }));
+        assert!(capabilities.compatibility_windows.is_empty());
     }
 
     #[test]

--- a/crates/homeboy-cli/src/command_contract/constants.rs
+++ b/crates/homeboy-cli/src/command_contract/constants.rs
@@ -376,7 +376,6 @@ pub(crate) fn runner_execution_record_constants() -> RunnerExecutionRecordConsta
             "job_id".to_string(),
             "local_run_id".to_string(),
             "remote_run_id".to_string(),
-            "agent_task_run_id".to_string(),
             "mirror_run_id".to_string(),
             "materialized_paths".to_string(),
             "artifact_refs".to_string(),

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -2457,7 +2457,6 @@ fn batch_cook_result(
                 .as_ref()
                 .map(|result| serde_json::to_value(result).unwrap_or(Value::Null))
                 .unwrap_or_else(|| serde_json::json!({ "error": cell.error }));
-            let lifecycle = cell.lifecycle();
             serde_json::json!({
                 "cook_id": cook.cook_id,
                 "run_id": cook.run_id(),
@@ -2465,12 +2464,6 @@ fn batch_cook_result(
                 "head": cook.head,
                 "workspace_materialization": cook.workspace_materialization,
                 "exit_code": cell.exit_code,
-                // The closed-vocabulary classification, so a caller reading
-                // this envelope out of a file or an HTTP response can decide
-                // completion and retry without a process exit code.
-                "lifecycle_status": lifecycle.lifecycle_status,
-                "terminal": lifecycle.terminal,
-                "retryable": lifecycle.retryable,
                 "result": cell_result,
             })
         })
@@ -11011,6 +11004,11 @@ fi
         active_failed_report.failed = 1;
         active_failed_report.cooks[0].status = "in_flight".to_string();
         let (data, exit_code) = batch_cook_result(&plan, result, &test_concurrency_decision());
+        for cook in data["cooks"].as_array().expect("batch cooks") {
+            assert!(cook.get("lifecycle_status").is_none());
+            assert!(cook.get("terminal").is_none());
+            assert!(cook.get("retryable").is_none());
+        }
         let envelope = crate::commands::utils::response::cli_response_for_json_result_for_command(
             &Ok(data),
             exit_code,

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -2176,7 +2176,6 @@ fn diagnose_surfaces_queued_runner_ownership_before_a_job_id_is_recorded() {
             record.metadata["runner_id"] = json!("homeboy-lab");
             record.metadata["runner_execution_record"] = json!({
                 "status": "planned",
-                "agent_task_run_id": run_id,
                 "runner_id": "homeboy-lab"
             });
             record.metadata["cook_progress"] = json!({ "phase": "provider_start" });

--- a/crates/homeboy-core/src/run_outcome_envelope.rs
+++ b/crates/homeboy-core/src/run_outcome_envelope.rs
@@ -76,12 +76,11 @@ impl RunOutcomeEnvelope {
         self
     }
 
-    pub fn from_runner_execution_record(record: &RunnerExecutionRecord) -> Self {
-        let run_id = runner_execution_record_run_id(record);
+    pub fn from_runner_execution_record(run_id: &str, record: &RunnerExecutionRecord) -> Self {
         let mut envelope = Self::new(record.status.clone())
-            .with_run_id(Some(run_id.clone()))
+            .with_run_id(Some(run_id.to_string()))
             .with_runner_id(Some(record.runner_id.clone()));
-        envelope.add_runner_execution_artifact_refs(&run_id, record.artifact_refs.clone());
+        envelope.add_runner_execution_artifact_refs(run_id, record.artifact_refs.clone());
         envelope
     }
 
@@ -261,17 +260,6 @@ fn metadata_string(metadata: Option<&Value>, key: &str) -> Option<String> {
     metadata?.get(key)?.as_str().map(ToString::to_string)
 }
 
-fn runner_execution_record_run_id(record: &RunnerExecutionRecord) -> String {
-    record
-        .remote_run_id
-        .clone()
-        .or_else(|| record.mirror_run_id.clone())
-        .or_else(|| record.agent_task_run_id.clone())
-        .or_else(|| record.local_run_id.clone())
-        .or_else(|| record.job_id.clone())
-        .unwrap_or_else(|| record.execution_id.clone())
-}
-
 fn artifact_type(path: Option<&str>, url: Option<&str>) -> String {
     if path.is_some() || url.is_some() {
         "file".to_string()
@@ -371,8 +359,10 @@ mod tests {
                 ..Default::default()
             }]);
 
-        let value = serde_json::to_value(RunOutcomeEnvelope::from_runner_execution_record(&record))
-            .expect("outcome json");
+        let value = serde_json::to_value(RunOutcomeEnvelope::from_runner_execution_record(
+            "run-1", &record,
+        ))
+        .expect("outcome json");
 
         assert_eq!(value["schema"], RUN_OUTCOME_ENVELOPE_SCHEMA);
         assert_eq!(value["status"], "succeeded");

--- a/crates/homeboy-lab-runner/src/worker/result.rs
+++ b/crates/homeboy-lab-runner/src/worker/result.rs
@@ -83,6 +83,18 @@ pub(super) fn remote_runner_result_from_exec_output(
         data[AGENT_TASK_DISPATCH_HANDOFF_EVENT_KEY] =
             serde_json::to_value(handoff_event).unwrap_or(serde_json::Value::Null);
     }
+    let fallback_outcome_run_id = lab_runner_workload
+        .as_ref()
+        .map(|workload| {
+            workload
+                .agent_task
+                .as_ref()
+                .map(|agent_task| agent_task.run_id.clone())
+                .unwrap_or_else(|| workload.workload_id.clone())
+        })
+        .or_else(|| exec_output.mirror_run_id.clone())
+        .or_else(|| exec_output.job_id.clone())
+        .unwrap_or_else(|| exec_output.runner_id.clone());
     if let Some(lab_runner_workload) = lab_runner_workload {
         data["runner_workload"] = serde_json::to_value(
             super::super::workload::lab_runner_workload_with_result_refs(
@@ -94,13 +106,8 @@ pub(super) fn remote_runner_result_from_exec_output(
         )
         .unwrap_or(serde_json::Value::Null);
     }
-    let fallback_outcome_run_id = exec_output
-        .mirror_run_id
-        .clone()
-        .or_else(|| exec_output.job_id.clone())
-        .unwrap_or_else(|| exec_output.runner_id.clone());
     let mut outcome = if let Some(execution_record) = execution_record.as_ref() {
-        RunOutcomeEnvelope::from_runner_execution_record(execution_record)
+        RunOutcomeEnvelope::from_runner_execution_record(&fallback_outcome_run_id, execution_record)
     } else {
         RunOutcomeEnvelope::new(if exit_code == 0 {
             "succeeded"


### PR DESCRIPTION
## Summary
- stop emitting Cook lifecycle/retry projections now owned by the canonical control-plane run resource
- remove the duplicate agent-task run ID from runner execution records and require canonical outer identity at conversion boundaries
- preserve legacy JSON readability while removing the expired compatibility windows

Part of #8282.

## Verification
- `cargo check --workspace --tests`
- focused Cook serialization, batch finalization, runner compatibility, Lab result, planned handoff, fanout CLI, and capability tests
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect the control-plane contracts, implement the projection removal, run regression tests, and review the final diff.