### PR TITLE
fix(component): overlay a registered component with its own checkout manifest

### DIFF
--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -3909,6 +3909,9 @@ fn blocker(record: &AgentTaskRunRecord) -> Option<ControlPlaneBlocker> {
                     .filter(|value| !value.trim().is_empty())
                     .map(|value| bounded(value, STATE_BOUND)),
                 message: redacted_bounded(message, MESSAGE_BOUND),
+                state: None,
+                reason: None,
+                retry: None,
             });
         }
     }

--- a/crates/homeboy-core/src/component/resolution.rs
+++ b/crates/homeboy-core/src/component/resolution.rs
@@ -739,6 +739,55 @@ fn prefer_cwd_for_component(
 /// configuration. A worktree manifest owns only the fields it explicitly
 /// declares, so it can intentionally override that contract without losing the
 /// canonical defaults required to run the checkout.
+/// Overlay a registered component with its own checkout's `homeboy.json`.
+///
+/// A registry entry is a point-in-time copy written when the component was
+/// registered. Any setting added to the checkout's manifest afterwards is
+/// invisible to consumers that resolve by id from outside the checkout —
+/// notably `homeboy release`, while `homeboy review` run inside the checkout
+/// sees the current manifest through `prefer_cwd_for_component`. That
+/// divergence silently changes behavior: extension `secret_env_projections`
+/// whose `when` condition reads a manifest-declared setting evaluate against
+/// the stale snapshot, declare no required secrets, and let a gate spawn its
+/// child without them (#14449).
+///
+/// Checkout-owned configuration therefore wins here exactly as it does for a
+/// matched worktree. A registration whose `local_path` is missing, unreadable,
+/// manifest-less, or owned by a different component id keeps the registry
+/// snapshot: those are legacy machine-local registrations, not checkout-owned
+/// configuration.
+fn overlay_registered_local_checkout(
+    config_root: Option<&Path>,
+    component_id: &str,
+    registered: Component,
+) -> Result<Component> {
+    if registered.local_path.trim().is_empty() {
+        return Ok(registered);
+    }
+
+    let checkout = Path::new(&registered.local_path);
+    if !checkout.is_dir() {
+        return Ok(registered);
+    }
+
+    let Some(discovered) = try_discover_from_portable(checkout)? else {
+        return Ok(registered);
+    };
+    if discovered.id != component_id {
+        return Ok(registered);
+    }
+
+    let Some(portable) = read_portable_config(checkout)? else {
+        return Ok(registered);
+    };
+
+    let mut component = overlay_portable_component_config(&registered, portable)?;
+    component.id = component_id.to_string();
+    component.local_path = registered.local_path.clone();
+    resolve_remote_path_at(config_root, &mut component);
+    Ok(component)
+}
+
 fn portable_component_for_checkout(
     config_root: Option<&Path>,
     component_id: &str,
@@ -1444,7 +1493,8 @@ fn resolve_effective_inner(
                     ]),
                 ));
             }
-            load_at(config_root, id)
+            let registered = load_at(config_root, id)?;
+            overlay_registered_local_checkout(config_root, id, registered)
         }
     } else {
         if let Some(path) = path_override {

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -3217,6 +3217,75 @@ mod tests {
         });
     }
 
+    /// Release resolves the component from its persisted `homeboy.json`
+    /// (portable discovery or the standalone overlay), not from an in-memory
+    /// fixture. The projection `when` must therefore be satisfied by settings
+    /// declared in the component config file — including when flat extension
+    /// keys sit beside the nested `settings` object, which is the shape
+    /// components like `data-machine-events` ship. (#14449)
+    #[test]
+    fn declared_secret_env_names_resolve_from_persisted_component_extension_settings() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let _guard = conditional_secret_env_guard();
+            let source = tempfile::tempdir().expect("source dir");
+            conditional_test_component(home.path(), source.path(), "remote");
+
+            std::fs::write(
+                source.path().join("homeboy.json"),
+                r#"{
+                    "id": "conditional-secret-consumer",
+                    "extensions": {
+                        "conditional-secret-fixture": {
+                            "toolchain": "fixture",
+                            "settings": {
+                                "service": {
+                                    "mode": "remote",
+                                    "secret_env": {
+                                        "first": "FIRST_PROJECTED_SECRET",
+                                        "second": "SECOND_PROJECTED_SECRET"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }"#,
+            )
+            .expect("persisted homeboy.json");
+
+            let component = crate::component::portable::try_discover_from_portable(source.path())
+                .expect("portable discovery")
+                .expect("component from persisted config");
+            assert_eq!(
+                component
+                    .extensions
+                    .as_ref()
+                    .and_then(|extensions| extensions
+                        .get("conditional-secret-fixture")
+                        .map(|config| config.settings.contains_key("service"))),
+                Some(true),
+                "fixture must model persisted extension settings"
+            );
+
+            let marker = source.path().join("declared-names-child-ran");
+            std::fs::write(
+                home.path()
+                    .join(".config/homeboy/extensions/conditional-secret-fixture/test.sh"),
+                format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+            )
+            .expect("marker script");
+            let names = crate::extension::test::declared_secret_env_names(&component)
+                .expect("persisted-settings declaration");
+            assert_eq!(
+                names,
+                vec!["FIRST_PROJECTED_SECRET", "SECOND_PROJECTED_SECRET"]
+            );
+            assert!(
+                !marker.exists(),
+                "resolving declared names must not spawn the test child"
+            );
+        });
+    }
+
     #[test]
     fn review_test_missing_projected_secret_fails_before_spawn() {
         homeboy_core::test_support::with_isolated_home(|home| {

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -1048,6 +1048,64 @@ mod tests {
         });
     }
 
+    /// Release resolves its component from the persisted `homeboy.json` on the
+    /// release source (portable discovery over the registered snapshot), not
+    /// from CLI-passed settings. The declared-test-secret gate must therefore
+    /// evaluate `secret_env_projections` against settings that live only in
+    /// the component config file and fail closed with the same `test.secret_env`
+    /// error the review-test runner produces — before anything spawns. (#14449)
+    #[test]
+    fn validate_test_secret_env_resolves_projections_from_persisted_component_settings() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let _guard = test_env_guard();
+            let source = tempfile::tempdir().expect("source dir");
+            let marker = source.path().join("preflight-child-ran");
+            let _ = conditional_extension_test_component(
+                home.path(),
+                source.path(),
+                &format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+            );
+            std::fs::write(
+                source.path().join("homeboy.json"),
+                r#"{
+                    "id": "fixture",
+                    "extensions": {
+                        "release-test-fixture": {
+                            "toolchain": "fixture",
+                            "settings": {
+                                "service": {
+                                    "mode": "remote",
+                                    "secret_env": {"token": "PROJECTED_RELEASE_SECRET"}
+                                }
+                            }
+                        }
+                    }
+                }"#,
+            )
+            .expect("persisted homeboy.json");
+            let component = homeboy_core::component::try_discover_from_portable(source.path())
+                .expect("portable discovery")
+                .expect("component from persisted config");
+            std::env::set_var("DECLARED_RELEASE_SECRET", "available-static-secret");
+            std::env::remove_var("PROJECTED_RELEASE_SECRET");
+
+            let error = validate_test_secret_env(&component)
+                .expect_err("persisted-settings projection must gate the release");
+            std::env::remove_var("DECLARED_RELEASE_SECRET");
+
+            assert_eq!(error.details["field"], "test.secret_env");
+            assert!(error.message.contains("PROJECTED_RELEASE_SECRET"));
+            assert!(
+                !error.to_string().contains("available-static-secret"),
+                "resolved values must never reach the diagnostic"
+            );
+            assert!(
+                !marker.exists(),
+                "the gate must not spawn the extension test child"
+            );
+        });
+    }
+
     #[test]
     fn validate_test_secret_env_reports_resolvable_identities_by_name() {
         homeboy_core::test_support::with_isolated_home(|home| {


### PR DESCRIPTION
Fixes #14449

## The issue's diagnosis was wrong — corrected here

#14449 blamed `declared_secret_env_names()` for evaluating projections against empty settings. It doesn't: that function resolves settings correctly **given a component**. The divergence is in *which component object* each caller gets.

`resolve_effective_inner()` (`crates/homeboy-core/src/component/resolution.rs`):

- **`review test` run inside the checkout** → `prefer_cwd_for_component()` → `portable_component_for_checkout()` → registry entry **overlaid with the checkout's `homeboy.json`**.
- **`release <id>` run from anywhere else** → falls through to `load_at(config_root, id)` → **bare registry snapshot**.

A registry entry is a point-in-time copy written at registration. On the extrachill controller, `~/.config/homeboy/components/data-machine-events.json` is dated **June 1** and its `extensions.wordpress` is:

```json
{ "database_type": "mysql", "node": "20", "php": "8.3" }
```

`wp_codebox_database_service` was added to the repo's `homeboy.json` by Extra-Chill/data-machine-events#795 on 2026-09-08. So the wordpress extension's projection

```json
{ "when": { "path": ["wp_codebox_database_service","provider"], "equals": "external" },
  "names_path": ["wp_codebox_database_service","secret_env"] }
```

never matched under release: `preflight.test_secret_env` reported `{"declared":[],"declared_count":0,"ran":false}`, the test child spawned without `WP_CODEBOX_DB_*`, the sandbox failed to provision, and the run surfaced as `PHPUNIT_ZERO_TESTS cause=recipe_run_payload_unparseable`. `homeboy --placement local review test data-machine-events` on the identical checkout failed closed correctly with `missing required extension child secret env: WP_CODEBOX_DB_HOST, WP_CODEBOX_DB_PASSWORD, WP_CODEBOX_DB_PORT, WP_CODEBOX_DB_USER`.

**This is broader than secrets.** Any component setting added after registration was invisible to every registry-resolved consumer.

## Change

New `overlay_registered_local_checkout()` applied to the `load_at()` fallback in the id-without-path branch. When the registration's `local_path` is a directory containing a `homeboy.json` whose id matches, the checkout manifest is overlaid onto the snapshot using the existing `overlay_portable_component_config()` — the same merge `portable_component_for_checkout()` already performs for a matched worktree. `local_path` is preserved and `resolve_remote_path_at()` re-runs.

Registrations whose `local_path` is empty, missing, manifest-less, or owned by a different component id keep the snapshot unchanged — the legacy machine-local registration case that `portable_component_for_checkout()` already documents.

Release plan ordering, the runner protocol, and the extension manifest schema are untouched.

## Tests

- New `validate_test_secret_env_resolves_projections_from_persisted_component_settings` (`crates/homeboy-release/src/release/planning_quality.rs`): a projection whose `when` is satisfied **only** by settings persisted in the checkout's `homeboy.json` must make `validate_test_secret_env` fail with field `test.secret_env` when the projected env var is unset, and must not spawn the child (asserted via a marker file the fixture test script would create).
- Companion coverage in `crates/homeboy-core/src/extension/test/run.rs` pinning the same resolution from persisted settings.
- The existing `declared_secret_env_names_match_the_runner_requirement_without_spawning` guarantee is preserved.

## What ran

Toolchain note: `rustup` could not sync on this host (`~/.rustup/tmp` is root-owned); the installed `stable` toolchain **is** 1.95.0, matching `rust-toolchain.toml`, so it was invoked directly.

- `cargo check -p homeboy-core` — clean (9 pre-existing warnings).
- `cargo test -p homeboy-core --lib extension::test` — **274 passed, 0 failed**.
- `cargo test -p homeboy-release --lib validate_test_secret_env` — **4 passed, 0 failed**, including the new test.
- `cargo test -p homeboy-release --lib` — 578 passed, **1 failed**: `release::workflow::tests::apply_release_already_at_head_runs_default_branch_preflight_before_skip`. **Pre-existing** — verified by stashing this change and re-running that test alone on the base commit, where it fails identically.
- `cargo fmt` unavailable (rustfmt component not present in the directly-invoked toolchain); no formatting-sensitive edits beyond one function insertion in existing style.

Authored by Extra Chill Bot (AI agent) via Kimaki session.
