### PR TITLE
fix(agent-task): heartbeat runner-owned Cook startup

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -5443,21 +5443,19 @@ fn run_cook_spine(
     }
     // Base resolution reaches origin. Keep its transport failure behind the
     // recipe/run saga so retry and replay have durable zero-provider evidence.
-    let has_startup_workspace = cook_startup_workspace(&options).is_some();
     let cook_id = options.identity.cook_id.clone();
     let run_id = options.identity.initial_run_id.clone();
-    let base_capture = if has_startup_workspace {
-        run_cook_startup_phase(
-            lifecycle_store,
-            durable_observer,
-            &cook_id,
-            &run_id,
-            "workspace_base_capture",
-            || pin_and_persist_initial_cook_workspace_base(store, lifecycle_store, &mut options),
-        )
-    } else {
-        pin_and_persist_initial_cook_workspace_base(store, lifecycle_store, &mut options)
-    };
+    // Even a runner-owned workspace can wait on this Cook's shared capture
+    // lock, so keep the durable attempt live regardless of whether the
+    // controller has a local path to pin.
+    let base_capture = run_cook_startup_phase(
+        lifecycle_store,
+        durable_observer,
+        &cook_id,
+        &run_id,
+        "workspace_base_capture",
+        || pin_and_persist_initial_cook_workspace_base(store, lifecycle_store, &mut options),
+    );
     base_capture.map_err(|error| {
         let mut error = error;
         error.details["cook_materialized_by_invocation"] = Value::Bool(true);

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -9152,6 +9152,11 @@ fn cook_repairs_initial_alias_after_submit_before_index_interruption() {
                     run_id.to_string()
                 ),
                 (
+                    "workspace_base_capture".to_string(),
+                    cook_id.to_string(),
+                    run_id.to_string()
+                ),
+                (
                     "provider_ready".to_string(),
                     cook_id.to_string(),
                     run_id.to_string()
@@ -10968,6 +10973,11 @@ fn cook_claims_its_durable_attempt_before_slow_baseline_materialization() {
             agent_task_lifecycle::reconcile_status("cook-slow-baseline-attempt-1")
                 .expect("staging attempt is durable before controller completion")
         });
+        assert_eq!(
+            dispatches.load(Ordering::SeqCst),
+            0,
+            "provider handoff must wait for startup base capture"
+        );
         std::fs::write(&release, "release").expect("release baseline staging");
         let result = controller
             .join()


### PR DESCRIPTION
## Summary
- heartbeat workspace base capture for runner-owned Cook attempts as well as controller-owned workspaces
- keep the durable attempt live while waiting on the shared capture lock
- verify provider handoff cannot begin before startup base capture completes

Follow-up correctness fix from the review of #14466 for #14459.

## Verification
- `cargo test -p homeboy-agents cook_repairs_initial_alias_after_submit_before_index_interruption --no-fail-fast`
- `cargo test -p homeboy-agents cook_claims_its_durable_attempt_before_slow_baseline_materialization --no-fail-fast`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode reviewed the merged implementation, identified the runner-owned startup gap, implemented the fix, and added focused regression coverage.