### PR TITLE
refactor(core): declare the extension root manifest once

### DIFF
--- a/crates/homeboy-core/src/extension/catalog/mod.rs
+++ b/crates/homeboy-core/src/extension/catalog/mod.rs
@@ -1,8 +1,8 @@
 use crate::config;
 use crate::error::{Error, ErrorCode, Result};
+use crate::extension::root_manifest::ExtensionRootManifest;
 use crate::output::MergeOutput;
 use crate::paths;
-use serde::Deserialize;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -181,27 +181,6 @@ fn discover_extensions_at(extensions_dir: &Path) -> Vec<DiscoveredExtension> {
     extensions
         .sort_by(|left, right| discovered_extension_id(left).cmp(discovered_extension_id(right)));
     extensions
-}
-
-#[derive(Deserialize)]
-struct ExtensionRootManifest {
-    #[serde(default)]
-    shared_assets: Vec<SharedAssetDeclaration>,
-}
-
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum SharedAssetDeclaration {
-    Path(String),
-    Object { path: String },
-}
-
-impl SharedAssetDeclaration {
-    fn path(self) -> String {
-        match self {
-            Self::Path(path) | Self::Object { path } => path,
-        }
-    }
 }
 
 /// Shared assets live beside installed extensions but are declared by a source

--- a/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
@@ -5,12 +5,12 @@
 //! assets, and linking a local source directory. Kept in a sibling module so
 //! the lifecycle root stays under the structural line/item thresholds (#5241).
 
-use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 use homeboy_core::config::{self, from_str};
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension::registry::ExtensionLifecycleValidation;
+use homeboy_core::extension::root_manifest::{ExtensionRootManifest, SharedAssetDeclaration};
 use homeboy_core::git;
 use homeboy_core::paths;
 use homeboy_engine_primitives::local_files;
@@ -21,28 +21,6 @@ use super::{
     InstallResult,
 };
 use homeboy_extension_contract::ExtensionManifest;
-
-#[derive(Debug, Deserialize)]
-struct ExtensionRootManifest {
-    #[serde(default)]
-    shared_assets: Vec<SharedAssetDeclaration>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum SharedAssetDeclaration {
-    Path(String),
-    Object { path: String },
-}
-
-impl SharedAssetDeclaration {
-    fn into_path(self) -> String {
-        match self {
-            SharedAssetDeclaration::Path(path) => path,
-            SharedAssetDeclaration::Object { path } => path,
-        }
-    }
-}
 
 const ROOT_MANIFEST: &str = "homeboy-extension-root.json";
 const INSTALLED_ROOT_MANIFEST: &str = ".homeboy-extension-root.json";
@@ -55,7 +33,7 @@ fn shared_assets_for_manifest(manifest_path: &Path) -> Vec<String> {
             manifest
                 .shared_assets
                 .into_iter()
-                .map(SharedAssetDeclaration::into_path)
+                .map(SharedAssetDeclaration::path)
                 .map(|path| path.trim().to_string())
                 .filter(|path| !path.is_empty())
                 .collect::<Vec<_>>()

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -18,6 +18,7 @@ pub mod readiness;
 pub mod recipe_run_api;
 pub mod registry;
 pub mod resolve;
+pub(crate) mod root_manifest;
 pub mod self_check;
 mod setup_env;
 pub mod test;

--- a/crates/homeboy-core/src/extension/root_manifest.rs
+++ b/crates/homeboy-core/src/extension/root_manifest.rs
@@ -1,0 +1,31 @@
+//! The extension source root manifest (`homeboy-extension-root.json`).
+//!
+//! Shared assets are declared by a source root rather than by extension
+//! manifests, in either a bare-path or object form. Catalog listing, install
+//! source resolution and runtime packaging all read that same declaration, so
+//! the shape lives here once instead of being restated per consumer.
+
+use serde::Deserialize;
+
+/// Manifest at the root of an extension source tree.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ExtensionRootManifest {
+    #[serde(default)]
+    pub(crate) shared_assets: Vec<SharedAssetDeclaration>,
+}
+
+/// A shared asset entry, accepted as `"path"` or `{"path": "path"}`.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum SharedAssetDeclaration {
+    Path(String),
+    Object { path: String },
+}
+
+impl SharedAssetDeclaration {
+    pub(crate) fn path(self) -> String {
+        match self {
+            Self::Path(path) | Self::Object { path } => path,
+        }
+    }
+}

--- a/crates/homeboy-core/src/runtime_package.rs
+++ b/crates/homeboy-core/src/runtime_package.rs
@@ -1,3 +1,4 @@
+use crate::extension::root_manifest::{ExtensionRootManifest, SharedAssetDeclaration};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs::{self, File};
@@ -34,27 +35,6 @@ pub struct RuntimePackageRefreshResult {
     pub manifest_path: PathBuf,
     pub source_revision: Option<String>,
     pub replaced_existing: bool,
-}
-
-#[derive(Debug, Deserialize)]
-struct RootManifest {
-    #[serde(default)]
-    shared_assets: Vec<SharedAssetDeclaration>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum SharedAssetDeclaration {
-    Path(String),
-    Object { path: String },
-}
-
-impl SharedAssetDeclaration {
-    fn path(self) -> String {
-        match self {
-            Self::Path(path) | Self::Object { path } => path,
-        }
-    }
 }
 
 #[derive(Debug, Serialize)]
@@ -454,7 +434,7 @@ fn materialize_declared_assets(root: &Path, stage: &Path, runtime_id: &str) -> R
     let Ok(raw) = fs::read_to_string(&manifest) else {
         return Ok(Vec::new());
     };
-    let parsed: RootManifest = serde_json::from_str(&raw).map_err(|error| {
+    let parsed: ExtensionRootManifest = serde_json::from_str(&raw).map_err(|error| {
         Error::validation_invalid_argument(
             "source",
             format!("invalid shared asset manifest: {error}"),
@@ -497,7 +477,7 @@ fn materialize_declared_assets(root: &Path, stage: &Path, runtime_id: &str) -> R
 fn materialize_all_declared_runtime_assets(root: &Path, stage: &Path) -> Result<()> {
     let manifest = root.join(ROOT_MANIFEST);
     let raw = fs::read_to_string(&manifest).map_err(io("read linked runtime asset manifest"))?;
-    let parsed: RootManifest = serde_json::from_str(&raw).map_err(|error| {
+    let parsed: ExtensionRootManifest = serde_json::from_str(&raw).map_err(|error| {
         Error::validation_invalid_argument(
             "source",
             format!("invalid shared asset manifest: {error}"),
@@ -1093,7 +1073,7 @@ mod tests {
                 staged_source.path().join(ROOT_MANIFEST),
             )
             .unwrap();
-            let manifest: RootManifest =
+            let manifest: ExtensionRootManifest =
                 serde_json::from_slice(&fs::read(source.join(ROOT_MANIFEST)).unwrap()).unwrap();
             for asset in manifest.shared_assets {
                 let asset = asset.path();


### PR DESCRIPTION
## Summary
`SharedAssetDeclaration` and its `ExtensionRootManifest` wrapper were defined **three separate times** inside `homeboy-core`, byte-identical apart from one method being called `into_path` instead of `path`:

- `extension/catalog/mod.rs`
- `extension/lifecycle/install_sources.rs`
- `runtime_package.rs` (as `RootManifest`)

All three parse the same on-disk file, `homeboy-extension-root.json`, and all three accept the same two forms (`"path"` or `{"path": "..."}`). Three copies of one wire format is three chances for them to drift apart silently.

Now declared once in `extension/root_manifest.rs` and shared.

## Net effect
70 lines removed, 8 added at the call sites, plus a 31-line shared module — **about 31 lines net removed**, and the untagged deserialiser that defines the accepted shape exists in exactly one place.

## Verification
`cargo check --workspace` is clean. The 48 tests covering catalog listing, install-source resolution, shared assets and runtime packaging all pass:

```
Summary [13.264s] 48 tests run: 48 passed, 3587 skipped
```

No behaviour change: same derives, same `serde(untagged)`, same accepted forms.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode found the triplication while auditing `serde(untagged)` compatibility readers, consolidated it, and ran the affected tests. Chris Huber directed the work and remains responsible for acceptance.