### PR TITLE
fix(status): report only enforced probe limits

### DIFF
--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -180,7 +180,6 @@ fn run_unisolated(
                     completed: Some(progress.completed),
                     total: Some(progress.total),
                     unfinished: progress.unfinished,
-                    item_deadline_ms: progress.item_deadline_ms,
                 };
                 if let Ok(progress) = serde_json::to_string(&progress) {
                     eprintln!("HOMEBOY_PROGRESS {progress}");
@@ -310,17 +309,12 @@ fn run_isolated_probe(
                     .as_deref()
                     .map(|current| format!(" {current}"))
                     .unwrap_or_default();
-                let deadline = progress
-                    .item_deadline_ms
-                    .map(|deadline| format!(" deadline={deadline}ms"))
-                    .unwrap_or_default();
                 eprintln!(
-                    "[status] {PHASE}: {}{}{} ({}ms){}",
+                    "[status] {PHASE}: {}{}{} ({}ms)",
                     progress.phase,
                     current,
                     counts,
                     heartbeat.elapsed.as_millis(),
-                    deadline,
                 );
             } else {
                 eprintln!(
@@ -1605,7 +1599,6 @@ mod tests {
             completed: Some(2),
             total: Some(4),
             unfinished: vec!["slow-component".to_string(), "queued-component".to_string()],
-            item_deadline_ms: Some(25_000),
         };
 
         assert_eq!(

--- a/crates/homeboy-core/src/context/report.rs
+++ b/crates/homeboy-core/src/context/report.rs
@@ -192,11 +192,9 @@ pub struct ReportProgress {
     pub completed: usize,
     pub total: usize,
     pub unfinished: Vec<String>,
-    pub item_deadline_ms: Option<u128>,
 }
 
 const CONTEXT_REPORT_WORKERS: usize = 4;
-const CONTEXT_REPORT_ITEM_DEADLINE_MS: u128 = 25_000;
 
 pub fn build_report(show_all_flag: bool, command: &str) -> Result<ContextReport> {
     build_report_with_progress(show_all_flag, command, |_| {})
@@ -236,7 +234,6 @@ fn build_report_at(
                 completed: 0,
                 total: 0,
                 unfinished: Vec::new(),
-                item_deadline_ms: None,
             });
         })?;
 
@@ -430,7 +427,6 @@ fn build_component_states(
         completed: initial.completed,
         total,
         unfinished: initial.unfinished.clone(),
-        item_deadline_ms: Some(CONTEXT_REPORT_ITEM_DEADLINE_MS),
     });
     drop(initial);
 
@@ -454,7 +450,6 @@ fn build_component_states(
                     completed: state.completed,
                     total,
                     unfinished: state.unfinished.clone(),
-                    item_deadline_ms: Some(CONTEXT_REPORT_ITEM_DEADLINE_MS),
                 };
                 drop(state);
                 progress(event);
@@ -480,7 +475,6 @@ fn build_component_states(
                     completed: state.completed,
                     total,
                     unfinished: state.unfinished.clone(),
-                    item_deadline_ms: Some(CONTEXT_REPORT_ITEM_DEADLINE_MS),
                 };
                 drop(state);
                 progress(event);
@@ -840,10 +834,6 @@ mod tests {
         );
         let progress = progress.into_inner().expect("progress lock");
         assert_eq!(progress[0].unfinished, ["alpha", "beta", "gamma"]);
-        assert_eq!(
-            progress[0].item_deadline_ms,
-            Some(CONTEXT_REPORT_ITEM_DEADLINE_MS)
-        );
         assert_eq!(progress.last().expect("completion event").completed, 3);
         assert!(progress
             .last()

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -764,8 +764,6 @@ pub struct CommandProgress {
     pub total: Option<usize>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub unfinished: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub item_deadline_ms: Option<u128>,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
## Summary
- stop advertising a per-item status deadline that is not enforced
- retain the aggregate isolated deadline and exact unfinished-probe diagnostics
- remove the misleading deadline field from progress output and its wire projection

Follow-up correctness fix from the review of #14472 for #14460.

## Verification
- `cargo test -p homeboy-core context::report::tests --no-fail-fast`
- `cargo test -p homeboy-cli commands::status::tests --no-fail-fast`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode reviewed the merged implementation, identified the unenforced deadline claim, implemented the correction, and verified the focused status suites.