### PR TITLE
fix(agent-task): rename the promotion request in its integration test

### DIFF
--- a/tests/agent_task_promotion_provider.rs
+++ b/tests/agent_task_promotion_provider.rs
@@ -117,7 +117,7 @@ fn promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_i
     .to_string();
 
     let report = homeboy::agents::agent_task_promotion::promote(
-        homeboy::agents::agent_task_promotion::AgentTaskPromotionOptions {
+        homeboy::agents::agent_task_promotion::AgentTaskPromotionRequest {
             source,
             source_run_id: Some(run_id.clone()),
             source_path: None,


### PR DESCRIPTION
One-line follow-up to #14512. The type collapse renamed `AgentTaskPromotionOptions` to `AgentTaskPromotionRequest` across `crates/`, but `tests/agent_task_promotion_provider.rs` still referenced the old name, so `homeboy`'s integration test target does not build on `main`.

Mine to fix, and fixed forward.

```
tests/agent_task_promotion_provider.rs:120:48: error[E0422]:
  cannot find struct, variant or union type `AgentTaskPromotionOptions`
```

`cargo check --workspace --tests --all-targets` is clean with this applied.

Worth noting for anyone reading later: `cargo check --workspace --tests` alone did **not** surface this. The root package's `tests/*.rs` integration targets only compile under `--all-targets`, which is why the rename passed local verification.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode introduced the break in #14512 and fixed it here. Chris Huber directed the work and remains responsible for acceptance.