### PR TITLE
fix(lab-runner): restore the test build by dropping an unrunnable authority test

### DIFF
--- a/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
+++ b/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
@@ -842,9 +842,6 @@ mod tests {
     use std::fs;
     use std::path::Path;
     use std::process::Command;
-    use std::sync::mpsc;
-    use std::thread;
-    use std::time::{Duration, Instant};
 
     use homeboy_core::engine::shell;
     use homeboy_core::test_support::GitFixture as GitRepository;
@@ -940,64 +937,6 @@ mod tests {
             git_output(checkout.path(), &["rev-parse", "HEAD"]),
             expected
         );
-    }
-
-    #[test]
-    fn dependency_refresh_waits_for_remote_tracking_authority() {
-        let fixture = GitDependencyFixture::new();
-        fixture.commit_file("initial.txt", "initial");
-        fixture.push();
-        let checkout = fixture.clone_checkout();
-        let (locked, ready) = mpsc::channel();
-        let (release, released) = mpsc::channel();
-        let locked_checkout = checkout.path().to_path_buf();
-        let holder = thread::spawn(move || {
-            homeboy_core::git::with_remote_tracking_authority_until(
-                &locked_checkout,
-                "test lock holder",
-                Instant::now() + Duration::from_secs(2),
-                |_| {
-                    locked.send(()).unwrap();
-                    released.recv().expect("release authority");
-                    Ok(())
-                },
-            )
-            .unwrap();
-        });
-        ready.recv().expect("authority acquired");
-
-        let attempted = fixture.temp.path().join("contender-attempted-authority");
-        let _attempted = homeboy_core::test_support::EnvVarGuard::set(
-            "HOMEB0Y_REMOTE_TRACKING_FETCH_LOCK_ATTEMPTED",
-            &attempted,
-        );
-        let (done, completed) = mpsc::channel();
-        let contender_checkout = checkout.path().to_path_buf();
-        let contender = thread::spawn(move || {
-            done.send(ensure_git_dependency_fresh(
-                &contender_checkout,
-                None,
-                false,
-            ))
-            .expect("report contender result");
-        });
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while !attempted.exists() && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(10));
-        }
-        assert!(attempted.exists(), "contender did not attempt authority");
-        assert!(
-            completed.try_recv().is_err(),
-            "contender proceeded before authority release"
-        );
-
-        release.send(()).expect("release holder");
-        holder.join().unwrap();
-        completed
-            .recv()
-            .expect("contender completes after authority release")
-            .expect("refresh succeeds");
-        contender.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## main test build is broken

`origin/main` at `9be3c7a78` compiles, but its **test** build does not:

```
error[E0609]: no field `temp` on type `GitDependencyFixture`
    --> crates/homeboy-lab-runner/src/git_dependency_materialization.rs:969:33
```

`cargo check --workspace` is clean, which is why this got past review — the break only appears under `--tests`. No `homeboy-lab-runner` test can run on `main` right now.

## The test could never have passed
#14497 added `dependency_refresh_waits_for_remote_tracking_authority`, adapted from `git::primitives::tests::update_to_remote_default_branch_waits_for_remote_tracking_authority` in `homeboy-core`. It references `fixture.temp`, but this file's `GitDependencyFixture` has `remote` and `work` — so it never compiled, and therefore never ran.

Fixing the field only moves the failure:

```
panicked at git_dependency_materialization.rs:988:
contender did not attempt authority
```

The test waits on a marker file written by `report_authority_attempt`, which is `#[cfg(test)]` **inside `homeboy-core`**. When `homeboy-lab-runner`'s tests run, `homeboy-core` is built as an ordinary dependency, so the `cfg(not(test))` no-op is linked and the marker is never written. The instrumentation cannot reach across the crate boundary, so this test cannot pass where it lives at all.

## Resolution
Removed, rather than papered over. The behaviour is already covered where the instrumentation works, in `homeboy-core`:

```
PASS git::primitives::tests::update_to_remote_default_branch_waits_for_remote_tracking_authority
PASS git::remote_tracking_authority::tests::sibling_worktrees_serialize_remote_tracking_operations
PASS git::remote_tracking_authority::tests::two_process_sibling_worktrees_serialize_fetch_paths
PASS git::remote_tracking_authority::tests::unrelated_repositories_keep_remote_tracking_concurrency
```

All four pass. Keeping a lab-runner copy that structurally cannot exercise the mechanism would assert nothing while costing a thread, two channels and a 2s deadline.

**−61 lines.**

## Verification
`cargo check -p homeboy-lab-runner --tests` is clean, and the module's remaining tests pass:

```
Summary [3.084s] 11 tests run: 11 passed, 2010 skipped
```

## Worth flagging separately
The env var is spelled `HOMEB0Y_REMOTE_TRACKING_FETCH_LOCK_ATTEMPTED` — digit zero, not the letter O — consistently in both the reader and its writers. It works because it is consistently wrong, but it is the only `HOMEB0Y_` in the tree. Left alone here to keep this a build fix.

This is the second broken merge on `main` today, after #14505. Both were changes that were green alone and only failed once combined.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode found the break while starting unrelated work, traced it to #14497, established that the test cannot pass from this crate, and confirmed the equivalent coverage in `homeboy-core`. Chris Huber directed the work and remains responsible for acceptance.