### PR TITLE
fix(runner): preserve compact daemon lease identity

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -1492,6 +1492,14 @@ fn remote_daemon_status_with_timeout(
     let data = envelope
         .data
         .ok_or_else(|| "remote daemon status returned no data".to_string())?;
+    Ok(remote_daemon_status_from_data(&data))
+}
+
+/// Status normally uses the compact projection, while older remotes and
+/// diagnostics may return the full lease state. Both expose the same daemon
+/// coordinates; keep that representation detail at this boundary so lifecycle
+/// selection always receives one authoritative lease/PID view.
+pub(super) fn remote_daemon_status_from_data(data: &Value) -> RemoteDaemonStatus {
     let stale_reason = data
         .get("stale_reason")
         .and_then(Value::as_str)
@@ -1508,13 +1516,17 @@ fn remote_daemon_status_with_timeout(
         .pointer("/freshness")
         .cloned()
         .and_then(|value| serde_json::from_value(value).ok());
+    let daemon = data
+        .get("state")
+        .or_else(|| data.get("daemon"))
+        .map(remote_daemon_from_status);
     if !data
         .get("running")
         .and_then(Value::as_bool)
         .unwrap_or(false)
     {
-        return Ok(RemoteDaemonStatus {
-            daemon: data.get("state").map(remote_daemon_from_state),
+        return RemoteDaemonStatus {
+            daemon,
             stale_reason,
             stale_reason_code,
             fresh: data.get("fresh").and_then(Value::as_bool).unwrap_or(false),
@@ -1527,10 +1539,10 @@ fn remote_daemon_status_with_timeout(
             endpoint_probe_error: None,
             termination_evidence,
             daemon_freshness,
-        });
+        };
     }
-    let Some(state) = data.get("state") else {
-        return Ok(RemoteDaemonStatus {
+    let Some(daemon) = daemon else {
+        return RemoteDaemonStatus {
             daemon: None,
             stale_reason: Some(
                 stale_reason
@@ -1547,10 +1559,10 @@ fn remote_daemon_status_with_timeout(
             endpoint_probe_error: None,
             termination_evidence,
             daemon_freshness,
-        });
+        };
     };
-    Ok(RemoteDaemonStatus {
-        daemon: Some(remote_daemon_from_state(state)),
+    RemoteDaemonStatus {
+        daemon: Some(daemon),
         stale_reason,
         stale_reason_code,
         fresh: data.get("fresh").and_then(Value::as_bool).unwrap_or(false),
@@ -1563,7 +1575,7 @@ fn remote_daemon_status_with_timeout(
         endpoint_probe_error: None,
         termination_evidence,
         daemon_freshness,
-    })
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -1758,7 +1770,7 @@ pub(super) fn probe_remote_daemon_endpoint_until(
         RemoteDaemonWorkEvidence::from_unresolved_count(active.len().saturating_add(stale.len()));
 }
 
-fn remote_daemon_from_state(state: &Value) -> RemoteDaemon {
+fn remote_daemon_from_status(state: &Value) -> RemoteDaemon {
     RemoteDaemon {
         address: state
             .get("address")
@@ -1773,8 +1785,24 @@ fn remote_daemon_from_state(state: &Value) -> RemoteDaemon {
             .get("lease_id")
             .and_then(Value::as_str)
             .map(str::to_string),
-        version: None,
-        build_identity: None,
+        version: state
+            .get("active_version")
+            .and_then(Value::as_str)
+            .or_else(|| {
+                state
+                    .pointer("/build_identity/version")
+                    .and_then(Value::as_str)
+            })
+            .map(str::to_string),
+        build_identity: state
+            .get("active_build")
+            .and_then(Value::as_str)
+            .or_else(|| {
+                state
+                    .pointer("/build_identity/display")
+                    .and_then(Value::as_str)
+            })
+            .map(str::to_string),
         inspected_freshness: None,
     }
 }

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -28,6 +28,100 @@ fn first_connect_routes_to_idempotent_ensure_start_when_no_daemon_exists() {
     );
 }
 
+fn compact_daemon_status(
+    fresh: bool,
+    active_jobs: usize,
+    build_identity: Option<&str>,
+) -> RemoteDaemonStatus {
+    let mut daemon = serde_json::json!({
+        "lease_id": "lease-live",
+        "pid": 4646,
+        "address": "127.0.0.1:49152",
+        "active_version": "0.367.13",
+    });
+    if let Some(build_identity) = build_identity {
+        daemon["active_build"] = serde_json::Value::String(build_identity.to_string());
+    }
+    let status = remote_daemon::remote_daemon_status_from_data(&serde_json::json!({
+        "running": true,
+        "fresh": fresh,
+        "reachable": true,
+        "freshness": {
+            "active_jobs": active_jobs,
+            "stale_reason_code": fresh.then_some(serde_json::Value::Null).unwrap_or(serde_json::json!("version_mismatch")),
+        },
+        "daemon": daemon,
+    }));
+    assert_eq!(
+        status.daemon.as_ref().and_then(|daemon| daemon.pid),
+        Some(4646)
+    );
+    assert_eq!(
+        status
+            .daemon
+            .as_ref()
+            .and_then(|daemon| daemon.lease_id.as_deref()),
+        Some("lease-live")
+    );
+    status
+}
+
+#[test]
+fn compact_live_lease_replaces_an_idle_stale_daemon_instead_of_starting_a_second_one() {
+    let session = direct_ssh_session("lease-recorded");
+    let mut status = compact_daemon_status(false, 0, Some("homeboy 0.367.13+stale"));
+    status.work_evidence = RemoteDaemonWorkEvidence::idle();
+
+    assert_eq!(
+        remote_daemon::remote_daemon_connect_action_for_runner(
+            Some(&session),
+            &status,
+            "homeboy 0.370.1+configured",
+            "runner-a",
+            None,
+        )
+        .expect("idle live lease has a bounded replacement path"),
+        RemoteDaemonConnectAction::ReplaceIdleStale
+    );
+}
+
+#[test]
+fn compact_live_lease_with_active_jobs_refuses_replacement_when_session_is_stale() {
+    let session = direct_ssh_session("lease-recorded");
+    let mut status = compact_daemon_status(false, 1, Some("homeboy 0.367.13+stale"));
+    status.work_evidence = RemoteDaemonWorkEvidence::ActiveOrUnresolved(1);
+
+    let error = remote_daemon::remote_daemon_connect_action_for_runner(
+        Some(&session),
+        &status,
+        "homeboy 0.370.1+configured",
+        "runner-a",
+        None,
+    )
+    .expect_err("active work cannot be replaced through a stale session");
+
+    assert!(error.contains("lease-live"));
+    assert!(error.contains("--adopt-live-lease lease-live --expected-live-pid 4646"));
+}
+
+#[test]
+fn compact_live_lease_without_binary_identity_remains_unadoptable() {
+    let session = direct_ssh_session("lease-recorded");
+    let status = compact_daemon_status(true, 0, None);
+
+    let error = remote_daemon::remote_daemon_connect_action_for_runner(
+        Some(&session),
+        &status,
+        "homeboy 0.370.1+configured",
+        "runner-a",
+        None,
+    )
+    .expect_err("an unknown live binary cannot be adopted from a stale session");
+
+    assert!(error.contains("lease-live"));
+    assert!(error.contains("--adopt-live-lease lease-live --expected-live-pid 4646"));
+}
+
 #[test]
 fn active_generation_fence_allows_reattach_but_rejects_new_admission() {
     let fence = crate::generation_store::AdmissionFence {
@@ -1510,17 +1604,12 @@ fn parses_remote_daemon_status_lease_as_single_source_of_truth() {
     )
     .expect("parse envelope");
     let data = envelope.data.expect("status data");
-    let state = data.get("state").expect("lease state");
+    let status = remote_daemon::remote_daemon_status_from_data(&data);
+    let daemon = status.daemon.expect("lease state");
 
-    assert!(data.get("running").and_then(Value::as_bool).unwrap());
-    assert_eq!(
-        state.get("lease_id").and_then(Value::as_str),
-        Some("lease-1")
-    );
-    assert_eq!(
-        state.get("address").and_then(Value::as_str),
-        Some("127.0.0.1:49152")
-    );
+    assert_eq!(daemon.lease_id.as_deref(), Some("lease-1"));
+    assert_eq!(daemon.address, "127.0.0.1:49152");
+    assert_eq!(daemon.pid, Some(123));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Preserve compact daemon lease identity for stale daemon resolution.

## What changed
- Normalizes compact daemon and full state projections into one lease, PID, address, and identity view.
- Keeps active or unresolved jobs fail-closed while allowing only bounded idle stale replacement.

## How to test
1. Run `cargo test -p homeboy-lab-runner connection::tests::session`; expect 89 session tests pass, including compact-response resolver coverage..
2. Run `cargo fmt --check`; expect format check passes..
3. Run `cargo build`; expect workspace build passes..

## Compatibility
No public contract change; full state responses retain their prior priority and compact responses now preserve their existing daemon fields.

## Evidence
- Base unchanged since verification: main remains at f6a7d70dcf523a34649b4b42dabf499a608e6418.
- Verified finalization base: main at f6a7d70dcf523a34649b4b42dabf499a608e6418
- build: passed (workspace build) (Passed)
- fmt: passed (format check) (Passed)
- session-tests: passed (89 scoped session tests) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Models:** OpenAI GPT-6 Astra via OpenCode orchestrated the work; the delegated agent reported OpenAI GPT-5.6 Terra.
- **Used for:** Inspected the compact and full status projections, implemented the parser boundary and resolver tests, and ran the recorded deterministic gates.