### PR TITLE
ci: enforce terminal required gates verdict

### DIFF
--- a/.github/ci-required-gates-executed.sh
+++ b/.github/ci-required-gates-executed.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+head_sha="${REQUIRED_GATES_HEAD_SHA:-${GITHUB_SHA:-unknown}}"
+results="${CI_GATE_RESULTS:-}"
+
+if ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"${results}"; then
+  echo "::error::required-gates-executed requires CI_GATE_RESULTS=toJSON(needs)"
+  exit 1
+fi
+
+failed="$(jq -r 'to_entries | map(select(.value.result != "success") | "\(.key)=\(.value.result // "missing")") | join(", ")' <<<"${results}")"
+missing=''
+for job in rustfmt lint homeboy; do
+  if ! jq -e --arg job "${job}" 'has($job)' >/dev/null <<<"${results}"; then
+    missing="${missing}${missing:+, }${job}"
+  fi
+done
+echo "required-gates-executed head=${head_sha} needs=$(jq -cS . <<<"${results}")"
+
+if [ -n "${failed}" ] || [ -n "${missing}" ]; then
+  echo "::error::required-gates-executed: required jobs did not all succeed for head ${head_sha}: ${failed} missing=[${missing}]"
+  exit 1
+fi
+
+echo "::notice::required-gates-executed: all required jobs succeeded for head ${head_sha}"

--- a/.github/required-gates-ruleset.json
+++ b/.github/required-gates-ruleset.json
@@ -34,6 +34,10 @@
           {
             "context": "homeboy / Test",
             "integration_id": 15368
+          },
+          {
+            "context": "homeboy / Required Gates Executed",
+            "integration_id": 15368
           }
         ],
         "strict_required_status_checks_policy": true

--- a/.github/validate-required-gates-ruleset.sh
+++ b/.github/validate-required-gates-ruleset.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "--github" ]; then
+  echo "usage: $0 --github" >&2
+  exit 2
+fi
+
+config="${REQUIRED_GATES_CONFIG:-.github/required-gates-ruleset.json}"
+ruleset_id="${GH_RULESET_ID:-13680120}"
+repository="${GITHUB_REPOSITORY:-Extra-Chill/homeboy}"
+branch="${GH_TARGET_BRANCH:-main}"
+head_sha="${REQUIRED_GATES_HEAD_SHA:-${GITHUB_SHA:-unknown}}"
+
+if [ ! -f "${config}" ]; then
+  echo "required-gates ruleset candidate not found: ${config}" >&2
+  exit 1
+fi
+
+live="${REQUIRED_GATES_LIVE_RULESET:-}"
+if [ -n "${live}" ]; then
+  if [ ! -f "${live}" ]; then
+    echo "required-gates live ruleset fixture not found: ${live}" >&2
+    exit 1
+  fi
+  payload="$(<"${live}")"
+else
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh is required to query the live ruleset" >&2
+    exit 1
+  fi
+  payload="$(gh api "repos/${repository}/rulesets/${ruleset_id}")"
+fi
+
+expected_contexts="$(jq -c '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | sort' "${config}")"
+live_contexts="$(jq -c '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | sort' <<<"${payload}")"
+expected_strict="$(jq -c '[.rules[] | select(.type == "required_status_checks") | .parameters.strict_required_status_checks_policy] | first' "${config}")"
+live_strict="$(jq -c '[.rules[] | select(.type == "required_status_checks") | .parameters.strict_required_status_checks_policy] | first' <<<"${payload}")"
+expected_bypass="$(jq -cS '.bypass_actors // []' "${config}")"
+live_bypass="$(jq -cS '.bypass_actors // []' <<<"${payload}")"
+
+outcome="enforced"
+reason=""
+if [ "${live_contexts}" = '[]' ]; then
+  outcome="absent"
+  reason="required_status_checks is absent"
+elif [ "${expected_contexts}" != "${live_contexts}" ] || [ "${expected_strict}" != "${live_strict}" ] || [ "${expected_bypass}" != "${live_bypass}" ] || [ "$(jq -r '.enforcement // empty' <<<"${payload}")" != "active" ]; then
+  outcome="divergent"
+  reason="live ruleset differs from the declared candidate"
+fi
+
+echo "required-gates-ruleset repo=${repository} branch=${branch} ruleset=${ruleset_id} head=${head_sha} outcome=${outcome} expected_contexts=${expected_contexts} live_contexts=${live_contexts} strict=${live_strict} bypass_actors=${live_bypass}"
+
+if [ "${outcome}" != "enforced" ]; then
+  echo "::error::required-gates-ruleset: ${reason}" >&2
+  exit 1
+fi

--- a/.github/validate-required-gates-ruleset.sh
+++ b/.github/validate-required-gates-ruleset.sh
@@ -32,24 +32,26 @@ else
   payload="$(gh api "repos/${repository}/rulesets/${ruleset_id}")"
 fi
 
-expected_contexts="$(jq -c '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | sort' "${config}")"
-live_contexts="$(jq -c '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | sort' <<<"${payload}")"
-expected_strict="$(jq -c '[.rules[] | select(.type == "required_status_checks") | .parameters.strict_required_status_checks_policy] | first' "${config}")"
-live_strict="$(jq -c '[.rules[] | select(.type == "required_status_checks") | .parameters.strict_required_status_checks_policy] | first' <<<"${payload}")"
-expected_bypass="$(jq -cS '.bypass_actors // []' "${config}")"
-live_bypass="$(jq -cS '.bypass_actors // []' <<<"${payload}")"
+project_contract() {
+  jq -cS '{name, target, enforcement, bypass_actors: (.bypass_actors // []), conditions, rules}'
+}
+
+expected_contract="$(project_contract < "${config}")"
+live_contract="$(project_contract <<<"${payload}")"
+expected_contexts="$(jq -c '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | sort' <<<"${expected_contract}")"
+live_contexts="$(jq -c '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | sort' <<<"${live_contract}")"
 
 outcome="enforced"
 reason=""
 if [ "${live_contexts}" = '[]' ]; then
   outcome="absent"
   reason="required_status_checks is absent"
-elif [ "${expected_contexts}" != "${live_contexts}" ] || [ "${expected_strict}" != "${live_strict}" ] || [ "${expected_bypass}" != "${live_bypass}" ] || [ "$(jq -r '.enforcement // empty' <<<"${payload}")" != "active" ]; then
+elif [ "${expected_contract}" != "${live_contract}" ]; then
   outcome="divergent"
   reason="live ruleset differs from the declared candidate"
 fi
 
-echo "required-gates-ruleset repo=${repository} branch=${branch} ruleset=${ruleset_id} head=${head_sha} outcome=${outcome} expected_contexts=${expected_contexts} live_contexts=${live_contexts} strict=${live_strict} bypass_actors=${live_bypass}"
+echo "required-gates-ruleset repo=${repository} branch=${branch} ruleset=${ruleset_id} head=${head_sha} outcome=${outcome} expected_contexts=${expected_contexts} live_contexts=${live_contexts} expected_contract=${expected_contract} live_contract=${live_contract}"
 
 if [ "${outcome}" != "enforced" ]; then
   echo "::error::required-gates-ruleset: ${reason}" >&2

--- a/.github/validate-required-gates-ruleset.sh
+++ b/.github/validate-required-gates-ruleset.sh
@@ -33,7 +33,37 @@ else
 fi
 
 project_contract() {
-  jq -cS '{name, target, enforcement, bypass_actors: (.bypass_actors // []), conditions, rules}'
+  jq -cS '
+    {
+      name,
+      target,
+      enforcement,
+      bypass_actors: [(.bypass_actors // [])[] | {actor_id, actor_type, bypass_mode}] | sort_by(.actor_id, .actor_type, .bypass_mode),
+      conditions: {
+        ref_name: {
+          include: (.conditions.ref_name.include // [] | sort),
+          exclude: (.conditions.ref_name.exclude // [] | sort)
+        }
+      },
+      rules: [
+        .rules[] |
+        if .type == "required_status_checks" then
+          {
+            type,
+            parameters: {
+              do_not_enforce_on_create: .parameters.do_not_enforce_on_create,
+              strict_required_status_checks_policy: .parameters.strict_required_status_checks_policy,
+              required_status_checks: [
+                .parameters.required_status_checks[]? | {context, integration_id}
+              ] | sort_by(.context, .integration_id)
+            }
+          }
+        else
+          {type}
+        end
+      ] | sort_by(.type)
+    }
+  '
 }
 
 expected_contract="$(project_contract < "${config}")"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - name: Verify every required gate completed for this PR head
         env:
           CI_GATE_RESULTS: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,15 @@ jobs:
       comment-section-key: test
       comment-section-title: Test
     secrets: inherit
+
+  required-gates-executed:
+    name: homeboy / Required Gates Executed
+    needs: [rustfmt, lint, homeboy]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify every required gate completed for this PR head
+        env:
+          CI_GATE_RESULTS: ${{ toJSON(needs) }}
+          REQUIRED_GATES_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: bash .github/ci-required-gates-executed.sh

--- a/.github/workflows/required-gates-ruleset-audit.yml
+++ b/.github/workflows/required-gates-ruleset-audit.yml
@@ -1,0 +1,21 @@
+name: Required Gates Ruleset Audit
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: homeboy / Required Gates Ruleset Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify the live main ruleset matches the declared candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUIRED_GATES_HEAD_SHA: ${{ github.sha }}
+        run: bash .github/validate-required-gates-ruleset.sh --github

--- a/docs/operations/required-gates-ruleset.md
+++ b/docs/operations/required-gates-ruleset.md
@@ -8,8 +8,10 @@ dependencies.
 
 The scheduled `Required Gates Ruleset Audit` workflow is read-only. It queries
 the live ruleset and fails with reviewer-resolvable evidence containing the
-repository, branch, ruleset ID, head SHA, expected and live contexts,
-strictness, and bypass actors.
+repository, branch, ruleset ID, head SHA, and expected and live ruleset
+contracts. The comparison covers the target and `main` ref conditions,
+enforcement, every required rule and status-check parameter (including
+strictness and create behavior), and bypass actors.
 
 ## Operator Application
 

--- a/docs/operations/required-gates-ruleset.md
+++ b/docs/operations/required-gates-ruleset.md
@@ -1,0 +1,26 @@
+# Required Gates Ruleset
+
+`.github/required-gates-ruleset.json` is the reviewed candidate for the active
+`main` ruleset `13680120`. It requires strict checks for the PR head, including
+`homeboy / Required Gates Executed`, which fails whenever Rustfmt, Lint, or Test
+is pending, skipped, cancelled, failed, or absent from the terminal job's
+dependencies.
+
+The scheduled `Required Gates Ruleset Audit` workflow is read-only. It queries
+the live ruleset and fails with reviewer-resolvable evidence containing the
+repository, branch, ruleset ID, head SHA, expected and live contexts,
+strictness, and bypass actors.
+
+## Operator Application
+
+After this candidate is reviewed and merged, an administrator must apply it to
+the existing live ruleset. This repository change deliberately does not mutate
+GitHub configuration:
+
+```sh
+gh api --method PUT repos/Extra-Chill/homeboy/rulesets/13680120 \
+  --input .github/required-gates-ruleset.json
+```
+
+Then manually run `Required Gates Ruleset Audit` and retain its successful run
+URL as the application evidence.

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -1,0 +1,105 @@
+use std::{
+    process::Command,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+const CANDIDATE: &str = include_str!("../.github/required-gates-ruleset.json");
+static FIXTURE_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
+
+fn run_validator(live: &str) -> std::process::Output {
+    let fixture = std::env::temp_dir().join(format!(
+        "homeboy-required-gates-ruleset-{}-{}.json",
+        std::process::id(),
+        FIXTURE_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::write(&fixture, live).expect("write live ruleset fixture");
+    let output = Command::new("bash")
+        .args([".github/validate-required-gates-ruleset.sh", "--github"])
+        .env("REQUIRED_GATES_LIVE_RULESET", &fixture)
+        .env(
+            "REQUIRED_GATES_HEAD_SHA",
+            "0123456789012345678901234567890123456789",
+        )
+        .output()
+        .expect("run ruleset validator");
+    let _ = std::fs::remove_file(fixture);
+    output
+}
+
+fn live_ruleset(contexts: serde_json::Value) -> String {
+    serde_json::json!({
+        "id": 13680120,
+        "name": "main",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "rules": [
+            { "type": "deletion" },
+            { "type": "non_fast_forward" },
+            { "type": "required_status_checks", "parameters": {
+                "do_not_enforce_on_create": false,
+                "strict_required_status_checks_policy": true,
+                "required_status_checks": contexts
+            }}
+        ]
+    })
+    .to_string()
+}
+
+#[test]
+fn candidate_requires_the_terminal_context_and_ci_emits_it() {
+    let candidate: serde_json::Value = serde_json::from_str(CANDIDATE).expect("candidate JSON");
+    let contexts = &candidate["rules"]
+        .as_array()
+        .expect("rules")
+        .iter()
+        .find(|rule| rule["type"] == "required_status_checks")
+        .expect("required-status-check rule")["parameters"]["required_status_checks"];
+    assert!(contexts
+        .as_array()
+        .expect("contexts")
+        .iter()
+        .any(|check| check["context"] == "homeboy / Required Gates Executed"));
+
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    assert!(workflow.contains("name: homeboy / Required Gates Executed"));
+    assert!(workflow.contains("if: ${{ always() }}"));
+    assert!(workflow.contains("CI_GATE_RESULTS: ${{ toJSON(needs) }}"));
+}
+
+#[test]
+fn live_ruleset_validation_fails_when_status_checks_are_absent_or_diverge() {
+    let absent = serde_json::json!({
+        "id": 13680120,
+        "name": "main",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "rules": [{ "type": "deletion" }, { "type": "non_fast_forward" }]
+    })
+    .to_string();
+    let absent_output = run_validator(&absent);
+    assert!(!absent_output.status.success());
+    assert!(String::from_utf8_lossy(&absent_output.stdout).contains("outcome=absent"));
+
+    let divergent_output = run_validator(
+        live_ruleset(serde_json::json!([
+            { "context": "homeboy / Rustfmt", "integration_id": 15368 }
+        ]))
+        .as_str(),
+    );
+    assert!(!divergent_output.status.success());
+    assert!(String::from_utf8_lossy(&divergent_output.stdout).contains("outcome=divergent"));
+}
+
+#[test]
+fn terminal_gate_rejects_cancelled_required_work() {
+    let output = Command::new("bash")
+        .arg(".github/ci-required-gates-executed.sh")
+        .env("REQUIRED_GATES_HEAD_SHA", "0123456789012345678901234567890123456789")
+        .env("CI_GATE_RESULTS", r#"{"rustfmt":{"result":"success"},"lint":{"result":"cancelled"},"homeboy":{"result":"success"}}"#)
+        .output()
+        .expect("run terminal gate");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("lint=cancelled"));
+}

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -62,6 +62,10 @@ fn terminal_job_checks_out_the_pr_head_before_running_its_script() {
         .split("  required-gates-executed:")
         .nth(1)
         .expect("terminal job");
+    assert!(
+        terminal_job.contains("needs: [rustfmt, lint, homeboy]"),
+        "the terminal job must depend only on the gates it evaluates"
+    );
     let checkout = terminal_job
         .find("- uses: actions/checkout@v6")
         .expect("terminal job checkout");
@@ -72,6 +76,28 @@ fn terminal_job_checks_out_the_pr_head_before_running_its_script() {
         checkout < script,
         "the repository script must be checked out first"
     );
+}
+
+#[test]
+fn live_ruleset_validation_ignores_status_check_order_and_response_metadata() {
+    let live = divergent_live_ruleset(|ruleset| {
+        ruleset["node_id"] = serde_json::json!("RRS_kwDOExample");
+        ruleset["updated_at"] = serde_json::json!("2026-09-09T13:00:00Z");
+        let checks = ruleset["rules"][2]["parameters"]["required_status_checks"]
+            .as_array_mut()
+            .expect("required status checks");
+        checks.reverse();
+        checks[0]["url"] = serde_json::json!("https://api.github.com/checks/1");
+        checks[0]["node_id"] = serde_json::json!("RSC_kwDOExample");
+    });
+
+    let output = run_validator(&live);
+    assert!(
+        output.status.success(),
+        "reordered checks and GitHub response metadata must not cause divergence: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("outcome=enforced"));
 }
 
 #[test]

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -26,24 +26,12 @@ fn run_validator(live: &str) -> std::process::Output {
     output
 }
 
-fn live_ruleset(contexts: serde_json::Value) -> String {
-    serde_json::json!({
-        "id": 13680120,
-        "name": "main",
-        "target": "branch",
-        "enforcement": "active",
-        "bypass_actors": [],
-        "rules": [
-            { "type": "deletion" },
-            { "type": "non_fast_forward" },
-            { "type": "required_status_checks", "parameters": {
-                "do_not_enforce_on_create": false,
-                "strict_required_status_checks_policy": true,
-                "required_status_checks": contexts
-            }}
-        ]
-    })
-    .to_string()
+fn divergent_live_ruleset(mutate: impl FnOnce(&mut serde_json::Value)) -> String {
+    let candidate: serde_json::Value = serde_json::from_str(CANDIDATE).expect("candidate JSON");
+    let mut live = candidate;
+    live["id"] = serde_json::json!(13680120);
+    mutate(&mut live);
+    live.to_string()
 }
 
 #[test]
@@ -68,7 +56,26 @@ fn candidate_requires_the_terminal_context_and_ci_emits_it() {
 }
 
 #[test]
-fn live_ruleset_validation_fails_when_status_checks_are_absent_or_diverge() {
+fn terminal_job_checks_out_the_pr_head_before_running_its_script() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+    let terminal_job = workflow
+        .split("  required-gates-executed:")
+        .nth(1)
+        .expect("terminal job");
+    let checkout = terminal_job
+        .find("- uses: actions/checkout@v6")
+        .expect("terminal job checkout");
+    let script = terminal_job
+        .find("bash .github/ci-required-gates-executed.sh")
+        .expect("terminal job script");
+    assert!(
+        checkout < script,
+        "the repository script must be checked out first"
+    );
+}
+
+#[test]
+fn live_ruleset_validation_fails_when_status_checks_are_absent_or_declared_contract_diverges() {
     let absent = serde_json::json!({
         "id": 13680120,
         "name": "main",
@@ -82,24 +89,91 @@ fn live_ruleset_validation_fails_when_status_checks_are_absent_or_diverge() {
     assert!(!absent_output.status.success());
     assert!(String::from_utf8_lossy(&absent_output.stdout).contains("outcome=absent"));
 
-    let divergent_output = run_validator(
-        live_ruleset(serde_json::json!([
-            { "context": "homeboy / Rustfmt", "integration_id": 15368 }
-        ]))
-        .as_str(),
-    );
-    assert!(!divergent_output.status.success());
-    assert!(String::from_utf8_lossy(&divergent_output.stdout).contains("outcome=divergent"));
+    for (name, live) in [
+        (
+            "target-branch",
+            divergent_live_ruleset(|ruleset| {
+                ruleset["conditions"]["ref_name"]["include"] =
+                    serde_json::json!(["refs/heads/release"]);
+            }),
+        ),
+        (
+            "missing-required-rule",
+            divergent_live_ruleset(|ruleset| {
+                ruleset["rules"][1] = serde_json::json!({ "type": "creation" });
+            }),
+        ),
+        (
+            "nonstrict",
+            divergent_live_ruleset(|ruleset| {
+                ruleset["rules"][2]["parameters"]["strict_required_status_checks_policy"] =
+                    serde_json::json!(false);
+            }),
+        ),
+        (
+            "bypass-actor",
+            divergent_live_ruleset(|ruleset| {
+                ruleset["bypass_actors"] = serde_json::json!([{ "actor_id": 1, "actor_type": "RepositoryRole", "bypass_mode": "always" }]);
+            }),
+        ),
+        (
+            "create-behavior",
+            divergent_live_ruleset(|ruleset| {
+                ruleset["rules"][2]["parameters"]["do_not_enforce_on_create"] =
+                    serde_json::json!(true);
+            }),
+        ),
+    ] {
+        let output = run_validator(&live);
+        assert!(
+            !output.status.success(),
+            "{name} divergence must fail the live audit"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("outcome=divergent"),
+            "{name} divergence must be reported"
+        );
+    }
 }
 
 #[test]
-fn terminal_gate_rejects_cancelled_required_work() {
-    let output = Command::new("bash")
-        .arg(".github/ci-required-gates-executed.sh")
-        .env("REQUIRED_GATES_HEAD_SHA", "0123456789012345678901234567890123456789")
-        .env("CI_GATE_RESULTS", r#"{"rustfmt":{"result":"success"},"lint":{"result":"cancelled"},"homeboy":{"result":"success"}}"#)
-        .output()
-        .expect("run terminal gate");
-    assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stdout).contains("lint=cancelled"));
+fn terminal_gate_rejects_cancelled_pending_and_absent_work_for_the_pr_head() {
+    const HEAD: &str = "0123456789012345678901234567890123456789";
+    for (name, results, expected) in [
+        (
+            "cancelled",
+            r#"{"rustfmt":{"result":"success"},"lint":{"result":"cancelled"},"homeboy":{"result":"success"}}"#,
+            "lint=cancelled",
+        ),
+        (
+            "pending",
+            r#"{"rustfmt":{"result":"success"},"lint":{"result":"success"},"homeboy":{"result":"pending"}}"#,
+            "homeboy=pending",
+        ),
+        (
+            "absent",
+            r#"{"rustfmt":{"result":"success"},"lint":{"result":"success"}}"#,
+            "missing=[homeboy]",
+        ),
+    ] {
+        let output = Command::new("bash")
+            .arg(".github/ci-required-gates-executed.sh")
+            .env("REQUIRED_GATES_HEAD_SHA", HEAD)
+            .env("CI_GATE_RESULTS", results)
+            .output()
+            .expect("run terminal gate");
+        assert!(
+            !output.status.success(),
+            "{name} work must fail the PR head"
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(HEAD),
+            "{name} result must identify the PR head"
+        );
+        assert!(
+            stdout.contains(expected),
+            "{name} result must identify the gate state"
+        );
+    }
 }


### PR DESCRIPTION
Closes #12833

## Summary
- declare `homeboy / Required Gates Executed` as a strict required status check
- add an always-run terminal CI verdict that fails if Rustfmt, Lint, or Test is not successful for the PR head
- checkout the repository before the terminal job invokes its versioned verdict script
- add a read-only scheduled/manual ruleset audit that compares the complete declared ruleset contract: target and `main` ref conditions, enforcement, required rules and status-check parameters, bypass actors, strictness, and create behavior
- cover missing checkout, target-branch and ruleset-contract divergence, and cancelled/pending/absent PR-head gates with focused policy tests

## Verification
- `cargo fmt --all --check`
- `cargo test --test required_gates_policy_test`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/ci.yml .github/workflows/required-gates-ruleset-audit.yml`
- `jq empty .github/required-gates-ruleset.json`
- `bash -n .github/ci-required-gates-executed.sh .github/validate-required-gates-ruleset.sh`

## Operator Step
This PR intentionally does not modify live GitHub configuration. Repository history shows the former approval-gated convergence machinery was reverted and later deliberately removed in #13998; this repair remains read-only rather than restoring that retired orchestration. After merge, an administrator must apply `.github/required-gates-ruleset.json` to existing ruleset `13680120` and manually run `Required Gates Ruleset Audit`; `docs/operations/required-gates-ruleset.md` contains the command and evidence requirement.

AI assistance: OpenAI `openai/gpt-5.6-terra` via OpenCode.