### PR TITLE
fix(agent-task): initialize pre-execution blocker metadata

### DIFF
--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -3909,6 +3909,9 @@ fn blocker(record: &AgentTaskRunRecord) -> Option<ControlPlaneBlocker> {
                     .filter(|value| !value.trim().is_empty())
                     .map(|value| bounded(value, STATE_BOUND)),
                 message: redacted_bounded(message, MESSAGE_BOUND),
+                state: None,
+                reason: None,
+                retry: None,
             });
         }
     }


### PR DESCRIPTION
## Summary

Initialize optional state, reason, and retry metadata when projecting pre-execution failures into `ControlPlaneBlocker`. This restores CLI compilation after the new projection introduced in #14492 and preserves the existing meaning of a pre-execution failure without admission retry metadata.

## Verification

- `CARGO_BUILD_JOBS=2 cargo check -p homeboy-cli` passed.
- `cargo fmt --check` passed.
- The change supplies the same absent optional values used by adjacent blocker projections.

## AI Assistance

GPT-6 Astra via OpenCode diagnosed the compile failure blocking parallel repairs, implemented the three-field initialization, and ran verification. Chris directed the repair.
