### PR TITLE
fix(daemon): make generation ownership durable

### DIFF
--- a/crates/homeboy-core/src/daemon/generation_store.rs
+++ b/crates/homeboy-core/src/daemon/generation_store.rs
@@ -1,7 +1,11 @@
 //! Stable routing state for local daemon generations.
 
-use std::fs;
+use std::collections::BTreeSet;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use fs4::fs_std::FileExt;
 
 use homeboy_engine_primitives::rolling_generation::{
     RollingDrainState, RollingGenerations, RollingStart,
@@ -39,6 +43,8 @@ impl LocalDaemonEndpoint {
 struct LocalDaemonGenerationRegistry {
     schema: String,
     generations: RollingGenerations<LocalDaemonEndpoint>,
+    #[serde(default)]
+    completed_jobs: BTreeSet<String>,
 }
 
 const SCHEMA: &str = "homeboy.daemon.generations.v1";
@@ -78,6 +84,50 @@ fn read_registry() -> Result<Option<LocalDaemonGenerationRegistry>> {
     }
 }
 
+fn mutate_registry<T>(
+    mutation: impl FnOnce(&mut Option<LocalDaemonGenerationRegistry>) -> Result<T>,
+) -> Result<T> {
+    static PROCESS_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _process_lock = PROCESS_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("daemon generation registry mutex poisoned");
+    let path = registry_path()?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| Error::internal_unexpected("daemon generation registry has no parent"))?;
+    fs::create_dir_all(parent).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", parent.display())),
+        )
+    })?;
+    let lock_path = parent.join(".generations.lock");
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(&lock_path)
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("open {}", lock_path.display())),
+            )
+        })?;
+    lock.lock_exclusive().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("lock {}", lock_path.display())),
+        )
+    })?;
+    let mut registry = read_registry()?;
+    let output = mutation(&mut registry)?;
+    if let Some(registry) = registry.as_ref() {
+        write_registry(registry)?;
+    }
+    Ok(output)
+}
+
 fn write_registry(registry: &LocalDaemonGenerationRegistry) -> Result<()> {
     let path = registry_path()?;
     let parent = path
@@ -96,10 +146,23 @@ fn write_registry(registry: &LocalDaemonGenerationRegistry) -> Result<()> {
             Some("serialize daemon generations".to_string()),
         )
     })?;
-    fs::write(&temporary, bytes).map_err(|error| {
+    let mut temporary_file = File::create(&temporary).map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some(format!("write {}", temporary.display())),
+        )
+    })?;
+    use std::io::Write;
+    temporary_file.write_all(&bytes).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("write {}", temporary.display())),
+        )
+    })?;
+    temporary_file.sync_all().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("sync {}", temporary.display())),
         )
     })?;
     fs::rename(&temporary, &path).map_err(|error| {
@@ -107,17 +170,28 @@ fn write_registry(registry: &LocalDaemonGenerationRegistry) -> Result<()> {
             error.to_string(),
             Some(format!("rename {}", path.display())),
         )
-    })
+    })?;
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("sync {}", parent.display())),
+            )
+        })
 }
 
 pub(super) fn seed(state: &DaemonState) -> Result<()> {
-    if read_registry()?.is_some() {
-        return Ok(());
-    }
-    let endpoint = LocalDaemonEndpoint::from_state(state);
-    write_registry(&LocalDaemonGenerationRegistry {
-        schema: SCHEMA.to_string(),
-        generations: RollingGenerations::new(endpoint.lease_id.clone(), endpoint),
+    mutate_registry(|registry| {
+        if registry.is_none() {
+            let endpoint = LocalDaemonEndpoint::from_state(state);
+            *registry = Some(LocalDaemonGenerationRegistry {
+                schema: SCHEMA.to_string(),
+                generations: RollingGenerations::new(endpoint.lease_id.clone(), endpoint),
+                completed_jobs: BTreeSet::new(),
+            });
+        }
+        Ok(())
     })
 }
 
@@ -144,50 +218,104 @@ pub(super) fn endpoint_for_job(job_id: &str) -> Result<Option<LocalDaemonEndpoin
 }
 
 pub(super) fn record_job(job_id: &str, lease_id: &str) -> Result<()> {
-    let Some(mut registry) = read_registry()? else {
-        return Err(Error::internal_unexpected(
-            "local daemon admitted a job without a generation registry",
-        ));
-    };
-    if !registry.generations.admit_job_for(lease_id, job_id)
-        && registry.generations.job_owner(job_id).is_none()
-    {
-        return Err(Error::internal_unexpected(
-            "local daemon job owner was not present in the generation registry",
-        ));
-    }
-    write_registry(&registry)
+    mutate_registry(|registry| {
+        let registry = registry.as_mut().ok_or_else(|| {
+            Error::internal_unexpected("local daemon admitted a job without a generation registry")
+        })?;
+        if !registry.generations.admit_job_for(lease_id, job_id)
+            && registry.generations.job_owner(job_id).is_none()
+        {
+            return Err(Error::internal_unexpected(
+                "local daemon job owner was not present in the generation registry",
+            ));
+        }
+        Ok(())
+    })
 }
 
 pub(super) fn activate(state: &DaemonState) -> Result<()> {
-    let endpoint = LocalDaemonEndpoint::from_state(state);
-    let mut registry = read_registry()?.ok_or_else(|| {
-        Error::internal_unexpected("local daemon rotation has no seeded generation registry")
-    })?;
-    if registry
-        .generations
-        .begin(endpoint.lease_id.clone(), endpoint)
-        == RollingStart::Start
-    {
-        // `begin` leaves candidates draining. Only a caller that has checked the
-        // published lease and exact build may expose it to admissions.
-    }
-    registry.generations.activate(&state.lease_id);
-    write_registry(&registry)
+    mutate_registry(|registry| {
+        let registry = registry.as_mut().ok_or_else(|| {
+            Error::internal_unexpected("local daemon rotation has no seeded generation registry")
+        })?;
+        let endpoint = LocalDaemonEndpoint::from_state(state);
+        if registry
+            .generations
+            .begin(endpoint.lease_id.clone(), endpoint)
+            == RollingStart::Start
+        {
+            // `begin` leaves candidates draining. Only a caller that has checked the
+            // published lease and exact build may expose it to admissions.
+        }
+        // A daemon generation must be lease-stopped before its routing entry is
+        // retired. Generic rolling users retain the normal eager cleanup.
+        registry
+            .generations
+            .activate_preserving_drained(&state.lease_id);
+        Ok(())
+    })
 }
 
-pub(super) fn complete_job(job_id: &str) -> Result<Option<LocalDaemonEndpoint>> {
-    let Some(mut registry) = read_registry()? else {
-        return Ok(None);
-    };
-    let endpoint = registry
-        .generations
-        .job_owner(job_id)
-        .and_then(|owner| registry.generations.generations.get(owner))
-        .map(|entry| entry.endpoint.clone());
-    let retired = registry.generations.complete_job(job_id);
-    write_registry(&registry)?;
-    Ok(retired.then_some(endpoint).flatten())
+pub(super) fn mark_job_terminal(job_id: &str) -> Result<()> {
+    mutate_registry(|registry| {
+        let Some(registry) = registry.as_mut() else {
+            return Ok(());
+        };
+        if !registry.completed_jobs.insert(job_id.to_string()) {
+            return Ok(());
+        }
+        if let Some(owner) = registry.generations.job_owner(job_id).map(str::to_string) {
+            if let Some(generation) = registry.generations.generations.get_mut(&owner) {
+                generation.active_jobs = generation.active_jobs.saturating_sub(1);
+            }
+        }
+        Ok(())
+    })
+}
+
+pub(super) fn reconcile_drained_generations(
+    serving_lease_id: &str,
+    stop: impl Fn(&LocalDaemonEndpoint) -> Result<()>,
+) -> Result<()> {
+    let endpoints = read_registry()?
+        .into_iter()
+        .flat_map(|registry| registry.generations.generations.into_iter())
+        .filter_map(|(lease_id, generation)| {
+            (lease_id != serving_lease_id
+                && generation.drain_state == RollingDrainState::Draining
+                && generation.active_jobs == 0)
+                .then_some((lease_id, generation.endpoint))
+        })
+        .collect::<Vec<_>>();
+    for (lease_id, endpoint) in endpoints {
+        stop(&endpoint)?;
+        mutate_registry(|registry| {
+            let Some(registry) = registry.as_mut() else {
+                return Ok(());
+            };
+            let can_retire =
+                registry
+                    .generations
+                    .generations
+                    .get(&lease_id)
+                    .is_some_and(|generation| {
+                        generation.drain_state == RollingDrainState::Draining
+                            && generation.active_jobs == 0
+                    });
+            if can_retire {
+                registry.generations.generations.remove(&lease_id);
+                registry
+                    .generations
+                    .job_owners
+                    .retain(|_, owner| owner != &lease_id);
+                registry
+                    .completed_jobs
+                    .retain(|job_id| registry.generations.job_owners.contains_key(job_id));
+            }
+            Ok(())
+        })?;
+    }
+    Ok(())
 }
 
 pub(super) fn generation_state_dir() -> Result<PathBuf> {
@@ -212,6 +340,7 @@ pub(super) fn generations() -> Result<Vec<LocalDaemonEndpoint>> {
         .unwrap_or_default())
 }
 
+#[cfg(test)]
 pub(super) fn is_draining(lease_id: &str) -> Result<bool> {
     Ok(read_registry()?.is_some_and(|registry| {
         registry
@@ -297,9 +426,82 @@ mod tests {
                 b.address
             );
             assert!(is_draining("A").expect("A drains"));
-            assert!(complete_job("job-a").expect("complete A").is_some());
+            mark_job_terminal("job-a").expect("mark A terminal");
+            // A failed stop retains the terminal job's owner for status and the
+            // next lifecycle pass rather than losing its recovery identity.
+            assert!(
+                reconcile_drained_generations("B", |_| Err(Error::internal_unexpected(
+                    "stop failed"
+                )))
+                .is_err()
+            );
+            assert_eq!(
+                endpoint_for_job("job-a")
+                    .expect("retain A route")
+                    .expect("A")
+                    .address,
+                a.address
+            );
+            reconcile_drained_generations("B", |endpoint| {
+                assert_eq!(endpoint.lease_id, "A");
+                Ok(())
+            })
+            .expect("retire stopped A");
             assert!(endpoint_for_job("job-a").expect("retired A").is_none());
             assert_eq!(admitting().expect("admitting").expect("B").lease_id, "B");
+        });
+    }
+
+    #[test]
+    fn concurrent_job_ownership_writes_preserve_every_admission() {
+        with_isolated_home(|_| {
+            let a = state("A", "127.0.0.1:1001");
+            seed(&a).expect("seed A");
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(17));
+            let workers = (0..16)
+                .map(|index| {
+                    let barrier = barrier.clone();
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        record_job(&format!("job-{index}"), "A")
+                    })
+                })
+                .collect::<Vec<_>>();
+            barrier.wait();
+            for worker in workers {
+                worker.join().expect("join writer").expect("record job");
+            }
+            for index in 0..16 {
+                assert_eq!(
+                    endpoint_for_job(&format!("job-{index}"))
+                        .expect("read owner")
+                        .expect("owner")
+                        .lease_id,
+                    "A"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn lost_admission_response_retry_keeps_the_original_generation_owner() {
+        with_isolated_home(|_| {
+            let a = state("A", "127.0.0.1:1001");
+            seed(&a).expect("seed A");
+            // The server committed this binding, but the client lost the response.
+            record_job("job-a", "A").expect("first server admission");
+            let b = state("B", "127.0.0.1:1002");
+            activate(&b).expect("rotate to B");
+            // A retry reaches B. Idempotent recording must preserve A rather than
+            // silently re-home the already durable job.
+            record_job("job-a", "B").expect("retry admission");
+            assert_eq!(
+                endpoint_for_job("job-a")
+                    .expect("route job")
+                    .expect("owner")
+                    .lease_id,
+                "A"
+            );
         });
     }
 

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -167,7 +167,6 @@ fn heartbeat_only_stall_reason(timeout: Duration) -> String {
 /// rather than carrying daemon HTTP or controller-job semantics themselves.
 pub struct LocalControllerJobClient {
     endpoint: String,
-    lease_id: String,
     client: reqwest::blocking::Client,
     // Keep the shared side until this client has durably handed off the job.
     // Recovery takes the exclusive side before proving zero active jobs, so a
@@ -284,7 +283,6 @@ impl LocalControllerJobClient {
             })?;
         Ok(Self {
             endpoint: format!("http://{}", endpoint.address),
-            lease_id: endpoint.lease_id,
             client,
             _admission_guard: None,
         })
@@ -301,7 +299,6 @@ impl LocalControllerJobClient {
             })?;
         Ok(Self {
             endpoint: format!("http://{}", daemon.address),
-            lease_id: daemon.lease_id,
             client,
             _admission_guard: admission_guard,
         })
@@ -311,16 +308,6 @@ impl LocalControllerJobClient {
         Ok(generation_store::endpoint_for_job(job_id)?
             .map(|endpoint| format!("http://{}", endpoint.address))
             .unwrap_or_else(|| self.endpoint.clone()))
-    }
-
-    fn retire_if_drained(&self, job: &crate::api_jobs::Job) -> Result<()> {
-        if !job.status.is_terminal() {
-            return Ok(());
-        }
-        if let Some(endpoint) = generation_store::complete_job(&job.id.to_string())? {
-            control::stop_drained_generation(&endpoint)?;
-        }
-        Ok(())
     }
 
     /// Persist a cancellation request and return the daemon's current job
@@ -408,9 +395,6 @@ impl LocalControllerJobClient {
                     Some("parse local controller job".to_string()),
                 )
             })?;
-        // The accepted durable record must be pinned before any later start or
-        // response boundary can expose a rotation to the caller.
-        generation_store::record_job(&job.id.to_string(), &self.lease_id)?;
         let disposition = match daemon_endpoint_payload(&value)
             .and_then(|payload| payload.pointer("/submission/disposition"))
             .and_then(serde_json::Value::as_str)
@@ -497,7 +481,6 @@ impl LocalControllerJobClient {
                     Some("parse local controller job".to_string()),
                 )
             })?;
-        self.retire_if_drained(&job)?;
         Ok(job)
     }
 
@@ -1591,6 +1574,10 @@ where
     generation_store::seed(&state)?;
     let job_store = JobStore::open_without_reconciliation(paths::daemon_jobs_file()?)
         .map(|store| store.with_daemon_lease(state.lease_id.clone()))?;
+    // If this process died after the durable job-store admission but before its
+    // registry write or HTTP response, rebuild the binding from the job's
+    // lease. Replays remain idempotent and retain the original owner.
+    rebuild_generation_job_ownership(&job_store)?;
     // A restart cannot resume the thread that owned a pre-spawn reservation.
     // Expire only reservations that never recorded a child identity.
     job_store.reconcile_expired_local_child_reservations()?;
@@ -1611,8 +1598,11 @@ where
         spawn_local_child_reservation_reconciler(job_store.clone(), local_shutdown_rx);
     let completion_notifier = spawn_completion_notifier(completion_shutdown_rx);
     let schedule_ticker = spawn_schedule_ticker(schedule_shutdown_rx);
-    let orchestration_reconciler =
-        spawn_orchestration_reconciler(job_store.clone(), orchestration_shutdown_rx);
+    let orchestration_reconciler = spawn_orchestration_reconciler(
+        job_store.clone(),
+        state.lease_id.clone(),
+        orchestration_shutdown_rx,
+    );
     let upload_reaper = spawn_upload_reaper(upload_shutdown_rx);
 
     let mut accepted = 0;
@@ -1648,6 +1638,19 @@ where
     let _ = orchestration_reconciler.join();
     let _ = upload_reaper.join();
     serve_result.map(|()| state)
+}
+
+fn rebuild_generation_job_ownership(job_store: &JobStore) -> Result<()> {
+    for job in job_store.list() {
+        let Some(lease_id) = job.daemon_lease_id.as_deref() else {
+            continue;
+        };
+        generation_store::record_job(&job.id.to_string(), lease_id)?;
+        if job.status.is_terminal() {
+            generation_store::mark_job_terminal(&job.id.to_string())?;
+        }
+    }
+    Ok(())
 }
 
 /// Environment variable overriding the completion-notifier poll interval in
@@ -1776,6 +1779,7 @@ fn parse_orchestration_tick_interval(configured: Option<&str>) -> Option<std::ti
 /// died stayed `running` forever. Loop Work jobs own controller waits.
 fn spawn_orchestration_reconciler(
     job_store: JobStore,
+    serving_lease_id: String,
     shutdown: mpsc::Receiver<()>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
@@ -1785,7 +1789,7 @@ fn spawn_orchestration_reconciler(
             let _ = shutdown.recv();
             return;
         };
-        orchestration_tick_loop(job_store, interval, shutdown)
+        orchestration_tick_loop(job_store, serving_lease_id, interval, shutdown)
     })
 }
 
@@ -1798,6 +1802,7 @@ fn spawn_orchestration_reconciler(
 /// processes the daemon owner lock already guarantees a single ticker.
 fn orchestration_tick_loop(
     job_store: JobStore,
+    serving_lease_id: String,
     interval: std::time::Duration,
     shutdown: mpsc::Receiver<()>,
 ) {
@@ -1813,6 +1818,22 @@ fn orchestration_tick_loop(
         // supervisor died without persisting anything.
         isolated_tick(|| {
             let _ = job_store.reconcile_terminal_linked_daemon_jobs();
+        });
+        // Generation retirement is lifecycle work, not a read-side effect. A
+        // failed lease stop leaves its identity and completed job routes durable
+        // so this existing reconciliation loop can retry on the next pass.
+        isolated_tick(|| {
+            for job in job_store
+                .list()
+                .into_iter()
+                .filter(|job| job.status.is_terminal())
+            {
+                let _ = generation_store::mark_job_terminal(&job.id.to_string());
+            }
+            let _ = generation_store::reconcile_drained_generations(
+                &serving_lease_id,
+                control::stop_drained_generation,
+            );
         });
         if shutdown.recv_timeout(interval).is_ok() {
             return;
@@ -2168,7 +2189,25 @@ where
             Err(err) => error_response(400, err),
         },
         ("POST", "/controller/jobs") => {
-            match with_daemon_job_admission(|| enqueue_controller_job(body, job_store)) {
+            match with_daemon_job_admission(|| {
+                let body = enqueue_controller_job(body, job_store)?;
+                let job_id = body
+                    .pointer("/job/id")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| {
+                        Error::internal_unexpected("controller admission has no job id")
+                    })?;
+                let lease_id = body
+                    .pointer("/job/daemon_lease_id")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|lease_id| !lease_id.is_empty())
+                    .ok_or_else(|| {
+                        Error::internal_unexpected("controller admission has no daemon lease owner")
+                    })?;
+                heartbeat_lease()?;
+                generation_store::record_job(job_id, lease_id)?;
+                Ok(body)
+            }) {
                 Ok(body) => daemon_endpoint_response("controller.jobs.create", body),
                 Err(err) => error_response(400, err),
             }
@@ -4715,7 +4754,6 @@ mod tests {
                 .expect("connect existing job");
 
             assert_eq!(client.endpoint, format!("http://{owner_address}"));
-            assert_eq!(client.lease_id, "draining");
             assert_eq!(
                 client.status(&job_id.to_string()).expect("read old job").id,
                 job_id
@@ -4911,7 +4949,12 @@ mod tests {
             let (tx, rx) = std::sync::mpsc::channel();
             let job_store = JobStore::default();
             let handle = std::thread::spawn(move || {
-                super::orchestration_tick_loop(job_store, Duration::from_secs(300), rx);
+                super::orchestration_tick_loop(
+                    job_store,
+                    "test-serving-lease".to_string(),
+                    Duration::from_secs(300),
+                    rx,
+                );
             });
 
             std::thread::sleep(Duration::from_millis(50));
@@ -4923,6 +4966,50 @@ mod tests {
                 start.elapsed() < Duration::from_secs(10),
                 "shutdown must not wait out the poll interval, took {:?}",
                 start.elapsed()
+            );
+        });
+    }
+
+    #[test]
+    fn restart_rebuilds_existing_job_ownership_from_the_durable_lease() {
+        crate::test_support::with_isolated_home(|_| {
+            let old = DaemonState {
+                schema: DAEMON_LEASE_SCHEMA.to_string(),
+                lease_id: "old-lease".to_string(),
+                startup_token: "old".to_string(),
+                address: "127.0.0.1:1001".to_string(),
+                pid: 1,
+                state_path: paths::daemon_state_file()
+                    .expect("state path")
+                    .display()
+                    .to_string(),
+                started_at: "now".to_string(),
+                last_seen_at: "now".to_string(),
+                build_identity: build_identity::current(),
+                binary_sha256: None,
+                runtime_paths: DaemonRuntimeSnapshot {
+                    loaded_at: "now".to_string(),
+                    paths: Vec::new(),
+                },
+            };
+            let replacement = DaemonState {
+                lease_id: "replacement-lease".to_string(),
+                address: "127.0.0.1:1002".to_string(),
+                ..old.clone()
+            };
+            generation_store::seed(&old).expect("seed old generation");
+            generation_store::activate(&replacement).expect("activate replacement");
+
+            let store = JobStore::default().with_daemon_lease(old.lease_id.clone());
+            let job = store.create("restart-recovery");
+            rebuild_generation_job_ownership(&store).expect("rebuild durable ownership");
+
+            assert_eq!(
+                generation_store::endpoint_for_job(&job.id.to_string())
+                    .expect("route job")
+                    .expect("old owner")
+                    .lease_id,
+                old.lease_id
             );
         });
     }

--- a/crates/homeboy-engine-primitives/src/rolling_generation.rs
+++ b/crates/homeboy-engine-primitives/src/rolling_generation.rs
@@ -84,6 +84,16 @@ impl<E> RollingGenerations<E> {
     }
 
     pub fn activate(&mut self, generation: &str) -> bool {
+        self.activate_inner(generation, true)
+    }
+
+    /// Activate a generation while leaving empty draining generations available
+    /// to a caller that must finish an external retirement protocol first.
+    pub fn activate_preserving_drained(&mut self, generation: &str) -> bool {
+        self.activate_inner(generation, false)
+    }
+
+    fn activate_inner(&mut self, generation: &str, retire_drained: bool) -> bool {
         if !self.generations.contains_key(generation) {
             return false;
         }
@@ -98,7 +108,9 @@ impl<E> RollingGenerations<E> {
             .get_mut(generation)
             .expect("generation was checked")
             .drain_state = RollingDrainState::Admitting;
-        self.retire_drained();
+        if retire_drained {
+            self.retire_drained();
+        }
         true
     }
 
@@ -278,5 +290,13 @@ mod tests {
         generations.recover();
         assert_eq!(generations.admission_owner, "A");
         assert_eq!(generations.job_owner("job-a"), Some("A"));
+    }
+
+    #[test]
+    fn ordinary_activation_retires_an_empty_drained_generation() {
+        let mut generations = RollingGenerations::new("A", "endpoint-a");
+        assert_eq!(generations.begin("B", "endpoint-b"), RollingStart::Start);
+        assert!(generations.activate("B"));
+        assert!(!generations.generations.contains_key("A"));
     }
 }


### PR DESCRIPTION
## Summary

Make local daemon generation ownership server-side and durable across admission, restart, rotation, and retirement.

- Record a controller job's generation binding inside the daemon admission transaction, before the HTTP response boundary.
- Rebuild bindings from durable job leases on daemon startup, retaining the original owner when an admission response is lost and retried.
- Serialize registry read-modify-write operations across threads and processes; fsync the registry file and parent directory.
- Keep status and cancellation read-only against the recorded owner endpoint.
- Retire an empty draining generation only from the lifecycle reconciler after its lease stop succeeds; a failed stop retains routing state for a later retry.

Related: #14434, #14467.

## Verification

Executed with an isolated `CARGO_TARGET_DIR`:

- `cargo fmt --check`
- `cargo test -p homeboy-core generation_store::tests`
- `cargo test -p homeboy-core concurrent_job_ownership_writes_preserve_every_admission`
- `cargo test -p homeboy-core lost_admission_response_retry_keeps_the_original_generation_owner`
- `cargo test -p homeboy-core restart_rebuilds_existing_job_ownership_from_the_durable_lease`
- `cargo test -p homeboy-core existing_job_connection_uses_the_draining_generation_for_status_and_cancellation`
- `cargo test -p homeboy-core replacement_generations_are_siblings_under_the_stable_router_root`
- `cargo test -p homeboy-engine-primitives ordinary_activation_retires_an_empty_drained_generation`
- `cargo check -p homeboy-core`
- `cargo check -p homeboy-agents -p homeboy-cli`

Focused tests passed. Compilation emitted existing unused-code/import warnings outside this change. A real process-crash/replacement HTTP workflow has not been verified. Broad workspace suites were not run, so this PR makes no claim about unrelated known failures.

## AI Assistance

GPT-6 Astra (openai/gpt-6-astra) via OpenCode assisted with implementation, tests, and PR preparation.