### PR TITLE
fix(agent-task): expose detached staging failures

### DIFF
--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -975,6 +975,14 @@ fn phase(record: &AgentTaskRunRecord) -> Option<String> {
                 .map(|adoption| bounded(&adoption.phase, STATE_BOUND))
                 .filter(|value| !value.is_empty())
         })
+        .or_else(|| {
+            record
+                .metadata
+                .get("phase")
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.trim().is_empty())
+                .map(|value| bounded(value, STATE_BOUND))
+        })
 }
 
 fn blocker(record: &AgentTaskRunRecord) -> Option<ControlPlaneBlocker> {
@@ -1016,6 +1024,22 @@ fn blocker(record: &AgentTaskRunRecord) -> Option<ControlPlaneBlocker> {
             code: Some("controller_failure".to_string()),
             message: redacted_bounded(message, MESSAGE_BOUND),
         });
+    }
+    if let Some(failure) = record.metadata.get("pre_execution_failure") {
+        if let Some(message) = failure
+            .get("message")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+        {
+            return Some(ControlPlaneBlocker {
+                code: failure
+                    .get("error_code")
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.trim().is_empty())
+                    .map(|value| bounded(value, STATE_BOUND)),
+                message: redacted_bounded(message, MESSAGE_BOUND),
+            });
+        }
     }
     record
         .candidate_adoption

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -60,6 +60,58 @@ fn diagnose_projects_causal_pre_execution_provider_evidence() {
 }
 
 #[test]
+fn status_projects_detached_staging_phase_and_failure_cause() {
+    with_temp_home(|| {
+        let run_id = "run-cli-detached-staging-failure";
+        let plan = test_plan();
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submit plan");
+        agent_task_lifecycle::record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "materializing",
+            None,
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("record staging phase");
+        let error = Error::validation_invalid_argument(
+            "rig",
+            "runner dispatch cannot materialize selected rig package",
+            Some("fixture-rig".to_string()),
+            None,
+        );
+        agent_task_lifecycle::record_pre_execution_failure(
+            run_id,
+            &plan,
+            "lab_staging_controller",
+            &error,
+        )
+        .expect("record staging failure");
+
+        let (status_value, exit_code) = status(StatusArgs {
+            run_id: run_id.to_string(),
+            interval: "5s".to_string(),
+            timeout: "30m".to_string(),
+            ..Default::default()
+        })
+        .expect("status projects staging failure");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(status_value["state"], "failed");
+        assert_eq!(status_value["phase"], "materializing");
+        assert_eq!(
+            status_value["blocker"]["code"],
+            "validation.invalid_argument"
+        );
+        assert_eq!(
+            status_value["blocker"]["message"],
+            "Invalid argument 'rig': runner dispatch cannot materialize selected rig package"
+        );
+    });
+}
+
+#[test]
 fn diagnose_preserves_controller_admission_hash_io_without_provider_replay() {
     with_temp_home(|| {
         let run_id = "run-cli-diagnose-controller-admission-hash-io";


### PR DESCRIPTION
## Summary

- Project durable detached staging phase into the canonical agent-task status resource.
- Surface the typed pre-execution failure as the status blocker, without replacing higher-priority lifecycle blockers.
- Cover the failed detached-staging lifecycle through the public `agent-task status` boundary.

Closes #14491
Related: #13758, #11839

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-cli --lib status_projects_detached_staging_phase_and_failure_cause`
- `cargo test -p homeboy-agents --lib orchestration`

## AI Assistance

OpenAI GPT-5.6 Terra via OpenCode implemented and verified this change.