### PR TITLE
ci: fail closed when the workspace test build breaks

### DIFF
--- a/.github/required-gates-ruleset.json
+++ b/.github/required-gates-ruleset.json
@@ -28,6 +28,10 @@
             "integration_id": 15368
           },
           {
+            "context": "homeboy / Workspace Tests Compile",
+            "integration_id": 15368
+          },
+          {
             "context": "homeboy / Lint",
             "integration_id": 15368
           },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,21 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  # The Test gate routes to changed test identities, and it reports success when
+  # the candidate fails to enumerate at all -- a broken test build produces zero
+  # test identities, so the differential comparison sees no candidate-only
+  # failures and passes. Two test-build breaks reached main that way on
+  # 2026-09-09 (#14505, #14507), both semantic conflicts between separately
+  # green PRs. This gate is codegen-free and fails closed on exactly that case.
+  workspace-tests-compile:
+    name: homeboy / Workspace Tests Compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - name: Compile every workspace test target
+        run: cargo check --workspace --tests --locked
+
   lint:
     name: homeboy / Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Two broken merges today, same hole

`main` took two test-build breaks on 2026-09-09 — #14505 and #14507 — and both passed every required check on the way in.

## The Test gate fails open on a broken test build
From #14497's **passing** Candidate Test log:

```
Rust test scope: Scoped to the exact union of changed Rust test identities.
Running cargo nextest...
Rust test shard error: could not enumerate nextest tests: ...
error: could not compile `homeboy-agents` (lib) due to 1 previous error
error: command `cargo test --no-run --workspace` exited with code 101
```

The candidate did not compile. The job reported **pass**.

The mechanism is structural: the differential gate compares failed *test identities* between baseline and candidate. A candidate that cannot compile enumerates **zero** identities, so there are no candidate-only failures, so the comparison is clean and the gate is green. The worse the breakage, the more certainly it passes.

## The gate that would have caught it was removed
`workspace-tests-compile` ran `cargo check --workspace --tests --locked` and failed closed. #13998 ("Simplify Homeboy tests and CI policy") removed it from `ci.yml` and from the required-checks ruleset together, leaving three gates: Rustfmt, Lint, Test.

That left no gate that fails closed on a broken test build, because the surviving one fails open on exactly that.

## Restored, and verified against the real breaks
I replayed the two commits that reached `main` with this gate's exact command:

| commit | | `cargo check --workspace --tests` |
|---|---|---|
| `ce3706b23` | #14497 | **1 error** |
| `9be3c7a78` | after #14504 | **1 error** |

Both caught. Both were invisible to the Test gate.

This is one codegen-free job, and the ruleset regains the matching required check.

## Why these slip past per-PR CI specifically
Neither break existed on its own branch. Both were semantic conflicts between separately green PRs — #14419 adding fields to `ControlPlaneBlocker` while #14492 added a construction site, and #14497 adding a test written against another crate's fixture shape. No textual conflict, so git merged both cleanly and each PR was genuinely green when it ran.

A compile gate is the cheapest thing that notices, which is why it is worth its runner minutes even in a simplified policy.

## Follow-up worth filing upstream
The deeper defect is in the action: `could not enumerate nextest tests` should be a hard failure, not an empty result set that reads as "no regressions". This PR guards the repository, but any consumer of the reusable workflow has the same hole.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced both of today's broken merges to the missing gate, confirmed the fail-open behaviour in #14497's own CI log, restored the job, and replayed it against both breaking commits. Chris Huber directed the work and remains responsible for acceptance.