### PR TITLE
fix(agent-task): restore the workspace build for detached staging blockers

### DIFF
--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -3909,6 +3909,9 @@ fn blocker(record: &AgentTaskRunRecord) -> Option<ControlPlaneBlocker> {
                     .filter(|value| !value.trim().is_empty())
                     .map(|value| bounded(value, STATE_BOUND)),
                 message: redacted_bounded(message, MESSAGE_BOUND),
+                state: None,
+                reason: None,
+                retry: None,
             });
         }
     }


### PR DESCRIPTION
## main does not compile

`origin/main` at `ae25eb97f` fails to build:

```
error[E0063]: missing fields `reason`, `retry` and `state`
               in initializer of `ControlPlaneBlocker`
    --> crates/homeboy-agents/src/orchestration.rs:3905:25
```

`homeboy-agents` does not compile, so every crate downstream of it cannot build or test.

## Cause: two green PRs, one broken merge
Neither PR was wrong on its own; they were never compiled together.

- **#14419** added `state`, `reason` and `retry` to `ControlPlaneBlocker` and updated every construction site that existed at the time.
- **#14492** added a new construction site for `pre_execution_failure`, written against the struct as it looked before #14419.

Each passed CI against a `main` that did not yet contain the other. A textbook semantic conflict: no textual overlap, so git merged both cleanly.

## Fix
The new site now sets the three fields to `None`, matching its four siblings in the same function — including the one immediately above it at line 3891, which is the same shape of blocker.

## Verification
`cargo check --workspace` is clean. Orchestration, blocker and control-plane tests in `homeboy-agents`:

```
Summary [28.878s] 82 tests run: 82 passed, 2261 skipped
```

## Worth noting
This is the second time in this session that a defect reached `main` because two changes were only ever validated separately. It is the same shape as the `TMPDIR` race in #14408, where a test was safe until its neighbours changed. Whatever ordering guarantee the merge queue is meant to provide is not catching struct-shape conflicts between concurrently-green PRs.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode found the break while starting unrelated work on the `homeboy-cli` suite, bisected it to the two contributing PRs with `git log -S`, and verified the fix. Chris Huber directed the work and remains responsible for acceptance.