### PR TITLE
refactor(agent-task): one promotion request type and one serialized shape

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -2815,7 +2815,7 @@ fn production_validator_finalizes_only_the_adopted_merge_candidate_and_resolutio
         .to_string();
         std::fs::write(outcome.path(), &source).expect("write adoption outcome");
         let promotion = crate::agent_task_promotion::promote_with_checkpoint(
-            crate::agent_task_promotion::AgentTaskPromotionOptions {
+            crate::agent_task_promotion::AgentTaskPromotionRequest {
                 source,
                 source_run_id: Some(run_id.to_string()),
                 source_path: Some(outcome.path().to_path_buf()),

--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 
 use homeboy_core::{Error, Result};
 
-use super::types::AgentTaskPromotionOptions;
+use super::types::AgentTaskPromotionRequest;
 
 pub(crate) struct CommittedChangesPatch {
     pub(crate) base_ref: String,
@@ -31,7 +31,7 @@ pub(crate) struct AdoptionMergeProof {
 }
 
 pub(crate) fn committed_changes_patch(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
 ) -> Result<Option<CommittedChangesPatch>> {
     let Some(worktree_path) = options.source_worktree_path.as_deref() else {
         return Ok(None);
@@ -317,7 +317,7 @@ fn resolve_candidate(cwd: &Path, requested: Option<&str>) -> Result<String> {
 }
 
 fn committed_changes_patch_path(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     sha256: &str,
 ) -> Result<PathBuf> {
     if let Some(parent) = options.source_path.as_deref().and_then(Path::parent) {

--- a/crates/homeboy-agents/src/agent_task_promotion/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/mod.rs
@@ -41,8 +41,8 @@ pub use promote::{
 pub use run_plan_projection::mirror_agent_task_run_plan_aggregate;
 pub use types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
-    AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
+    AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionReport,
+    AgentTaskPromotionRequest, AgentTaskPromotionSource, AgentTaskPromotionStatus,
     AgentTaskPromotionTarget, AgentTaskPromotionVerifiedBase, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
 };
 

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -48,7 +48,7 @@ pub(crate) use super::patch::{normalize_promotion_patch, validate_artifact_conte
 use super::tests::FakePromotionWorkspaceProvider;
 use super::types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport, AgentTaskPromotionNotification,
-    AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionSource,
+    AgentTaskPromotionReport, AgentTaskPromotionRequest, AgentTaskPromotionSource,
     AgentTaskPromotionStatus, AgentTaskPromotionTarget, AgentTaskPromotionVerifiedBase,
     AGENT_TASK_PROMOTION_REPORT_SCHEMA,
 };
@@ -133,14 +133,14 @@ pub(crate) fn with_gate_supervision<T>(
     })
 }
 
-pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
+pub fn promote(options: AgentTaskPromotionRequest) -> Result<AgentTaskPromotionReport> {
     promote_with_checkpoint(options, |_| Ok(()))
 }
 
 /// Promote a patch while recording the recoverable post-apply boundary before
 /// dependency materialization or verification is attempted.
 pub fn promote_with_checkpoint(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     mut checkpoint: impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
 ) -> Result<AgentTaskPromotionReport> {
     // One promotion is one unit of work, so the store it records against
@@ -165,7 +165,7 @@ pub fn promote_with_checkpoint(
 }
 
 pub(crate) fn promote_with_checkpoint_in_observation_store(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     observation_store: &homeboy_core::observation::ObservationStore,
     mut checkpoint: impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
 ) -> Result<AgentTaskPromotionReport> {
@@ -187,7 +187,7 @@ pub(crate) fn promote_with_checkpoint_in_observation_store(
 /// The reverse apply check proves the original artifact remains in the candidate
 /// before any gate result is trusted.
 pub fn resume_promoted_patch(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     target_path: &Path,
     previous: &Value,
 ) -> Result<AgentTaskPromotionReport> {
@@ -207,7 +207,7 @@ pub fn resume_promoted_patch(
 }
 
 pub(crate) fn resume_promoted_patch_in_observation_store(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     target_path: &Path,
     previous: &Value,
     observation_store: &homeboy_core::observation::ObservationStore,
@@ -226,7 +226,7 @@ pub(crate) fn resume_promoted_patch_in_observation_store(
 /// Re-run corrected gates against an already-applied candidate while preserving
 /// all candidate, base, target, source, and artifact resume validation.
 pub(crate) fn resume_promoted_patch_replacement_gates_in_observation_store<'a>(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     target_path: &Path,
     previous: &Value,
     gate_workspace: Option<&Path>,
@@ -245,7 +245,7 @@ pub(crate) fn resume_promoted_patch_replacement_gates_in_observation_store<'a>(
 }
 
 fn resume_promoted_patch_internal<'a>(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     target_path: &Path,
     previous: &Value,
     observation_store: &homeboy_core::observation::ObservationStore,
@@ -374,7 +374,7 @@ struct PatchArtifactAdmission {
 fn patch_artifact_admission(
     artifact: &AgentTaskArtifact,
     outcome: &AgentTaskOutcome,
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<PatchArtifactAdmission> {
     let path = resolve_artifact_path(
@@ -403,7 +403,7 @@ fn patch_artifact_admission(
 
 pub(crate) fn preflight_patch_artifact_admission_in_observation_store(
     outcome: &AgentTaskOutcome,
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<AgentTaskArtifact> {
     let artifact = select_patch_artifact(outcome, options.artifact_id.as_deref())?;
@@ -412,7 +412,7 @@ pub(crate) fn preflight_patch_artifact_admission_in_observation_store(
 }
 
 fn resume_promoted_patch_admission(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     target_path: &Path,
     previous: &Value,
     observation_store: &homeboy_core::observation::ObservationStore,
@@ -457,7 +457,7 @@ fn resume_promoted_patch_admission(
 }
 
 fn validate_resume_provenance(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     target_path: &Path,
     previous: &Value,
 ) -> Result<()> {
@@ -503,7 +503,7 @@ fn validate_resume_provenance(
 }
 
 fn validate_resume_candidate(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     target_path: &Path,
     previous: &Value,
     outcome: &AgentTaskOutcome,
@@ -704,7 +704,7 @@ fn verify_patch_is_present(
 #[cfg(test)]
 // Provider-injection seam: production promotes through `promote`.
 pub(crate) fn promote_with_provider(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     provider: &mut FakePromotionWorkspaceProvider,
 ) -> Result<AgentTaskPromotionReport> {
     promote_with_provider_and_checkpoint(options, provider, &mut |_| Ok(()))
@@ -713,7 +713,7 @@ pub(crate) fn promote_with_provider(
 #[cfg(test)]
 // Checkpoint seam reached only by the promotion test shards.
 pub(super) fn promote_with_provider_and_checkpoint(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     provider: &mut FakePromotionWorkspaceProvider,
     checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
 ) -> Result<AgentTaskPromotionReport> {
@@ -728,7 +728,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
 
 #[cfg(test)]
 pub(super) fn promote_with_provider_in_observation_store(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     provider: &mut FakePromotionWorkspaceProvider,
     observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<AgentTaskPromotionReport> {
@@ -739,7 +739,7 @@ pub(super) fn promote_with_provider_in_observation_store(
 
 #[cfg(test)]
 pub(super) fn promote_with_provider_and_checkpoint_in_observation_store(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     provider: &mut FakePromotionWorkspaceProvider,
     checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
     observation_store: &homeboy_core::observation::ObservationStore,
@@ -849,7 +849,7 @@ fn verify_promotion_gate(
 }
 
 fn promote_with_provider_and_checkpoint_internal(
-    options: AgentTaskPromotionOptions,
+    options: AgentTaskPromotionRequest,
     checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
     observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<AgentTaskPromotionReport> {
@@ -1558,7 +1558,7 @@ pub(crate) fn outcome_has_patch_artifacts(outcome: &AgentTaskOutcome) -> bool {
 }
 
 fn has_recoverable_candidate_provenance(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     outcome: &AgentTaskOutcome,
     artifact: &AgentTaskArtifact,
 ) -> bool {
@@ -1604,7 +1604,7 @@ struct RecoverableCandidatePromotionAdmission {
 fn recoverable_candidate_promotion_admission(
     source: &Value,
     outcome: &AgentTaskOutcome,
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<RecoverableCandidatePromotionAdmission> {
     let artifact = select_recoverable_patch_artifact(outcome, options, observation_store)?;
@@ -1630,7 +1630,7 @@ fn recoverable_candidate_promotion_admission(
 }
 
 pub(crate) fn preflight_recoverable_candidate_promotion_in_observation_store(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<AgentTaskArtifact> {
     validate_workspace_handle(&options.to_worktree)?;
@@ -1850,7 +1850,7 @@ mod declared_base_tests {
 }
 
 fn promote_committed_changes(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
     observation_store: &homeboy_core::observation::ObservationStore,
     source_kind: &str,
@@ -2071,7 +2071,7 @@ fn promote_committed_changes(
 /// Retain the controller-generated committed delta before its producer path can
 /// be cleaned up. Only an existing controller run may own this projection.
 pub(super) fn retain_committed_changes_artifact(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     outcome: &AgentTaskOutcome,
     patch: &str,
     sha256: &str,
@@ -2133,7 +2133,7 @@ pub(super) fn retain_committed_changes_artifact(
 }
 
 fn run_promotion_gates(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     worktree_path: &Path,
     expected_candidate: Option<&crate::agent_task_promotion::AgentTaskPromotionCandidate>,
     gate_workspace: Option<&Path>,
@@ -2329,7 +2329,7 @@ fn run_promotion_gates(
 }
 
 fn run_declared_promotion_test(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     worktree_path: &Path,
     index: usize,
     plan: &homeboy_engine_primitives::test_execution::TestExecutionPlan,
@@ -2374,7 +2374,7 @@ fn run_declared_promotion_test(
     result
 }
 
-fn gate_workspace_path(options: &AgentTaskPromotionOptions, worktree_path: &Path) -> PathBuf {
+fn gate_workspace_path(options: &AgentTaskPromotionRequest, worktree_path: &Path) -> PathBuf {
     options
         .source_worktree_path
         .as_ref()
@@ -2593,7 +2593,7 @@ fn git_output(path: &Path, args: &[&str]) -> Result<String> {
 }
 
 fn run_promotion_gate(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     worktree_path: &Path,
     index: usize,
     command: &str,
@@ -2728,7 +2728,7 @@ fn finish_promotion_gate_run_dir(run_dir: &homeboy_core::engine::run_dir::RunDir
 fn promotion_source(
     source_kind: &str,
     outcome: &AgentTaskOutcome,
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
 ) -> AgentTaskPromotionSource {
     AgentTaskPromotionSource {
         kind: source_kind.to_string(),
@@ -3224,7 +3224,7 @@ fn promotion_notification_with_gate_summary(
     reason = "report construction keeps durable promotion evidence explicit"
 )]
 fn post_apply_report(
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     source_kind: &str,
     outcome: &AgentTaskOutcome,
     patch_artifact: AgentTaskPromotionArtifactRef,
@@ -3459,7 +3459,7 @@ pub(crate) fn select_patch_artifact(
 /// not turn one patch into a false review choice.
 fn select_recoverable_patch_artifact(
     outcome: &AgentTaskOutcome,
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<AgentTaskArtifact> {
     let canonical =
@@ -3512,7 +3512,7 @@ pub struct CanonicalRecoverablePatchArtifacts {
 /// materialization, including controller projections and hydrated runner bytes.
 pub fn canonical_recoverable_patch_artifacts(
     outcome: &AgentTaskOutcome,
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
 ) -> Result<CanonicalRecoverablePatchArtifacts> {
     // One call is one unit of work, so the store resolves once here rather
     // than at each projection lookup inside (#7505).
@@ -3522,7 +3522,7 @@ pub fn canonical_recoverable_patch_artifacts(
 
 pub(crate) fn canonical_recoverable_patch_artifacts_in_observation_store(
     outcome: &AgentTaskOutcome,
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<CanonicalRecoverablePatchArtifacts> {
     canonical_recoverable_patch_artifacts_internal(outcome, options, observation_store)
@@ -3530,7 +3530,7 @@ pub(crate) fn canonical_recoverable_patch_artifacts_in_observation_store(
 
 fn canonical_recoverable_patch_artifacts_internal(
     outcome: &AgentTaskOutcome,
-    options: &AgentTaskPromotionOptions,
+    options: &AgentTaskPromotionRequest,
     observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<CanonicalRecoverablePatchArtifacts> {
     let mut candidates = outcome

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
@@ -9,8 +9,8 @@ use super::apply::{AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace};
 
 use super::promote::promote_with_provider;
 use super::types::{
-    AgentTaskPromotionCommandCapture, AgentTaskPromotionCommandReport, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport,
+    AgentTaskPromotionCommandCapture, AgentTaskPromotionCommandReport, AgentTaskPromotionReport,
+    AgentTaskPromotionRequest,
 };
 use crate::agent_task::{AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA};
 use crate::agent_task_gate::{
@@ -339,7 +339,7 @@ pub(super) fn promote_recoverable_patch_count(
         ..Default::default()
     };
     let result = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("recoverable-run".to_string()),
             source_path: Some(source_path),
@@ -374,8 +374,8 @@ pub(super) fn git(cwd: &Path, args: &[&str]) {
     );
 }
 
-pub(super) fn promotion_options(to_worktree: &str) -> AgentTaskPromotionOptions {
-    AgentTaskPromotionOptions {
+pub(super) fn promotion_options(to_worktree: &str) -> AgentTaskPromotionRequest {
+    AgentTaskPromotionRequest {
         source: "{}".to_string(),
         source_run_id: None,
         source_path: None,
@@ -399,7 +399,7 @@ pub(super) fn adopted_commit_options(
     base: String,
     candidate_ref: String,
     gates: VerifyGateOptions,
-) -> AgentTaskPromotionOptions {
+) -> AgentTaskPromotionRequest {
     let source_path = temp.path().join("adoption-outcome.json");
     let source = serde_json::json!({
         "schema": AGENT_TASK_OUTCOME_SCHEMA,
@@ -409,7 +409,7 @@ pub(super) fn adopted_commit_options(
     })
     .to_string();
     std::fs::write(&source_path, &source).expect("write adoption outcome");
-    AgentTaskPromotionOptions {
+    AgentTaskPromotionRequest {
         source,
         source_run_id: Some("adoption-run".to_string()),
         source_path: Some(source_path),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -7,7 +7,7 @@ use super::super::promote::{
     promote_with_provider_in_observation_store, resume_promoted_patch,
     retain_committed_changes_artifact,
 };
-use super::super::types::{AgentTaskPromotionOptions, AgentTaskPromotionStatus};
+use super::super::types::{AgentTaskPromotionRequest, AgentTaskPromotionStatus};
 use super::*;
 use crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA;
 use crate::agent_task_gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
@@ -34,7 +34,7 @@ fn promotion_rejects_missing_or_mismatched_recovered_controller_projection() {
             workspace_path: Some(temp.path().join("target")),
             ..Default::default()
         };
-        let options = || AgentTaskPromotionOptions {
+        let options = || AgentTaskPromotionRequest {
             source: source.clone(),
             source_run_id: Some(run_id.to_string()),
             source_path: None,
@@ -102,7 +102,7 @@ fn promotion_uses_recovered_controller_projection_without_public_artifact_path()
         };
 
         let result = promote_with_provider_in_observation_store(
-            AgentTaskPromotionOptions {
+            AgentTaskPromotionRequest {
                 source: source.to_string(),
                 source_run_id: Some(run_id.to_string()),
                 source_path: None,
@@ -196,7 +196,7 @@ fn recoverable_promotion_projection_uses_the_explicit_observation_store() {
     };
 
     let result = promote_with_provider_and_checkpoint_in_observation_store(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source: source.to_string(),
             source_run_id: Some(run_id.to_string()),
             source_path: None,
@@ -285,7 +285,7 @@ fn promote_recoverable_candidate_rejects_mismatched_run_provenance() {
     };
 
     let error = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source: source.to_string(),
             source_run_id: Some("recoverable-run".to_string()),
             source_path: Some(source_path),
@@ -339,7 +339,7 @@ fn empty_patch_failing_gate_is_reported_against_destination() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("run-empty-fail".to_string()),
             source_path: Some(source_path),
@@ -423,7 +423,7 @@ fn promote_exports_committed_changes_when_executor_reports_no_patch_artifact() {
         ..Default::default()
     };
 
-    let options = |base_ref: &str| AgentTaskPromotionOptions {
+    let options = |base_ref: &str| AgentTaskPromotionRequest {
         source: source.clone(),
         source_run_id: Some("run-no-artifact".to_string()),
         source_path: Some(source_path.clone()),
@@ -489,7 +489,7 @@ fn spoofed_generated_patch_provenance_does_not_change_promotion_artifact_id() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source: source.to_string(),
             source_run_id: None,
             source_path: Some(source_path),
@@ -562,7 +562,7 @@ fn promotion_checkpoints_applied_target_before_gate_transport_failure() {
     let mut checkpoints = Vec::new();
 
     let error = promote_with_provider_and_checkpoint(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source: source.clone(),
             source_run_id: Some("restartable-run".to_string()),
             source_path: Some(source_path.clone()),
@@ -623,7 +623,7 @@ fn promotion_checkpoints_applied_target_before_gate_transport_failure() {
         b" M src/lib.rs\n"
     );
 
-    let resume_options = || AgentTaskPromotionOptions {
+    let resume_options = || AgentTaskPromotionRequest {
         source: source.clone(),
         source_run_id: Some("restartable-run".to_string()),
         source_path: Some(source_path.clone()),
@@ -757,7 +757,7 @@ fn promotion_validates_declared_base_before_mutating_the_target_worktree() {
         git(&worktree_path, &["push", "-u", "origin", "main"]);
 
         let (source_path, source) = write_patch_source(&temp);
-        let options = |base: &str| AgentTaskPromotionOptions {
+        let options = |base: &str| AgentTaskPromotionRequest {
             source: source.clone(),
             source_run_id: Some("cook-9400".to_string()),
             source_path: Some(source_path.clone()),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -10,7 +10,7 @@ use super::super::promote::{
     promote_with_provider_and_checkpoint, promote_with_provider_in_observation_store,
     resume_promoted_patch, select_patch_artifact, validate_artifact_content,
 };
-use super::super::types::{AgentTaskPromotionOptions, AgentTaskPromotionStatus};
+use super::super::types::{AgentTaskPromotionRequest, AgentTaskPromotionStatus};
 use super::*;
 use crate::agent_task::{
     AgentTaskArtifact, AgentTaskOutcome, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
@@ -230,7 +230,7 @@ fn bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_ide
             ..Default::default()
         };
         let report = promote_with_provider_in_observation_store(
-            AgentTaskPromotionOptions {
+            AgentTaskPromotionRequest {
                 source: serde_json::to_string(&aggregate).expect("aggregate json"),
                 source_run_id: Some(run_id.to_string()),
                 source_path: None,
@@ -331,7 +331,7 @@ fn aggregate_promotion_forwards_canonical_gate_feedback_baseline() {
             ..Default::default()
         };
         promote_with_provider_in_observation_store(
-            AgentTaskPromotionOptions {
+            AgentTaskPromotionRequest {
                 source,
                 source_run_id: Some("follow-up-run".to_string()),
                 source_path: None,
@@ -422,7 +422,7 @@ fn follow_up_promotion_records_and_forwards_verified_chain_baseline() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("v2-run".to_string()),
             source_path: None,
@@ -492,7 +492,7 @@ fn promote_recoverable_candidate_retains_patch_larger_than_256_kib() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("recoverable-run".to_string()),
             source_path: Some(source_path),
@@ -536,7 +536,7 @@ fn canonical_recoverable_candidates_reject_aggregate_byte_overflow() {
 
         let canonical = canonical_recoverable_patch_artifacts_in_observation_store(
             &outcome,
-            &AgentTaskPromotionOptions {
+            &AgentTaskPromotionRequest {
                 source: source.to_string(),
                 source_run_id: Some("recoverable-run".to_string()),
                 source_path: Some(source_path),
@@ -601,7 +601,7 @@ fn promote_recoverable_candidate_reports_distinct_patch_review_choices() {
     };
 
     let error = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("recoverable-run".to_string()),
             source_path: Some(source_path),
@@ -639,7 +639,7 @@ fn promote_recoverable_candidate_keeps_same_patch_from_distinct_attempts() {
     };
 
     let error = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("recoverable-run".to_string()),
             source_path: Some(source_path),
@@ -742,7 +742,7 @@ fn promote_no_op_outcome_uses_audited_committed_candidate() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("run".to_string()),
             source_path: Some(source_path),
@@ -818,7 +818,7 @@ fn adopt_no_op_pre_existing_candidate_when_base_equals_candidate() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("run".to_string()),
             source_path: Some(source_path),
@@ -885,7 +885,7 @@ fn adoption_scopes_a_rebased_two_file_candidate_to_its_parent() {
     let (source_path, source) = write_empty_patch_source(&temp);
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("adopted-run".to_string()),
             source_path: Some(source_path),
@@ -973,7 +973,7 @@ fn adoption_accepts_a_two_parent_merge_and_exports_only_the_candidate_delta() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("adopted-run".to_string()),
             source_path: Some(source_path),
@@ -1061,7 +1061,7 @@ fn adoption_rejects_merge_candidates_without_a_related_advanced_base() {
     let (source_path, source) = write_empty_patch_source(&temp);
 
     let error = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("adopted-run".to_string()),
             source_path: Some(source_path),
@@ -1115,7 +1115,7 @@ fn adoption_rejects_an_unrelated_historical_task_base() {
     let (source_path, source) = write_empty_patch_source(&temp);
 
     let error = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("adopted-run".to_string()),
             source_path: Some(source_path),
@@ -1181,7 +1181,7 @@ fn promote_exports_all_agent_commits_after_the_recorded_task_base() {
     let (source_path, source) = write_empty_patch_source(&temp);
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("run-two-commits".to_string()),
             source_path: Some(source_path),
@@ -1242,7 +1242,7 @@ fn shared_patch_preflight_rejects_execution_hash_and_normalization_failures() {
         let temp = tempfile::tempdir().expect("tempdir");
         let (source_path, source) = write_patch_source(&temp);
         let mut outcome: AgentTaskOutcome = serde_json::from_str(&source).expect("outcome JSON");
-        let options = AgentTaskPromotionOptions {
+        let options = AgentTaskPromotionRequest {
             source,
             source_run_id: None,
             source_path: Some(source_path),
@@ -1283,7 +1283,7 @@ fn execution_revalidates_artifact_bytes_after_passing_preflight() {
         let temp = tempfile::tempdir().expect("tempdir");
         let (source_path, source) = write_patch_source(&temp);
         let outcome: AgentTaskOutcome = serde_json::from_str(&source).expect("outcome JSON");
-        let options = AgentTaskPromotionOptions {
+        let options = AgentTaskPromotionRequest {
             source,
             source_run_id: None,
             source_path: Some(source_path),
@@ -1344,7 +1344,7 @@ fn resume_promoted_patch_rebuilds_green_proof_from_pending_post_apply_checkpoint
     git(&target, &["add", "."]);
     git(&target, &["commit", "-m", "candidate plus gate correction"]);
     let (source_path, source) = write_patch_source(&temp);
-    let options = AgentTaskPromotionOptions {
+    let options = AgentTaskPromotionRequest {
         source,
         source_run_id: Some("run-8307".to_string()),
         source_path: Some(source_path),
@@ -1446,7 +1446,7 @@ fn legacy_post_apply_checkpoint_recovers_only_with_corrected_non_main_base() {
     let candidate = crate::agent_task_promotion::candidate_fingerprint(target.to_str().unwrap())
         .expect("legacy candidate");
     let (source_path, source) = write_patch_source(&temp);
-    let options = AgentTaskPromotionOptions {
+    let options = AgentTaskPromotionRequest {
         source,
         source_run_id: Some("cook-9400-attempt-1".to_string()),
         source_path: Some(source_path),
@@ -1510,7 +1510,7 @@ fn resume_applied_promotion_reruns_gates_for_exact_dirty_candidate() {
         crate::agent_task_promotion::candidate_fingerprint(target.to_string_lossy().as_ref())
             .expect("candidate fingerprint");
     let (source_path, source) = write_patch_source(&temp);
-    let options = |rerun_completed_gates| AgentTaskPromotionOptions {
+    let options = |rerun_completed_gates| AgentTaskPromotionRequest {
         source: source.clone(),
         source_run_id: Some("run-9392".to_string()),
         source_path: Some(source_path.clone()),
@@ -1550,53 +1550,6 @@ fn resume_applied_promotion_reruns_gates_for_exact_dirty_candidate() {
     assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
     assert_eq!(report.gate_results.len(), 1);
     assert_eq!(report.provenance["resumed_post_apply_promotion"], true);
-}
-
-#[test]
-fn promotion_options_keep_flat_verify_gate_serialized_shape() {
-    // #4910: the shared VerifyGateOptions is `#[serde(flatten)]`-embedded so
-    // the historical flat `verify` / `private_verify` / `private_gate_reveal`
-    // keys must stay at the top level of the serialized options.
-    let options = AgentTaskPromotionOptions {
-        source: "source.json".to_string(),
-        source_run_id: Some("run-1".to_string()),
-        source_path: None,
-        source_worktree_path: None,
-        base_ref: None,
-        task_base_sha: None,
-        candidate_ref: None,
-        to_worktree: "repo@flatten".to_string(),
-        task_id: None,
-        artifact_id: None,
-        dry_run: false,
-        gates: VerifyGateOptions {
-            verify: vec!["cargo test".to_string()],
-            private_verify: vec!["cargo test --lib hidden".to_string()],
-            private_gate_reveal: AgentTaskGateRevealPolicy::SummaryOnly,
-            ..Default::default()
-        },
-        provider_command: None,
-        provider_invocation: None,
-    };
-
-    let value = serde_json::to_value(&options).expect("serialize options");
-    assert_eq!(value["verify"], serde_json::json!(["cargo test"]));
-    assert_eq!(
-        value["private_verify"],
-        serde_json::json!(["cargo test --lib hidden"])
-    );
-    assert_eq!(
-        value["private_gate_reveal"],
-        serde_json::json!("summary_only")
-    );
-    assert!(
-        value.get("gates").is_none(),
-        "flattened gate fields must not nest under a `gates` key: {value}"
-    );
-
-    let round_trip: AgentTaskPromotionOptions =
-        serde_json::from_value(value).expect("deserialize flat options");
-    assert_eq!(round_trip, options);
 }
 
 #[test]
@@ -1648,7 +1601,7 @@ fn ordered_gate_failure_skips_downstream_command_with_durable_blocker_evidence()
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("ordered-fail-fast".to_string()),
             source_path: Some(source_path),
@@ -1740,7 +1693,7 @@ fn promotion_rejects_a_cargo_gate_that_selected_zero_tests() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("zero-selected-cargo-gate".to_string()),
             source_path: Some(source_path),
@@ -1821,7 +1774,7 @@ fn continue_all_gate_policy_runs_downstream_command_after_failure() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("continue-all".to_string()),
             source_path: Some(source_path),
@@ -1906,7 +1859,7 @@ fn typed_plan_and_legacy_gate_keep_contiguous_gate_ids() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("typed-and-legacy-ids".to_string()),
             source_path: Some(source_path),
@@ -1968,7 +1921,7 @@ fn promotion_runs_gates_in_the_destination_workspace() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("immutable-candidate-first-attempt".to_string()),
             source_path: Some(source_path),
@@ -2049,7 +2002,7 @@ fn promotion_hydrates_destination_package_execution_projections_before_gates() {
         };
 
         let report = promote_with_provider(
-            AgentTaskPromotionOptions {
+            AgentTaskPromotionRequest {
                 source,
                 source_run_id: Some("nested-dependency-hydration".to_string()),
                 source_path: Some(source_path),
@@ -2124,7 +2077,7 @@ fn promotion_can_disable_candidate_dependency_hydration() {
         ..Default::default()
     };
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("disable-dependency-hydration".to_string()),
             source_path: Some(source_path),
@@ -2184,7 +2137,7 @@ fn promotion_setup_failure_is_bounded_and_never_dispatches_a_gate() {
         };
 
         let error = promote_with_provider(
-            AgentTaskPromotionOptions {
+            AgentTaskPromotionRequest {
                 source,
                 source_run_id: Some("setup-failure-no-gate-dispatch".to_string()),
                 source_path: Some(source_path),
@@ -2257,7 +2210,7 @@ fn missing_destination_tool_is_a_typed_setup_failure_before_provider_verificatio
     };
 
     let error = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("missing-destination-tool".to_string()),
             source_path: Some(source_path),
@@ -2320,7 +2273,7 @@ fn promotion_rejects_mutation_after_checkpoint_before_gate_materialization() {
     };
 
     let error = promote_with_provider_and_checkpoint(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("immutable-candidate-checkpoint".to_string()),
             source_path: Some(source_path),
@@ -2370,7 +2323,7 @@ fn resumed_verification_runs_destination_gate_for_exact_dirty_candidate() {
         crate::agent_task_promotion::candidate_fingerprint(target.to_string_lossy().as_ref())
             .expect("candidate fingerprint");
     let (source_path, source) = write_patch_source(&temp);
-    let options = AgentTaskPromotionOptions {
+    let options = AgentTaskPromotionRequest {
         source,
         source_run_id: Some("immutable-candidate-follow-up".to_string()),
         source_path: Some(source_path),
@@ -2440,7 +2393,7 @@ fn gate_failure_preserves_the_pre_gate_candidate_baseline_for_feedback_retry() {
     };
     let mut checkpoint = None;
     let report = promote_with_provider_and_checkpoint(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("gate-failure-run".to_string()),
             source_path: Some(source_path),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -4,7 +4,7 @@
 use super::super::promote::{
     normalize_promotion_patch, promote, promote_with_provider, select_patch_artifact,
 };
-use super::super::types::{AgentTaskPromotionOptions, AgentTaskPromotionStatus};
+use super::super::types::{AgentTaskPromotionRequest, AgentTaskPromotionStatus};
 use super::*;
 use crate::agent_task::{
     AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
@@ -100,7 +100,7 @@ fn promote_recoverable_candidate_reports_unreadable_patch_evidence() {
         ..Default::default()
     };
     let error = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("recoverable-run".to_string()),
             source_path: Some(source_path),
@@ -169,7 +169,7 @@ fn promote_reports_no_changes_for_empty_patch_metadata() {
         let source = serde_json::to_string(&outcome).expect("serialize outcome");
         std::fs::write(&source_path, &source).expect("write source");
 
-        let report = promote(AgentTaskPromotionOptions {
+        let report = promote(AgentTaskPromotionRequest {
             source,
             source_run_id: Some("run-empty".to_string()),
             source_path: Some(source_path),
@@ -229,7 +229,7 @@ fn promote_no_op_outcome_without_committed_candidate_rejects_before_apply() {
     };
 
     let error = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("run".to_string()),
             source_path: Some(source_path),
@@ -283,7 +283,7 @@ fn committed_change_promotion_rejects_a_non_ancestor_task_base() {
     let (source_path, source) = write_empty_patch_source(&temp);
 
     let error = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: None,
             source_path: Some(source_path),
@@ -363,7 +363,7 @@ fn promote_applies_patch_with_fake_workspace_provider() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("run-1".to_string()),
             source_path: Some(source_path),
@@ -454,7 +454,7 @@ fn promote_persists_force_added_ignored_git_candidate_paths() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("run-8935".to_string()),
             source_path: Some(source_path),
@@ -519,7 +519,7 @@ fn promote_materializes_worktree_dependencies_before_verify_gate() {
         };
 
         let report = promote_with_provider(
-            AgentTaskPromotionOptions {
+            AgentTaskPromotionRequest {
                 source,
                 source_run_id: Some("run-3771".to_string()),
                 source_path: Some(source_path),
@@ -655,26 +655,4 @@ fn explicit_candidate_adopts_only_durable_pre_provider_transport_failures() {
             error.message
         );
     }
-}
-
-#[test]
-fn promotion_options_deserialize_legacy_flat_gate_payload() {
-    // Payloads authored before the refactor used flat keys; they must still
-    // deserialize into the flattened `gates` field unchanged.
-    let payload = serde_json::json!({
-        "source": "source.json",
-        "to_worktree": "repo@legacy",
-        "verify": ["cargo build"],
-        "private_verify": [],
-        "private_gate_reveal": "full_evidence"
-    });
-
-    let options: AgentTaskPromotionOptions =
-        serde_json::from_value(payload).expect("deserialize legacy flat payload");
-    assert_eq!(options.gates.verify, vec!["cargo build".to_string()]);
-    assert!(options.gates.private_verify.is_empty());
-    assert_eq!(
-        options.gates.private_gate_reveal,
-        AgentTaskGateRevealPolicy::FullEvidence
-    );
 }

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -5,8 +5,8 @@ use super::super::promote::{
     normalize_promotion_patch, promote_with_provider, promote_with_provider_in_observation_store,
 };
 use super::super::types::{
-    AgentTaskPromotionArtifactRef, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
+    AgentTaskPromotionArtifactRef, AgentTaskPromotionNotification, AgentTaskPromotionReport,
+    AgentTaskPromotionRequest, AgentTaskPromotionSource, AgentTaskPromotionStatus,
     AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
 };
 use super::*;
@@ -45,7 +45,7 @@ fn promotion_uses_verified_controller_projection_for_recovered_runner_aggregate_
             };
 
             let report = promote_with_provider_in_observation_store(
-                AgentTaskPromotionOptions {
+                AgentTaskPromotionRequest {
                     source: source.clone(),
                     source_run_id: Some(run_id.to_string()),
                     source_path,
@@ -90,7 +90,7 @@ fn promotion_applies_verified_snapshot_when_source_artifact_is_replaced() {
     };
 
     promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: None,
             source_path: Some(source_path),
@@ -167,7 +167,7 @@ fn empty_patch_records_declared_base_candidate_delta_before_running_gates() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("run-empty".to_string()),
             source_path: Some(source_path),
@@ -240,7 +240,7 @@ fn promote_exports_committed_changes_when_patch_artifact_is_empty() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some("run-committed".to_string()),
             source_path: Some(source_path),
@@ -310,7 +310,7 @@ fn committed_changes_retain_a_controller_baseline_before_source_cleanup() {
         };
 
         let report = promote_with_provider_in_observation_store(
-            AgentTaskPromotionOptions {
+            AgentTaskPromotionRequest {
                 source,
                 source_run_id: Some("baseline-run".to_string()),
                 source_path: Some(source_path),
@@ -412,7 +412,7 @@ fn promote_dry_run_validates_provider_request_without_applying() {
         ..Default::default()
     };
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: None,
             source_path: Some(source_path),
@@ -463,7 +463,7 @@ fn promote_verification_failure_keeps_the_applied_target_recoverable() {
         };
 
         let report = promote_with_provider(
-            AgentTaskPromotionOptions {
+            AgentTaskPromotionRequest {
                 source,
                 source_run_id: Some("runner-only-run".to_string()),
                 source_path: Some(source_path),
@@ -525,7 +525,7 @@ fn promote_applies_normalized_lab_sandbox_patch_with_fake_workspace_provider() {
     };
 
     let report = promote_with_provider(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: None,
             source_path: Some(source_path),

--- a/crates/homeboy-agents/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/types.rs
@@ -11,41 +11,37 @@ use homeboy_core::stream_capture::StreamCaptureMetadata;
 
 pub const AGENT_TASK_PROMOTION_REPORT_SCHEMA: &str = "homeboy/agent-task-promotion-report/v1";
 
+/// A fully resolved promotion input.
+///
+/// This is the durable shape: `AgentTaskPromotionJob` persists it under
+/// `homeboy/agent-task-promotion-job/v1`, so a recovered job never reparses
+/// operator argv or reselects an aggregate candidate. It is also what the
+/// in-process promotion path takes, so there is one field group and one
+/// serialized shape rather than two that must be kept in step by hand.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AgentTaskPromotionOptions {
+pub struct AgentTaskPromotionRequest {
     pub source: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_run_id: Option<String>,
     pub source_path: Option<PathBuf>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_worktree_path: Option<PathBuf>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_worktree: String,
     pub base_ref: Option<String>,
     /// Immutable task workspace base captured before provider dispatch. This is
     /// required when recovering agent-created commits so promotion never picks
     /// up commits that were already present in a reused workspace.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task_base_sha: Option<String>,
     /// An immutable commit selected by a controller-owned candidate adoption.
     /// When present promotion derives the patch from this revision rather than
     /// the source workspace's current HEAD.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub candidate_ref: Option<String>,
-    pub to_worktree: String,
     pub task_id: Option<String>,
     pub artifact_id: Option<String>,
     #[serde(default)]
     pub dry_run: bool,
-    /// Deterministic verification gates. Flattened so the serialized shape keeps
-    /// the historical flat `verify` / `private_verify` / `private_gate_reveal`
-    /// keys while the field group is defined once in `VerifyGateOptions`.
-    #[serde(flatten)]
+    /// Deterministic verification gates.
+    #[serde(default)]
     pub gates: VerifyGateOptions,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_command: Option<String>,
-    /// Structured provider invocation. This preserves argv boundaries for
-    /// portable providers; `provider_command` remains a deprecated fallback.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_invocation: Option<CommandInvocation>,
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -25,8 +25,8 @@ use crate::agent_task_lifecycle;
 use crate::agent_task_model::normalize_concrete_model_identifier;
 use crate::agent_task_promotion::resolve_candidate_revision;
 use crate::agent_task_promotion::{
-    promote_with_checkpoint_in_observation_store, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport,
+    promote_with_checkpoint_in_observation_store, AgentTaskPromotionReport,
+    AgentTaskPromotionRequest,
 };
 use crate::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use crate::agent_task_scheduler::SharedAgentTaskExecutor;
@@ -551,7 +551,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
                 || {
                     let observation_store = lifecycle_store.open_observation_initialized()?;
                     promote_with_checkpoint_in_observation_store(
-                        AgentTaskPromotionOptions {
+                        AgentTaskPromotionRequest {
                             source,
                             source_run_id: Some(record.run_id.clone()),
                             source_path,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -32,7 +32,7 @@ use crate::agent_task_promotion::{
     preflight_recoverable_candidate_promotion_in_observation_store,
     promote_with_checkpoint_in_observation_store, resume_promoted_patch_in_observation_store,
     resume_promoted_patch_replacement_gates_in_observation_store, AgentTaskPromotionCandidate,
-    AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
+    AgentTaskPromotionReport, AgentTaskPromotionRequest, AgentTaskPromotionStatus,
 };
 use crate::agent_task_review_dossier::{
     resolve_review_profile, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
@@ -386,7 +386,7 @@ pub(crate) fn promote_attempt_in_store(
     };
     let observation_store = lifecycle_store.open_observation_initialized()?;
     promote_with_checkpoint_in_observation_store(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some(run_id.to_string()),
             source_path,
@@ -517,7 +517,7 @@ pub fn preflight_cook_promotion_for_observation_in_store(
             Some(format!("serialize agent-task aggregate {run_id}")),
         )
     })?;
-    let promotion_options = AgentTaskPromotionOptions {
+    let promotion_options = AgentTaskPromotionRequest {
         source,
         source_run_id: Some(run_id.to_string()),
         source_path: Some(lifecycle_store.aggregate_path(run_id)),
@@ -654,7 +654,7 @@ pub(crate) fn canonical_cook_patch_artifact_id_in_store(
     else {
         return Ok(None);
     };
-    let promotion_options = AgentTaskPromotionOptions {
+    let promotion_options = AgentTaskPromotionRequest {
         source,
         source_run_id: Some(run_id.to_string()),
         source_path,
@@ -1086,7 +1086,7 @@ pub(crate) fn promote_or_load_attempt_in_store(
             let (source, source_path) = promotion_source_in_store(lifecycle_store, run_id)?;
             let observation_store = lifecycle_store.open_observation_initialized()?;
             let resumed = resume_promoted_patch_in_observation_store(
-                AgentTaskPromotionOptions {
+                AgentTaskPromotionRequest {
                     source,
                     source_run_id: Some(run_id.to_string()),
                     source_path,
@@ -1724,7 +1724,7 @@ fn verify_replacement_gates_owned(
     let observation_store = lifecycle_store.open_observation_initialized()?;
     let replacement_gate_workspace = replacement_component_workspace(&original, &target_path)?;
     let mut replacement = resume_promoted_patch_replacement_gates_in_observation_store(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some(run_id.to_string()),
             source_path,
@@ -2393,7 +2393,7 @@ pub(crate) fn recover_moving_base_cook_candidate_in_store(
     let (source, source_path) = promotion_source_in_store(lifecycle_store, &recovery.run_id)?;
     let observation_store = lifecycle_store.open_observation_initialized()?;
     let refreshed = resume_promoted_patch_in_observation_store(
-        AgentTaskPromotionOptions {
+        AgentTaskPromotionRequest {
             source,
             source_run_id: Some(recovery.run_id.clone()),
             source_path,
@@ -6190,7 +6190,7 @@ fn ambiguous_promotion_artifact_ids(
     };
     canonical_recoverable_patch_artifacts(
         outcome,
-        &AgentTaskPromotionOptions {
+        &AgentTaskPromotionRequest {
             source,
             source_run_id: Some(run_id.to_string()),
             source_path,

--- a/crates/homeboy-agents/src/agent_task_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_service/mod.rs
@@ -36,6 +36,9 @@ mod status_support;
 /// Shared daemon lifecycle for newly submitted orchestration work.
 mod work_job;
 
+/// The promotion request is defined once in `agent_task_promotion`; the service
+/// layer re-exports it so existing importers keep one canonical type.
+pub use crate::agent_task_promotion::AgentTaskPromotionRequest;
 pub use cook::*;
 pub use cook_activity::{worktree_files_changed, CookActivityProbe, CookProviderActivity};
 pub use cook_adoption::*;

--- a/crates/homeboy-agents/src/agent_task_service/promotion_service.rs
+++ b/crates/homeboy-agents/src/agent_task_service/promotion_service.rs
@@ -10,38 +10,18 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::daemon::controller_job_driver::{
     self, ControllerJobDriver, ControllerJobHandle, ControllerJobPublicError,
 };
 use homeboy_core::Result;
 
-use crate::agent_task_gate::VerifyGateOptions;
 use crate::agent_task_lifecycle;
 use crate::agent_task_promotion::{
     promote_with_checkpoint, resume_promoted_patch, with_gate_supervision, with_promotion_progress,
-    AgentTaskPromotionOptions, AgentTaskPromotionReport, PromotionProgressCallback,
+    AgentTaskPromotionReport, AgentTaskPromotionRequest, PromotionProgressCallback,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentTaskPromotionRequest {
-    pub source: String,
-    pub source_run_id: Option<String>,
-    pub source_path: Option<std::path::PathBuf>,
-    pub source_worktree_path: Option<std::path::PathBuf>,
-    pub to_worktree: String,
-    pub base_ref: Option<String>,
-    pub task_base_sha: Option<String>,
-    pub candidate_ref: Option<String>,
-    pub task_id: Option<String>,
-    pub artifact_id: Option<String>,
-    #[serde(default)]
-    pub dry_run: bool,
-    #[serde(default)]
-    pub gates: VerifyGateOptions,
-    pub provider_command: Option<String>,
-    pub provider_invocation: Option<CommandInvocation>,
-}
+use crate::agent_task_gate::VerifyGateOptions;
 
 pub const AGENT_TASK_PROMOTION_JOB_TYPE: &str = "agent-task-promotion";
 pub const AGENT_TASK_PROMOTION_JOB_VERSION: u32 = 1;
@@ -312,26 +292,7 @@ pub fn register_promotion_job_driver() {
     });
 }
 
-impl AgentTaskPromotionRequest {
-    fn options(&self) -> AgentTaskPromotionOptions {
-        AgentTaskPromotionOptions {
-            source: self.source.clone(),
-            source_run_id: self.source_run_id.clone(),
-            source_path: self.source_path.clone(),
-            source_worktree_path: self.source_worktree_path.clone(),
-            base_ref: self.base_ref.clone(),
-            task_base_sha: self.task_base_sha.clone(),
-            candidate_ref: self.candidate_ref.clone(),
-            to_worktree: self.to_worktree.clone(),
-            task_id: self.task_id.clone(),
-            artifact_id: self.artifact_id.clone(),
-            dry_run: self.dry_run,
-            gates: self.gates.clone(),
-            provider_command: self.provider_command.clone(),
-            provider_invocation: self.provider_invocation.clone(),
-        }
-    }
-}
+impl AgentTaskPromotionRequest {}
 
 /// Execute or resume an immutable controller-owned promotion. The durable run
 /// is the operation key: each post-apply checkpoint is persisted before gates,
@@ -420,9 +381,12 @@ fn execute_promotion_inner(request: AgentTaskPromotionRequest) -> Result<AgentTa
             .ok()
             .and_then(|record| record.metadata.get("latest_promotion").cloned())
     });
-    let options = request.options();
+    // Promotion consumes the request, so capture the fields the finalization
+    // path needs before handing it over.
+    let source_run_id = request.source_run_id.clone();
+    let dry_run = request.dry_run;
     let report = if let Some(previous) = previous
-        .filter(|previous| promotion_is_resumable(previous, options.gates.rerun_completed_gates))
+        .filter(|previous| promotion_is_resumable(previous, request.gates.rerun_completed_gates))
     {
         let target_path = previous
             .pointer("/target/path")
@@ -435,12 +399,10 @@ fn execute_promotion_inner(request: AgentTaskPromotionRequest) -> Result<AgentTa
                     None,
                 )
             })?;
-        resume_promoted_patch(options, Path::new(target_path), &previous)?
+        resume_promoted_patch(request, Path::new(target_path), &previous)?
     } else {
-        let checkpoint_run_id = (!request.dry_run)
-            .then(|| request.source_run_id.clone())
-            .flatten();
-        promote_with_checkpoint(options, |checkpoint| {
+        let checkpoint_run_id = (!dry_run).then(|| source_run_id.clone()).flatten();
+        promote_with_checkpoint(request, |checkpoint| {
             if let Some(run_id) = checkpoint_run_id.as_deref() {
                 let mut checkpoint = checkpoint.clone();
                 bind_promotion_request_fingerprint(&mut checkpoint, &request_fingerprint);
@@ -464,7 +426,7 @@ fn execute_promotion_inner(request: AgentTaskPromotionRequest) -> Result<AgentTa
         None,
         Some("persisting promotion result".to_string()),
     );
-    if let Some(run_id) = request.source_run_id.filter(|_| !request.dry_run) {
+    if let Some(run_id) = source_run_id.filter(|_| !dry_run) {
         agent_task_lifecycle::record_promotion(
             &run_id,
             serde_json::to_value(&report).map_err(|error| {
@@ -505,6 +467,28 @@ mod tests {
     use super::*;
     use homeboy_core::api_jobs::JobEventKind;
     use homeboy_core::test_support::ControllerJobHarness;
+
+    /// The promotion request is the durable shape persisted under
+    /// `homeboy/agent-task-promotion-job/v1`. Round-trip every field so a field
+    /// added to the struct but dropped on the recovery path fails here rather
+    /// than silently losing its value after a restart (#13347).
+    #[test]
+    fn promotion_request_round_trips_every_field_through_its_durable_shape() {
+        let original = request();
+
+        let encoded = serde_json::to_value(&original).expect("serialize request");
+        assert!(
+            encoded.get("gates").is_some(),
+            "gates is a nested object in the durable shape: {encoded}"
+        );
+
+        let decoded: AgentTaskPromotionRequest =
+            serde_json::from_value(encoded).expect("deserialize request");
+        assert_eq!(
+            decoded, original,
+            "a field declared on the request was lost through its durable shape"
+        );
+    }
 
     fn request() -> AgentTaskPromotionRequest {
         AgentTaskPromotionRequest {

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -926,7 +926,7 @@ fn persisted_timeout_candidate_is_admitted_for_continuation() {
 
         let source = serde_json::to_string(&aggregate).expect("serialize persisted aggregate");
         let admitted = crate::agent_task_promotion::preflight_recoverable_candidate_promotion_in_observation_store(
-            &crate::agent_task_promotion::AgentTaskPromotionOptions {
+            &crate::agent_task_promotion::AgentTaskPromotionRequest {
                 source,
                 source_run_id: Some("service-timeout-candidate".to_string()),
                 source_path: Some(lifecycle_store.aggregate_path("service-timeout-candidate")),

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -307,8 +307,8 @@ pub mod loop_definition {
 pub mod promotion {
     pub use super::super::agent_task_promotion::{
         canonical_recoverable_patch_artifacts, promote, AgentTaskPromotionArtifactRef,
-        AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
-        AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
+        AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionReport,
+        AgentTaskPromotionRequest, AgentTaskPromotionSource, AgentTaskPromotionStatus,
         AgentTaskPromotionTarget, AgentTaskPromotionVerifiedBase, PromotionProgressCallback,
     };
 }

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -1343,7 +1343,7 @@ fn review_promotion_candidates(
                 .and_then(|outcome| {
                     crate::agent_task_promotion::canonical_recoverable_patch_artifacts_in_observation_store(
                         outcome,
-                        &crate::agent_task_promotion::AgentTaskPromotionOptions {
+                        &crate::agent_task_promotion::AgentTaskPromotionRequest {
                             source: "{}".to_string(),
                             source_run_id: Some(run_id.to_string()),
                             source_path: None,


### PR DESCRIPTION
Closes #13347.

## Summary
`AgentTaskPromotionOptions` and `AgentTaskPromotionRequest` carried the **same fourteen fields** and were converted between by a hand-written exhaustive literal. Both are now one type, `AgentTaskPromotionRequest`, defined once in `agent_task_promotion::types`.

**−256/+170, net 86 lines removed.**

## The blocker in #13347 does not hold
That issue declined to collapse these because either direction looked like a migration:

> adopt `Request`'s shape → `Options` loses the historical flat `verify` keys its own comment says are load-bearing

Those keys are not load-bearing. `AgentTaskPromotionOptions` **was never serialized or deserialized anywhere outside its own tests** — no `to_value`, no `from_value`, no `from_str`, in any non-test path. Its `Serialize`/`Deserialize` derives and its `#[serde(flatten)]` existed only to satisfy two tests asserting a shape that nothing produced and nothing consumed.

So the collapse is free: `Request`'s nested shape is the one persisted under `homeboy/agent-task-promotion-job/v1`, and it is untouched here. **No wire format changes.**

## Closing the silent half-land
#13347 also flagged the asymmetric hazard: adding a field to `Request` — the durable type — and forgetting to plumb it through `options()` compiled clean and silently dropped the value on the recovery path, surfacing only after a restart.

That converter no longer exists, so the hazard is gone structurally rather than by discipline. The two tests covering the fictional flat shape are replaced by one that round-trips the real durable shape:

```rust
fn promotion_request_round_trips_every_field_through_its_durable_shape()
```

It asserts `gates` stays a nested object and that a decoded request equals the original, so a field added to the struct but lost through its durable shape fails here.

## Verification
Full `homeboy-agents` lib suite against a baseline worktree at the same commit:

| | tests | passed | not passing |
|---|---|---|---|
| baseline | 2339 | 2330 | 9 failed |
| this branch | 2338 | 2329 | 8 failed + 1 timed out |

The test count drops by exactly one, as expected: two flat-shape tests removed, one durable round-trip added. Non-passing counts are equal at nine on both sides; that population is the crate's existing flaky set, and the one timeout on this side appears as a plain failure on baseline.

Promotion-scoped tests specifically: **160 run, 160 passed**.

`cargo check --workspace --tests` is clean once #14507 lands — `main` currently has an unrelated test-build break in `homeboy-lab-runner` that this branch does not touch.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode established that the flat shape had no producer or consumer, collapsed the two types, replaced the fictional coverage with durable round-trip coverage, and compared the full crate suite against a baseline worktree. Chris Huber directed the work and remains responsible for acceptance.