### PR TITLE
fix(release): resolve secret_env_projections from component settings in preflight.test_secret_env

### DIFF
--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -3909,6 +3909,9 @@ fn blocker(record: &AgentTaskRunRecord) -> Option<ControlPlaneBlocker> {
                     .filter(|value| !value.trim().is_empty())
                     .map(|value| bounded(value, STATE_BOUND)),
                 message: redacted_bounded(message, MESSAGE_BOUND),
+                state: None,
+                reason: None,
+                retry: None,
             });
         }
     }

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -3217,6 +3217,75 @@ mod tests {
         });
     }
 
+    /// Release resolves the component from its persisted `homeboy.json`
+    /// (portable discovery or the standalone overlay), not from an in-memory
+    /// fixture. The projection `when` must therefore be satisfied by settings
+    /// declared in the component config file — including when flat extension
+    /// keys sit beside the nested `settings` object, which is the shape
+    /// components like `data-machine-events` ship. (#14449)
+    #[test]
+    fn declared_secret_env_names_resolve_from_persisted_component_extension_settings() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let _guard = conditional_secret_env_guard();
+            let source = tempfile::tempdir().expect("source dir");
+            conditional_test_component(home.path(), source.path(), "remote");
+
+            std::fs::write(
+                source.path().join("homeboy.json"),
+                r#"{
+                    "id": "conditional-secret-consumer",
+                    "extensions": {
+                        "conditional-secret-fixture": {
+                            "toolchain": "fixture",
+                            "settings": {
+                                "service": {
+                                    "mode": "remote",
+                                    "secret_env": {
+                                        "first": "FIRST_PROJECTED_SECRET",
+                                        "second": "SECOND_PROJECTED_SECRET"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }"#,
+            )
+            .expect("persisted homeboy.json");
+
+            let component = crate::component::portable::try_discover_from_portable(source.path())
+                .expect("portable discovery")
+                .expect("component from persisted config");
+            assert_eq!(
+                component
+                    .extensions
+                    .as_ref()
+                    .and_then(|extensions| extensions
+                        .get("conditional-secret-fixture")
+                        .map(|config| config.settings.contains_key("service"))),
+                Some(true),
+                "fixture must model persisted extension settings"
+            );
+
+            let marker = source.path().join("declared-names-child-ran");
+            std::fs::write(
+                home.path()
+                    .join(".config/homeboy/extensions/conditional-secret-fixture/test.sh"),
+                format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+            )
+            .expect("marker script");
+            let names = crate::extension::test::declared_secret_env_names(&component)
+                .expect("persisted-settings declaration");
+            assert_eq!(
+                names,
+                vec!["FIRST_PROJECTED_SECRET", "SECOND_PROJECTED_SECRET"]
+            );
+            assert!(
+                !marker.exists(),
+                "resolving declared names must not spawn the test child"
+            );
+        });
+    }
+
     #[test]
     fn review_test_missing_projected_secret_fails_before_spawn() {
         homeboy_core::test_support::with_isolated_home(|home| {

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -1048,6 +1048,64 @@ mod tests {
         });
     }
 
+    /// Release resolves its component from the persisted `homeboy.json` on the
+    /// release source (portable discovery over the registered snapshot), not
+    /// from CLI-passed settings. The declared-test-secret gate must therefore
+    /// evaluate `secret_env_projections` against settings that live only in
+    /// the component config file and fail closed with the same `test.secret_env`
+    /// error the review-test runner produces — before anything spawns. (#14449)
+    #[test]
+    fn validate_test_secret_env_resolves_projections_from_persisted_component_settings() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let _guard = test_env_guard();
+            let source = tempfile::tempdir().expect("source dir");
+            let marker = source.path().join("preflight-child-ran");
+            let _ = conditional_extension_test_component(
+                home.path(),
+                source.path(),
+                &format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+            );
+            std::fs::write(
+                source.path().join("homeboy.json"),
+                r#"{
+                    "id": "fixture",
+                    "extensions": {
+                        "release-test-fixture": {
+                            "toolchain": "fixture",
+                            "settings": {
+                                "service": {
+                                    "mode": "remote",
+                                    "secret_env": {"token": "PROJECTED_RELEASE_SECRET"}
+                                }
+                            }
+                        }
+                    }
+                }"#,
+            )
+            .expect("persisted homeboy.json");
+            let component = homeboy_core::component::try_discover_from_portable(source.path())
+                .expect("portable discovery")
+                .expect("component from persisted config");
+            std::env::set_var("DECLARED_RELEASE_SECRET", "available-static-secret");
+            std::env::remove_var("PROJECTED_RELEASE_SECRET");
+
+            let error = validate_test_secret_env(&component)
+                .expect_err("persisted-settings projection must gate the release");
+            std::env::remove_var("DECLARED_RELEASE_SECRET");
+
+            assert_eq!(error.details["field"], "test.secret_env");
+            assert!(error.message.contains("PROJECTED_RELEASE_SECRET"));
+            assert!(
+                !error.to_string().contains("available-static-secret"),
+                "resolved values must never reach the diagnostic"
+            );
+            assert!(
+                !marker.exists(),
+                "the gate must not spawn the extension test child"
+            );
+        });
+    }
+
     #[test]
     fn validate_test_secret_env_reports_resolvable_identities_by_name() {
         homeboy_core::test_support::with_isolated_home(|home| {


### PR DESCRIPTION
Fixes #14449

## What this PR is

Investigation + the regression pins #14449 asks for, plus a one-line fix that unblocks the build.

**The name-resolution parity the issue demands already holds at origin/main.** `declared_secret_env_names` and the review-test runner both resolve settings through the same path — `prepare_capability_run(...).settings_json`, built from `ExtensionScope::effective_settings` over the component's `extensions.<id>.settings`, then evaluated by `effective_secret_env_names` — and the release component is loaded through `resolve_effective`, which merges the persisted `homeboy.json` over the registered snapshot for every release shape (in-place head, in-place default-branch, and managed worktree via `portable_component_for_checkout`).

The `declared: []` evidence in the issue is explained by source timing: `data-machine-events` gained `wp_codebox_database_service` in data-machine-events#795 (merged 2026-09-08 16:34 UTC), and the failing release staged a source revision without it — the projection's `when` correctly did not match for that source, so the gate declared nothing and the doomed child spawned. Once the staged source carries the settings, the gate engages.

## Verified live on the release host (homeboy 0.369.0, data-machine-events @ f2da9fe, external MySQL provider)

- `homeboy release data-machine-events` with `WP_CODEBOX_DB_*` **unset**:
  `preflight.test_secret_env → failed`, field `test.secret_env`, message `missing required extension child secret env: WP_CODEBOX_DB_HOST, WP_CODEBOX_DB_PASSWORD, WP_CODEBOX_DB_PORT, WP_CODEBOX_DB_USER` — byte-identical to `homeboy review test data-machine-events --placement local`, and it fails before hydration or spawn.
- Same release with `WP_CODEBOX_DB_*` set: `preflight.test_secret_env → success, declared_count: 4, ran: true`.

So release now fails closed exactly where #14449's Expected #1 wants it. What was missing is the regression coverage the issue calls out: the existing `declared_secret_env_names_match_the_runner_requirement_without_spawning` fixture builds the component **in memory**, so it would not catch a regression in the persisted-config path release actually exercises.

## Changes

1. `test(release)` — the missing pins from the issue's Expected #2:
   - `homeboy-core`: `declared_secret_env_names_resolve_from_persisted_component_extension_settings` — component discovered via `try_discover_from_portable` from an on-disk `homeboy.json` (nested `settings` object beside flat extension keys, the shape data-machine-events ships); asserts the projected names resolve and the child never spawns.
   - `homeboy-release`: `validate_test_secret_env_resolves_projections_from_persisted_component_settings` — same persisted-settings component through the release gate; asserts the `test.secret_env` fail-closed error with names but never values, and no spawn.
2. `fix(agents)` — Fixes #14501: #14492 left a `ControlPlaneBlocker` initializer incomplete, breaking every workspace build/test run (this is almost certainly why earlier attempts at #14449 stalled with zero commits). Completes it to match the sibling initializer.

## What ran

- `cargo test -p homeboy-core --lib extension::test` → **274 passed, 0 failed**
- `cargo test -p homeboy-release --lib` → **578 passed, 1 failed** — the failure (`apply_release_already_at_head_runs_default_branch_preflight_before_skip`) is pre-existing and environment-dependent; it reproduces on clean main without my changes and is tracked at #14502, out of scope here.
- `cargo fmt --check` → clean
- `cargo clippy -p homeboy-core -p homeboy-release` → exit 0, no warnings in changed files

Not changed: release plan ordering, the runner protocol, or the extension manifest schema.

Authored by Extra Chill Bot (AI agent) via Kimaki session.