### PR TITLE
fix(agent-task): discover unmaterialized Cook admissions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -78,8 +78,12 @@ pub struct AgentTaskDiscoveryReport {
     pub next_cursor: Option<usize>,
     pub runs: Vec<AgentTaskDiscoveryRun>,
     /// Bounded health evidence for malformed, legacy, conflicting, or
-    /// quarantined lifecycle rows omitted from the typed run projection.
+    /// quarantined lifecycle rows in the returned page.
     pub record_health: agent_task_lifecycle::AgentTaskRecordHealthSummary,
+    /// Health for the complete local lifecycle registry. This is deliberately
+    /// separate from `record_health` so a narrow filter is not obscured by
+    /// unrelated historical rows.
+    pub global_record_health: agent_task_lifecycle::AgentTaskRecordHealthSummary,
     /// Liveness buckets for the `active` filter so operators can separate
     /// genuinely-active runs from stale/suspect/unreconciled records at a
     /// glance. Only populated for the `active` filter; `None` elsewhere.
@@ -310,6 +314,10 @@ fn discovery_report(
     // Cook test. Treat only the durable fixture provenance as non-production;
     // an unknown runner with any real/unknown executor stays visible and blocks.
     records.retain(|record| !is_fixture_runner_record(record));
+    // Lifecycle records and unmaterialized Cook admissions share durable run
+    // IDs. Keep one canonical control-plane record if a source is replayed.
+    let mut seen_run_ids = BTreeSet::new();
+    records.retain(|record| seen_run_ids.insert(record.run_id.clone()));
     let is_active = filter == AgentTaskDiscoveryFilter::Active;
     if is_active {
         records.retain(|record| {
@@ -344,6 +352,11 @@ fn discovery_report(
         .map(|limit| cursor.saturating_add(limit).min(total))
         .unwrap_or(total);
     let records = records.drain(cursor..end).collect::<Vec<_>>();
+    let scoped_record_health = AgentTaskRecordHealthSummary {
+        schema: agent_task_lifecycle::AGENT_TASK_RECORD_HEALTH_SCHEMA.to_string(),
+        healthy: records.len(),
+        ..Default::default()
+    };
 
     let runs: Vec<_> = records
         .into_iter()
@@ -368,7 +381,8 @@ fn discovery_report(
         truncated,
         next_cursor: truncated.then_some(end),
         runs,
-        record_health,
+        record_health: scoped_record_health,
+        global_record_health: record_health,
         liveness_summary,
         federated_command: FEDERATED_DISCOVERY_COMMAND,
     })
@@ -409,20 +423,7 @@ fn matches_discovery_options(
 
     let plan = agent_task_lifecycle::load_controller_plan(&record.run_id).ok();
     let first_task = plan.as_ref().and_then(|plan| plan.tasks.first());
-    let repo = plan
-        .as_ref()
-        .and_then(|plan| plan.group_key.as_deref())
-        .or_else(|| first_task.and_then(|task| task.group_key.as_deref()))
-        .or_else(|| first_task.and_then(|task| task.workspace.component_id.as_deref()))
-        .or_else(|| first_task.and_then(|task| task.workspace.slug.as_deref()));
-    let remote_workspace = metadata_string(&record.metadata, "remote_workspace");
-    let workspace = first_task
-        .and_then(|task| task.workspace.root.as_deref())
-        .or(remote_workspace.as_deref());
-    let sourced_task_url = first_task.and_then(task_source_url);
-    let task_url = first_task
-        .and_then(|task| task.workspace.task_url.as_deref())
-        .or(sourced_task_url.as_deref());
+    let identity = discovery_identity(record);
     let parent_matches = first_task
         .map(|task| task.parent_plan_id.as_deref() == options.parent_id.as_deref())
         .unwrap_or(false);
@@ -430,16 +431,64 @@ fn matches_discovery_options(
     options
         .repo
         .as_deref()
-        .is_none_or(|value| repo == Some(value))
+        .is_none_or(|value| identity.repo.as_deref() == Some(value))
         && options
             .workspace
             .as_deref()
-            .is_none_or(|value| workspace == Some(value))
+            .is_none_or(|value| identity.workspace.as_deref() == Some(value))
         && options
             .task_url
             .as_deref()
-            .is_none_or(|value| task_url == Some(value))
+            .is_none_or(|value| identity.task_url.as_deref() == Some(value))
         && options.parent_id.as_deref().is_none_or(|_| parent_matches)
+}
+
+struct DiscoveryIdentity {
+    repo: Option<String>,
+    workspace: Option<String>,
+    task_url: Option<String>,
+}
+
+/// Materialized plans are the primary identity source. Before Cook creates a
+/// task, its immutable admission binding is the only durable task identity.
+fn discovery_identity(record: &AgentTaskRunRecord) -> DiscoveryIdentity {
+    let plan = agent_task_lifecycle::load_controller_plan(&record.run_id).ok();
+    let first_task = plan.as_ref().and_then(|plan| plan.tasks.first());
+    let plan_repo = plan
+        .as_ref()
+        .and_then(|plan| plan.group_key.clone())
+        .or_else(|| first_task.and_then(|task| task.group_key.clone()))
+        .or_else(|| first_task.and_then(|task| task.workspace.component_id.clone()))
+        .or_else(|| first_task.and_then(|task| task.workspace.slug.clone()));
+    let plan_workspace = first_task
+        .and_then(|task| task.workspace.root.clone())
+        .or_else(|| metadata_string(&record.metadata, "remote_workspace"));
+    let plan_task_url = first_task
+        .and_then(|task| task.workspace.task_url.clone())
+        .or_else(|| first_task.and_then(task_source_url));
+    let binding = record
+        .metadata
+        .pointer("/unmaterialized_cook_admission/binding");
+    DiscoveryIdentity {
+        repo: plan_repo.or_else(|| {
+            binding
+                .and_then(|value| value.pointer("/source/repository"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        }),
+        workspace: plan_workspace.or_else(|| {
+            binding
+                .and_then(|value| value.get("worktree_ref"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        }),
+        task_url: plan_task_url.or_else(|| {
+            binding
+                .and_then(|value| value.pointer("/source/task_refs/0"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        }),
+    }
 }
 
 fn parse_submitted_after(value: &str) -> Result<chrono::DateTime<chrono::Utc>> {
@@ -883,13 +932,7 @@ fn discovery_run(
     now: chrono::DateTime<chrono::Utc>,
 ) -> AgentTaskDiscoveryRun {
     let plan = agent_task_lifecycle::load_controller_plan(&record.run_id).ok();
-    let first_task = plan.as_ref().and_then(|plan| plan.tasks.first());
-    let repo = plan
-        .as_ref()
-        .and_then(|plan| plan.group_key.clone())
-        .or_else(|| first_task.and_then(|task| task.group_key.clone()))
-        .or_else(|| first_task.and_then(|task| task.workspace.component_id.clone()))
-        .or_else(|| first_task.and_then(|task| task.workspace.slug.clone()));
+    let identity = discovery_identity(&record);
     let component = plan.as_ref().and_then(|plan| {
         plan.metadata
             .pointer("/cook_repository_identity/component_id")
@@ -897,12 +940,6 @@ fn discovery_run(
             .and_then(Value::as_str)
             .map(str::to_string)
     });
-    let workspace = first_task
-        .and_then(|task| task.workspace.root.clone())
-        .or_else(|| metadata_string(&record.metadata, "remote_workspace"));
-    let task_url = first_task
-        .and_then(|task| task.workspace.task_url.clone())
-        .or_else(|| first_task.and_then(task_source_url));
     let aggregate_path = record.aggregate_path.clone();
     let run_id = record.run_id.clone();
 
@@ -940,10 +977,10 @@ fn discovery_run(
     AgentTaskDiscoveryRun {
         run_id: run_id.clone(),
         state: record.state,
-        repo,
+        repo: identity.repo,
         component,
-        workspace,
-        task_url,
+        workspace: identity.workspace,
+        task_url: identity.task_url,
         counts: discovery_counts(&record.tasks),
         submitted_at: record.submitted_at,
         updated_at: record.updated_at,
@@ -1093,5 +1130,21 @@ mod tests {
             classify_liveness(&invalid, Some(10), now),
             AgentTaskLiveness::Stale
         );
+    }
+
+    #[test]
+    fn discovery_deduplicates_replayed_control_plane_records_by_run_id() {
+        let record = queued_record(json!({}));
+        let report = discovery_report(
+            AgentTaskDiscoveryFilter::All,
+            AgentTaskDiscoveryOptions::default(),
+            vec![record.clone(), record],
+            AgentTaskRecordHealthSummary::healthy(),
+        )
+        .expect("deduplicated discovery report");
+
+        assert_eq!(report.total, 1);
+        assert_eq!(report.count, 1);
+        assert_eq!(report.runs[0].run_id, "retry-attempt");
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -3004,6 +3004,96 @@ fn discovery_filters_by_cook_identity_and_classifies_only_live_queued_records_as
 }
 
 #[test]
+fn discovery_federates_unmaterialized_cook_admissions_by_task_identity() {
+    with_isolated_home(|_| {
+        let store = test_lifecycle_store();
+        agent_task_lifecycle::record_unmaterialized_cook_admission_in_store(
+            &store,
+            "cook-pending-admission",
+            serde_json::json!({
+                "schema": "homeboy/unmaterialized-cook-binding/v1",
+                "source": {
+                    "repository": "Extra-Chill/homeboy",
+                    "task_refs": ["https://github.com/Extra-Chill/homeboy/issues/14463"]
+                },
+                "worktree_ref": "/work/homeboy@fix-14463"
+            }),
+            "queued",
+            "awaiting runner admission",
+        )
+        .expect("persist admission");
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some("unrelated-materialized"))
+            .expect("persist unrelated lifecycle record");
+
+        let report = discover_runs_with_options(
+            AgentTaskDiscoveryFilter::All,
+            AgentTaskDiscoveryOptions {
+                repo: Some("Extra-Chill/homeboy".to_string()),
+                workspace: Some("/work/homeboy@fix-14463".to_string()),
+                task_url: Some("https://github.com/Extra-Chill/homeboy/issues/14463".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("discover matching admission");
+
+        assert_eq!(report.total, 1);
+        assert_eq!(report.runs.len(), 1);
+        let admission = &report.runs[0];
+        assert_eq!(admission.run_id, "cook-pending-admission");
+        assert_eq!(admission.state, AgentTaskRunState::Queued);
+        assert_eq!(
+            admission.task_url.as_deref(),
+            Some("https://github.com/Extra-Chill/homeboy/issues/14463")
+        );
+        assert!(admission
+            .commands
+            .status
+            .ends_with("cook-pending-admission"));
+        assert_eq!(report.record_health.healthy, 1);
+        assert_eq!(report.global_record_health.healthy, 2);
+    });
+}
+
+#[test]
+fn discovery_keeps_cancelled_unmaterialized_admissions_in_filtered_history() {
+    with_isolated_home(|_| {
+        let store = test_lifecycle_store();
+        agent_task_lifecycle::record_unmaterialized_cook_admission_in_store(
+            &store,
+            "cook-cancelled-admission",
+            serde_json::json!({
+                "schema": "homeboy/unmaterialized-cook-binding/v1",
+                "source": {
+                    "repository": "Extra-Chill/homeboy",
+                    "task_refs": ["https://github.com/Extra-Chill/homeboy/issues/14463"]
+                }
+            }),
+            "queued",
+            "awaiting runner admission",
+        )
+        .expect("persist admission");
+        agent_task_lifecycle::rewrite_record_for_test("cook-cancelled-admission", |record| {
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Cancelled);
+        })
+        .expect("cancel admission");
+
+        let report = discover_runs_with_options(
+            AgentTaskDiscoveryFilter::All,
+            AgentTaskDiscoveryOptions {
+                task_url: Some("https://github.com/Extra-Chill/homeboy/issues/14463".to_string()),
+                state: Some("cancelled".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("discover cancelled admission");
+
+        assert_eq!(report.total, 1);
+        assert_eq!(report.runs[0].run_id, "cook-cancelled-admission");
+        assert_eq!(report.runs[0].state, AgentTaskRunState::Cancelled);
+    });
+}
+
+#[test]
 fn upgrade_admission_ignores_terminal_records_with_stale_owner_metadata() {
     with_isolated_home(|_| {
         for (run_id, state) in [


### PR DESCRIPTION
## Summary
- federate unmaterialized Cook admission bindings with materialized lifecycle identity for agent-task discovery filters
- deduplicate control-plane records and separate page-scoped health from explicit global health
- retain cancelled admissions in filtered history with focused lifecycle coverage

## Verification
- cargo fmt --check
- cargo test -p homeboy-agents discovery_federates_unmaterialized_cook_admissions_by_task_identity --lib
- cargo test -p homeboy-agents discovery_keeps_cancelled_unmaterialized_admissions_in_filtered_history --lib
- cargo test -p homeboy-agents discovery_deduplicates_replayed_control_plane_records_by_run_id --lib
- cargo check --workspace

Closes #14463

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode.