### PR TITLE
perf(lab-runner): stop paying production probe budgets and thousand-entry fixtures in tests

### DIFF
--- a/crates/homeboy-lab-runner/src/readonly_probe.rs
+++ b/crates/homeboy-lab-runner/src/readonly_probe.rs
@@ -24,7 +24,15 @@ use serde::Serialize;
 ///
 /// Matches the existing `REMOTE_DAEMON_STATUS_TIMEOUT` used by the remote
 /// daemon status probe so the read-only surface has one consistent budget.
+#[cfg(not(test))]
 pub const DEFAULT_READONLY_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Under test the probe never reaches a real remote, so the production budget
+/// is pure dead wall-clock: a single refresh test spent 90s waiting out probe
+/// deadlines it could never beat. Tests that assert the bound itself pass the
+/// value explicitly rather than depending on this default.
+#[cfg(test)]
+pub const DEFAULT_READONLY_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Environment override for [`readonly_probe_timeout`], in whole seconds.
 pub const READONLY_PROBE_TIMEOUT_ENV: &str = "HOMEBOY_READONLY_PROBE_TIMEOUT_SECONDS";

--- a/crates/homeboy-lab-runner/src/runner_probe_gate.rs
+++ b/crates/homeboy-lab-runner/src/runner_probe_gate.rs
@@ -61,7 +61,12 @@ pub const DEFAULT_PROBE_FAILURE_TTL: Duration = Duration::from_secs(5);
 /// Maximum probes in flight to a single runner, across all callers.
 pub const DEFAULT_PROBE_CONCURRENCY: usize = 2;
 /// How long a coalesced caller waits on the in-flight probe before taking over.
+#[cfg(not(test))]
 pub const DEFAULT_PROBE_WAIT: Duration = Duration::from_secs(60);
+/// See [`crate::readonly_probe::DEFAULT_READONLY_PROBE_TIMEOUT`]: a coalesced
+/// wait under test is waiting on a probe that will never answer.
+#[cfg(test)]
+pub const DEFAULT_PROBE_WAIT: Duration = Duration::from_secs(1);
 
 /// Override for [`DEFAULT_PROBE_CACHE_TTL`], in whole seconds. `0` disables
 /// caching while leaving single-flight and the concurrency cap intact.

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -1155,8 +1155,12 @@ fn prune_convergence_resumes_durable_receipts_across_more_than_twenty_pages() {
 #[test]
 fn prune_workspaces_advances_through_thousands_of_mixed_entries() {
     homeboy_core::test_support::with_isolated_home(|_| {
-        const WORKSPACE_COUNT: usize = 5_214;
-        const ORPHAN_INDICES: [usize; 3] = [1_333, 2_607, 5_213];
+        // Pagination is what this covers: the scan limit below is 127, so this
+        // still walks several pages and places orphans mid-page, on a later
+        // page, and on the final entry. Thousands of fixtures only multiplied
+        // setup I/O without adding a distinct cursor transition.
+        const WORKSPACE_COUNT: usize = 640;
+        const ORPHAN_INDICES: [usize; 3] = [200, 401, 639];
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         let workspaces_root = runner_root.path().join("_lab_workspaces");
         fs::create_dir_all(&workspaces_root).expect("workspaces root");
@@ -1230,7 +1234,11 @@ fn prune_workspaces_advances_through_thousands_of_mixed_entries() {
 #[test]
 fn ssh_prune_scan_command_bounds_thousands_of_entries() {
     let temp = tempfile::tempdir().expect("tempdir");
-    for index in 0..5_214 {
+    // The generated scan breaks out of its read loop once `scan_limit` entries
+    // are counted, so entries beyond the limit are never processed. Size the
+    // fixture to prove the bound and the `partial` marker, not to benchmark
+    // `find`.
+    for index in 0..40 {
         write_orphan_workspace(&temp.path().join(format!("workspace-{index:05}")));
     }
 


### PR DESCRIPTION
## Summary
Three changes, 24 lines added. `homeboy_refresh` goes from **111.5s to 33.3s** with an identical result set.

## Measured
`cargo nextest run -p homeboy-lab-runner --lib -E "test(/^homeboy_refresh/)"`, same commit, clean worktrees:

| | baseline | this branch |
|---|---|---|
| `homeboy_refresh` | **111.5s** | **33.3s** |
| tests run | 102 | 102 |
| failures | 2 | 2 (same two) |

Both failures are pre-existing on this commit: `part_a::materialize_failure_preserves_compiler_diagnostics_and_active_binary` and `part_b::contending_refreshes_cannot_let_an_old_materialized_request_replace_new_selection`.

Individual tests:

| test | before | after |
|---|---|---|
| `stale_session_refresh_blocker_starts_the_newly_selected_binary` | 90.2s | **14.7s** |
| `prune_workspaces_advances_through_thousands_of_mixed_entries` | 17.4s | **3.9s** |
| `ssh_prune_scan_command_bounds_thousands_of_entries` | 14.5s | **3.5s** |

## 1. Probe budgets are dead wall-clock under test
`DEFAULT_READONLY_PROBE_TIMEOUT` is 15s and `DEFAULT_PROBE_WAIT` is 60s. Under test the probe never reaches a real remote, so those budgets are spent waiting for an answer that cannot arrive. One test alone burned 90s this way.

Both now resolve to 1s under `#[cfg(test)]`. The environment overrides and the production values are untouched, and tests that assert the bound itself pass the value explicitly rather than relying on the default.

## 2. Two fixtures built thousands of directories to prove small bounds
`ssh_prune_scan_command_bounds_thousands_of_entries` created **5,214** workspace directories to assert that a scan with `scan_limit = 5` returns 5 rows and reports `partial`. The generated shell breaks out of its read loop once the limit is counted, so entries 6 through 5,214 were never processed — the fixture was proving that `find` and `sort` work. Now 40.

`prune_workspaces_advances_through_thousands_of_mixed_entries` created the same 5,214 to exercise pagination at `limit: 127`. The property is cursor advancement across pages with orphans mid-page, on a later page, and on the final entry. That still holds at 640 entries across several pages; the extra thousands only multiplied setup I/O without adding a distinct cursor transition.

## Context
The `homeboy-lab-runner` lib binary runs against a 1500s per-binary deadline in `scripts/nextest-hermetic-test-environment.sh`. It currently exceeds that locally — it was killed at 1502s on a clean checkout. This does not fix that on its own, but it removes roughly 100s of pure waiting from the worst offenders.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode used `cargo nextest` slow-test reporting to identify the six slowest tests in the crate, verified each change against a clean baseline worktree at the same commit, and confirmed the failure set is unchanged. Chris Huber directed the work and remains responsible for acceptance.