### PR TITLE
fix(runner): remove derived job authority

### DIFF
--- a/crates/contracts/homeboy-api-jobs-contract/src/types.rs
+++ b/crates/contracts/homeboy-api-jobs-contract/src/types.rs
@@ -167,13 +167,38 @@ pub struct ActiveRunnerJobSummary {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stale_reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lifecycle_state: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub retryable: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_child_count: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_cell_count: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActiveRunnerJobSummary;
+
+    #[test]
+    fn legacy_runner_summary_authority_fields_deserialize_without_reemitting() {
+        let legacy = serde_json::json!({
+            "runner_id": "runner-a",
+            "job_id": "job-a",
+            "operation": "runner.exec",
+            "source": "daemon",
+            "kind": "runner.exec",
+            "status": "running",
+            "command": "true",
+            "started_at_ms": 1,
+            "elapsed_ms": 0,
+            "lifecycle_state": "active",
+            "retryable": false
+        });
+
+        let summary: ActiveRunnerJobSummary =
+            serde_json::from_value(legacy).expect("old daemon summary deserializes");
+        let emitted = serde_json::to_value(summary).expect("summary serializes");
+
+        assert!(emitted.get("lifecycle_state").is_none());
+        assert!(emitted.get("retryable").is_none());
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-cli/src/commands/runner/jobs.rs
+++ b/crates/homeboy-cli/src/commands/runner/jobs.rs
@@ -205,8 +205,7 @@ fn project_job_list(
                 .flatten(),
         )
         .map(|job| {
-            let unknown_owner = job.lifecycle_state.as_deref() == Some("unknown_owner")
-                && job.job_id.starts_with("unknown-daemon-owner-");
+            let unknown_owner = job.job_id.starts_with("unknown-daemon-owner-");
             RunnerJobListEntry {
                 job_id: job.job_id.clone(),
                 source: if unknown_owner {
@@ -782,8 +781,6 @@ mod tests {
             claim_expires_in_ms: None,
             durable_run_id: Some("run-11770".to_string()),
             stale_reason: None,
-            lifecycle_state: Some("active".to_string()),
-            retryable: Some(false),
             artifact_refs: Vec::new(),
         }
     }
@@ -901,13 +898,11 @@ mod tests {
 
     #[test]
     fn unknown_daemon_owner_is_inspect_only() {
-        let mut unknown = runner_job(
+        let unknown = runner_job(
             "unknown-daemon-owner-lease-live-1",
             JobStatus::Running,
             "unprojected daemon child",
         );
-        unknown.lifecycle_state = Some("unknown_owner".to_string());
-
         let jobs = project_job_list(
             "homeboy-lab",
             &[unknown],

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -1966,7 +1966,7 @@ fn runner_status_operator_commands_with_recovery_guidance(
         .iter()
         .chain(report.stale_runner_jobs.iter())
     {
-        if job.lifecycle_state.as_deref() == Some("unknown_owner") {
+        if job.job_id.starts_with("unknown-daemon-owner-") {
             if !commands
                 .iter()
                 .any(|command| command.scope == "unknown_owner_reconcile")
@@ -1981,7 +1981,7 @@ fn runner_status_operator_commands_with_recovery_guidance(
             }
             continue;
         }
-        if job.lifecycle_state.as_deref() == Some("recoverable_orphan") {
+        if job.stale_reason.as_deref() == Some("child_run_running_without_active_runner_job") {
             if let Some(run_id) = job.durable_run_id.as_deref() {
                 commands.push(RunnerOperatorCommand {
                     scope: "agent_task_status",
@@ -2013,7 +2013,7 @@ fn runner_status_operator_commands_with_recovery_guidance(
             ),
             description: "Follow the active runner job event stream.".to_string(),
         });
-        if matches!(job.lifecycle_state.as_deref(), None | Some("active")) {
+        if !job.status.is_terminal() {
             commands.push(RunnerOperatorCommand {
                 scope: "job_cancel",
                 runner_id: report.runner_id.clone(),

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -521,8 +521,6 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
             lifecycle: None,
             durable_run_id: Some("run-123".to_string()),
             stale_reason: None,
-            lifecycle_state: Some("active".to_string()),
-            retryable: Some(false),
             active_child_count: None,
             active_cell_count: None,
         }],
@@ -549,8 +547,6 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
             claim_expires_in_ms: Some(29_500),
             durable_run_id: Some("run-123".to_string()),
             stale_reason: None,
-            lifecycle_state: Some("active".to_string()),
-            retryable: Some(false),
             artifact_refs: Vec::new(),
         }],
         active_job_count: 1,
@@ -582,9 +578,7 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
 
     let mut orphan = report.active_runner_jobs[0].clone();
     orphan.job_id = "orphaned-child-run-run-123".to_string();
-    orphan.lifecycle_state = Some("recoverable_orphan".to_string());
     orphan.stale_reason = Some("child_run_running_without_active_runner_job".to_string());
-    orphan.retryable = Some(true);
     report.active_runner_jobs.clear();
     report.active_jobs.clear();
     report.active_job_count = 0;
@@ -764,8 +758,6 @@ fn unknown_owner_has_reconcile_guidance_but_no_logs_or_cancel_command() {
         lifecycle: None,
         durable_run_id: None,
         stale_reason: Some("daemon_freshness_count_exceeds_typed_jobs".to_string()),
-        lifecycle_state: Some("unknown_owner".to_string()),
-        retryable: Some(false),
         active_child_count: None,
         active_cell_count: None,
     };

--- a/crates/homeboy-cli/src/commands/runs/remote.rs
+++ b/crates/homeboy-cli/src/commands/runs/remote.rs
@@ -579,8 +579,6 @@ mod tests {
             lifecycle: None,
             durable_run_id: Some("bench-run-123".to_string()),
             stale_reason: None,
-            lifecycle_state: Some("active".to_string()),
-            retryable: Some(true),
             active_child_count: None,
             active_cell_count: None,
         };

--- a/crates/homeboy-core/src/activity/runner_sessions.rs
+++ b/crates/homeboy-core/src/activity/runner_sessions.rs
@@ -327,8 +327,6 @@ mod tests {
             lifecycle: None,
             durable_run_id: durable_run_id.map(str::to_string),
             stale_reason: None,
-            lifecycle_state: None,
-            retryable: None,
             active_child_count: None,
             active_cell_count: None,
         }

--- a/crates/homeboy-core/src/api_jobs/summary.rs
+++ b/crates/homeboy-core/src/api_jobs/summary.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use super::store::LocalRunnerJob;
-use super::types::{ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, Job, JobStatus};
+use super::types::{ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, Job};
 use crate::redaction::redact_argv_display;
 use crate::runner_execution_envelope::RunnerExecutionEnvelope;
 
@@ -54,8 +54,6 @@ pub(super) fn active_runner_job_summary(
             .or_else(|| envelope_metadata_string(envelope, "run_id"))
             .or_else(|| envelope_metadata_string(envelope, "record_run_id")),
         stale_reason: job.stale_reason.clone(),
-        lifecycle_state: Some(runner_job_lifecycle_state(job).to_string()),
-        retryable: Some(runner_job_retryable(job)),
         active_child_count: lifecycle
             .as_ref()
             .and_then(|lifecycle| lifecycle.active_child_count)
@@ -107,8 +105,6 @@ pub(super) fn active_daemon_job_summary(job: &Job, now_ms: u64) -> ActiveRunnerJ
             .and_then(|lifecycle| lifecycle.durable_run_id.clone()),
         lifecycle,
         stale_reason: job.stale_reason.clone(),
-        lifecycle_state: Some(runner_job_lifecycle_state(job).to_string()),
-        retryable: Some(runner_job_retryable(job)),
         active_child_count: None,
         active_cell_count: None,
     }
@@ -152,8 +148,6 @@ pub(super) fn active_local_runner_job_summary(
         lifecycle: lifecycle.clone(),
         durable_run_id: lifecycle.and_then(|lifecycle| lifecycle.durable_run_id),
         stale_reason: job.stale_reason.clone(),
-        lifecycle_state: Some(runner_job_lifecycle_state(job).to_string()),
-        retryable: Some(runner_job_retryable(job)),
         active_child_count: None,
         active_cell_count: None,
     }
@@ -239,26 +233,4 @@ fn ms_to_rfc3339(ms: u64) -> String {
     chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms as i64)
         .unwrap_or_else(chrono::Utc::now)
         .to_rfc3339()
-}
-
-fn runner_job_lifecycle_state(job: &Job) -> &'static str {
-    if job.status == JobStatus::Failed
-        && job.stale_reason.as_deref()
-            == Some("control plane lost before the job reached a terminal status")
-    {
-        "orphaned_after_control_plane_loss"
-    } else if job.stale_reason.is_some() {
-        "stale"
-    } else if matches!(job.status, JobStatus::Queued | JobStatus::Running) {
-        "active"
-    } else {
-        "terminal"
-    }
-}
-
-fn runner_job_retryable(job: &Job) -> bool {
-    matches!(
-        runner_job_lifecycle_state(job),
-        "orphaned_after_control_plane_loss" | "stale"
-    )
 }

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -334,11 +334,6 @@ fn durable_remote_runner_restart_failure_moves_to_stale_runner_jobs() {
     assert_eq!(stale_jobs[0].runner_id, "homeboy-lab");
     assert_eq!(stale_jobs[0].status, JobStatus::Failed);
     assert_eq!(
-        stale_jobs[0].lifecycle_state.as_deref(),
-        Some("orphaned_after_control_plane_loss")
-    );
-    assert_eq!(stale_jobs[0].retryable, Some(true));
-    assert_eq!(
         stale_jobs[0].stale_reason.as_deref(),
         Some("control plane lost before the job reached a terminal status")
     );

--- a/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
@@ -382,9 +382,7 @@ pub fn refresh_selected_mirrored_daemon_evidence(
                         "runner_id": runner_id,
                         "job_id": job_id,
                         "status": "evidence_unavailable",
-                        "lifecycle_state": "stale",
                         "stale_reason": "authoritative_generation_did_not_retain_job",
-                        "retryable": false,
                         "diagnostic": {
                             "code": err.code.as_str(),
                             "message": err.message,
@@ -451,9 +449,7 @@ fn finish_stale_runner_child_run(store: &ObservationStore, job: &StaleRunnerJobI
                 "runner_id": job.runner_id,
                 "job_id": job.job_id,
                 "status": job.status,
-                "lifecycle_state": job.lifecycle_state,
                 "stale_reason": job.stale_reason,
-                "retryable": job.retryable,
                 "reconciled_at": chrono::Utc::now().to_rfc3339(),
             }),
         );
@@ -515,9 +511,7 @@ mod stale_runner_tests {
                 runner_id: "homeboy-lab".to_string(),
                 job_id: "orphaned-child-run-run-1".to_string(),
                 status: "failed".to_string(),
-                lifecycle_state: Some("stale".to_string()),
                 stale_reason: Some("child_run_running_without_active_runner_job".to_string()),
-                retryable: Some(true),
             };
 
             finish_stale_runner_child_run(&store, &job);

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -52,9 +52,7 @@ pub struct StaleRunnerJobInfo {
     pub runner_id: String,
     pub job_id: String,
     pub status: String,
-    pub lifecycle_state: Option<String>,
     pub stale_reason: Option<String>,
-    pub retryable: Option<bool>,
 }
 
 /// The result of downloading a remote runner artifact, slimmed to what

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -3223,8 +3223,6 @@ fn orphaned_child_run_job(runner_id: &str, run: RunSummary) -> ActiveRunnerJobSu
         lifecycle: None,
         durable_run_id: Some(run.id),
         stale_reason: Some("child_run_running_without_active_runner_job".to_string()),
-        lifecycle_state: Some("recoverable_orphan".to_string()),
-        retryable: Some(true),
         active_child_count: None,
         active_cell_count: None,
     }

--- a/crates/homeboy-lab-runner/src/connection/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/mod.rs
@@ -706,8 +706,6 @@ pub(super) fn sample_active_job(
         lifecycle: None,
         durable_run_id: durable_run_id.map(str::to_string),
         stale_reason: None,
-        lifecycle_state: Some("running".to_string()),
-        retryable: Some(false),
         active_child_count: None,
         active_cell_count: None,
     }

--- a/crates/homeboy-lab-runner/src/evidence/provider.rs
+++ b/crates/homeboy-lab-runner/src/evidence/provider.rs
@@ -72,9 +72,7 @@ impl RunnerEvidenceProvider for RunnerEvidence {
                         runner_id: job.runner_id,
                         job_id: job.job_id,
                         status: job.status.as_str().to_string(),
-                        lifecycle_state: job.lifecycle_state,
                         stale_reason: job.stale_reason,
-                        retryable: job.retryable,
                     })
                     .collect(),
             })

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -3546,8 +3546,6 @@ mod tests {
                     lifecycle: None,
                     durable_run_id: None,
                     stale_reason: None,
-                    lifecycle_state: None,
-                    retryable: None,
                     active_child_count: None,
                     active_cell_count: None,
                 }],

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -213,8 +213,6 @@ fn active_admission(job_id: &str) -> homeboy_core::api_jobs::ActiveRunnerJobSumm
         lifecycle: None,
         durable_run_id: None,
         stale_reason: None,
-        lifecycle_state: Some("active".to_string()),
-        retryable: Some(false),
         active_child_count: None,
         active_cell_count: None,
     }

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -85,8 +85,6 @@ fn lost_exec_response_reconciles_the_single_accepted_durable_job() {
             claim_expires_in_ms: None,
             durable_run_id: Some(run_id.to_string()),
             stale_reason: None,
-            lifecycle_state: Some("running".to_string()),
-            retryable: Some(false),
             artifact_refs: Vec::new(),
         });
 

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -223,10 +223,6 @@ pub struct RunnerJob {
     pub durable_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stale_reason: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lifecycle_state: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub retryable: Option<bool>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_refs: Vec<RunnerArtifactRef>,
 }
@@ -252,8 +248,6 @@ impl From<&ActiveRunnerJobSummary> for RunnerJob {
             claim_expires_in_ms: job.claim_expires_in_ms,
             durable_run_id: job.durable_run_id.clone(),
             stale_reason: job.stale_reason.clone(),
-            lifecycle_state: job.lifecycle_state.clone(),
-            retryable: job.retryable,
             artifact_refs: Vec::new(),
         }
     }
@@ -294,8 +288,6 @@ impl RunnerJob {
             claim_expires_in_ms: None,
             durable_run_id: None,
             stale_reason: job.stale_reason.clone(),
-            lifecycle_state: job.stale_reason.as_ref().map(|_| "stale".to_string()),
-            retryable: job.stale_reason.as_ref().map(|_| true),
             artifact_refs: job
                 .artifacts
                 .iter()


### PR DESCRIPTION
## Summary
- remove derived lifecycle and retryability fields from active and stale runner job summaries and evidence
- preserve operator guidance through reserved unknown-owner IDs, stale reasons, and terminal job status
- accept legacy daemon payload fields without re-emitting them

## Verification
- `cargo test -p homeboy-api-jobs-contract legacy_runner_summary_authority_fields_deserialize_without_reemitting`
- `cargo test -p homeboy-core durable_remote_runner_restart_failure_moves_to_stale_runner_jobs`
- `cargo test -p homeboy-core stale_runner_child_finalizes_matching_running_observation`
- `cargo test -p homeboy-cli unknown_owner_has_reconcile_guidance_but_no_logs_or_cancel_command`
- `cargo test -p homeboy-cli unknown_daemon_owner_is_inspect_only`
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-api-jobs-contract -p homeboy-core -p homeboy-lab-runner -p homeboy-cli`

Closes #14477

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented and verified this change.