### PR TITLE
fix(runner): ignore admission reservation sidecars

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -982,6 +982,7 @@ fn is_controller_session_file(path: &std::path::Path) -> bool {
         "generations.json",
         "pending-replacement.json",
         "replacement-operation.json",
+        "admission-mutation-reservation.json",
     ];
 
     path.is_file()
@@ -1327,8 +1328,16 @@ mod tests {
             "generations.json",
             "pending-replacement.json",
             "replacement-operation.json",
+            "admission-mutation-reservation.json",
         ] {
-            std::fs::write(root.path().join(sidecar), "{}").expect("write reserved sidecar");
+            let contents = match sidecar {
+                "admission-mutation-reservation.json" => {
+                    r#"{"operation_id":"operation","owner_pid":1,"owner_start_identity":{"platform":"macos","start_seconds":1,"start_microseconds":1},"created_at":"2026-09-09T00:00:00Z","operation":"ensure_remote_daemon"}"#
+                }
+                "replacement-operation.json" => r#"{"runner_id":"lab","operation_id":"operation"}"#,
+                _ => "{}",
+            };
+            std::fs::write(root.path().join(sidecar), contents).expect("write reserved sidecar");
         }
 
         let live_peer = live_peer_session_in(


### PR DESCRIPTION
## Summary
- classify `admission-mutation-reservation.json` as runner state rather than a controller session
- cover a live peer session alongside valid reservation and replacement records

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner peer_scans_ignore_reserved_sidecars --lib`
- `cargo test -p homeboy-lab-runner live_reservation_blocks_admission_with_retryable_reconcile_action --lib`

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode identified the schema-classification bug, implemented the minimal fix and regression coverage, and ran the listed verification. Chris Huber reviewed the change and remains responsible for it.