### PR TITLE
fix(status): bound and diagnose full inventory probes

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -627,6 +627,7 @@ fn public_candidate_adoption_gate_progress_is_durable() {
             progress: Some(homeboy_engine_primitives::command::CommandProgress {
                 phase: "tests".to_string(),
                 current: Some("case".to_string()),
+                ..Default::default()
             }),
             output_tail: "running output tail".to_string(),
         },
@@ -705,6 +706,7 @@ fn private_candidate_adoption_gate_progress_is_redacted_before_persistence() {
             progress: Some(homeboy_engine_primitives::command::CommandProgress {
                 phase: "private-phase-secret".to_string(),
                 current: Some("sha256:private-digest-123 count=42".to_string()),
+                ..Default::default()
             }),
             output_tail: "private output secret".to_string(),
         },

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -18,7 +18,7 @@ use homeboy::core::scope::{self, Scope};
 use homeboy::runner::runners as runner;
 use homeboy_deploy::ReleaseStateStatus;
 use homeboy_engine_primitives::command::{
-    wait_with_bounded_output_supervised_with_progress, ControllerChildGuard,
+    wait_with_bounded_output_supervised_with_progress, CommandProgress, ControllerChildGuard,
     SupervisedCommandTermination,
 };
 use homeboy_release::release::version;
@@ -172,7 +172,21 @@ fn run_unisolated(
 
     if args.full {
         timer.begin("build_full_context");
-        let mut report = context::build_report(args.all, "status")?;
+        let mut report = context::build_report_with_progress(args.all, "status", |progress| {
+            if std::env::var_os("HOMEBOY_STATUS_PROBE_CHILD").is_some() {
+                let progress = CommandProgress {
+                    phase: progress.phase.to_string(),
+                    current: progress.current,
+                    completed: Some(progress.completed),
+                    total: Some(progress.total),
+                    unfinished: progress.unfinished,
+                    item_deadline_ms: progress.item_deadline_ms,
+                };
+                if let Ok(progress) = serde_json::to_string(&progress) {
+                    eprintln!("HOMEBOY_PROGRESS {progress}");
+                }
+            }
+        })?;
         timer.finish("build_full_context");
         report.command = "status".to_string();
         return Ok((StatusResult::Full(Box::new(report)), 0));
@@ -276,6 +290,7 @@ fn run_isolated_probe(
         .global
         .then_some(remaining.min(GLOBAL_STATUS_PROBE_BUDGET))
         .unwrap_or(remaining);
+    let mut latest_progress = None;
     let supervised = wait_with_bounded_output_supervised_with_progress(
         &mut child,
         STATUS_PROBE_CAPTURE_LIMIT,
@@ -285,7 +300,28 @@ fn run_isolated_probe(
         || false,
         |heartbeat| {
             if let Some(progress) = heartbeat.progress {
-                eprintln!("[status] {PHASE}: {}", progress.phase);
+                latest_progress = Some(progress.clone());
+                let counts = progress
+                    .total
+                    .map(|total| format!(" {}/{}", progress.completed.unwrap_or_default(), total))
+                    .unwrap_or_default();
+                let current = progress
+                    .current
+                    .as_deref()
+                    .map(|current| format!(" {current}"))
+                    .unwrap_or_default();
+                let deadline = progress
+                    .item_deadline_ms
+                    .map(|deadline| format!(" deadline={deadline}ms"))
+                    .unwrap_or_default();
+                eprintln!(
+                    "[status] {PHASE}: {}{}{} ({}ms){}",
+                    progress.phase,
+                    current,
+                    counts,
+                    heartbeat.elapsed.as_millis(),
+                    deadline,
+                );
             } else {
                 eprintln!(
                     "[status] {PHASE}: waiting ({}ms)",
@@ -304,11 +340,21 @@ fn run_isolated_probe(
                 controller,
                 partial: StatusPartial {
                     reason,
-                    phase: PHASE,
-                    omitted_components: Vec::new(),
+                    phase: status_probe_partial_phase(latest_progress.as_ref()),
+                    omitted_components: latest_progress
+                        .as_ref()
+                        .map(|progress| progress.unfinished.clone())
+                        .unwrap_or_default(),
                     degraded_components: Vec::new(),
                     degraded_component_phases: Vec::new(),
-                    replay_commands: status_probe_replay_commands(args),
+                    unfinished_probes: latest_progress
+                        .as_ref()
+                        .map(|progress| progress.unfinished.clone())
+                        .unwrap_or_default(),
+                    current_probe: latest_progress
+                        .as_ref()
+                        .and_then(|progress| progress.current.clone()),
+                    replay_commands: status_probe_replay_commands(args, latest_progress.as_ref()),
                 },
                 diagnostic,
             }),
@@ -384,7 +430,10 @@ fn status_probe_replay(args: &StatusArgs) -> String {
     status_probe_argv(args).join(" ")
 }
 
-fn status_probe_replay_commands(args: &StatusArgs) -> Vec<String> {
+fn status_probe_replay_commands(
+    args: &StatusArgs,
+    progress: Option<&CommandProgress>,
+) -> Vec<String> {
     if args.global {
         return vec![
             "homeboy daemon status".to_string(),
@@ -395,7 +444,35 @@ fn status_probe_replay_commands(args: &StatusArgs) -> Vec<String> {
         ];
     }
 
+    let unfinished = progress
+        .map(|progress| progress.unfinished.as_slice())
+        .unwrap_or_default();
+    if !unfinished.is_empty() {
+        return unfinished
+            .iter()
+            .map(|component_id| format!("homeboy status --component {component_id} --timings"))
+            .collect();
+    }
+    if let Some(progress) = progress {
+        return match progress.phase.as_str() {
+            "resolve_context_target" => vec![
+                "homeboy status --global".to_string(),
+                "homeboy component list".to_string(),
+            ],
+            "build_component_inventory" => vec!["homeboy component list".to_string()],
+            _ => vec![status_probe_replay(args)],
+        };
+    }
     vec![status_probe_replay(args)]
+}
+
+fn status_probe_partial_phase(progress: Option<&CommandProgress>) -> &'static str {
+    match progress.map(|progress| progress.phase.as_str()) {
+        Some("resolve_context_target") => "resolve_context_target",
+        Some("build_component_inventory") => "build_component_inventory",
+        Some("calculate_release_state") => "calculate_release_state",
+        _ => "probe_context_inventory_scope",
+    }
 }
 
 /// Entry point used only by the private same-binary child protocol.
@@ -698,6 +775,8 @@ fn summarize_components(
                 reason: "component_git_probe_degraded",
                 phase: "component_git_probe",
                 omitted_components: Vec::new(),
+                unfinished_probes: Vec::new(),
+                current_probe: None,
                 replay_commands: replay_component_commands(&git_cache.degraded_components, args),
                 degraded_components: sorted_component_ids(git_cache.degraded_components),
                 degraded_component_phases: sorted_degraded_component_phases(
@@ -840,6 +919,8 @@ fn partial_status(
                 degraded_component_phases: sorted_degraded_component_phases(
                     degraded_component_phases,
                 ),
+                unfinished_probes: Vec::new(),
+                current_probe: None,
                 replay_commands,
             }),
             controller,
@@ -981,6 +1062,8 @@ fn run_project_dashboard(
                         .collect(),
                     degraded_components: Vec::new(),
                     degraded_component_phases: Vec::new(),
+                    unfinished_probes: Vec::new(),
+                    current_probe: None,
                     replay_commands: vec![format!(
                         "homeboy status {project_id}{}",
                         replay_status_flags(args)
@@ -1206,6 +1289,8 @@ fn run_project_dashboard(
                     git_cache.degraded_component_phases,
                     &remote_diagnostics,
                 ),
+                unfinished_probes: Vec::new(),
+                current_probe: None,
                 replay_commands: vec![format!(
                     "homeboy status {project_id}{}",
                     replay_status_flags(args)
@@ -1500,7 +1585,7 @@ mod tests {
 
         assert_eq!(status_probe_argv(&args), ["homeboy", "status", "--global"]);
         assert_eq!(
-            status_probe_replay_commands(&args),
+            status_probe_replay_commands(&args, None),
             [
                 "homeboy daemon status",
                 "homeboy runner status --full",
@@ -1508,6 +1593,71 @@ mod tests {
                 "homeboy runs list --limit 100",
                 "homeboy component list",
             ]
+        );
+    }
+
+    #[test]
+    fn timed_out_full_probe_replays_only_unfinished_components() {
+        let args = parse_status(&["homeboy", "status", "--full"]);
+        let progress = CommandProgress {
+            phase: "calculate_release_state".to_string(),
+            current: Some("slow-component".to_string()),
+            completed: Some(2),
+            total: Some(4),
+            unfinished: vec!["slow-component".to_string(), "queued-component".to_string()],
+            item_deadline_ms: Some(25_000),
+        };
+
+        assert_eq!(
+            status_probe_replay_commands(&args, Some(&progress)),
+            [
+                "homeboy status --component slow-component --timings",
+                "homeboy status --component queued-component --timings",
+            ]
+        );
+    }
+
+    #[test]
+    fn timed_out_context_target_probe_names_provider_and_avoids_full_replay() {
+        let args = parse_status(&["homeboy", "status", "--full"]);
+        let progress = CommandProgress {
+            phase: "resolve_context_target".to_string(),
+            current: Some("/workspace/blocked".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            status_probe_partial_phase(Some(&progress)),
+            "resolve_context_target"
+        );
+        assert_eq!(
+            status_probe_replay_commands(&args, Some(&progress)),
+            ["homeboy status --global", "homeboy component list"]
+        );
+    }
+
+    #[test]
+    fn status_partial_serializes_exact_unfinished_probe_diagnostics() {
+        let partial = StatusPartial {
+            reason: "status_probe_timeout",
+            phase: "probe_context_inventory_scope",
+            omitted_components: vec!["slow-component".to_string()],
+            degraded_components: Vec::new(),
+            degraded_component_phases: Vec::new(),
+            unfinished_probes: vec!["slow-component".to_string()],
+            current_probe: Some("slow-component".to_string()),
+            replay_commands: vec!["homeboy status --component slow-component --timings".to_string()],
+        };
+
+        let value = serde_json::to_value(partial).expect("serialize partial status");
+        assert_eq!(
+            value["unfinished_probes"],
+            serde_json::json!(["slow-component"])
+        );
+        assert_eq!(value["current_probe"], "slow-component");
+        assert_eq!(
+            value["replay_commands"],
+            serde_json::json!(["homeboy status --component slow-component --timings"])
         );
     }
 

--- a/crates/homeboy-cli/src/commands/status/types.rs
+++ b/crates/homeboy-cli/src/commands/status/types.rs
@@ -204,6 +204,11 @@ pub struct StatusPartial {
     /// The inspection phases that produced degraded observations per component.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub degraded_component_phases: Vec<StatusPartialComponent>,
+    /// Exact context probes that had not completed when an isolated probe was stopped.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unfinished_probes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_probe: Option<String>,
     /// Deterministic commands that replay the omitted or degraded inspection.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub replay_commands: Vec<String>,

--- a/crates/homeboy-core/src/context/mod.rs
+++ b/crates/homeboy-core/src/context/mod.rs
@@ -11,7 +11,7 @@ use homeboy_extension_contract::{DiscoveryMarkerConfig, ExtensionManifest};
 
 pub mod report;
 
-pub use report::{build_report, build_report_for_component};
+pub use report::{build_report, build_report_for_component, build_report_with_progress};
 
 // === Local Context Detection (homeboy context command) ===
 
@@ -70,12 +70,23 @@ pub fn run(path: Option<&str>) -> Result<(ContextOutput, i32)> {
 pub fn run_with_inventory(
     path: Option<&str>,
 ) -> Result<(ContextOutput, Vec<component::Component>, i32)> {
+    run_with_inventory_with_progress(path, |_, _| {})
+}
+
+/// Detect local context while exposing the two potentially blocking providers.
+/// This lets isolated callers distinguish target resolution from registry
+/// inventory without changing the ordinary context API.
+pub fn run_with_inventory_with_progress(
+    path: Option<&str>,
+    progress: impl Fn(&'static str, Option<String>),
+) -> Result<(ContextOutput, Vec<component::Component>, i32)> {
     let cwd = match path {
         Some(p) => PathBuf::from(p),
         None => std::env::current_dir().map_err(|e| Error::internal_io(e.to_string(), None))?,
     };
 
     let cwd_str = cwd.to_string_lossy().to_string();
+    progress("resolve_context_target", Some(cwd_str.clone()));
     let resolved_target = component::resolve_target(component::TargetSpec {
         path_override: Some(&cwd_str),
         allow_synthetic: true,
@@ -87,6 +98,10 @@ pub fn run_with_inventory(
         .as_ref()
         .map(|path| path.to_string_lossy().to_string());
 
+    progress(
+        "build_component_inventory",
+        Some("component_registry".to_string()),
+    );
     let components = component::inventory().unwrap_or_default();
     let matched_components: Vec<String> = components
         .iter()

--- a/crates/homeboy-core/src/context/report.rs
+++ b/crates/homeboy-core/src/context/report.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use serde::Serialize;
 
@@ -181,8 +182,34 @@ pub struct ComponentWithState {
     pub gaps: Vec<ComponentGap>,
 }
 
+/// Structured progress for the expensive, independently executable parts of a
+/// context report. Callers can expose this across an isolation boundary without
+/// parsing human-oriented stderr.
+#[derive(Debug, Clone)]
+pub struct ReportProgress {
+    pub phase: &'static str,
+    pub current: Option<String>,
+    pub completed: usize,
+    pub total: usize,
+    pub unfinished: Vec<String>,
+    pub item_deadline_ms: Option<u128>,
+}
+
+const CONTEXT_REPORT_WORKERS: usize = 4;
+const CONTEXT_REPORT_ITEM_DEADLINE_MS: u128 = 25_000;
+
 pub fn build_report(show_all_flag: bool, command: &str) -> Result<ContextReport> {
-    build_report_at(show_all_flag, command, None, None)
+    build_report_with_progress(show_all_flag, command, |_| {})
+}
+
+/// Build a context report and expose the current inventory/release-state work.
+/// The caller retains ownership of enforcing the aggregate process deadline.
+pub fn build_report_with_progress(
+    show_all_flag: bool,
+    command: &str,
+    progress: impl Fn(ReportProgress) + Sync,
+) -> Result<ContextReport> {
+    build_report_at(show_all_flag, command, None, None, &progress)
 }
 
 pub fn build_report_for_component(
@@ -191,7 +218,7 @@ pub fn build_report_for_component(
     component: Component,
     path: Option<&str>,
 ) -> Result<ContextReport> {
-    build_report_at(show_all_flag, command, path, Some(component))
+    build_report_at(show_all_flag, command, path, Some(component), &|_| {})
 }
 
 fn build_report_at(
@@ -199,8 +226,19 @@ fn build_report_at(
     command: &str,
     path: Option<&str>,
     focused_component: Option<Component>,
+    progress: &(impl Fn(ReportProgress) + Sync),
 ) -> Result<ContextReport> {
-    let (context_output, _) = super::run(path)?;
+    let (context_output, all_components, _) =
+        super::run_with_inventory_with_progress(path, |phase, current| {
+            progress(ReportProgress {
+                phase,
+                current,
+                completed: 0,
+                total: 0,
+                unfinished: Vec::new(),
+                item_deadline_ms: None,
+            });
+        })?;
 
     let relevant_ids: HashSet<String> = context_output
         .matched_components
@@ -209,7 +247,6 @@ fn build_report_at(
         .cloned()
         .collect();
 
-    let all_components = component::inventory().unwrap_or_default();
     let all_projects = project::list().unwrap_or_default();
     let all_servers = server::list().unwrap_or_default();
     let all_extensions = load_all_extensions().unwrap_or_default();
@@ -232,26 +269,7 @@ fn build_report_at(
     let cwd = path
         .map(PathBuf::from)
         .or_else(|| std::env::current_dir().ok());
-    let components_with_state: Vec<ComponentWithState> = filtered_components
-        .into_iter()
-        .map(|component| {
-            let release_state = release_provider::calculate_release_state(&component);
-            let gaps = if let Some(ref cwd_path) = cwd {
-                if component::resolution::component_is_contained_in_path(&component, cwd_path) {
-                    build_component_info(&component).gaps
-                } else {
-                    Vec::new()
-                }
-            } else {
-                Vec::new()
-            };
-            ComponentWithState {
-                component,
-                release_state,
-                gaps,
-            }
-        })
-        .collect();
+    let components_with_state = build_component_states(filtered_components, cwd.clone(), progress);
 
     let bucket_entries: Vec<ReleaseStateEntry<'_>> = components_with_state
         .iter()
@@ -383,6 +401,98 @@ fn build_report_at(
         agent_context_files,
         warnings,
     })
+}
+
+fn build_component_states(
+    components: Vec<Component>,
+    cwd: Option<PathBuf>,
+    progress: &(impl Fn(ReportProgress) + Sync),
+) -> Vec<ComponentWithState> {
+    let total = components.len();
+    if total == 0 {
+        return Vec::new();
+    }
+    struct ProbeState {
+        completed: usize,
+        unfinished: Vec<String>,
+    }
+    let probe_state = Mutex::new(ProbeState {
+        completed: 0,
+        unfinished: components
+            .iter()
+            .map(|component| component.id.clone())
+            .collect(),
+    });
+    let initial = probe_state.lock().expect("probe state lock");
+    progress(ReportProgress {
+        phase: "calculate_release_state",
+        current: None,
+        completed: initial.completed,
+        total,
+        unfinished: initial.unfinished.clone(),
+        item_deadline_ms: Some(CONTEXT_REPORT_ITEM_DEADLINE_MS),
+    });
+    drop(initial);
+
+    let work = Mutex::new(components.into_iter().enumerate());
+    let states = Mutex::new(
+        std::iter::repeat_with(|| None)
+            .take(total)
+            .collect::<Vec<Option<ComponentWithState>>>(),
+    );
+    let workers = total.min(CONTEXT_REPORT_WORKERS);
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| loop {
+                let Some((index, component)) = work.lock().expect("report work lock").next() else {
+                    break;
+                };
+                let state = probe_state.lock().expect("probe state lock");
+                let event = ReportProgress {
+                    phase: "calculate_release_state",
+                    current: Some(component.id.clone()),
+                    completed: state.completed,
+                    total,
+                    unfinished: state.unfinished.clone(),
+                    item_deadline_ms: Some(CONTEXT_REPORT_ITEM_DEADLINE_MS),
+                };
+                drop(state);
+                progress(event);
+                let release_state = release_provider::calculate_release_state(&component);
+                let gaps = cwd
+                    .as_ref()
+                    .filter(|cwd_path| {
+                        component::resolution::component_is_contained_in_path(&component, cwd_path)
+                    })
+                    .map(|_| build_component_info(&component).gaps)
+                    .unwrap_or_default();
+                states.lock().expect("report states lock")[index] = Some(ComponentWithState {
+                    component: component.clone(),
+                    release_state,
+                    gaps,
+                });
+                let mut state = probe_state.lock().expect("probe state lock");
+                state.completed += 1;
+                state.unfinished.retain(|id| id != &component.id);
+                let event = ReportProgress {
+                    phase: "calculate_release_state",
+                    current: Some(component.id),
+                    completed: state.completed,
+                    total,
+                    unfinished: state.unfinished.clone(),
+                    item_deadline_ms: Some(CONTEXT_REPORT_ITEM_DEADLINE_MS),
+                };
+                drop(state);
+                progress(event);
+            });
+        }
+    });
+    states
+        .into_inner()
+        .expect("report states lock")
+        .into_iter()
+        .map(|state| state.expect("every report component is processed"))
+        .collect()
 }
 
 fn collect_focused_components(
@@ -703,6 +813,44 @@ fn resolve_git_snapshot(
         baseline_ref: snapshot.baseline_ref,
         baseline_warning: snapshot.baseline_warning,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_state_progress_names_all_unfinished_probes_and_preserves_order() {
+        let components = ["alpha", "beta", "gamma"]
+            .into_iter()
+            .map(|id| Component::new(id.to_string(), format!("/tmp/{id}"), String::new(), None))
+            .collect();
+        let progress = Mutex::new(Vec::new());
+
+        let states = build_component_states(components, None, &|event| {
+            progress.lock().expect("progress lock").push(event);
+        });
+
+        assert_eq!(
+            states
+                .iter()
+                .map(|state| state.component.id.as_str())
+                .collect::<Vec<_>>(),
+            ["alpha", "beta", "gamma"]
+        );
+        let progress = progress.into_inner().expect("progress lock");
+        assert_eq!(progress[0].unfinished, ["alpha", "beta", "gamma"]);
+        assert_eq!(
+            progress[0].item_deadline_ms,
+            Some(CONTEXT_REPORT_ITEM_DEADLINE_MS)
+        );
+        assert_eq!(progress.last().expect("completion event").completed, 3);
+        assert!(progress
+            .last()
+            .expect("completion event")
+            .unfinished
+            .is_empty());
+    }
 }
 
 fn resolve_changelog_snapshots(

--- a/crates/homeboy-core/src/deps.rs
+++ b/crates/homeboy-core/src/deps.rs
@@ -1392,6 +1392,7 @@ mod tests {
             progress: Some(homeboy_engine_primitives::command::CommandProgress {
                 phase: "building".to_string(),
                 current: Some("shared-component".to_string()),
+                ..Default::default()
             }),
             output_tail: String::new(),
         };

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -758,6 +758,14 @@ pub struct CommandProgress {
     pub phase: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total: Option<usize>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unfinished: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_deadline_ms: Option<u128>,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
Closes #14460

## Summary
- reuse the context inventory snapshot, identify target and registry providers, and surface probe counts, item deadlines, and exact unfinished component probes
- bound independent release-state calculations to four concurrent workers under the existing isolated aggregate deadline
- return focused component or provider remediation instead of only replaying `status --full`

## Verification
- `cargo test -p homeboy-core context::report::tests::component_state_progress_names_all_unfinished_probes_and_preserves_order`
- `cargo test -p homeboy-cli commands::status::tests::timed_out_full_probe_replays_only_unfinished_components`
- `cargo test -p homeboy-cli commands::status::tests::timed_out_context_target_probe_names_provider_and_avoids_full_replay`
- `cargo test -p homeboy-cli commands::status::tests::status_partial_serializes_exact_unfinished_probe_diagnostics`
- `cargo check`
- `cargo fmt --check`

## AI assistance
Implemented with OpenAI GPT-5.6 Terra via OpenCode.