### PR TITLE
fix(daemon): preserve draining generation ownership

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -595,8 +595,10 @@ fn cancel_resolved_run_in_store(
         // The controller owns every child admitted during staging, including the
         // final runner job. Never bypass it merely because that child identity
         // was already projected onto the parent.
-        let controller_job = homeboy_core::daemon::LocalControllerJobClient::connect()?
-            .cancel(&controller_job_id, cancellation_reason)?;
+        let controller_job = homeboy_core::daemon::LocalControllerJobClient::connect_existing_job(
+            &controller_job_id,
+        )?
+        .cancel(&controller_job_id, cancellation_reason)?;
         let metadata = record.ensure_metadata_object();
         metadata.insert(
             "controller_job_cancellation".to_string(),
@@ -820,7 +822,7 @@ pub(super) fn reconcile_controller_job_cancellation_in_store(
         return Ok(false);
     };
 
-    let job = match homeboy_core::daemon::LocalControllerJobClient::connect()
+    let job = match homeboy_core::daemon::LocalControllerJobClient::connect_existing_job(job_id)
         .and_then(|client| client.status(job_id))
     {
         Ok(job) => job,

--- a/crates/homeboy-cli/src/commands/agent_task/controller.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/controller.rs
@@ -390,7 +390,7 @@ fn loop_work_projection(controller: &Value) -> Value {
     else {
         return Value::Null;
     };
-    match homeboy::core::daemon::LocalControllerJobClient::connect()
+    match homeboy::core::daemon::LocalControllerJobClient::connect_existing_job(job_id)
         .and_then(|client| client.status(job_id))
     {
         Ok(job) => serde_json::json!({
@@ -420,7 +420,8 @@ fn cancel_loop_work(
     else {
         return Ok(Value::Null);
     };
-    let job = homeboy::core::daemon::LocalControllerJobClient::connect()?.cancel(job_id, reason)?;
+    let job = homeboy::core::daemon::LocalControllerJobClient::connect_existing_job(job_id)?
+        .cancel(job_id, reason)?;
     Ok(serde_json::json!({
         "job_id": job_id,
         "status": job.status,

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -510,7 +510,7 @@ fn submit_cleanup(args: CleanupArgs) -> homeboy::core::Result<Value> {
 }
 
 fn cleanup_job_status(job_id: &str, full: bool) -> homeboy::core::Result<Value> {
-    let job = LocalControllerJobClient::connect()?.status(job_id)?;
+    let job = LocalControllerJobClient::connect_existing_job(job_id)?.status(job_id)?;
     if full {
         return serde_json::to_value(job).map_err(|error| {
             homeboy::core::Error::internal_json(
@@ -525,7 +525,7 @@ fn cleanup_job_status(job_id: &str, full: bool) -> homeboy::core::Result<Value> 
 fn cleanup_job_resume(job_id: &str) -> homeboy::core::Result<Value> {
     // Starting is idempotent: a running or terminal job returns its durable state.
     Ok(compact_cleanup_job(
-        &LocalControllerJobClient::connect()?.start(job_id)?,
+        &LocalControllerJobClient::connect_existing_job(job_id)?.start(job_id)?,
         "resume",
     ))
 }

--- a/crates/homeboy-core/src/daemon/generation_store.rs
+++ b/crates/homeboy-core/src/daemon/generation_store.rs
@@ -191,11 +191,10 @@ pub(super) fn complete_job(job_id: &str) -> Result<Option<LocalDaemonEndpoint>> 
 }
 
 pub(super) fn generation_state_dir() -> Result<PathBuf> {
-    let root = crate::paths::daemon_state_file()?;
-    let parent = root
-        .parent()
-        .ok_or_else(|| Error::internal_unexpected("daemon state path has no parent"))?;
-    Ok(parent
+    // A replacement inherits HOMEBOY_DAEMON_STATE_DIR from its generation. The
+    // router location is stable across that handoff and therefore owns sibling
+    // generation allocation.
+    Ok(router_dir()?
         .join("generations")
         .join(uuid::Uuid::new_v4().to_string()))
 }
@@ -228,6 +227,28 @@ mod tests {
     use super::*;
     use crate::build_identity;
     use crate::test_support::with_isolated_home;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        prior: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &Path) -> Self {
+            let prior = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, prior }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     fn state(lease_id: &str, address: &str) -> DaemonState {
         DaemonState {
@@ -279,6 +300,30 @@ mod tests {
             assert!(complete_job("job-a").expect("complete A").is_some());
             assert!(endpoint_for_job("job-a").expect("retired A").is_none());
             assert_eq!(admitting().expect("admitting").expect("B").lease_id, "B");
+        });
+    }
+
+    #[test]
+    fn replacement_generations_are_siblings_under_the_stable_router_root() {
+        with_isolated_home(|home| {
+            let router = home.path().join("stable-router");
+            let first_generation = router.join("generations").join("first");
+            let _router_env = EnvVarGuard::set(DAEMON_ROUTER_DIR_ENV, &router);
+            std::env::set_var(crate::paths::DAEMON_STATE_DIR_ENV, &first_generation);
+
+            let second_generation = generation_state_dir().expect("allocate second generation");
+            std::env::set_var(crate::paths::DAEMON_STATE_DIR_ENV, &second_generation);
+            let third_generation = generation_state_dir().expect("allocate third generation");
+
+            assert_eq!(
+                second_generation.parent(),
+                Some(router.join("generations").as_path())
+            );
+            assert_eq!(
+                third_generation.parent(),
+                Some(router.join("generations").as_path())
+            );
+            assert!(!third_generation.starts_with(&second_generation));
         });
     }
 }

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -261,6 +261,35 @@ impl LocalControllerJobClient {
         Self::connect_with_admission_guard(None)
     }
 
+    /// Connect to the daemon generation that already owns `job_id`.
+    ///
+    /// Observation and cancellation must retain the job's original generation.
+    /// In particular, they must not call `ensure_running`, which can rotate a
+    /// stale admission daemon to the caller's build.
+    pub fn connect_existing_job(job_id: &str) -> Result<Self> {
+        let endpoint = generation_store::endpoint_for_job(job_id)?.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller_job_id",
+                "controller job has no recorded daemon generation",
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+        let client = reqwest::blocking::Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .map_err(|error| {
+                Error::internal_unexpected(format!("build local controller-job client: {error}"))
+            })?;
+        Ok(Self {
+            endpoint: format!("http://{}", endpoint.address),
+            lease_id: endpoint.lease_id,
+            client,
+            _admission_guard: None,
+        })
+    }
+
     fn connect_with_admission_guard(admission_guard: Option<File>) -> Result<Self> {
         let daemon = ensure_running(DEFAULT_ADDR)?;
         let client = reqwest::blocking::Client::builder()
@@ -4591,6 +4620,157 @@ mod tests {
             controller_job_response(&wire).expect("reader recovers the written job")["id"],
             "written-by-the-daemon"
         );
+    }
+
+    #[test]
+    fn existing_job_connection_uses_the_draining_generation_for_status_and_cancellation() {
+        crate::test_support::with_isolated_home(|_| {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake daemon");
+            let owner_address = listener
+                .local_addr()
+                .expect("fake daemon address")
+                .to_string();
+            let job_id = Uuid::new_v4();
+            let (requests_tx, requests_rx) = mpsc::channel();
+            let server = std::thread::spawn(move || {
+                for _ in 0..2 {
+                    let (mut stream, _) = listener.accept().expect("accept fake daemon request");
+                    let mut request = [0_u8; 4096];
+                    let length = stream.read(&mut request).expect("read fake daemon request");
+                    let request_line = std::str::from_utf8(&request[..length])
+                        .expect("decode fake daemon request")
+                        .lines()
+                        .next()
+                        .expect("request line")
+                        .to_string();
+                    requests_tx.send(request_line).expect("record request");
+                    let job = json!({
+                        "id": job_id,
+                        "operation": "test",
+                        "status": "running",
+                        "created_at_ms": 1,
+                        "updated_at_ms": 1,
+                        "event_count": 0,
+                        "artifacts": [],
+                        "daemon_lease_id": "draining",
+                    });
+                    let body = json!({
+                        "success": true,
+                        "data": { "body": { "job": job } },
+                    })
+                    .to_string();
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body,
+                    )
+                    .expect("respond from fake daemon");
+                    stream.flush().expect("flush fake daemon response");
+                }
+            });
+            let state =
+                |lease_id: &str,
+                 address: &str,
+                 build_identity: crate::build_identity::BuildIdentity| {
+                    DaemonState {
+                        schema: DAEMON_LEASE_SCHEMA.to_string(),
+                        lease_id: lease_id.to_string(),
+                        startup_token: "test".to_string(),
+                        address: address.to_string(),
+                        pid: 1,
+                        state_path: crate::paths::daemon_state_file()
+                            .expect("state path")
+                            .display()
+                            .to_string(),
+                        started_at: "now".to_string(),
+                        last_seen_at: "now".to_string(),
+                        build_identity,
+                        binary_sha256: None,
+                        runtime_paths: DaemonRuntimeSnapshot {
+                            loaded_at: "now".to_string(),
+                            paths: Vec::new(),
+                        },
+                    }
+                };
+            let draining_identity = crate::build_identity::BuildIdentity {
+                version: "0.370.0".to_string(),
+                git_commit: Some("old".to_string()),
+                git_dirty: None,
+                display: "homeboy 0.370.0+old".to_string(),
+            };
+            let admission_identity = crate::build_identity::BuildIdentity {
+                version: "0.370.1".to_string(),
+                git_commit: Some("new".to_string()),
+                git_dirty: None,
+                display: "homeboy 0.370.1+new".to_string(),
+            };
+            let draining = state("draining", &owner_address, draining_identity.clone());
+            generation_store::seed(&draining).expect("seed draining generation");
+            generation_store::record_job(&job_id.to_string(), "draining").expect("record job");
+            let admission = state("admission", "127.0.0.1:1002", admission_identity.clone());
+            generation_store::activate(&admission).expect("activate new generation");
+
+            let client = LocalControllerJobClient::connect_existing_job(&job_id.to_string())
+                .expect("connect existing job");
+
+            assert_eq!(client.endpoint, format!("http://{owner_address}"));
+            assert_eq!(client.lease_id, "draining");
+            assert_eq!(
+                client.status(&job_id.to_string()).expect("read old job").id,
+                job_id
+            );
+            assert_eq!(
+                client
+                    .cancel(&job_id.to_string(), "test cancellation")
+                    .expect("cancel old job")
+                    .id,
+                job_id
+            );
+            server.join().expect("stop fake daemon");
+            assert_eq!(
+                requests_rx.recv().expect("status request"),
+                format!("GET /jobs/{job_id} HTTP/1.1")
+            );
+            assert_eq!(
+                requests_rx.recv().expect("cancellation request"),
+                format!("POST /controller/jobs/{job_id}/cancel HTTP/1.1")
+            );
+            assert_eq!(
+                generation_store::admitting()
+                    .expect("read admission generation")
+                    .expect("admission generation")
+                    .lease_id,
+                "admission"
+            );
+            assert_eq!(
+                generation_store::generations()
+                    .expect("read generations")
+                    .into_iter()
+                    .find(|endpoint| endpoint.lease_id == "draining")
+                    .expect("draining generation")
+                    .build_identity,
+                draining_identity.display
+            );
+            assert_eq!(
+                generation_store::admitting()
+                    .expect("read admission generation")
+                    .expect("admission generation")
+                    .build_identity,
+                admission_identity.display
+            );
+            let state_path = crate::paths::daemon_state_file().expect("state path");
+            assert!(!state_path.exists());
+            let error = match LocalControllerJobClient::connect_existing_job("missing-job") {
+                Ok(_) => panic!("missing job owner must fail closed"),
+                Err(error) => error,
+            };
+            assert_eq!(
+                error.code,
+                crate::error::ErrorCode::ValidationInvalidArgument
+            );
+            assert!(!state_path.exists());
+        });
     }
 
     /// `LocalControllerJobClient::status` polls the read-only `GET /jobs/<id>`


### PR DESCRIPTION
## Incident

A lifecycle fault allowed roughly 1,950 local daemon processes to accumulate while generations were being replaced. Existing-job status, resume, and cancellation could call `ensure_running` through a fresh connection, upgrading the admission daemon instead of retaining the generation that owns the job. Replacement state allocation could also nest a new generation beneath its predecessor.

Related: #14434 (closed).

## Fix

- Route existing controller-job status, resume, and cancellation through the recorded owner endpoint, without calling `ensure_running` or upgrading the admission daemon.
- Allocate replacement state directories as siblings below the stable router root.
- Add regressions proving a draining generation remains routable for status and cancellation while the replacement admits work, and that successive replacement directories remain siblings.

## Verification

Executed with an isolated `CARGO_TARGET_DIR`:

- `cargo test -p homeboy-core existing_job_connection_uses_the_draining_generation_for_status_and_cancellation`
- `cargo test -p homeboy-core replacement_generations_are_siblings_under_the_stable_router_root`
- `cargo check -p homeboy-agents -p homeboy-cli`

## AI Assistance

GPT-6 Astra (openai/gpt-6-astra) via OpenCode assisted with implementation, testing, and PR preparation.