### PR TITLE
fix(git): cover remaining fetch authority paths

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -832,10 +832,14 @@ impl DependencyActionExecutor for LocalDependencyActionExecutor {
     }
 
     fn fetch(&mut self, action: &DependencyAction) -> Result<()> {
-        run_dependency_command(
-            &action.worktree,
+        homeboy::core::git::fetch_remote_tracking_refs_until(
+            Path::new(&action.worktree),
             &["fetch", "--no-tags", "origin", &action.upstream_revision],
+            "git fetch dependency upstream revision",
+            &[],
+            Instant::now() + Duration::from_secs(30),
         )
+        .map(|_| ())
     }
 
     fn rebase(&mut self, action: &DependencyAction) -> Result<()> {

--- a/crates/homeboy-core/src/git/changes.rs
+++ b/crates/homeboy-core/src/git/changes.rs
@@ -1,10 +1,11 @@
 use std::path::{Component, Path};
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 
 use crate::error::{Error, Result};
 
-use super::execute_git;
+use super::{execute_git, fetch_remote_tracking_refs_until, resolve_default_remote};
 
 const VERBOSE_UNTRACKED_THRESHOLD: usize = 200;
 
@@ -158,10 +159,34 @@ fn build_untracked_hint(path: &str, untracked_count: usize) -> Option<String> {
 
 /// Get file paths changed between a ref and HEAD.
 ///
-/// Relocated to [`homeboy_engine_primitives::git_changes::get_files_changed_since`]
-/// (a std-only git primitive shared by audit, refactor, and lint/test scoping);
-/// re-exported here so `git::get_files_changed_since` callers are unaffected.
-pub use homeboy_engine_primitives::git_changes::get_files_changed_since;
+/// This core-owned entrypoint serializes shallow-clone deepening for linked
+/// worktrees. Engine primitives retain their standalone implementation for
+/// isolated callers that cannot depend on core.
+pub fn get_files_changed_since(path: &str, git_ref: &str) -> Result<Vec<String>> {
+    ensure_ancestry_for_ref(path, git_ref)?;
+    let output = execute_git(
+        path,
+        &[
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            &format!("{git_ref}...HEAD"),
+        ],
+    )
+    .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !output.status.success() {
+        return Err(Error::git_command_failed(format!(
+            "git diff {git_ref}...HEAD failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    let mut files: std::collections::BTreeSet<String> = parse_changed_since_output(&output.stdout)
+        .into_iter()
+        .collect();
+    files.extend(get_working_tree_files_for_changed_since(path)?);
+    Ok(files.into_iter().collect())
+}
 
 /// Ensure a ref's merge base with HEAD is reachable, then return it.
 ///
@@ -172,7 +197,7 @@ pub use homeboy_engine_primitives::git_changes::get_files_changed_since;
 /// behavior should treat the error as a signal to skip changed-since scoping
 /// rather than aborting.
 pub fn resolve_merge_base(path: &str, git_ref: &str) -> Result<String> {
-    homeboy_engine_primitives::git_changes::ensure_ancestry_for_ref(path, git_ref)?;
+    ensure_ancestry_for_ref(path, git_ref)?;
 
     let output = execute_git(path, &["merge-base", git_ref, "HEAD"])
         .map_err(|e| Error::git_command_failed(e.to_string()))?;
@@ -193,6 +218,101 @@ pub fn resolve_merge_base(path: &str, git_ref: &str) -> Result<String> {
     }
 
     Ok(merge_base)
+}
+
+fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
+    if has_merge_base(path, git_ref) {
+        return Ok(());
+    }
+    if !is_shallow_repo(path) {
+        return Err(Error::git_command_failed(format!(
+            "Cannot resolve merge base for {git_ref}: ref is not reachable and repository is not shallow (is the ref valid?)"
+        )));
+    }
+
+    eprintln!("Shallow clone detected — deepening to resolve merge base for {git_ref}");
+    let repository = Path::new(path);
+    let remote = resolve_default_remote(repository);
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let _ = fetch_remote_tracking_refs_until(
+        repository,
+        &["fetch", &remote, git_ref, "--depth=50"],
+        "git fetch changed-since ref",
+        &[],
+        deadline,
+    );
+    for depth in ["50", "200"] {
+        let _ = fetch_remote_tracking_refs_until(
+            repository,
+            &["fetch", "--deepen", depth],
+            "git deepen changed-since history",
+            &[],
+            deadline,
+        );
+        if has_merge_base(path, git_ref) {
+            eprintln!("Merge base found after deepening by {depth} commits");
+            return Ok(());
+        }
+    }
+    eprintln!("Merge base not found with depth 200, unshallowing repository");
+    let _ = fetch_remote_tracking_refs_until(
+        repository,
+        &["fetch", "--unshallow"],
+        "git unshallow changed-since history",
+        &[],
+        deadline,
+    );
+    if has_merge_base(path, git_ref) {
+        eprintln!("Merge base found after full unshallow");
+        Ok(())
+    } else {
+        Err(Error::git_command_failed(format!(
+            "Cannot resolve merge base for {git_ref} even after full unshallow — the ref may not exist in the remote"
+        )))
+    }
+}
+
+fn is_shallow_repo(path: &str) -> bool {
+    execute_git(path, &["rev-parse", "--is-shallow-repository"])
+        .ok()
+        .filter(|output| output.status.success())
+        .is_some_and(|output| String::from_utf8_lossy(&output.stdout).trim() == "true")
+}
+
+fn has_merge_base(path: &str, git_ref: &str) -> bool {
+    execute_git(path, &["merge-base", git_ref, "HEAD"])
+        .ok()
+        .is_some_and(|output| output.status.success())
+}
+
+fn get_working_tree_files_for_changed_since(path: &str) -> Result<Vec<String>> {
+    let _ = execute_git(path, &["update-index", "--refresh"]);
+    let mut files = std::collections::BTreeSet::new();
+    for args in [
+        vec!["diff", "--name-only", "--diff-filter=ACMR"],
+        vec!["diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        vec!["ls-files", "--others", "--exclude-standard"],
+    ] {
+        let output = execute_git(path, &args)
+            .map_err(|error| Error::git_command_failed(error.to_string()))?;
+        if !output.status.success() {
+            return Err(Error::git_command_failed(format!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        files.extend(parse_changed_since_output(&output.stdout));
+    }
+    Ok(files.into_iter().collect())
+}
+
+fn parse_changed_since_output(stdout: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 /// Get all dirty files in the working tree (modified, new, deleted).
@@ -515,6 +635,23 @@ mod tests {
             .contains(&"untracked name.txt".to_string()));
         assert!(changes.untracked.contains(&"worktree name.txt".to_string()));
         assert!(changes.staged.iter().all(|path| !path.contains(" -> ")));
+    }
+
+    #[test]
+    fn get_files_changed_since_uses_core_owned_changed_since_path() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().to_str().unwrap();
+        init_repo_with_initial_commit(path);
+        git(path, &["checkout", "-qb", "candidate"]);
+        fs::write(dir.path().join("changed.txt"), "changed\n").unwrap();
+        git(path, &["add", "changed.txt"]);
+        git(path, &["commit", "-qm", "changed"]);
+        fs::write(dir.path().join("untracked.txt"), "untracked\n").unwrap();
+
+        let files = get_files_changed_since(path, "main").expect("changed files");
+
+        assert!(files.contains(&"changed.txt".to_string()));
+        assert!(files.contains(&"untracked.txt".to_string()));
     }
 
     fn init_repo_with_initial_commit(path: &str) {

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -92,11 +92,12 @@ pub use pr_refresh::{
 pub(crate) use primitives::list_tracked_markdown_files;
 pub use primitives::{
     clone_repo, clone_repo_at_ref, clone_repo_at_ref_with_timeout, commit_staged_with_author,
-    default_branch_name, default_remote_branch, fetch_remote_tracking_refs_until,
-    get_component_path_prefix, get_git_root, get_git_root_with_timeout, git_probe_path,
-    has_staged_changes, is_workdir_clean_or_not_git, pull_repo, resolve_default_remote, run_git,
-    run_git_output, run_git_output_with_env, run_git_output_with_env_timeout, run_git_with_env,
-    run_git_with_env_timeout, stage_all, update_to_remote_default_branch,
+    default_branch_name, default_remote_branch, fetch_and_merge_upstream_ff_only,
+    fetch_remote_tracking_refs_until, get_component_path_prefix, get_git_root,
+    get_git_root_with_timeout, git_probe_path, has_staged_changes, is_workdir_clean_or_not_git,
+    pull_repo, resolve_default_remote, run_git, run_git_output, run_git_output_with_env,
+    run_git_output_with_env_timeout, run_git_with_env, run_git_with_env_timeout, stage_all,
+    update_to_remote_default_branch,
 };
 pub use primitives::{is_git_repo, is_tracked_path};
 pub use primitives_query::{

--- a/crates/homeboy-core/src/git/operations.rs
+++ b/crates/homeboy-core/src/git/operations.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, Result};
 use crate::output::BulkResult;
 
 use super::operation_output::{run_bulk_ids, GitOutput};
-use super::primitives::is_git_repo;
+use super::primitives::{fetch_and_merge_upstream_ff_only, is_git_repo};
 use super::{execute_git, resolve_target};
 
 #[derive(Debug, Clone, Serialize)]
@@ -175,7 +175,12 @@ pub fn pull(component_id: Option<&str>) -> Result<GitOutput> {
 
 /// Like [`pull`] but with an explicit path override for git operations.
 pub fn pull_at(component_id: Option<&str>, path_override: Option<&str>) -> Result<GitOutput> {
-    super::run_resolved_git(component_id, path_override, "pull", &["pull"])
+    let (id, path) = resolve_target(component_id, path_override)?;
+    let output = fetch_and_merge_upstream_ff_only(
+        Path::new(&path),
+        std::time::Instant::now() + Duration::from_secs(30),
+    )?;
+    Ok(GitOutput::from_output(id, path, "pull", output))
 }
 
 /// Options for [`rebase`].
@@ -425,8 +430,13 @@ pub fn fetch_and_fast_forward(path: &str) -> Result<Option<u32>> {
     match behind {
         None => Ok(None),
         Some(n) => {
-            // Attempt fast-forward pull
-            let output = execute_git(path, &["pull", "--ff-only"])
+            let upstream = crate::engine::command::run_in_optional(
+                path,
+                "git",
+                &["rev-parse", "--abbrev-ref", "@{upstream}"],
+            )
+            .ok_or_else(|| Error::git_command_failed("resolve git upstream"))?;
+            let output = execute_git(path, &["merge", "--ff-only", upstream.trim()])
                 .map_err(|e| Error::git_command_failed(e.to_string()))?;
 
             if !output.status.success() {

--- a/crates/homeboy-core/src/git/primitives.rs
+++ b/crates/homeboy-core/src/git/primitives.rs
@@ -28,6 +28,31 @@ fn git_failure_message(context: &str, detail: &str) -> String {
     }
 }
 
+fn ensure_git_success(
+    git_root: &Path,
+    args: &[&str],
+    context: &str,
+    output: &std::process::Output,
+) -> Result<()> {
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if stderr.is_empty() { stdout } else { stderr };
+    Err(Error::git_command_failed_with_details(
+        git_failure_message(context, &detail),
+        GitCommandFailedDetails {
+            command: git_command_display(args),
+            cwd: git_cwd_display(git_root),
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            io_error: None,
+        },
+    ))
+}
+
 /// Clone a git repository to a target directory.
 pub fn clone_repo(url: &str, target_dir: &Path) -> Result<()> {
     run_git(
@@ -84,7 +109,14 @@ pub fn clone_repo_at_ref_with_timeout(
 
 /// Pull latest changes in a git repository.
 pub fn pull_repo(repo_dir: &Path) -> Result<()> {
-    run_git(repo_dir, &["pull"], "git pull")?;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let output = fetch_and_merge_upstream_ff_only(repo_dir, deadline)?;
+    ensure_git_success(
+        repo_dir,
+        &["merge", "--ff-only", "@{upstream}"],
+        "git merge --ff-only",
+        &output,
+    )?;
     Ok(())
 }
 
@@ -134,24 +166,7 @@ pub fn run_git_with_env(
     env: &[(String, String)],
 ) -> Result<String> {
     let output = run_git_output_with_env(git_root, args, context, env)?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let detail = if stderr.is_empty() { stdout } else { stderr };
-        return Err(Error::git_command_failed_with_details(
-            git_failure_message(context, &detail),
-            GitCommandFailedDetails {
-                command: git_command_display(args),
-                cwd: git_cwd_display(git_root),
-                exit_code: output.status.code(),
-                stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
-                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
-                io_error: None,
-            },
-        ));
-    }
-
+    ensure_git_success(git_root, args, context, &output)?;
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
@@ -277,6 +292,26 @@ pub fn fetch_remote_tracking_refs_until(
     with_remote_tracking_authority_until(git_root, context, deadline, |remaining| {
         run_git_with_env_timeout(git_root, args, context, env, remaining)
     })
+}
+
+/// Fetch the current repository under remote-tracking authority, then merge its
+/// already-fetched upstream ref without allowing Git to fetch a second time.
+pub fn fetch_and_merge_upstream_ff_only(
+    git_root: &Path,
+    deadline: Instant,
+) -> Result<std::process::Output> {
+    fetch_remote_tracking_refs_until(git_root, &["fetch"], "git fetch", &[], deadline)?;
+    let upstream = run_git(
+        git_root,
+        &["rev-parse", "--abbrev-ref", "@{upstream}"],
+        "git upstream",
+    )?;
+    let upstream = upstream.trim();
+    run_git_output(
+        git_root,
+        &["merge", "--ff-only", upstream],
+        "git merge --ff-only",
+    )
 }
 
 /// Run a git command in a repository and return raw output without treating
@@ -455,21 +490,12 @@ pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
             "git merge default branch --ff-only",
         )?;
     } else {
-        // Preserve the prior behavior for repositories whose default branch
-        // cannot be identified. `pull` may fetch, so retain authority for it.
-        with_remote_tracking_authority_until(
+        let output = fetch_and_merge_upstream_ff_only(git_root, deadline)?;
+        ensure_git_success(
             git_root,
-            "git pull --ff-only",
-            deadline,
-            |remaining| {
-                run_git_with_env_timeout(
-                    git_root,
-                    &["pull", "--ff-only"],
-                    "git pull --ff-only",
-                    &[],
-                    remaining,
-                )
-            },
+            &["merge", "--ff-only", "@{upstream}"],
+            "git merge --ff-only",
+            &output,
         )?;
     }
 
@@ -767,6 +793,29 @@ mod tests {
                 checkout.to_str().unwrap(),
             ],
         );
+        let fetches = tmp.path().join("fetches");
+        let upload_pack = tmp.path().join("count-upload-pack");
+        std::fs::write(
+            &upload_pack,
+            format!(
+                "#!/bin/sh\nprintf fetch >> {}\nexec git upload-pack \"$@\"\n",
+                fetches.display()
+            ),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&upload_pack, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        git(
+            &checkout,
+            &[
+                "config",
+                "remote.origin.uploadpack",
+                upload_pack.to_str().unwrap(),
+            ],
+        );
         std::fs::write(seed.join("f.txt"), "two\n").unwrap();
         git(&seed, &["commit", "-qam", "advance"]);
         git(&seed, &["push", "-q", "origin", "main"]);
@@ -774,6 +823,67 @@ mod tests {
 
         update_to_remote_default_branch(&checkout).expect("fast forward checkout");
 
+        assert_eq!(
+            run_git(&checkout, &["rev-parse", "HEAD"], "checkout head").unwrap(),
+            expected
+        );
+        assert_eq!(
+            std::fs::read_to_string(fetches).unwrap().lines().count(),
+            1,
+            "the update must merge the authority-fetched tracking ref without a second fetch"
+        );
+    }
+
+    #[test]
+    fn update_to_remote_default_branch_detaches_when_the_local_default_branch_is_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = tmp.path().join("remote.git");
+        let seed = tmp.path().join("seed");
+        let checkout = tmp.path().join("checkout");
+        git(
+            tmp.path(),
+            &["init", "--bare", "-b", "main", remote.to_str().unwrap()],
+        );
+        git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                seed.to_str().unwrap(),
+            ],
+        );
+        git(&seed, &["config", "user.email", "t@x.test"]);
+        git(&seed, &["config", "user.name", "T"]);
+        std::fs::write(seed.join("f.txt"), "one\n").unwrap();
+        git(&seed, &["add", "."]);
+        git(&seed, &["commit", "-qm", "initial"]);
+        git(&seed, &["push", "-q", "origin", "main"]);
+        git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                checkout.to_str().unwrap(),
+            ],
+        );
+        git(&checkout, &["switch", "--detach"]);
+        let parked = tmp.path().join("parked-main");
+        // Make `main` unavailable in this checkout so the update takes its
+        // detached tracking-ref fallback rather than Git's auto-track path.
+        git(
+            &checkout,
+            &["worktree", "add", "-q", parked.to_str().unwrap(), "main"],
+        );
+        std::fs::write(seed.join("f.txt"), "two\n").unwrap();
+        git(&seed, &["commit", "-qam", "advance"]);
+        git(&seed, &["push", "-q", "origin", "main"]);
+        let expected = run_git(&seed, &["rev-parse", "HEAD"], "seed head").unwrap();
+
+        update_to_remote_default_branch(&checkout).expect("detached fallback update");
+
+        assert_eq!(current_branch(&checkout), None);
         assert_eq!(
             run_git(&checkout, &["rev-parse", "HEAD"], "checkout head").unwrap(),
             expected
@@ -800,6 +910,7 @@ mod tests {
             ],
         );
         let (locked, ready) = mpsc::channel();
+        let (release, released) = mpsc::channel();
         let locked_repository = repository.to_path_buf();
         let holder = thread::spawn(move || {
             with_remote_tracking_authority_until(
@@ -808,7 +919,7 @@ mod tests {
                 Instant::now() + Duration::from_secs(2),
                 |_| {
                     locked.send(()).unwrap();
-                    thread::sleep(Duration::from_millis(200));
+                    released.recv().expect("release authority");
                     Ok(())
                 },
             )
@@ -816,10 +927,33 @@ mod tests {
         });
         ready.recv().expect("authority acquired");
 
-        let started = Instant::now();
-        let _ = update_to_remote_default_branch(repository).expect_err("missing remote fails");
+        let attempted = dir.path().join("contender-attempted-authority");
+        let _attempted = crate::test_support::EnvVarGuard::set(
+            "HOMEB0Y_REMOTE_TRACKING_FETCH_LOCK_ATTEMPTED",
+            &attempted,
+        );
+        let (done, completed) = mpsc::channel();
+        let contender_repository = repository.to_path_buf();
+        let contender = thread::spawn(move || {
+            done.send(update_to_remote_default_branch(&contender_repository))
+                .expect("report contender result");
+        });
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !attempted.exists() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(attempted.exists(), "contender did not attempt authority");
+        assert!(
+            completed.try_recv().is_err(),
+            "contender proceeded before authority release"
+        );
 
-        assert!(started.elapsed() >= Duration::from_millis(150));
+        release.send(()).expect("release holder");
         holder.join().unwrap();
+        let _ = completed
+            .recv()
+            .expect("contender completes after authority release")
+            .expect_err("missing remote fails");
+        contender.join().unwrap();
     }
 }

--- a/crates/homeboy-core/src/git/primitives.rs
+++ b/crates/homeboy-core/src/git/primitives.rs
@@ -419,15 +419,14 @@ pub fn default_branch_name(path: &Path) -> Option<String> {
 pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
     let remote = resolve_default_remote(git_root);
     let old_branch = current_branch(git_root);
+    let deadline = Instant::now() + Duration::from_secs(30);
     fetch_remote_tracking_refs_until(
         git_root,
         &["fetch", &remote],
         &format!("git fetch {remote}"),
         &[],
-        Instant::now() + Duration::from_secs(30),
+        deadline,
     )?;
-    let mut detached_default_branch: Option<String> = None;
-
     if let Some(remote_branch) = default_remote_branch(git_root) {
         let local_branch = remote_branch
             .strip_prefix(&format!("{remote}/"))
@@ -447,18 +446,31 @@ pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
                 &["switch", "--detach", &remote_branch],
                 "git switch detached default branch",
             )?;
-            detached_default_branch = Some(local_branch);
         }
-    }
-
-    if let Some(branch) = detached_default_branch {
+        // `pull` fetches again after the authoritative fetch above. Merge the
+        // already-fetched tracking ref instead so linked worktrees do not race.
         run_git(
             git_root,
-            &["pull", "--ff-only", &remote, &branch],
-            "git pull detached default branch --ff-only",
+            &["merge", "--ff-only", &remote_branch],
+            "git merge default branch --ff-only",
         )?;
     } else {
-        run_git(git_root, &["pull", "--ff-only"], "git pull --ff-only")?;
+        // Preserve the prior behavior for repositories whose default branch
+        // cannot be identified. `pull` may fetch, so retain authority for it.
+        with_remote_tracking_authority_until(
+            git_root,
+            "git pull --ff-only",
+            deadline,
+            |remaining| {
+                run_git_with_env_timeout(
+                    git_root,
+                    &["pull", "--ff-only"],
+                    "git pull --ff-only",
+                    &[],
+                    remaining,
+                )
+            },
+        )?;
     }
 
     Ok(())
@@ -566,6 +578,9 @@ pub fn get_component_path_prefix(local_path: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::mpsc;
+    use std::thread;
+
     use super::*;
 
     use crate::test_support::run_git_command as git;
@@ -716,5 +731,95 @@ mod tests {
             Some("upstream/main")
         );
         assert_eq!(default_branch_name(&clone).as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn update_to_remote_default_branch_fast_forwards_from_fetched_tracking_ref() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = tmp.path().join("remote.git");
+        let seed = tmp.path().join("seed");
+        let checkout = tmp.path().join("checkout");
+        git(
+            tmp.path(),
+            &["init", "--bare", "-b", "main", remote.to_str().unwrap()],
+        );
+        git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                seed.to_str().unwrap(),
+            ],
+        );
+        git(&seed, &["config", "user.email", "t@x.test"]);
+        git(&seed, &["config", "user.name", "T"]);
+        std::fs::write(seed.join("f.txt"), "one\n").unwrap();
+        git(&seed, &["add", "."]);
+        git(&seed, &["commit", "-qm", "initial"]);
+        git(&seed, &["push", "-q", "origin", "main"]);
+        git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                checkout.to_str().unwrap(),
+            ],
+        );
+        std::fs::write(seed.join("f.txt"), "two\n").unwrap();
+        git(&seed, &["commit", "-qam", "advance"]);
+        git(&seed, &["push", "-q", "origin", "main"]);
+        let expected = run_git(&seed, &["rev-parse", "HEAD"], "seed head").unwrap();
+
+        update_to_remote_default_branch(&checkout).expect("fast forward checkout");
+
+        assert_eq!(
+            run_git(&checkout, &["rev-parse", "HEAD"], "checkout head").unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn update_to_remote_default_branch_waits_for_remote_tracking_authority() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repository = dir.path();
+        git(repository, &["init", "-q", "-b", "main"]);
+        git(repository, &["config", "user.email", "t@x.test"]);
+        git(repository, &["config", "user.name", "T"]);
+        std::fs::write(repository.join("f.txt"), "x\n").unwrap();
+        git(repository, &["add", "."]);
+        git(repository, &["commit", "-qm", "initial"]);
+        git(
+            repository,
+            &[
+                "remote",
+                "add",
+                "origin",
+                dir.path().join("missing.git").to_str().unwrap(),
+            ],
+        );
+        let (locked, ready) = mpsc::channel();
+        let locked_repository = repository.to_path_buf();
+        let holder = thread::spawn(move || {
+            with_remote_tracking_authority_until(
+                &locked_repository,
+                "test lock holder",
+                Instant::now() + Duration::from_secs(2),
+                |_| {
+                    locked.send(()).unwrap();
+                    thread::sleep(Duration::from_millis(200));
+                    Ok(())
+                },
+            )
+            .unwrap();
+        });
+        ready.recv().expect("authority acquired");
+
+        let started = Instant::now();
+        let _ = update_to_remote_default_branch(repository).expect_err("missing remote fails");
+
+        assert!(started.elapsed() >= Duration::from_millis(150));
+        holder.join().unwrap();
     }
 }

--- a/crates/homeboy-core/src/git/remote_tracking_authority.rs
+++ b/crates/homeboy-core/src/git/remote_tracking_authority.rs
@@ -24,6 +24,7 @@ pub fn with_remote_tracking_authority_until<T>(
     deadline: Instant,
     action: impl FnOnce(Duration) -> Result<T>,
 ) -> Result<T> {
+    report_authority_attempt();
     let common_dir = git_common_dir(repository)?;
     let authority = {
         let mut authorities = AUTHORITIES
@@ -126,7 +127,7 @@ fn acquire_file_guard(
                 return Ok(());
             }
             Ok(false) | Err(_) if Instant::now() < deadline => {
-                report_file_lock_attempt();
+                report_authority_attempt();
                 if !reported_wait {
                     let owner = fs::read_to_string(lock_path)
                         .ok()
@@ -174,14 +175,14 @@ fn acquire_file_guard(
 }
 
 #[cfg(test)]
-fn report_file_lock_attempt() {
+fn report_authority_attempt() {
     if let Some(path) = std::env::var_os("HOMEB0Y_REMOTE_TRACKING_FETCH_LOCK_ATTEMPTED") {
         std::fs::write(path, "attempted\n").expect("write remote-tracking lock attempt");
     }
 }
 
 #[cfg(not(test))]
-fn report_file_lock_attempt() {}
+fn report_authority_attempt() {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/homeboy-core/src/git/remote_tracking_authority.rs
+++ b/crates/homeboy-core/src/git/remote_tracking_authority.rs
@@ -126,6 +126,7 @@ fn acquire_file_guard(
                 return Ok(());
             }
             Ok(false) | Err(_) if Instant::now() < deadline => {
+                report_file_lock_attempt();
                 if !reported_wait {
                     let owner = fs::read_to_string(lock_path)
                         .ok()
@@ -173,6 +174,16 @@ fn acquire_file_guard(
 }
 
 #[cfg(test)]
+fn report_file_lock_attempt() {
+    if let Some(path) = std::env::var_os("HOMEB0Y_REMOTE_TRACKING_FETCH_LOCK_ATTEMPTED") {
+        std::fs::write(path, "attempted\n").expect("write remote-tracking lock attempt");
+    }
+}
+
+#[cfg(not(test))]
+fn report_file_lock_attempt() {}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::process::Command;
@@ -202,9 +213,6 @@ mod tests {
         const CHILD: &str = "HOMEB0Y_REMOTE_TRACKING_FETCH_CHILD";
         if let Some(path) = std::env::var_os(CHILD) {
             let path = Path::new(&path);
-            if let Some(attempted) = std::env::var_os("HOMEB0Y_REMOTE_TRACKING_FETCH_ATTEMPTED") {
-                std::fs::write(attempted, "attempted\n").expect("write child fetch attempt");
-            }
             match std::env::var("HOMEB0Y_REMOTE_TRACKING_FETCH_OPERATION").as_deref() {
                 Ok("behind") => {
                     crate::git::fetch_and_get_behind_count(path.to_str().expect("path"))
@@ -306,7 +314,7 @@ mod tests {
                     .env("HOMEB0Y_REMOTE_TRACKING_FETCH_RELEASE", &release);
             }
             if let Some(attempted) = attempted {
-                command.env("HOMEB0Y_REMOTE_TRACKING_FETCH_ATTEMPTED", attempted);
+                command.env("HOMEB0Y_REMOTE_TRACKING_FETCH_LOCK_ATTEMPTED", attempted);
             }
             if let Some(reached) = reached {
                 command.env("HOMEB0Y_REMOTE_TRACKING_FETCH_REACHED", reached);
@@ -339,7 +347,7 @@ mod tests {
         }
         assert!(
             second_attempted.exists(),
-            "second fetch did not attempt authority"
+            "second fetch did not contend for remote-tracking authority"
         );
         let contention_deadline = Instant::now() + Duration::from_millis(500);
         while !second_reached.exists() && Instant::now() < contention_deadline {

--- a/crates/homeboy-core/src/hygiene.rs
+++ b/crates/homeboy-core/src/hygiene.rs
@@ -406,7 +406,13 @@ fn checkout_hygiene_snapshot(
     let branch = git_output(&path, &["rev-parse", "--abbrev-ref", "HEAD"]);
     let upstream = git_output(&path, &["rev-parse", "--abbrev-ref", "@{upstream}"]);
     if upstream.is_some() {
-        let _ = git_output(&path, &["fetch", "--quiet"]);
+        let _ = crate::git::fetch_remote_tracking_refs_until(
+            &path,
+            &["fetch", "--quiet"],
+            "git fetch checkout hygiene",
+            &[],
+            std::time::Instant::now() + std::time::Duration::from_secs(30),
+        );
     }
     let dirty = git_output(&path, &["status", "--porcelain=v1"]).map(|value| !value.is_empty());
     let (mut behind, mut ahead) = git_ahead_behind(&path);

--- a/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
+++ b/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
@@ -949,6 +949,7 @@ mod tests {
         fixture.push();
         let checkout = fixture.clone_checkout();
         let (locked, ready) = mpsc::channel();
+        let (release, released) = mpsc::channel();
         let locked_checkout = checkout.path().to_path_buf();
         let holder = thread::spawn(move || {
             homeboy_core::git::with_remote_tracking_authority_until(
@@ -957,7 +958,7 @@ mod tests {
                 Instant::now() + Duration::from_secs(2),
                 |_| {
                     locked.send(()).unwrap();
-                    thread::sleep(Duration::from_millis(200));
+                    released.recv().expect("release authority");
                     Ok(())
                 },
             )
@@ -965,11 +966,38 @@ mod tests {
         });
         ready.recv().expect("authority acquired");
 
-        let started = Instant::now();
-        ensure_git_dependency_fresh(checkout.path(), None, false).expect("refresh succeeds");
+        let attempted = fixture.temp.path().join("contender-attempted-authority");
+        let _attempted = homeboy_core::test_support::EnvVarGuard::set(
+            "HOMEB0Y_REMOTE_TRACKING_FETCH_LOCK_ATTEMPTED",
+            &attempted,
+        );
+        let (done, completed) = mpsc::channel();
+        let contender_checkout = checkout.path().to_path_buf();
+        let contender = thread::spawn(move || {
+            done.send(ensure_git_dependency_fresh(
+                &contender_checkout,
+                None,
+                false,
+            ))
+            .expect("report contender result");
+        });
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !attempted.exists() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(attempted.exists(), "contender did not attempt authority");
+        assert!(
+            completed.try_recv().is_err(),
+            "contender proceeded before authority release"
+        );
 
-        assert!(started.elapsed() >= Duration::from_millis(150));
+        release.send(()).expect("release holder");
         holder.join().unwrap();
+        completed
+            .recv()
+            .expect("contender completes after authority release")
+            .expect("refresh succeeds");
+        contender.join().unwrap();
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
+++ b/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
@@ -1,6 +1,7 @@
 use homeboy_engine_primitives::content_hash;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -651,7 +652,14 @@ fn ensure_git_dependency_fresh(
         return Err(terminal_dependency_error(local_path, &freshness, None));
     }
 
-    let fetch_error = run_git(local_path, &["fetch", "--prune", remote]).err();
+    let fetch_error = homeboy_core::git::fetch_remote_tracking_refs_until(
+        local_path,
+        &["fetch", "--prune", remote],
+        "git fetch runner dependency",
+        &[],
+        Instant::now() + Duration::from_secs(30),
+    )
+    .err();
     let upstream_head = git_output(local_path, &["rev-parse", "@{u}"]).ok();
     let status = git_output(local_path, &["status", "--porcelain=v1"])?;
     if !status.trim().is_empty() {
@@ -834,6 +842,9 @@ mod tests {
     use std::fs;
     use std::path::Path;
     use std::process::Command;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     use homeboy_core::engine::shell;
     use homeboy_core::test_support::GitFixture as GitRepository;
@@ -929,6 +940,36 @@ mod tests {
             git_output(checkout.path(), &["rev-parse", "HEAD"]),
             expected
         );
+    }
+
+    #[test]
+    fn dependency_refresh_waits_for_remote_tracking_authority() {
+        let fixture = GitDependencyFixture::new();
+        fixture.commit_file("initial.txt", "initial");
+        fixture.push();
+        let checkout = fixture.clone_checkout();
+        let (locked, ready) = mpsc::channel();
+        let locked_checkout = checkout.path().to_path_buf();
+        let holder = thread::spawn(move || {
+            homeboy_core::git::with_remote_tracking_authority_until(
+                &locked_checkout,
+                "test lock holder",
+                Instant::now() + Duration::from_secs(2),
+                |_| {
+                    locked.send(()).unwrap();
+                    thread::sleep(Duration::from_millis(200));
+                    Ok(())
+                },
+            )
+            .unwrap();
+        });
+        ready.recv().expect("authority acquired");
+
+        let started = Instant::now();
+        ensure_git_dependency_fresh(checkout.path(), None, false).expect("refresh succeeds");
+
+        assert!(started.elapsed() >= Duration::from_millis(150));
+        holder.join().unwrap();
     }
 
     #[test]

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -2598,8 +2598,14 @@ fn home_dir_for_user(user: &str) -> Option<PathBuf> {
 /// fetch. Returns `None` when the count can't be determined (no upstream, not a
 /// repo, fetch failed). Best-effort and read-only — never mutates the worktree.
 fn git_commits_behind_upstream(git_root: &Path) -> Option<u32> {
-    // Read-only fetch to learn upstream state without touching the worktree.
-    let _ = git::run_git(git_root, &["fetch", "origin"], "git fetch origin");
+    // Fetch updates shared remote-tracking refs even though it leaves the worktree unchanged.
+    let _ = git::fetch_remote_tracking_refs_until(
+        git_root,
+        &["fetch", "origin"],
+        "git fetch origin",
+        &[],
+        std::time::Instant::now() + Duration::from_secs(30),
+    );
     let count = git::run_git(
         git_root,
         &["rev-list", "--count", "HEAD..@{upstream}"],


### PR DESCRIPTION
Closes #14479.

Routes the remaining shared-checkout fetch paths through the canonical remote-tracking authority.

Tests:
- `cargo fmt --check`
- focused `homeboy-core` authority and changed-since tests
- `cargo test -p homeboy-lab-runner git_dependency_materialization::tests::auto_update_clean_dependency_fast_forwards_to_upstream` (blocked by pre-existing `ControlPlaneBlocker` missing fields in `homeboy-agents/src/orchestration.rs:3905`)

AI assistance: OpenAI GPT-5.6 Terra via OpenCode implemented and verified the shared-fetch authority corrections.