### PR TITLE
fix(git): complete remote tracking fetch authority

### DIFF
--- a/crates/homeboy-agents/src/agent_task_config_materialization.rs
+++ b/crates/homeboy-agents/src/agent_task_config_materialization.rs
@@ -164,11 +164,13 @@ fn materialize_configured_ref(
             &checkout,
             "git fetch provider ref",
             std::time::Instant::now() + std::time::Duration::from_secs(30),
-            |_| {
-                git::run_git(
+            |remaining| {
+                git::run_git_with_env_timeout(
                     &checkout,
                     &["fetch", "--prune", "origin"],
                     "git fetch provider ref",
+                    &[],
+                    remaining,
                 )
                 .map(|_| ())
             },

--- a/crates/homeboy-agents/src/agent_task_config_materialization.rs
+++ b/crates/homeboy-agents/src/agent_task_config_materialization.rs
@@ -160,14 +160,19 @@ fn materialize_configured_ref(
     let checkout =
         materialized_checkout_path(data_root, &configured_ref.repo, &configured_ref.ref_name);
     if checkout.join(".git").exists() {
-        git::with_remote_tracking_authority(&checkout, "git fetch provider ref", || {
-            git::run_git(
-                &checkout,
-                &["fetch", "--prune", "origin"],
-                "git fetch provider ref",
-            )
-            .map(|_| ())
-        })?;
+        git::with_remote_tracking_authority_until(
+            &checkout,
+            "git fetch provider ref",
+            std::time::Instant::now() + std::time::Duration::from_secs(30),
+            |_| {
+                git::run_git(
+                    &checkout,
+                    &["fetch", "--prune", "origin"],
+                    "git fetch provider ref",
+                )
+                .map(|_| ())
+            },
+        )?;
     } else {
         if let Some(parent) = checkout.parent() {
             fs::create_dir_all(parent).map_err(|err| {

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -132,10 +132,11 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
 
     fn resolve_base(&mut self, path: &str, base: &str) -> Result<AgentTaskPrResolvedBase> {
         let reference = format!("refs/homeboy/finalization/base/{base}");
-        let output = homeboy_core::git::with_remote_tracking_authority(
+        let output = homeboy_core::git::with_remote_tracking_authority_until(
             Path::new(path),
             "fetch requested finalization base",
-            || {
+            std::time::Instant::now() + std::time::Duration::from_secs(30),
+            |_| {
                 std::process::Command::new("git")
                     .args([
                         "fetch",
@@ -188,10 +189,11 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
             ],
         )
         .or_else(|_| {
-            let fetch = homeboy_core::git::with_remote_tracking_authority(
+            let fetch = homeboy_core::git::with_remote_tracking_authority_until(
                 Path::new(path),
                 "materialize verified finalization base",
-                || {
+                std::time::Instant::now() + std::time::Duration::from_secs(30),
+                |_| {
                     std::process::Command::new("git")
                         .args([
                             "fetch",
@@ -775,10 +777,11 @@ fn remote_head_is_ancestor_of_candidate(path: &str, remote_head: &str, local_hea
     // Best-effort: bring the remote-only commit into the local object database
     // so ancestry can be evaluated. Ignore failure; the ancestry check below
     // fails closed when the object is unavailable.
-    let _ = homeboy_core::git::with_remote_tracking_authority(
+    let _ = homeboy_core::git::with_remote_tracking_authority_until(
         Path::new(path),
         "materialize finalization remote head",
-        || {
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+        |_| {
             std::process::Command::new("git")
                 .args(["fetch", "--no-tags", "origin", remote_head])
                 .current_dir(path)

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -136,17 +136,19 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
             Path::new(path),
             "fetch requested finalization base",
             std::time::Instant::now() + std::time::Duration::from_secs(30),
-            |_| {
-                std::process::Command::new("git")
-                    .args([
+            |remaining| {
+                homeboy_core::git::run_git_output_with_env_timeout(
+                    Path::new(path),
+                    &[
                         "fetch",
                         "--no-tags",
                         "origin",
                         &format!("refs/heads/{base}:{reference}"),
-                    ])
-                    .current_dir(path)
-                    .output()
-                    .map_err(|error| Error::git_command_failed(error.to_string()))
+                    ],
+                    "fetch requested finalization base",
+                    &[],
+                    remaining,
+                )
             },
         )?;
         if !output.status.success() {
@@ -193,19 +195,19 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
                 Path::new(path),
                 "materialize verified finalization base",
                 std::time::Instant::now() + std::time::Duration::from_secs(30),
-                |_| {
-                    std::process::Command::new("git")
-                        .args([
-                            "fetch",
-                            "--no-tags",
-                            "--no-write-fetch-head",
-                            "origin",
-                            verified_base_sha,
-                        ])
-                        .current_dir(path)
-                        .output()
-                        .map_err(|error| Error::git_command_failed(error.to_string()))
-                },
+                |remaining| homeboy_core::git::run_git_output_with_env_timeout(
+                    Path::new(path),
+                    &[
+                        "fetch",
+                        "--no-tags",
+                        "--no-write-fetch-head",
+                        "origin",
+                        verified_base_sha,
+                    ],
+                    "materialize verified finalization base",
+                    &[],
+                    remaining,
+                ),
             )?;
             if !fetch.status.success() {
                 return Err(Error::validation_invalid_argument(
@@ -781,12 +783,14 @@ fn remote_head_is_ancestor_of_candidate(path: &str, remote_head: &str, local_hea
         Path::new(path),
         "materialize finalization remote head",
         std::time::Instant::now() + std::time::Duration::from_secs(30),
-        |_| {
-            std::process::Command::new("git")
-                .args(["fetch", "--no-tags", "origin", remote_head])
-                .current_dir(path)
-                .output()
-                .map_err(|error| Error::git_command_failed(error.to_string()))
+        |remaining| {
+            homeboy_core::git::run_git_output_with_env_timeout(
+                Path::new(path),
+                &["fetch", "--no-tags", "origin", remote_head],
+                "materialize finalization remote head",
+                &[],
+                remaining,
+            )
         },
     );
     std::process::Command::new("git")

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -2899,10 +2899,11 @@ fn capture_declared_base_with_git_and_timeout(
             )
         })?
         .to_string();
-    let fetch = homeboy_core::git::with_remote_tracking_authority(
+    let fetch = homeboy_core::git::with_remote_tracking_authority_until(
         worktree_path,
         "fetch declared promotion base",
-        || {
+        std::time::Instant::now() + timeout,
+        |_| {
             run_declared_base_git(
                 worktree_path,
                 git,

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -2903,7 +2903,7 @@ fn capture_declared_base_with_git_and_timeout(
         worktree_path,
         "fetch declared promotion base",
         std::time::Instant::now() + timeout,
-        |_| {
+        |remaining| {
             run_declared_base_git(
                 worktree_path,
                 git,
@@ -2917,7 +2917,7 @@ fn capture_declared_base_with_git_and_timeout(
                 environment,
                 base_ref,
                 "fetch",
-                timeout,
+                remaining,
             )
         },
     )?;

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -8128,8 +8128,8 @@ fn materialize_prepared_cook_base(target: &Path, base_sha: &str) -> Result<Strin
         target,
         "materialize prepared Cook base",
         std::time::Instant::now() + std::time::Duration::from_secs(30),
-        |_| {
-            homeboy_core::git::run_git(
+        |remaining| {
+            homeboy_core::git::run_git_with_env_timeout(
                 target,
                 &[
                     "fetch",
@@ -8139,6 +8139,8 @@ fn materialize_prepared_cook_base(target: &Path, base_sha: &str) -> Result<Strin
                     base_sha,
                 ],
                 "materialize prepared Cook base",
+                &[],
+                remaining,
             )
             .map(|_| ())
         },

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -8124,10 +8124,11 @@ fn materialize_prepared_cook_base(target: &Path, base_sha: &str) -> Result<Strin
     ) {
         return Ok(resolved.trim().to_string());
     }
-    homeboy_core::git::with_remote_tracking_authority(
+    homeboy_core::git::with_remote_tracking_authority_until(
         target,
         "materialize prepared Cook base",
-        || {
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+        |_| {
             homeboy_core::git::run_git(
                 target,
                 &[

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2714,18 +2714,20 @@ fn observe_and_fetch_base(path: &str, base: &str) -> Result<String> {
         Path::new(path),
         "materialize refreshed destination base",
         std::time::Instant::now() + std::time::Duration::from_secs(30),
-        |_| {
-            std::process::Command::new("git")
-                .args([
+        |remaining| {
+            homeboy_core::git::run_git_output_with_env_timeout(
+                Path::new(path),
+                &[
                     "fetch",
                     "--no-tags",
                     "--no-write-fetch-head",
                     "origin",
                     &sha,
-                ])
-                .current_dir(path)
-                .output()
-                .map_err(|error| Error::git_command_failed(error.to_string()))
+                ],
+                "materialize refreshed destination base",
+                &[],
+                remaining,
+            )
         },
     )?;
     if !fetched.status.success() {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2710,10 +2710,11 @@ fn observe_and_fetch_base(path: &str, base: &str) -> Result<String> {
             )
         })?
         .to_string();
-    let fetched = homeboy_core::git::with_remote_tracking_authority(
+    let fetched = homeboy_core::git::with_remote_tracking_authority_until(
         Path::new(path),
         "materialize refreshed destination base",
-        || {
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+        |_| {
             std::process::Command::new("git")
                 .args([
                     "fetch",

--- a/crates/homeboy-cli/src/commands/status/git_cache.rs
+++ b/crates/homeboy-cli/src/commands/status/git_cache.rs
@@ -215,12 +215,12 @@ fn fetch_origin_tags(path: &str, timer: &StatusTimer) {
     let Some(remaining) = timer.remaining() else {
         return;
     };
-    let _ = git::run_git_with_env_timeout(
+    let _ = git::fetch_remote_tracking_refs_until(
         std::path::Path::new(path),
         &["fetch", "--tags", "--quiet"],
         "status fetch origin tags",
         &[],
-        remaining.min(STATUS_FETCH_TIMEOUT),
+        std::time::Instant::now() + remaining.min(STATUS_FETCH_TIMEOUT),
     );
 }
 

--- a/crates/homeboy-core/src/deps.rs
+++ b/crates/homeboy-core/src/deps.rs
@@ -161,9 +161,7 @@ pub fn hydrate_declared_dependencies(
     package_root: &str,
     policy: &DependencyHydrationPolicy,
 ) -> Result<Vec<DependencyHydrationOutcome>> {
-    crate::git::with_remote_tracking_authority_if_git(path, "hydrate declared dependencies", || {
-        hydrate_declared_dependencies_unlocked(path, workspace, package_root, policy)
-    })
+    hydrate_declared_dependencies_unlocked(path, workspace, package_root, policy)
 }
 
 fn hydrate_declared_dependencies_unlocked(

--- a/crates/homeboy-core/src/git/github/readiness.rs
+++ b/crates/homeboy-core/src/git/github/readiness.rs
@@ -113,10 +113,12 @@ pub fn pr_reconcile_mergeability(
 }
 
 fn fetch_ref_sha(repo_path: &Path, remote_ref: &str) -> Result<String> {
-    run_git(
+    super::super::fetch_remote_tracking_refs_until(
         repo_path,
         &["fetch", "--quiet", "origin", remote_ref],
         "git fetch",
+        &[],
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
     )?;
     Ok(
         run_git(repo_path, &["rev-parse", "FETCH_HEAD"], "git rev-parse")?

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -95,8 +95,8 @@ pub use primitives::{
     default_branch_name, default_remote_branch, fetch_remote_tracking_refs_until,
     get_component_path_prefix, get_git_root, get_git_root_with_timeout, git_probe_path,
     has_staged_changes, is_workdir_clean_or_not_git, pull_repo, resolve_default_remote, run_git,
-    run_git_output, run_git_output_with_env, run_git_with_env, run_git_with_env_timeout, stage_all,
-    update_to_remote_default_branch,
+    run_git_output, run_git_output_with_env, run_git_output_with_env_timeout, run_git_with_env,
+    run_git_with_env_timeout, stage_all, update_to_remote_default_branch,
 };
 pub use primitives::{is_git_repo, is_tracked_path};
 pub use primitives_query::{

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -92,10 +92,11 @@ pub use pr_refresh::{
 pub(crate) use primitives::list_tracked_markdown_files;
 pub use primitives::{
     clone_repo, clone_repo_at_ref, clone_repo_at_ref_with_timeout, commit_staged_with_author,
-    default_branch_name, default_remote_branch, get_component_path_prefix, get_git_root,
-    get_git_root_with_timeout, git_probe_path, has_staged_changes, is_workdir_clean_or_not_git,
-    pull_repo, resolve_default_remote, run_git, run_git_output, run_git_output_with_env,
-    run_git_with_env, run_git_with_env_timeout, stage_all, update_to_remote_default_branch,
+    default_branch_name, default_remote_branch, fetch_remote_tracking_refs_until,
+    get_component_path_prefix, get_git_root, get_git_root_with_timeout, git_probe_path,
+    has_staged_changes, is_workdir_clean_or_not_git, pull_repo, resolve_default_remote, run_git,
+    run_git_output, run_git_output_with_env, run_git_with_env, run_git_with_env_timeout, stage_all,
+    update_to_remote_default_branch,
 };
 pub use primitives::{is_git_repo, is_tracked_path};
 pub use primitives_query::{
@@ -104,9 +105,7 @@ pub use primitives_query::{
     rev_parse, short_head_revision, status_porcelain, status_porcelain_bytes,
     status_porcelain_scoped, toplevel, BoundedGitRead, DEFAULT_GIT_READ_PROBE_TIMEOUT,
 };
-pub use remote_tracking_authority::{
-    with_remote_tracking_authority, with_remote_tracking_authority_if_git,
-};
+pub use remote_tracking_authority::with_remote_tracking_authority_until;
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/crates/homeboy-core/src/git/operations.rs
+++ b/crates/homeboy-core/src/git/operations.rs
@@ -381,7 +381,13 @@ pub fn pull_bulk(json_spec: &str) -> Result<BulkResult<GitOutput>> {
 /// Returns Ok(Some(n)) if behind by n commits, Ok(None) if not behind or no upstream.
 pub fn fetch_and_get_behind_count(path: &str) -> Result<Option<u32>> {
     // Run git fetch (update tracking refs)
-    crate::engine::command::run_in(path, "git", &["fetch"], "git fetch")?;
+    super::fetch_remote_tracking_refs_until(
+        Path::new(path),
+        &["fetch"],
+        "git fetch",
+        &[],
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+    )?;
 
     // Check if upstream exists
     let upstream = crate::engine::command::run_in_optional(

--- a/crates/homeboy-core/src/git/operations_changes.rs
+++ b/crates/homeboy-core/src/git/operations_changes.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::path::Path;
 
 use crate::config::read_json_spec_to_string;
 use crate::error::{Error, Result};
@@ -122,7 +123,13 @@ pub fn detect_baseline_with_version_and_tag_prefix(
     // machine) are available before we resolve the baseline. Best-effort:
     // if there is no remote or the network is unavailable we silently
     // proceed with whatever tags are already local.
-    let _ = crate::engine::command::run_in_optional(path, "git", &["fetch", "--tags", "--quiet"]);
+    let _ = super::fetch_remote_tracking_refs_until(
+        Path::new(path),
+        &["fetch", "--tags", "--quiet"],
+        "git fetch --tags",
+        &[],
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+    );
 
     detect_baseline_with_version_and_tag_prefix_from_fetched_tags(path, current_version, tag_prefix)
 }

--- a/crates/homeboy-core/src/git/operations_tags.rs
+++ b/crates/homeboy-core/src/git/operations_tags.rs
@@ -157,11 +157,12 @@ pub fn remote_branch_commit(path: &str, branch: &str) -> Result<Option<String>> 
 /// resolved from the repository (preferring `origin`) rather than assumed.
 pub fn fetch_origin(path: &str) -> Result<()> {
     let remote = super::resolve_default_remote(Path::new(path));
-    crate::engine::command::run_in(
-        path,
-        "git",
+    super::fetch_remote_tracking_refs_until(
+        Path::new(path),
         &["fetch", &remote],
         &format!("git fetch {remote}"),
+        &[],
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
     )?;
     Ok(())
 }
@@ -193,17 +194,25 @@ pub fn fetch_tags(path: &str) -> Result<()> {
     // commits and ancestry can be evaluated. `--unshallow` errors on a complete
     // repo, so it is gated on the shallow marker and run best-effort.
     if is_shallow(path) {
-        let _ = crate::engine::command::run_in_optional(
-            path,
-            "git",
+        let _ = super::fetch_remote_tracking_refs_until(
+            Path::new(path),
             &["fetch", "--unshallow", "--tags", &remote],
+            "git fetch --unshallow --tags",
+            &[],
+            std::time::Instant::now() + std::time::Duration::from_secs(30),
         );
     }
 
     // Fetch tags from the remote so the latest release tag and its commits are
     // present locally. Best-effort: offline/no-remote checkouts fall through to
     // the guard with whatever local history exists.
-    let _ = crate::engine::command::run_in_optional(path, "git", &["fetch", "--tags", &remote]);
+    let _ = super::fetch_remote_tracking_refs_until(
+        Path::new(path),
+        &["fetch", "--tags", &remote],
+        "git fetch --tags",
+        &[],
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+    );
 
     Ok(())
 }

--- a/crates/homeboy-core/src/git/pr_refresh.rs
+++ b/crates/homeboy-core/src/git/pr_refresh.rs
@@ -124,10 +124,12 @@ pub fn pr_refresh(
         ));
     }
 
-    git_checked(
+    super::fetch_remote_tracking_refs_until(
         root,
         &["fetch", "origin", &pr.base_ref_name],
         "git fetch base",
+        &[],
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
     )?;
 
     let strategy = resolve_strategy(root, options.strategy, &branch)?;

--- a/crates/homeboy-core/src/git/primitives.rs
+++ b/crates/homeboy-core/src/git/primitives.rs
@@ -166,6 +166,37 @@ pub fn run_git_with_env_timeout(
     env: &[(String, String)],
     timeout: Duration,
 ) -> Result<String> {
+    let output = run_git_output_with_env_timeout(git_root, args, context, env, timeout)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(Error::git_command_failed_with_details(
+            git_failure_message(context, &detail),
+            GitCommandFailedDetails {
+                command: git_command_display(args),
+                cwd: git_cwd_display(git_root),
+                exit_code: output.status.code(),
+                stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+                io_error: None,
+            },
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Run Git with a deadline and preserve its exit status and captured output.
+///
+/// This supports callers that need command-specific diagnostics while still
+/// sharing a caller-owned deadline with remote-tracking authority waits.
+pub fn run_git_output_with_env_timeout(
+    git_root: &Path,
+    args: &[&str],
+    context: &str,
+    env: &[(String, String)],
+    timeout: Duration,
+) -> Result<std::process::Output> {
     let mut command = Command::new("git");
     command
         .args(args)
@@ -214,31 +245,23 @@ pub fn run_git_with_env_timeout(
         )
     })?
     .into_output();
-    if !output.status.success() {
-        let mut stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        if timed_out {
-            if !stderr.is_empty() {
-                stderr.push('\n');
-            }
-            stderr.push_str(&format!(
-                "Git phase timed out after {}s; terminated child process group.",
-                timeout.as_secs()
-            ));
-        }
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if timed_out {
         return Err(Error::git_command_failed_with_details(
-            git_failure_message(context, if stderr.is_empty() { &stdout } else { &stderr }),
+            format!(
+                "{context} timed out after {}s; terminated child process group.",
+                timeout.as_secs()
+            ),
             GitCommandFailedDetails {
                 command: git_command_display(args),
                 cwd: git_cwd_display(git_root),
                 exit_code: output.status.code(),
-                stdout,
-                stderr,
+                stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
                 io_error: None,
             },
         ));
     }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(output)
 }
 
 /// Fetch remote refs while serializing the shared remote-tracking namespace of

--- a/crates/homeboy-core/src/git/primitives.rs
+++ b/crates/homeboy-core/src/git/primitives.rs
@@ -6,6 +6,7 @@ use crate::engine::command;
 use crate::error::{Error, GitCommandFailedDetails, Result};
 
 use super::primitives_query::current_branch;
+use super::with_remote_tracking_authority_until;
 
 fn git_command_display(args: &[&str]) -> String {
     if args.is_empty() {
@@ -240,6 +241,21 @@ pub fn run_git_with_env_timeout(
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Fetch remote refs while serializing the shared remote-tracking namespace of
+/// linked worktrees. Waiting and Git execution consume one caller-owned budget.
+pub fn fetch_remote_tracking_refs_until(
+    git_root: &Path,
+    args: &[&str],
+    context: &str,
+    env: &[(String, String)],
+    deadline: Instant,
+) -> Result<String> {
+    debug_assert_eq!(args.first(), Some(&"fetch"));
+    with_remote_tracking_authority_until(git_root, context, deadline, |remaining| {
+        run_git_with_env_timeout(git_root, args, context, env, remaining)
+    })
+}
+
 /// Run a git command in a repository and return raw output without treating
 /// non-zero exit status as an error.
 pub fn run_git_output(
@@ -380,10 +396,12 @@ pub fn default_branch_name(path: &Path) -> Option<String> {
 pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
     let remote = resolve_default_remote(git_root);
     let old_branch = current_branch(git_root);
-    run_git(
+    fetch_remote_tracking_refs_until(
         git_root,
         &["fetch", &remote],
         &format!("git fetch {remote}"),
+        &[],
+        Instant::now() + Duration::from_secs(30),
     )?;
     let mut detached_default_branch: Option<String> = None;
 

--- a/crates/homeboy-core/src/git/remote_tracking_authority.rs
+++ b/crates/homeboy-core/src/git/remote_tracking_authority.rs
@@ -197,34 +197,31 @@ mod tests {
         git(path, &["commit", "-qm", "fixture"]);
     }
 
-    fn git_stdout(path: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(output.status.success(), "git {:?} failed", args);
-        String::from_utf8(output.stdout)
-            .expect("git output")
-            .trim()
-            .to_string()
-    }
-
     #[test]
-    fn two_process_sibling_worktrees_fetch_requested_revisions() {
+    fn two_process_sibling_worktrees_serialize_fetch_paths() {
         const CHILD: &str = "HOMEB0Y_REMOTE_TRACKING_FETCH_CHILD";
-        if let (Some(path), Some(revision)) = (
-            std::env::var_os(CHILD),
-            std::env::var_os("HOMEB0Y_REMOTE_TRACKING_FETCH_REVISION"),
-        ) {
-            crate::git::fetch_remote_tracking_refs_until(
-                Path::new(&path),
-                &["fetch", "origin", revision.to_str().expect("revision")],
-                "two-process remote-tracking fetch",
-                &[],
-                Instant::now() + Duration::from_secs(10),
-            )
-            .expect("child fetch");
+        if let Some(path) = std::env::var_os(CHILD) {
+            let path = Path::new(&path);
+            if let Some(attempted) = std::env::var_os("HOMEB0Y_REMOTE_TRACKING_FETCH_ATTEMPTED") {
+                std::fs::write(attempted, "attempted\n").expect("write child fetch attempt");
+            }
+            match std::env::var("HOMEB0Y_REMOTE_TRACKING_FETCH_OPERATION").as_deref() {
+                Ok("behind") => {
+                    crate::git::fetch_and_get_behind_count(path.to_str().expect("path"))
+                        .expect("child behind fetch");
+                }
+                Ok("origin") => {
+                    crate::git::fetch_origin(path.to_str().expect("path"))
+                        .expect("child origin fetch");
+                }
+                Ok("tags") => {
+                    crate::git::fetch_tags(path.to_str().expect("path")).expect("child tag fetch");
+                }
+                operation => panic!("unexpected child fetch operation: {operation:?}"),
+            }
+            if let Some(done) = std::env::var_os("HOMEB0Y_REMOTE_TRACKING_FETCH_DONE") {
+                std::fs::write(done, "done\n").expect("write child completion");
+            }
             return;
         }
 
@@ -242,16 +239,6 @@ mod tests {
             &["remote", "add", "origin", remote.to_str().expect("path")],
         );
         git(&source, &["push", "-q", "origin", "HEAD:main"]);
-        for revision in ["requested-a", "requested-b"] {
-            std::fs::write(source.join(revision), format!("{revision}\n")).expect("revision");
-            git(&source, &["add", revision]);
-            git(&source, &["commit", "-qm", revision]);
-            git(
-                &source,
-                &["push", "-q", "origin", &format!("HEAD:{revision}")],
-            );
-            git(&source, &["reset", "--hard", "-q", "HEAD~1"]);
-        }
         let sibling = temp.path().join("sibling");
         git(
             &source,
@@ -265,31 +252,109 @@ mod tests {
         );
 
         let executable = std::env::current_exe().expect("test executable");
-        let test_name = "git::remote_tracking_authority::tests::two_process_sibling_worktrees_fetch_requested_revisions";
-        let spawn = |path: &Path, revision: &str| {
-            Command::new(&executable)
+        let test_name =
+            "git::remote_tracking_authority::tests::two_process_sibling_worktrees_serialize_fetch_paths";
+        let wrapper_dir = temp.path().join("bin");
+        std::fs::create_dir(&wrapper_dir).expect("wrapper directory");
+        let started = temp.path().join("first-fetch-started");
+        let release = temp.path().join("release-first-fetch");
+        let upload_pack = wrapper_dir.join("git-upload-pack");
+        std::fs::write(
+            &upload_pack,
+            "#!/bin/sh\nif [ -n \"$HOMEB0Y_REMOTE_TRACKING_FETCH_REACHED\" ]; then\n  touch \"$HOMEB0Y_REMOTE_TRACKING_FETCH_REACHED\"\nfi\nif [ -n \"$HOMEB0Y_REMOTE_TRACKING_FETCH_STARTED\" ]; then\n  touch \"$HOMEB0Y_REMOTE_TRACKING_FETCH_STARTED\"\n  while ! test -e \"$HOMEB0Y_REMOTE_TRACKING_FETCH_RELEASE\"; do sleep 0.01; done\nfi\nexec \"$HOMEB0Y_REMOTE_TRACKING_REAL_GIT\" upload-pack \"$@\"\n",
+        )
+        .expect("write upload-pack wrapper");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&upload_pack, std::fs::Permissions::from_mode(0o755))
+                .expect("make upload-pack wrapper executable");
+        }
+        git(
+            &source,
+            &[
+                "config",
+                "remote.origin.uploadpack",
+                upload_pack.to_str().expect("upload-pack path"),
+            ],
+        );
+        let real_git = std::env::split_paths(&std::env::var_os("PATH").expect("PATH"))
+            .map(|directory| directory.join("git"))
+            .find_map(|candidate| candidate.canonicalize().ok())
+            .expect("real git executable");
+        let path_env = format!(
+            "{}:{}",
+            wrapper_dir.display(),
+            std::env::var("PATH").expect("PATH")
+        );
+        let spawn = |path: &Path,
+                     operation: &str,
+                     hold_fetch: bool,
+                     attempted: Option<&Path>,
+                     reached: Option<&Path>,
+                     done: Option<&Path>| {
+            let mut command = Command::new(&executable);
+            command
                 .args(["--exact", test_name, "--nocapture"])
                 .env(CHILD, path)
-                .env("HOMEB0Y_REMOTE_TRACKING_FETCH_REVISION", revision)
-                .spawn()
-                .expect("spawn fetch child")
+                .env("HOMEB0Y_REMOTE_TRACKING_FETCH_OPERATION", operation)
+                .env("PATH", &path_env)
+                .env("HOMEB0Y_REMOTE_TRACKING_REAL_GIT", &real_git);
+            if hold_fetch {
+                command
+                    .env("HOMEB0Y_REMOTE_TRACKING_FETCH_STARTED", &started)
+                    .env("HOMEB0Y_REMOTE_TRACKING_FETCH_RELEASE", &release);
+            }
+            if let Some(attempted) = attempted {
+                command.env("HOMEB0Y_REMOTE_TRACKING_FETCH_ATTEMPTED", attempted);
+            }
+            if let Some(reached) = reached {
+                command.env("HOMEB0Y_REMOTE_TRACKING_FETCH_REACHED", reached);
+            }
+            if let Some(done) = done {
+                command.env("HOMEB0Y_REMOTE_TRACKING_FETCH_DONE", done);
+            }
+            command.spawn().expect("spawn fetch child")
         };
-        let mut first = spawn(&source, "requested-a");
-        let mut second = spawn(&sibling, "requested-b");
+        let mut first = spawn(&source, "behind", true, None, None, None);
+        let wait_deadline = Instant::now() + Duration::from_secs(2);
+        while !started.exists() && Instant::now() < wait_deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(started.exists(), "first fetch did not reach upload-pack");
+        let second_attempted = temp.path().join("second-fetch-attempted");
+        let second_reached = temp.path().join("second-fetch-reached-upload-pack");
+        let second_done = temp.path().join("second-fetch-done");
+        let mut second = spawn(
+            &sibling,
+            "origin",
+            false,
+            Some(&second_attempted),
+            Some(&second_reached),
+            Some(&second_done),
+        );
+        let attempt_deadline = Instant::now() + Duration::from_secs(2);
+        while !second_attempted.exists() && Instant::now() < attempt_deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            second_attempted.exists(),
+            "second fetch did not attempt authority"
+        );
+        let contention_deadline = Instant::now() + Duration::from_millis(500);
+        while !second_reached.exists() && Instant::now() < contention_deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !second_reached.exists(),
+            "sibling fetch reached transport while the first fetch held remote-tracking authority"
+        );
+        std::fs::write(&release, "release\n").expect("release first fetch");
         assert!(first.wait().expect("wait first").success());
         assert!(second.wait().expect("wait second").success());
-
-        for revision in ["requested-a", "requested-b"] {
-            assert!(!git_stdout(
-                &source,
-                &[
-                    "rev-parse",
-                    "--verify",
-                    &format!("refs/remotes/origin/{revision}^{{commit}}")
-                ],
-            )
-            .is_empty());
-        }
+        assert!(second_done.exists(), "sibling fetch did not complete");
+        let mut tags = spawn(&sibling, "tags", false, None, None, None);
+        assert!(tags.wait().expect("wait tag fetch").success());
     }
 
     #[test]

--- a/crates/homeboy-core/src/git/remote_tracking_authority.rs
+++ b/crates/homeboy-core/src/git/remote_tracking_authority.rs
@@ -10,7 +10,6 @@ use fs4::fs_std::FileExt;
 
 use crate::error::{Error, Result};
 
-const WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 const WAIT_INTERVAL: Duration = Duration::from_millis(50);
 const LOCK_FILE: &str = "homeboy-remote-tracking.lock";
 
@@ -19,10 +18,11 @@ static AUTHORITIES: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock
 /// Serialize Homeboy operations that can update remote-tracking refs for one
 /// repository. Linked worktrees share a Git common directory, while unrelated
 /// repositories retain independent concurrency.
-pub fn with_remote_tracking_authority<T>(
+pub fn with_remote_tracking_authority_until<T>(
     repository: &Path,
     operation: &str,
-    action: impl FnOnce() -> Result<T>,
+    deadline: Instant,
+    action: impl FnOnce(Duration) -> Result<T>,
 ) -> Result<T> {
     let common_dir = git_common_dir(repository)?;
     let authority = {
@@ -35,7 +35,7 @@ pub fn with_remote_tracking_authority<T>(
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()
     };
-    let _process_guard = acquire_process_guard(&authority, &common_dir, operation)?;
+    let _process_guard = acquire_process_guard(&authority, &common_dir, operation, deadline)?;
     let lock_path = common_dir.join(LOCK_FILE);
     let mut lock = OpenOptions::new()
         .create(true)
@@ -43,22 +43,14 @@ pub fn with_remote_tracking_authority<T>(
         .write(true)
         .open(&lock_path)
         .map_err(|error| authority_error(operation, &common_dir, &lock_path, None, error))?;
-    acquire_file_guard(&mut lock, &common_dir, &lock_path, operation)?;
-    action()
-}
-
-/// Run an action under the repository authority when `path` is a Git checkout.
-/// Non-Git dependency roots retain their existing provider-owned behavior.
-pub fn with_remote_tracking_authority_if_git<T>(
-    path: &Path,
-    operation: &str,
-    action: impl FnOnce() -> Result<T>,
-) -> Result<T> {
-    if git_common_dir(path).is_ok() {
-        with_remote_tracking_authority(path, operation, action)
-    } else {
-        action()
-    }
+    acquire_file_guard(&mut lock, &common_dir, &lock_path, operation, deadline)?;
+    action(remaining(
+        deadline,
+        operation,
+        &common_dir,
+        &lock_path,
+        None,
+    )?)
 }
 
 fn git_common_dir(repository: &Path) -> Result<PathBuf> {
@@ -81,14 +73,14 @@ fn acquire_process_guard<'a>(
     authority: &'a Mutex<()>,
     common_dir: &Path,
     operation: &str,
+    deadline: Instant,
 ) -> Result<std::sync::MutexGuard<'a, ()>> {
-    let started = Instant::now();
     let mut reported_wait = false;
     loop {
         match authority.try_lock() {
             Ok(guard) => return Ok(guard),
             Err(std::sync::TryLockError::Poisoned(poisoned)) => return Ok(poisoned.into_inner()),
-            Err(std::sync::TryLockError::WouldBlock) if started.elapsed() < WAIT_TIMEOUT => {
+            Err(std::sync::TryLockError::WouldBlock) if Instant::now() < deadline => {
                 if !reported_wait {
                     crate::log_status!(
                         "git",
@@ -106,7 +98,7 @@ fn acquire_process_guard<'a>(
                     common_dir,
                     &common_dir.join(LOCK_FILE),
                     Some("another Homeboy operation in this process".to_string()),
-                    std::io::Error::new(std::io::ErrorKind::TimedOut, "authority wait timed out"),
+                    timed_out_error(),
                 ));
             }
         }
@@ -118,8 +110,8 @@ fn acquire_file_guard(
     common_dir: &Path,
     lock_path: &Path,
     operation: &str,
+    deadline: Instant,
 ) -> Result<()> {
-    let started = Instant::now();
     let mut reported_wait = false;
     loop {
         match lock.try_lock_exclusive() {
@@ -133,7 +125,7 @@ fn acquire_file_guard(
                     })?;
                 return Ok(());
             }
-            Ok(false) | Err(_) if started.elapsed() < WAIT_TIMEOUT => {
+            Ok(false) | Err(_) if Instant::now() < deadline => {
                 if !reported_wait {
                     let owner = fs::read_to_string(lock_path)
                         .ok()
@@ -152,10 +144,15 @@ fn acquire_file_guard(
                 thread::sleep(WAIT_INTERVAL)
             }
             Ok(false) => {
-                let error = std::io::Error::new(
-                    std::io::ErrorKind::WouldBlock,
-                    "remote-tracking authority is held by another process",
-                );
+                let error = timed_out_error();
+                let owner = fs::read_to_string(lock_path)
+                    .ok()
+                    .map(|value| value.trim().to_string());
+                return Err(authority_error(
+                    operation, common_dir, lock_path, owner, error,
+                ));
+            }
+            Err(error) if Instant::now() >= deadline => {
                 let owner = fs::read_to_string(lock_path)
                     .ok()
                     .map(|value| value.trim().to_string());
@@ -200,6 +197,101 @@ mod tests {
         git(path, &["commit", "-qm", "fixture"]);
     }
 
+    fn git_stdout(path: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(output.status.success(), "git {:?} failed", args);
+        String::from_utf8(output.stdout)
+            .expect("git output")
+            .trim()
+            .to_string()
+    }
+
+    #[test]
+    fn two_process_sibling_worktrees_fetch_requested_revisions() {
+        const CHILD: &str = "HOMEB0Y_REMOTE_TRACKING_FETCH_CHILD";
+        if let (Some(path), Some(revision)) = (
+            std::env::var_os(CHILD),
+            std::env::var_os("HOMEB0Y_REMOTE_TRACKING_FETCH_REVISION"),
+        ) {
+            crate::git::fetch_remote_tracking_refs_until(
+                Path::new(&path),
+                &["fetch", "origin", revision.to_str().expect("revision")],
+                "two-process remote-tracking fetch",
+                &[],
+                Instant::now() + Duration::from_secs(10),
+            )
+            .expect("child fetch");
+            return;
+        }
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote = temp.path().join("remote.git");
+        git(
+            temp.path(),
+            &["init", "--bare", "-q", remote.to_str().expect("path")],
+        );
+        let source = temp.path().join("source");
+        std::fs::create_dir(&source).expect("source");
+        repository(&source);
+        git(
+            &source,
+            &["remote", "add", "origin", remote.to_str().expect("path")],
+        );
+        git(&source, &["push", "-q", "origin", "HEAD:main"]);
+        for revision in ["requested-a", "requested-b"] {
+            std::fs::write(source.join(revision), format!("{revision}\n")).expect("revision");
+            git(&source, &["add", revision]);
+            git(&source, &["commit", "-qm", revision]);
+            git(
+                &source,
+                &["push", "-q", "origin", &format!("HEAD:{revision}")],
+            );
+            git(&source, &["reset", "--hard", "-q", "HEAD~1"]);
+        }
+        let sibling = temp.path().join("sibling");
+        git(
+            &source,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                "-q",
+                sibling.to_str().expect("path"),
+            ],
+        );
+
+        let executable = std::env::current_exe().expect("test executable");
+        let test_name = "git::remote_tracking_authority::tests::two_process_sibling_worktrees_fetch_requested_revisions";
+        let spawn = |path: &Path, revision: &str| {
+            Command::new(&executable)
+                .args(["--exact", test_name, "--nocapture"])
+                .env(CHILD, path)
+                .env("HOMEB0Y_REMOTE_TRACKING_FETCH_REVISION", revision)
+                .spawn()
+                .expect("spawn fetch child")
+        };
+        let mut first = spawn(&source, "requested-a");
+        let mut second = spawn(&sibling, "requested-b");
+        assert!(first.wait().expect("wait first").success());
+        assert!(second.wait().expect("wait second").success());
+
+        for revision in ["requested-a", "requested-b"] {
+            assert!(!git_stdout(
+                &source,
+                &[
+                    "rev-parse",
+                    "--verify",
+                    &format!("refs/remotes/origin/{revision}^{{commit}}")
+                ],
+            )
+            .is_empty());
+        }
+    }
+
     #[test]
     fn sibling_worktrees_serialize_remote_tracking_operations() {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -221,28 +313,38 @@ mod tests {
         let (release_tx, release_rx) = mpsc::channel();
         let source_for_thread = source.clone();
         let first = thread::spawn(move || {
-            with_remote_tracking_authority(&source_for_thread, "first fetch", || {
-                entered_tx.send(()).expect("entered");
-                release_rx.recv().expect("release");
-                git(
-                    &source_for_thread,
-                    &["update-ref", "refs/remotes/origin/concurrent", "HEAD"],
-                );
-                Ok(())
-            })
+            with_remote_tracking_authority_until(
+                &source_for_thread,
+                "first fetch",
+                Instant::now() + Duration::from_secs(5),
+                |_| {
+                    entered_tx.send(()).expect("entered");
+                    release_rx.recv().expect("release");
+                    git(
+                        &source_for_thread,
+                        &["update-ref", "refs/remotes/origin/concurrent", "HEAD"],
+                    );
+                    Ok(())
+                },
+            )
         });
         entered_rx.recv().expect("first entered");
 
         let (second_tx, second_rx) = mpsc::channel();
         let second = thread::spawn(move || {
-            with_remote_tracking_authority(&sibling, "second fetch", || {
-                git(
-                    &sibling,
-                    &["update-ref", "refs/remotes/origin/concurrent", "HEAD"],
-                );
-                second_tx.send(()).expect("second entered");
-                Ok(())
-            })
+            with_remote_tracking_authority_until(
+                &sibling,
+                "second fetch",
+                Instant::now() + Duration::from_secs(5),
+                |_| {
+                    git(
+                        &sibling,
+                        &["update-ref", "refs/remotes/origin/concurrent", "HEAD"],
+                    );
+                    second_tx.send(()).expect("second entered");
+                    Ok(())
+                },
+            )
         });
         assert!(second_rx.recv_timeout(Duration::from_millis(150)).is_err());
         release_tx.send(()).expect("release first");
@@ -276,21 +378,47 @@ mod tests {
         let (entered_tx, entered_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();
         let first = thread::spawn(move || {
-            with_remote_tracking_authority(&first_repo, "first fetch", || {
-                entered_tx.send(()).expect("first entered");
-                release_rx.recv().expect("release");
-                Ok(())
-            })
+            with_remote_tracking_authority_until(
+                &first_repo,
+                "first fetch",
+                Instant::now() + Duration::from_secs(5),
+                |_| {
+                    entered_tx.send(()).expect("first entered");
+                    release_rx.recv().expect("release");
+                    Ok(())
+                },
+            )
         });
         entered_rx.recv().expect("first entered");
-        with_remote_tracking_authority(&second_repo, "second fetch", || Ok(()))
-            .expect("unrelated authority");
+        with_remote_tracking_authority_until(
+            &second_repo,
+            "second fetch",
+            Instant::now() + Duration::from_secs(5),
+            |_| Ok(()),
+        )
+        .expect("unrelated authority");
         release_tx.send(()).expect("release first");
         first
             .join()
             .expect("first thread")
             .expect("first authority");
     }
+}
+
+fn remaining(
+    deadline: Instant,
+    operation: &str,
+    common_dir: &Path,
+    lock_path: &Path,
+    owner: Option<String>,
+) -> Result<Duration> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .ok_or_else(|| authority_error(operation, common_dir, lock_path, owner, timed_out_error()))
+}
+
+fn timed_out_error() -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::TimedOut, "authority deadline exhausted")
 }
 
 fn authority_error(
@@ -304,8 +432,7 @@ fn authority_error(
         .filter(|owner| !owner.is_empty())
         .unwrap_or_else(|| "unknown owner".to_string());
     Error::git_command_failed(format!(
-        "{operation} waited {}s for remote-tracking authority at {} (owner: {}; lock: {}): {error}",
-        WAIT_TIMEOUT.as_secs(),
+        "{operation} exhausted its caller deadline waiting for remote-tracking authority at {} (owner: {}; lock: {}): {error}",
         common_dir.display(),
         owner,
         lock_path.display(),

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -663,16 +663,13 @@ struct PendingHandoffFreshness {
 
 fn prepare_handoff_freshness(source: &Path, base_ref: &str) -> Result<PendingHandoffFreshness> {
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-    git::with_remote_tracking_authority(source, "git fetch origin for worktree handoff", || {
-        git::run_git_with_env_timeout(
-            source,
-            &["fetch", "origin"],
-            "git fetch origin for worktree handoff",
-            &[],
-            TIMEOUT,
-        )
-        .map(|_| ())
-    })?;
+    git::fetch_remote_tracking_refs_until(
+        source,
+        &["fetch", "origin"],
+        "git fetch origin for worktree handoff",
+        &[],
+        std::time::Instant::now() + TIMEOUT,
+    )?;
     let advertised = git::run_git_with_env_timeout(
         source,
         &["ls-remote", "--symref", "origin", "HEAD"],

--- a/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
+++ b/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
@@ -396,22 +396,19 @@ fn ensure_resolved_commit_is_available(
         identity.requested_ref,
         identity.resolved_sha
     );
-    git::with_remote_tracking_authority(source_root, "fetch preflighted exact deploy ref", || {
-        git::run_git_with_env_timeout(
-            source_root,
-            &[
-                "fetch",
-                "--no-tags",
-                "--no-write-fetch-head",
-                &remote,
-                &format!("+{}:", identity.resolved_sha),
-            ],
-            "fetch preflighted exact deploy ref",
-            &transport_env,
-            REMOTE_REF_QUERY_TIMEOUT,
-        )
-        .map(|_| ())
-    })
+    git::fetch_remote_tracking_refs_until(
+        source_root,
+        &[
+            "fetch",
+            "--no-tags",
+            "--no-write-fetch-head",
+            &remote,
+            &format!("+{}:", identity.resolved_sha),
+        ],
+        "fetch preflighted exact deploy ref",
+        &transport_env,
+        std::time::Instant::now() + REMOTE_REF_QUERY_TIMEOUT,
+    )
     .map_err(|error| remote_transport_error(&remote, &component.id, &error))?;
     let fetched = git::run_git(
         source_root,

--- a/crates/homeboy-deploy/src/planning.rs
+++ b/crates/homeboy-deploy/src/planning.rs
@@ -588,13 +588,13 @@ pub(super) fn calculate_component_status_with_git_cache(
 
 fn fetch_default_remote(path: &Path) {
     let remote = git::resolve_default_remote(path);
-    let _ = Command::new("git")
-        .args(["fetch", "--quiet", &remote])
-        .current_dir(path)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
+    let _ = git::fetch_remote_tracking_refs_until(
+        path,
+        &["fetch", "--quiet", &remote],
+        "git fetch deploy planning remote",
+        &[],
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+    );
 }
 
 fn git_output(path: &Path, args: &[&str]) -> Option<String> {

--- a/crates/homeboy-stack/src/stack/apply.rs
+++ b/crates/homeboy-stack/src/stack/apply.rs
@@ -403,16 +403,13 @@ pub(crate) fn conflict_guidance(ctx: &ConflictContext<'_>, message: &str) -> Str
 }
 
 pub(super) fn fetch_remote_branch(path: &str, remote: &str, branch: &str) -> Result<()> {
-    let output = run_git(path, &["fetch", remote, branch])?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::git_command_failed(format!(
-            "git fetch {} {}: {}",
-            remote,
-            branch,
-            stderr.trim()
-        )));
-    }
+    homeboy_core::git::fetch_remote_tracking_refs_until(
+        Path::new(path),
+        &["fetch", remote, branch],
+        &format!("git fetch {remote} {branch}"),
+        &[],
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+    )?;
     Ok(())
 }
 
@@ -530,16 +527,13 @@ pub(crate) fn url_matches(a: &str, b: &str) -> bool {
 }
 
 pub(super) fn fetch_sha(path: &str, remote: &str, sha: &str) -> Result<()> {
-    let output = run_git(path, &["fetch", remote, sha])?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::git_command_failed(format!(
-            "git fetch {} {}: {}",
-            remote,
-            sha,
-            stderr.trim()
-        )));
-    }
+    homeboy_core::git::fetch_remote_tracking_refs_until(
+        Path::new(path),
+        &["fetch", remote, sha],
+        &format!("git fetch {remote} {sha}"),
+        &[],
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
Follow-up to merged #14484: restores and completes repository-scoped serialization for every production fetch that can update shared remote-tracking refs in linked worktrees.

Includes `fetch_and_get_behind_count`, `fetch_origin`, `fetch_tags`, and the status tag refresh path; lock waits consume the caller deadline, dependency hydration remains outside the lock, and sibling-worktree two-process coverage uses explicit contention rendezvous.

Closes #14479

AI assistance: OpenAI GPT-5.6 Terra via OpenCode.