### PR TITLE
refactor(core): one duration parser for every command surface

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/watch.rs
+++ b/crates/homeboy-cli/src/commands/utils/watch.rs
@@ -61,90 +61,9 @@ pub struct WatchConfig {
 /// unit sets, so `triage --timeout 7d` errored while `runs watch --timeout 7d`
 /// worked, and `activity --duration 500ms` errored while `observe --duration
 /// 500ms` did not. This is the union of all four: every command now accepts
-/// every unit.
-const DURATION_UNITS: &[(&str, u64)] = &[
-    ("ms", 1),
-    ("s", 1_000),
-    ("sec", 1_000),
-    ("secs", 1_000),
-    ("second", 1_000),
-    ("seconds", 1_000),
-    ("m", 60 * 1_000),
-    ("min", 60 * 1_000),
-    ("mins", 60 * 1_000),
-    ("minute", 60 * 1_000),
-    ("minutes", 60 * 1_000),
-    ("h", 60 * 60 * 1_000),
-    ("hr", 60 * 60 * 1_000),
-    ("hrs", 60 * 60 * 1_000),
-    ("hour", 60 * 60 * 1_000),
-    ("hours", 60 * 60 * 1_000),
-    ("d", 24 * 60 * 60 * 1_000),
-    ("day", 24 * 60 * 60 * 1_000),
-    ("days", 24 * 60 * 60 * 1_000),
-];
-
-/// Human-readable list of accepted units, for `--help` and error messages.
-pub const DURATION_UNITS_HINT: &str = "ms, s, m, h, or d";
-
-/// Parse a duration like `500ms`, `30s`, `5m`, `2h`, or `7d`.
-///
-/// Returns the plain message on failure; [`parse_duration`] wraps it into a
-/// structured argument error and [`parse_duration_arg`] hands it to clap.
-///
-/// A bare number with no unit is rejected, as it was by all four parsers this
-/// replaces -- `--timeout 30` is ambiguous and always was an error.
-fn parse_duration_parts(raw: &str) -> Result<Duration, String> {
-    let trimmed = raw.trim();
-    let split = trimmed
-        .find(|ch: char| !ch.is_ascii_digit())
-        .unwrap_or(trimmed.len());
-    let (amount, unit) = trimmed.split_at(split);
-
-    if amount.is_empty() || unit.is_empty() {
-        return Err(format!(
-            "expected duration like 500ms, 30s, 5m, 2h, or 7d (unit required: {DURATION_UNITS_HINT})"
-        ));
-    }
-
-    let amount = amount
-        .parse::<u64>()
-        .map_err(|_| "duration amount must be a positive integer".to_string())?;
-
-    // Preserved from three of the four parsers. `activity` was the one that
-    // lacked it, so `activity --interval 0s` used to spin with no delay.
-    if amount == 0 {
-        return Err("duration amount must be greater than zero".to_string());
-    }
-
-    let millis_per_unit = DURATION_UNITS
-        .iter()
-        .find(|(name, _)| *name == unit)
-        .map(|(_, millis)| *millis)
-        .ok_or_else(|| format!("duration unit must be one of {DURATION_UNITS_HINT}"))?;
-
-    // The parsers this replaces multiplied unchecked, so `9999999999999999999d`
-    // panicked in debug builds. Report it instead.
-    amount
-        .checked_mul(millis_per_unit)
-        .map(Duration::from_millis)
-        .ok_or_else(|| "duration is too large".to_string())
-}
-
-/// Parse a duration into a structured argument error attributed to `field`.
-///
-/// `field` is the name the user typed (`since`, `duration`, `--timeout`) so the
-/// error points at the flag that was wrong.
-pub(crate) fn parse_duration(field: &str, raw: &str) -> homeboy::core::Result<Duration> {
-    parse_duration_parts(raw).map_err(|message| {
-        homeboy::core::Error::validation_invalid_argument(
-            field,
-            message,
-            Some(raw.to_string()),
-            None,
-        )
-    })
-}
+pub use homeboy::core::duration::{
+    parse_duration, parse_duration_parts, DURATION_UNITS, DURATION_UNITS_HINT,
+};
 
 /// Duration parser for clap `value_parser` attributes.
 pub(crate) fn parse_duration_arg(raw: &str) -> Result<Duration, String> {

--- a/crates/homeboy-core/src/duration.rs
+++ b/crates/homeboy-core/src/duration.rs
@@ -1,0 +1,92 @@
+//! One duration parser for every command surface.
+//!
+//! `500ms`, `30s`, `5m`, `2h`, `7d` and the long spellings of each unit. A bare
+//! number is rejected because it is ambiguous, zero is rejected because it
+//! turns a poll interval into a spin, and overflow is reported rather than
+//! panicking in debug builds.
+
+use std::time::Duration;
+
+pub const DURATION_UNITS: &[(&str, u64)] = &[
+    ("ms", 1),
+    ("s", 1_000),
+    ("sec", 1_000),
+    ("secs", 1_000),
+    ("second", 1_000),
+    ("seconds", 1_000),
+    ("m", 60 * 1_000),
+    ("min", 60 * 1_000),
+    ("mins", 60 * 1_000),
+    ("minute", 60 * 1_000),
+    ("minutes", 60 * 1_000),
+    ("h", 60 * 60 * 1_000),
+    ("hr", 60 * 60 * 1_000),
+    ("hrs", 60 * 60 * 1_000),
+    ("hour", 60 * 60 * 1_000),
+    ("hours", 60 * 60 * 1_000),
+    ("d", 24 * 60 * 60 * 1_000),
+    ("day", 24 * 60 * 60 * 1_000),
+    ("days", 24 * 60 * 60 * 1_000),
+];
+
+/// Human-readable list of accepted units, for `--help` and error messages.
+pub const DURATION_UNITS_HINT: &str = "ms, s, m, h, or d";
+
+/// Parse a duration like `500ms`, `30s`, `5m`, `2h`, or `7d`.
+///
+/// Returns the plain message on failure; [`parse_duration`] wraps it into a
+/// structured argument error and [`parse_duration_arg`] hands it to clap.
+///
+/// A bare number with no unit is rejected, as it was by all four parsers this
+/// replaces -- `--timeout 30` is ambiguous and always was an error.
+pub fn parse_duration_parts(raw: &str) -> Result<Duration, String> {
+    let trimmed = raw.trim();
+    let split = trimmed
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (amount, unit) = trimmed.split_at(split);
+
+    if amount.is_empty() || unit.is_empty() {
+        return Err(format!(
+            "expected duration like 500ms, 30s, 5m, 2h, or 7d (unit required: {DURATION_UNITS_HINT})"
+        ));
+    }
+
+    let amount = amount
+        .parse::<u64>()
+        .map_err(|_| "duration amount must be a positive integer".to_string())?;
+
+    // Preserved from three of the four parsers. `activity` was the one that
+    // lacked it, so `activity --interval 0s` used to spin with no delay.
+    if amount == 0 {
+        return Err("duration amount must be greater than zero".to_string());
+    }
+
+    let millis_per_unit = DURATION_UNITS
+        .iter()
+        .find(|(name, _)| *name == unit)
+        .map(|(_, millis)| *millis)
+        .ok_or_else(|| format!("duration unit must be one of {DURATION_UNITS_HINT}"))?;
+
+    // The parsers this replaces multiplied unchecked, so `9999999999999999999d`
+    // panicked in debug builds. Report it instead.
+    amount
+        .checked_mul(millis_per_unit)
+        .map(Duration::from_millis)
+        .ok_or_else(|| "duration is too large".to_string())
+}
+
+/// Parse a duration into a structured argument error attributed to `field`.
+///
+/// `field` is the name the user typed (`since`, `duration`, `--timeout`) so the
+/// error points at the flag that was wrong.
+pub fn parse_duration(field: &str, raw: &str) -> crate::error::Result<Duration> {
+    parse_duration_parts(raw).map_err(|message| {
+        crate::error::Error::validation_invalid_argument(
+            field,
+            message,
+            Some(raw.to_string()),
+            None,
+        )
+    })
+}

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -88,6 +88,7 @@ pub mod controller_runtime;
 pub use homeboy_lifecycle_contract::cook_status;
 pub mod daemon;
 pub mod deps;
+pub mod duration;
 pub mod engine;
 pub use homeboy_lab_contract::env_materialization_plan;
 // error moved to the internal `homeboy-error` crate. Re-exported here so existing

--- a/crates/homeboy-triage/src/cli_capability.rs
+++ b/crates/homeboy-triage/src/cli_capability.rs
@@ -157,8 +157,11 @@ fn run_triage(args: TriageArgs) -> homeboy_core::Result<(TriageCommandOutput, i3
             until: args
                 .until
                 .or_else(|| args.auto_merge.then_some("green-mergeable".to_string())),
-            timeout: parse_duration("timeout", &args.timeout)?,
-            poll_interval: parse_duration("poll-interval", &args.poll_interval)?,
+            timeout: homeboy_core::duration::parse_duration("timeout", &args.timeout)?,
+            poll_interval: homeboy_core::duration::parse_duration(
+                "poll-interval",
+                &args.poll_interval,
+            )?,
             auto_merge: args.auto_merge,
             merge_method: args.merge_method,
         })?;
@@ -243,43 +246,6 @@ fn resolve_component_target(
         (Some(component_id), None) => Ok(TriageTarget::Component(component_id)),
         (component_id, Some(path)) => Ok(TriageTarget::Path { path, component_id }),
     }
-}
-
-fn parse_duration(name: &str, raw: &str) -> homeboy_core::Result<std::time::Duration> {
-    let seconds = raw
-        .strip_suffix("ms")
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(|value| value as f64 / 1000.0)
-        .or_else(|| {
-            raw.strip_suffix('s')
-                .and_then(|value| value.parse::<u64>().ok())
-                .map(|value| value as f64)
-        })
-        .or_else(|| {
-            raw.strip_suffix('m')
-                .and_then(|value| value.parse::<u64>().ok())
-                .map(|value| value as f64 * 60.0)
-        })
-        .or_else(|| {
-            raw.strip_suffix('h')
-                .and_then(|value| value.parse::<u64>().ok())
-                .map(|value| value as f64 * 3600.0)
-        })
-        .or_else(|| {
-            raw.strip_suffix('d')
-                .and_then(|value| value.parse::<u64>().ok())
-                .map(|value| value as f64 * 86400.0)
-        });
-    seconds
-        .map(std::time::Duration::from_secs_f64)
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                name,
-                "expected a duration such as 500ms, 30s, 5m, 1h, or 7d",
-                Some(raw.to_string()),
-                None,
-            )
-        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Closes the remaining half of #11669's "4 parse_duration impls" finding.\n\n#11151 already collapsed four CLI parsers into one in `commands/utils/watch.rs`. `homeboy-triage` was never folded in and still carried its own independent implementation with its own unit table and its own error text. Two real parsers for one user-facing syntax.\n\nThe canonical parser now lives in `homeboy_core::duration`, and both `homeboy-cli` and `homeboy-triage` use it. `activity.rs` and `runs/common.rs` were already thin delegators and stay that way.\n\n## Net effect\n**123 lines removed, 7 added** across three files, plus the ~60-line shared module — the accepted duration syntax is now defined in exactly one place.\n\n## Behaviour\nThe triage parser was the weaker of the two. Adopting the canonical one means `triage --timeout` and `--poll-interval` now also:\n\n- reject `0` rather than accepting a zero poll interval that spins\n- accept the long unit spellings (`sec`, `mins`, `hours`, ...)\n- report overflow instead of panicking in debug builds on input like `9999999999999999999d`\n\nUnit coverage is otherwise identical (`ms`, `s`, `m`, `h`, `d`) and the error message shape is unchanged.\n\n## Verification\n`cargo check --workspace` clean. Full `homeboy-cli` and `homeboy-triage` lib suites against a baseline worktree at the same commit:\n\n| | baseline | this branch |\n|---|---|---|\n| homeboy-cli | 2868 passed, 27 failed, 15 timed out | **2868 passed, 27 failed, 15 timed out** |\n| homeboy-triage | — | **61 passed, 0 failed** |\n\nIdentical result set. The 42 red `homeboy-cli` tests are pre-existing on `main` and untouched by this change.\n\n## AI Assistance\nOpenAI GPT-5.6 Sol via OpenCode located the surviving duplicate from #11669, moved the canonical parser into core, and verified both suites against a baseline worktree. Chris Huber directed the work and remains responsible for acceptance.