### PR TITLE
fix(git): serialize remote tracking fetches

### DIFF
--- a/crates/homeboy-agents/src/agent_task_config_materialization.rs
+++ b/crates/homeboy-agents/src/agent_task_config_materialization.rs
@@ -160,11 +160,14 @@ fn materialize_configured_ref(
     let checkout =
         materialized_checkout_path(data_root, &configured_ref.repo, &configured_ref.ref_name);
     if checkout.join(".git").exists() {
-        git::run_git(
-            &checkout,
-            &["fetch", "--prune", "origin"],
-            "git fetch provider ref",
-        )?;
+        git::with_remote_tracking_authority(&checkout, "git fetch provider ref", || {
+            git::run_git(
+                &checkout,
+                &["fetch", "--prune", "origin"],
+                "git fetch provider ref",
+            )
+            .map(|_| ())
+        })?;
     } else {
         if let Some(parent) = checkout.parent() {
             fs::create_dir_all(parent).map_err(|err| {

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -12,6 +12,7 @@ use homeboy_core::git::{
 };
 use homeboy_core::run_lifecycle_record::RunLifecycleRecord;
 use serde::de::DeserializeOwned;
+use std::path::Path;
 
 pub struct RealAgentTaskPrFinalizationBackend;
 
@@ -131,16 +132,22 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
 
     fn resolve_base(&mut self, path: &str, base: &str) -> Result<AgentTaskPrResolvedBase> {
         let reference = format!("refs/homeboy/finalization/base/{base}");
-        let output = std::process::Command::new("git")
-            .args([
-                "fetch",
-                "--no-tags",
-                "origin",
-                &format!("refs/heads/{base}:{reference}"),
-            ])
-            .current_dir(path)
-            .output()
-            .map_err(|error| Error::git_command_failed(error.to_string()))?;
+        let output = homeboy_core::git::with_remote_tracking_authority(
+            Path::new(path),
+            "fetch requested finalization base",
+            || {
+                std::process::Command::new("git")
+                    .args([
+                        "fetch",
+                        "--no-tags",
+                        "origin",
+                        &format!("refs/heads/{base}:{reference}"),
+                    ])
+                    .current_dir(path)
+                    .output()
+                    .map_err(|error| Error::git_command_failed(error.to_string()))
+            },
+        )?;
         if !output.status.success() {
             return Err(Error::validation_invalid_argument(
                 "base",
@@ -181,17 +188,23 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
             ],
         )
         .or_else(|_| {
-            let fetch = std::process::Command::new("git")
-                .args([
-                    "fetch",
-                    "--no-tags",
-                    "--no-write-fetch-head",
-                    "origin",
-                    verified_base_sha,
-                ])
-                .current_dir(path)
-                .output()
-                .map_err(|error| Error::git_command_failed(error.to_string()))?;
+            let fetch = homeboy_core::git::with_remote_tracking_authority(
+                Path::new(path),
+                "materialize verified finalization base",
+                || {
+                    std::process::Command::new("git")
+                        .args([
+                            "fetch",
+                            "--no-tags",
+                            "--no-write-fetch-head",
+                            "origin",
+                            verified_base_sha,
+                        ])
+                        .current_dir(path)
+                        .output()
+                        .map_err(|error| Error::git_command_failed(error.to_string()))
+                },
+            )?;
             if !fetch.status.success() {
                 return Err(Error::validation_invalid_argument(
                     "verified_base_sha",
@@ -762,10 +775,17 @@ fn remote_head_is_ancestor_of_candidate(path: &str, remote_head: &str, local_hea
     // Best-effort: bring the remote-only commit into the local object database
     // so ancestry can be evaluated. Ignore failure; the ancestry check below
     // fails closed when the object is unavailable.
-    let _ = std::process::Command::new("git")
-        .args(["fetch", "--no-tags", "origin", remote_head])
-        .current_dir(path)
-        .output();
+    let _ = homeboy_core::git::with_remote_tracking_authority(
+        Path::new(path),
+        "materialize finalization remote head",
+        || {
+            std::process::Command::new("git")
+                .args(["fetch", "--no-tags", "origin", remote_head])
+                .current_dir(path)
+                .output()
+                .map_err(|error| Error::git_command_failed(error.to_string()))
+        },
+    );
     std::process::Command::new("git")
         .args(["merge-base", "--is-ancestor", remote_head, local_head])
         .current_dir(path)

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -2899,20 +2899,26 @@ fn capture_declared_base_with_git_and_timeout(
             )
         })?
         .to_string();
-    let fetch = run_declared_base_git(
+    let fetch = homeboy_core::git::with_remote_tracking_authority(
         worktree_path,
-        git,
-        &[
-            "fetch",
-            "--no-tags",
-            "--no-write-fetch-head",
-            "origin",
-            &sha,
-        ],
-        environment,
-        base_ref,
-        "fetch",
-        timeout,
+        "fetch declared promotion base",
+        || {
+            run_declared_base_git(
+                worktree_path,
+                git,
+                &[
+                    "fetch",
+                    "--no-tags",
+                    "--no-write-fetch-head",
+                    "origin",
+                    &sha,
+                ],
+                environment,
+                base_ref,
+                "fetch",
+                timeout,
+            )
+        },
     )?;
     if !fetch.status.success() {
         return Err(declared_base_git_failure(

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -8085,16 +8085,23 @@ fn materialize_prepared_cook_base(target: &Path, base_sha: &str) -> Result<Strin
     ) {
         return Ok(resolved.trim().to_string());
     }
-    homeboy_core::git::run_git(
+    homeboy_core::git::with_remote_tracking_authority(
         target,
-        &[
-            "fetch",
-            "--no-tags",
-            "--no-write-fetch-head",
-            "origin",
-            base_sha,
-        ],
         "materialize prepared Cook base",
+        || {
+            homeboy_core::git::run_git(
+                target,
+                &[
+                    "fetch",
+                    "--no-tags",
+                    "--no-write-fetch-head",
+                    "origin",
+                    base_sha,
+                ],
+                "materialize prepared Cook base",
+            )
+            .map(|_| ())
+        },
     )?;
     Ok(homeboy_core::git::run_git(
         target,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -12,7 +12,7 @@
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use homeboy_core::cook_status::{CookDisposition, CookStatus};
 use homeboy_core::engine::canonical_json::canonical_json_bytes;
@@ -2710,17 +2710,23 @@ fn observe_and_fetch_base(path: &str, base: &str) -> Result<String> {
             )
         })?
         .to_string();
-    let fetched = std::process::Command::new("git")
-        .args([
-            "fetch",
-            "--no-tags",
-            "--no-write-fetch-head",
-            "origin",
-            &sha,
-        ])
-        .current_dir(path)
-        .output()
-        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    let fetched = homeboy_core::git::with_remote_tracking_authority(
+        Path::new(path),
+        "materialize refreshed destination base",
+        || {
+            std::process::Command::new("git")
+                .args([
+                    "fetch",
+                    "--no-tags",
+                    "--no-write-fetch-head",
+                    "origin",
+                    &sha,
+                ])
+                .current_dir(path)
+                .output()
+                .map_err(|error| Error::git_command_failed(error.to_string()))
+        },
+    )?;
     if !fetched.status.success() {
         return Err(Error::validation_invalid_argument(
             "base",

--- a/crates/homeboy-core/src/deps.rs
+++ b/crates/homeboy-core/src/deps.rs
@@ -161,6 +161,17 @@ pub fn hydrate_declared_dependencies(
     package_root: &str,
     policy: &DependencyHydrationPolicy,
 ) -> Result<Vec<DependencyHydrationOutcome>> {
+    crate::git::with_remote_tracking_authority_if_git(path, "hydrate declared dependencies", || {
+        hydrate_declared_dependencies_unlocked(path, workspace, package_root, policy)
+    })
+}
+
+fn hydrate_declared_dependencies_unlocked(
+    path: &Path,
+    workspace: &str,
+    package_root: &str,
+    policy: &DependencyHydrationPolicy,
+) -> Result<Vec<DependencyHydrationOutcome>> {
     let path_arg = path.display().to_string();
     let Ok(mut component) = component::resolve_effective(None, Some(&path_arg), None) else {
         return Ok(Vec::new());

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -18,6 +18,7 @@ mod pr_refresh;
 mod primitives;
 mod primitives_query;
 pub mod release_download;
+mod remote_tracking_authority;
 
 #[cfg(test)]
 mod operation_tests;
@@ -102,6 +103,9 @@ pub use primitives_query::{
     output_optional_bytes, output_optional_within, remote_origin_url, remote_url, repo_root,
     rev_parse, short_head_revision, status_porcelain, status_porcelain_bytes,
     status_porcelain_scoped, toplevel, BoundedGitRead, DEFAULT_GIT_READ_PROBE_TIMEOUT,
+};
+pub use remote_tracking_authority::{
+    with_remote_tracking_authority, with_remote_tracking_authority_if_git,
 };
 
 use serde::{Deserialize, Serialize};

--- a/crates/homeboy-core/src/git/remote_tracking_authority.rs
+++ b/crates/homeboy-core/src/git/remote_tracking_authority.rs
@@ -1,0 +1,313 @@
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use fs4::fs_std::FileExt;
+
+use crate::error::{Error, Result};
+
+const WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+const WAIT_INTERVAL: Duration = Duration::from_millis(50);
+const LOCK_FILE: &str = "homeboy-remote-tracking.lock";
+
+static AUTHORITIES: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+
+/// Serialize Homeboy operations that can update remote-tracking refs for one
+/// repository. Linked worktrees share a Git common directory, while unrelated
+/// repositories retain independent concurrency.
+pub fn with_remote_tracking_authority<T>(
+    repository: &Path,
+    operation: &str,
+    action: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    let common_dir = git_common_dir(repository)?;
+    let authority = {
+        let mut authorities = AUTHORITIES
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        authorities
+            .entry(common_dir.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    };
+    let _process_guard = acquire_process_guard(&authority, &common_dir, operation)?;
+    let lock_path = common_dir.join(LOCK_FILE);
+    let mut lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| authority_error(operation, &common_dir, &lock_path, None, error))?;
+    acquire_file_guard(&mut lock, &common_dir, &lock_path, operation)?;
+    action()
+}
+
+/// Run an action under the repository authority when `path` is a Git checkout.
+/// Non-Git dependency roots retain their existing provider-owned behavior.
+pub fn with_remote_tracking_authority_if_git<T>(
+    path: &Path,
+    operation: &str,
+    action: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    if git_common_dir(path).is_ok() {
+        with_remote_tracking_authority(path, operation, action)
+    } else {
+        action()
+    }
+}
+
+fn git_common_dir(repository: &Path) -> Result<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .current_dir(repository)
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !output.status.success() {
+        return Err(Error::git_command_failed(format!(
+            "resolve Git common directory for {}",
+            repository.display()
+        )));
+    }
+    let common_dir = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+    fs::canonicalize(&common_dir).map_err(|error| Error::git_command_failed(error.to_string()))
+}
+
+fn acquire_process_guard<'a>(
+    authority: &'a Mutex<()>,
+    common_dir: &Path,
+    operation: &str,
+) -> Result<std::sync::MutexGuard<'a, ()>> {
+    let started = Instant::now();
+    let mut reported_wait = false;
+    loop {
+        match authority.try_lock() {
+            Ok(guard) => return Ok(guard),
+            Err(std::sync::TryLockError::Poisoned(poisoned)) => return Ok(poisoned.into_inner()),
+            Err(std::sync::TryLockError::WouldBlock) if started.elapsed() < WAIT_TIMEOUT => {
+                if !reported_wait {
+                    crate::log_status!(
+                        "git",
+                        "phase=remote_tracking_wait operation={} common_dir={} owner=local_process",
+                        operation,
+                        common_dir.display()
+                    );
+                    reported_wait = true;
+                }
+                thread::sleep(WAIT_INTERVAL)
+            }
+            Err(std::sync::TryLockError::WouldBlock) => {
+                return Err(authority_error(
+                    operation,
+                    common_dir,
+                    &common_dir.join(LOCK_FILE),
+                    Some("another Homeboy operation in this process".to_string()),
+                    std::io::Error::new(std::io::ErrorKind::TimedOut, "authority wait timed out"),
+                ));
+            }
+        }
+    }
+}
+
+fn acquire_file_guard(
+    lock: &mut File,
+    common_dir: &Path,
+    lock_path: &Path,
+    operation: &str,
+) -> Result<()> {
+    let started = Instant::now();
+    let mut reported_wait = false;
+    loop {
+        match lock.try_lock_exclusive() {
+            Ok(true) => {
+                let owner = format!("pid={} operation={}\n", std::process::id(), operation);
+                lock.set_len(0)
+                    .and_then(|()| lock.write_all(owner.as_bytes()))
+                    .and_then(|()| lock.sync_data())
+                    .map_err(|error| {
+                        authority_error(operation, common_dir, lock_path, None, error)
+                    })?;
+                return Ok(());
+            }
+            Ok(false) | Err(_) if started.elapsed() < WAIT_TIMEOUT => {
+                if !reported_wait {
+                    let owner = fs::read_to_string(lock_path)
+                        .ok()
+                        .map(|value| value.trim().to_string())
+                        .filter(|value| !value.is_empty())
+                        .unwrap_or_else(|| "unknown owner".to_string());
+                    crate::log_status!(
+                        "git",
+                        "phase=remote_tracking_wait operation={} common_dir={} owner={}",
+                        operation,
+                        common_dir.display(),
+                        owner
+                    );
+                    reported_wait = true;
+                }
+                thread::sleep(WAIT_INTERVAL)
+            }
+            Ok(false) => {
+                let error = std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "remote-tracking authority is held by another process",
+                );
+                let owner = fs::read_to_string(lock_path)
+                    .ok()
+                    .map(|value| value.trim().to_string());
+                return Err(authority_error(
+                    operation, common_dir, lock_path, owner, error,
+                ));
+            }
+            Err(error) => {
+                let owner = fs::read_to_string(lock_path)
+                    .ok()
+                    .map(|value| value.trim().to_string());
+                return Err(authority_error(
+                    operation, common_dir, lock_path, owner, error,
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use std::sync::mpsc;
+
+    fn git(path: &Path, args: &[&str]) {
+        assert!(Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git")
+            .status
+            .success());
+    }
+
+    fn repository(path: &Path) {
+        git(path, &["init", "-q"]);
+        git(path, &["config", "user.email", "homeboy@example.test"]);
+        git(path, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(path.join("README"), "fixture\n").expect("write fixture");
+        git(path, &["add", "."]);
+        git(path, &["commit", "-qm", "fixture"]);
+    }
+
+    #[test]
+    fn sibling_worktrees_serialize_remote_tracking_operations() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source = temp.path().join("source");
+        std::fs::create_dir(&source).expect("source");
+        repository(&source);
+        let sibling = temp.path().join("sibling");
+        git(
+            &source,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                sibling.to_str().expect("path"),
+            ],
+        );
+
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let source_for_thread = source.clone();
+        let first = thread::spawn(move || {
+            with_remote_tracking_authority(&source_for_thread, "first fetch", || {
+                entered_tx.send(()).expect("entered");
+                release_rx.recv().expect("release");
+                git(
+                    &source_for_thread,
+                    &["update-ref", "refs/remotes/origin/concurrent", "HEAD"],
+                );
+                Ok(())
+            })
+        });
+        entered_rx.recv().expect("first entered");
+
+        let (second_tx, second_rx) = mpsc::channel();
+        let second = thread::spawn(move || {
+            with_remote_tracking_authority(&sibling, "second fetch", || {
+                git(
+                    &sibling,
+                    &["update-ref", "refs/remotes/origin/concurrent", "HEAD"],
+                );
+                second_tx.send(()).expect("second entered");
+                Ok(())
+            })
+        });
+        assert!(second_rx.recv_timeout(Duration::from_millis(150)).is_err());
+        release_tx.send(()).expect("release first");
+        first
+            .join()
+            .expect("first thread")
+            .expect("first authority");
+        second_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("second entered after release");
+        second
+            .join()
+            .expect("second thread")
+            .expect("second authority");
+        git(
+            &source,
+            &["rev-parse", "--verify", "refs/remotes/origin/concurrent"],
+        );
+    }
+
+    #[test]
+    fn unrelated_repositories_keep_remote_tracking_concurrency() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let first_repo = temp.path().join("first");
+        let second_repo = temp.path().join("second");
+        std::fs::create_dir(&first_repo).expect("first repo");
+        std::fs::create_dir(&second_repo).expect("second repo");
+        repository(&first_repo);
+        repository(&second_repo);
+
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let first = thread::spawn(move || {
+            with_remote_tracking_authority(&first_repo, "first fetch", || {
+                entered_tx.send(()).expect("first entered");
+                release_rx.recv().expect("release");
+                Ok(())
+            })
+        });
+        entered_rx.recv().expect("first entered");
+        with_remote_tracking_authority(&second_repo, "second fetch", || Ok(()))
+            .expect("unrelated authority");
+        release_tx.send(()).expect("release first");
+        first
+            .join()
+            .expect("first thread")
+            .expect("first authority");
+    }
+}
+
+fn authority_error(
+    operation: &str,
+    common_dir: &Path,
+    lock_path: &Path,
+    owner: Option<String>,
+    error: std::io::Error,
+) -> Error {
+    let owner = owner
+        .filter(|owner| !owner.is_empty())
+        .unwrap_or_else(|| "unknown owner".to_string());
+    Error::git_command_failed(format!(
+        "{operation} waited {}s for remote-tracking authority at {} (owner: {}; lock: {}): {error}",
+        WAIT_TIMEOUT.as_secs(),
+        common_dir.display(),
+        owner,
+        lock_path.display(),
+    ))
+}

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -663,13 +663,16 @@ struct PendingHandoffFreshness {
 
 fn prepare_handoff_freshness(source: &Path, base_ref: &str) -> Result<PendingHandoffFreshness> {
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-    git::run_git_with_env_timeout(
-        source,
-        &["fetch", "origin"],
-        "git fetch origin for worktree handoff",
-        &[],
-        TIMEOUT,
-    )?;
+    git::with_remote_tracking_authority(source, "git fetch origin for worktree handoff", || {
+        git::run_git_with_env_timeout(
+            source,
+            &["fetch", "origin"],
+            "git fetch origin for worktree handoff",
+            &[],
+            TIMEOUT,
+        )
+        .map(|_| ())
+    })?;
     let advertised = git::run_git_with_env_timeout(
         source,
         &["ls-remote", "--symref", "origin", "HEAD"],

--- a/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
+++ b/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
@@ -396,19 +396,22 @@ fn ensure_resolved_commit_is_available(
         identity.requested_ref,
         identity.resolved_sha
     );
-    git::run_git_with_env_timeout(
-        source_root,
-        &[
-            "fetch",
-            "--no-tags",
-            "--no-write-fetch-head",
-            &remote,
-            &format!("+{}:", identity.resolved_sha),
-        ],
-        "fetch preflighted exact deploy ref",
-        &transport_env,
-        REMOTE_REF_QUERY_TIMEOUT,
-    )
+    git::with_remote_tracking_authority(source_root, "fetch preflighted exact deploy ref", || {
+        git::run_git_with_env_timeout(
+            source_root,
+            &[
+                "fetch",
+                "--no-tags",
+                "--no-write-fetch-head",
+                &remote,
+                &format!("+{}:", identity.resolved_sha),
+            ],
+            "fetch preflighted exact deploy ref",
+            &transport_env,
+            REMOTE_REF_QUERY_TIMEOUT,
+        )
+        .map(|_| ())
+    })
     .map_err(|error| remote_transport_error(&remote, &component.id, &error))?;
     let fetched = git::run_git(
         source_root,


### PR DESCRIPTION
## Summary
- serialize mutable remote-tracking fetches by canonical Git common directory across linked worktrees and Homeboy processes
- route fanout, worktree freshness, exact-ref materialization, and Git-checkout dependency hydration through the shared authority
- add deterministic sibling-worktree ref-lock coverage while preserving unrelated-repository concurrency

## Verification
- cargo test -p homeboy-core remote_tracking_authority --lib
- cargo fmt --all -- --check
- cargo check -p homeboy-core -p homeboy-agents -p homeboy-deploy

Closes #14479

AI disclosure: OpenAI GPT-5.6 Terra via OpenCode.