### PR TITLE
refactor(test-support): one env guard instead of nine hand-rolled copies

### DIFF
--- a/crates/homeboy-cli/src/commands/audit.rs
+++ b/crates/homeboy-cli/src/commands/audit.rs
@@ -678,33 +678,6 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    struct XdgGuard {
-        prior: Option<String>,
-    }
-
-    impl XdgGuard {
-        fn unset() -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::remove_var("XDG_DATA_HOME");
-            Self { prior }
-        }
-
-        fn set(value: &std::path::Path) -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::set_var("XDG_DATA_HOME", value);
-            Self { prior }
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            match &self.prior {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
-    }
-
     fn tmp_dir(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1134,7 +1107,7 @@ mod tests {
     #[test]
     fn audit_observation_start_persists_run_record() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
 
             let result = finish_adapted_observed_workflow(
@@ -1179,7 +1152,7 @@ mod tests {
     #[test]
     fn audit_observation_finish_persists_findings() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
             let workflow = sample_audit_workflow(home.path());
 
@@ -1221,7 +1194,7 @@ mod tests {
     #[test]
     fn audit_full_reports_use_run_scoped_resolvable_artifacts() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
             let first = ActiveObservation::start(
                 AuditObservationAdapter::new("homeboy", &home.path().to_string_lossy(), &args)
@@ -1259,7 +1232,7 @@ mod tests {
     #[test]
     fn required_audit_report_failure_terminalizes_observation() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
             let adapter =
                 AuditObservationAdapter::new("homeboy", &home.path().to_string_lossy(), &args);
@@ -1297,7 +1270,8 @@ mod tests {
         with_isolated_home(|home| {
             let bad_data_home = home.path().join("not-a-dir");
             fs::write(&bad_data_home, "file blocks observation dir").expect("write marker");
-            let _xdg = XdgGuard::set(&bad_data_home);
+            let _xdg =
+                homeboy_core::test_support::EnvVarGuard::set("XDG_DATA_HOME", &bad_data_home);
 
             let result = finish_adapted_observed_workflow(
                 AuditObservationAdapter::new(

--- a/crates/homeboy-cli/src/commands/bench/observation/tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/tests.rs
@@ -23,47 +23,6 @@ use crate::commands::utils::resource_policy::{
 };
 use crate::test_support::{serve_public_artifact_base_once, with_isolated_home};
 
-pub(super) struct XdgGuard(Option<String>);
-
-struct EnvGuard {
-    key: &'static str,
-    prior: Option<String>,
-}
-
-impl XdgGuard {
-    pub(super) fn unset() -> Self {
-        let prior = std::env::var("XDG_DATA_HOME").ok();
-        std::env::remove_var("XDG_DATA_HOME");
-        Self(prior)
-    }
-}
-
-impl Drop for XdgGuard {
-    fn drop(&mut self) {
-        match &self.0 {
-            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
-    }
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let prior = std::env::var(key).ok();
-        std::env::set_var(key, value);
-        Self { key, prior }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match &self.prior {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
-        }
-    }
-}
-
 pub(super) fn bench_results(component_id: &str, scenario_id: &str, p95: f64) -> BenchResults {
     serde_json::from_value(serde_json::json!({
         "component_id": component_id,
@@ -120,9 +79,9 @@ pub(super) fn bench_args() -> BenchRunArgs {
 #[test]
 fn bench_observation_persists_success_with_metrics_and_artifacts() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let public_artifact_base = serve_public_artifact_base_once(200);
-        let _public_artifact_base = EnvGuard::set(
+        let _public_artifact_base = homeboy_core::test_support::EnvVarGuard::set(
             homeboy::core::artifacts::PUBLIC_ARTIFACT_BASE_URL_ENV,
             &public_artifact_base,
         );
@@ -322,7 +281,7 @@ fn bench_observation_persists_success_with_metrics_and_artifacts() {
 #[test]
 fn bench_observation_writes_status_file_at_start_and_finish() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
         fs::write(run_dir.step_file(run_dir::files::RESOURCE_SUMMARY), b"{}").expect("resources");
@@ -379,7 +338,7 @@ fn bench_observation_writes_status_file_at_start_and_finish() {
 #[test]
 fn bench_observation_persists_phase_evidence_and_classification() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
 
@@ -457,7 +416,7 @@ fn bench_observation_persists_phase_evidence_and_classification() {
 #[test]
 fn bench_observation_rewrites_invocation_artifacts_to_persisted_paths() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
         let invocation_artifact = run_dir
@@ -543,7 +502,7 @@ fn bench_observation_rewrites_invocation_artifacts_to_persisted_paths() {
 #[test]
 fn bench_observation_persists_nested_failure_diagnostics_before_cleanup() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         let diagnostic = run_dir
             .path()
@@ -617,7 +576,7 @@ fn bench_observation_persists_nested_failure_diagnostics_before_cleanup() {
 #[test]
 fn bench_observation_mirrors_url_artifact_from_run_artifacts_dir() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
         let runtime_artifact = run_dir.path().join("artifacts/finding-packets.json");
@@ -710,7 +669,7 @@ fn bench_observation_mirrors_url_artifact_from_run_artifacts_dir() {
 #[test]
 fn bench_observation_rewrites_cleaned_short_invocation_artifact_paths() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
         let preserved_artifact = run_dir
@@ -780,7 +739,7 @@ fn bench_observation_rewrites_cleaned_short_invocation_artifact_paths() {
 #[test]
 fn bench_observation_persists_workload_artifact_directories() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
         let artifact_dir = run_dir
@@ -866,7 +825,7 @@ fn bench_observation_persists_workload_artifact_directories() {
 #[test]
 fn bench_observation_persists_workflow_error() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
         let mut args = bench_args();
@@ -961,7 +920,7 @@ fn ready_lab() -> LabRunnerReadiness {
 #[test]
 fn bench_observation_persists_resource_policy_warning_for_hot_machine() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         resource_policy::reset_captured_context_for_test();
 
         let synthetic = synthetic_resources(ResourceRecommendation::Hot);
@@ -1033,7 +992,7 @@ fn bench_observation_persists_resource_policy_warning_for_hot_machine() {
 #[test]
 fn bench_observation_records_local_placement_override_with_legacy_evidence() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         resource_policy::reset_captured_context_for_test();
 
         let synthetic = synthetic_resources(ResourceRecommendation::Hot);
@@ -1099,7 +1058,7 @@ fn bench_observation_records_local_placement_override_with_legacy_evidence() {
 #[test]
 fn bench_observation_omits_resource_policy_when_not_captured() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         resource_policy::reset_captured_context_for_test();
 
         let run_dir = RunDir::create().expect("run dir");

--- a/crates/homeboy-cli/src/commands/runs/artifact_index_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/artifact_index_tests.rs
@@ -13,26 +13,7 @@ fn test_store() -> homeboy::core::observation::ObservationStore {
     homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
 }
 
-struct XdgGuard(Option<String>);
-
 struct PublicArtifactBaseGuard(Option<String>);
-
-impl XdgGuard {
-    fn unset() -> Self {
-        let prior = std::env::var("XDG_DATA_HOME").ok();
-        std::env::remove_var("XDG_DATA_HOME");
-        Self(prior)
-    }
-}
-
-impl Drop for XdgGuard {
-    fn drop(&mut self) {
-        match &self.0 {
-            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
-    }
-}
 
 impl PublicArtifactBaseGuard {
     fn unset() -> Self {
@@ -69,7 +50,7 @@ fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> 
 #[test]
 fn runs_list_rig_filter_surfaces_compact_artifact_index() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -161,7 +142,7 @@ fn runs_list_rig_filter_surfaces_compact_artifact_index() {
 #[test]
 fn runs_artifacts_surfaces_matrix_summary_from_typed_packets() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -240,7 +221,7 @@ fn runs_artifacts_surfaces_matrix_summary_from_typed_packets() {
 #[test]
 fn runs_artifacts_pages_large_inventory_and_filters_before_rendering() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -330,7 +311,7 @@ fn runs_artifacts_pages_large_inventory_and_filters_before_rendering() {
 #[test]
 fn runs_artifacts_classifies_persisted_bench_artifact_from_metadata() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -382,7 +363,7 @@ fn runs_artifacts_classifies_persisted_bench_artifact_from_metadata() {
 #[test]
 fn runs_artifacts_recognizes_canonical_fuzz_result_envelope() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -456,7 +437,7 @@ fn runs_artifacts_recognizes_canonical_fuzz_result_envelope() {
 #[test]
 fn runs_artifacts_summarizes_static_site_fixture_matrix_artifacts() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -603,7 +584,7 @@ fn runs_artifacts_summarizes_static_site_fixture_matrix_artifacts() {
 #[test]
 fn runs_artifacts_surfaces_static_html_preview_entrypoints() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let _public_artifact_base = PublicArtifactBaseGuard::unset();
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
@@ -660,7 +641,7 @@ fn runs_artifacts_surfaces_static_html_preview_entrypoints() {
 #[test]
 fn runs_artifacts_returns_empty_for_run_when_only_mismatched_related_artifacts_exist() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let job_id = "job-123";
         let requested_run = store

--- a/crates/homeboy-cli/src/commands/runs/bench/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/bench/mod.rs
@@ -556,25 +556,6 @@ mod tests {
     use homeboy::core::observation::NewRunRecord;
     use homeboy::test_support::with_isolated_home;
 
-    struct XdgGuard(Option<String>);
-
-    impl XdgGuard {
-        fn unset() -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::remove_var("XDG_DATA_HOME");
-            Self(prior)
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
-    }
-
     fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
         NewRunRecord::builder(kind)
             .component_id(component_id)
@@ -590,7 +571,7 @@ mod tests {
     #[test]
     fn bench_compare_reports_deltas_and_missing_metrics() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let from = store
                 .start_run(sample_run(
@@ -718,7 +699,7 @@ mod tests {
     #[test]
     fn bench_compare_rejects_mismatched_shared_context() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let from = store
                 .start_run(sample_run(

--- a/crates/homeboy-cli/src/commands/runs/bundle_import_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/bundle_import_tests.rs
@@ -20,29 +20,10 @@ fn test_store() -> homeboy::core::observation::ObservationStore {
     homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
 }
 
-struct XdgGuard(Option<String>);
-
-impl XdgGuard {
-    fn unset() -> Self {
-        let prior = std::env::var("XDG_DATA_HOME").ok();
-        std::env::remove_var("XDG_DATA_HOME");
-        Self(prior)
-    }
-}
-
-impl Drop for XdgGuard {
-    fn drop(&mut self) {
-        match &self.0 {
-            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
-    }
-}
-
 #[test]
 fn lab_bundle_run_id_conflicts_are_remapped_idempotently() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -207,7 +188,7 @@ fn runs_export_import_preserves_file_artifact_bytes_with_checksum_refs() {
     let mut exported_size_bytes = None;
 
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("fuzz", "homeboy", "rig-a", Value::Null))
@@ -257,7 +238,7 @@ fn runs_export_import_preserves_file_artifact_bytes_with_checksum_refs() {
     });
 
     with_isolated_home(|_| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         import_runs(
             &test_store(),
             RunsImportArgs {
@@ -289,7 +270,7 @@ fn runs_export_import_preserves_directory_artifact_as_checksumed_archive() {
     let mut exported_size_bytes = None;
 
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("fuzz", "homeboy", "rig-a", Value::Null))
@@ -343,7 +324,7 @@ fn runs_export_import_preserves_directory_artifact_as_checksumed_archive() {
     });
 
     with_isolated_home(|_| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         import_runs(
             &test_store(),
             RunsImportArgs {

--- a/crates/homeboy-cli/src/commands/runs/compare.rs
+++ b/crates/homeboy-cli/src/commands/runs/compare.rs
@@ -284,25 +284,6 @@ mod tests {
     use homeboy::core::observation::{NewRunRecord, RunStatus};
     use homeboy::test_support::with_isolated_home;
 
-    struct XdgGuard(Option<String>);
-
-    impl XdgGuard {
-        fn unset() -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::remove_var("XDG_DATA_HOME");
-            Self(prior)
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
-    }
-
     fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
         NewRunRecord::builder(kind)
             .component_id(component_id)
@@ -318,7 +299,7 @@ mod tests {
     #[test]
     fn runs_compare_filters_history_and_reports_selected_metrics() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let old = store
                 .start_run(sample_run(

--- a/crates/homeboy-cli/src/commands/runs/corpus_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/corpus_tests.rs
@@ -24,24 +24,6 @@ fn test_store() -> homeboy::core::observation::ObservationStore {
 
 /// Restore `XDG_DATA_HOME` for the test scope so the observation store
 /// resolves under the temporary home created by `with_isolated_home`.
-struct XdgGuard(Option<String>);
-
-impl XdgGuard {
-    fn unset() -> Self {
-        let prior = std::env::var("XDG_DATA_HOME").ok();
-        std::env::remove_var("XDG_DATA_HOME");
-        Self(prior)
-    }
-}
-
-impl Drop for XdgGuard {
-    fn drop(&mut self) {
-        match &self.0 {
-            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
-    }
-}
 
 fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
     NewRunRecord::builder(kind)
@@ -76,7 +58,7 @@ fn install_artifact(
 #[test]
 fn runs_query_projects_select_jsonpath_over_artifact_corpus() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         install_artifact(
             &store,
@@ -128,7 +110,7 @@ fn runs_query_projects_select_jsonpath_over_artifact_corpus() {
 #[test]
 fn runs_query_groups_by_jsonpath_with_count() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         for theme in ["noir", "noir", "vivid"] {
             install_artifact(
@@ -171,7 +153,7 @@ fn runs_query_groups_by_jsonpath_with_count() {
 #[test]
 fn runs_drift_reports_dominant_value_above_threshold() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         for theme in ["noir", "noir", "noir", "vivid"] {
             install_artifact(
@@ -220,7 +202,7 @@ fn runs_drift_reports_dominant_value_above_threshold() {
 #[test]
 fn import_from_gh_actions_requires_gh_specific_arguments() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         // Without --component, --repo, --workflow/--run-id, --artifact-glob, the
         // gh-actions branch must reject with a missing-argument error.
         let err = import_runs(
@@ -240,7 +222,7 @@ fn import_from_gh_actions_requires_gh_specific_arguments() {
 #[test]
 fn import_from_gh_actions_requires_workflow_or_run_id() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let err = import_runs(
             &test_store(),
             RunsImportArgs {
@@ -265,7 +247,7 @@ fn bundle_import_restores_file_artifacts_and_query_reads_embedded_bytes() {
     let mut source_home_path = String::new();
 
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         source_home_path = home.path().display().to_string();
         let store = ObservationStore::open_initialized().expect("store");
         let run = install_artifact(
@@ -290,7 +272,7 @@ fn bundle_import_restores_file_artifacts_and_query_reads_embedded_bytes() {
     });
 
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let (output, _) = import_runs(
             &test_store(),
             RunsImportArgs {
@@ -338,7 +320,7 @@ fn bundle_import_restores_file_artifacts_and_query_reads_embedded_bytes() {
 #[test]
 fn runs_query_rejects_invalid_jsonpath() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let err = query::runs_query(
             &test_store(),
             query::RunsQueryArgs {
@@ -361,7 +343,7 @@ fn runs_query_rejects_invalid_jsonpath() {
 #[test]
 fn runs_drift_rejects_threshold_outside_unit_interval() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let err = drift::runs_drift(
             &test_store(),
             drift::RunsDriftArgs {

--- a/crates/homeboy-cli/src/commands/runs/distribution.rs
+++ b/crates/homeboy-cli/src/commands/runs/distribution.rs
@@ -224,25 +224,6 @@ mod tests {
     use homeboy::core::observation::{NewRunRecord, RunStatus};
     use homeboy::test_support::with_isolated_home;
 
-    struct XdgGuard(Option<String>);
-
-    impl XdgGuard {
-        fn unset() -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::remove_var("XDG_DATA_HOME");
-            Self(prior)
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
-    }
-
     fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
         NewRunRecord::builder(kind)
             .component_id(component_id)
@@ -258,7 +239,7 @@ mod tests {
     #[test]
     fn distribution_counts_scalar_metadata_values() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             for family in ["serif", "sans", "serif"] {
                 let run = store
@@ -298,7 +279,7 @@ mod tests {
     #[test]
     fn distribution_flattens_array_metadata_values() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             for motifs in [
                 serde_json::json!(["grid", "cards"]),
@@ -338,7 +319,7 @@ mod tests {
     #[test]
     fn distribution_reports_missing_fields() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             for metadata in [
                 serde_json::json!({ "category": "timeout" }),
@@ -370,7 +351,7 @@ mod tests {
     #[test]
     fn distribution_applies_run_filters_and_scenario_filter() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let matching = store
                 .start_run(sample_run(
@@ -449,7 +430,7 @@ mod tests {
     #[test]
     fn distribution_traverses_nested_arrays_in_metadata_paths() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             for motifs in [
                 serde_json::json!(["terminal_window", "glow_overlay"]),
@@ -496,7 +477,7 @@ mod tests {
     #[test]
     fn distribution_reports_repeated_categories_by_occurrence() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run(

--- a/crates/homeboy-cli/src/commands/runs/evidence.rs
+++ b/crates/homeboy-cli/src/commands/runs/evidence.rs
@@ -288,53 +288,6 @@ mod tests {
     };
     use super::*;
 
-    struct XdgGuard(Option<String>);
-
-    struct EnvGuard {
-        key: &'static str,
-        prior: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let prior = std::env::var(key).ok();
-            std::env::set_var(key, value);
-            Self { key, prior }
-        }
-
-        fn unset(key: &'static str) -> Self {
-            let prior = std::env::var(key).ok();
-            std::env::remove_var(key);
-            Self { key, prior }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.prior {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-
-    impl XdgGuard {
-        fn unset() -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::remove_var("XDG_DATA_HOME");
-            Self(prior)
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
-    }
-
     fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
         NewRunRecord::builder(kind)
             .component_id(component_id)
@@ -350,8 +303,9 @@ mod tests {
     #[test]
     fn evidence_command_reports_registry_artifacts_retention_and_failure_summary() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let _public_artifact_base = EnvGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
+            let _public_artifact_base =
+                homeboy_core::test_support::EnvVarGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
             let artifact_root = home.path().join("agent-readable-artifacts");
             homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));
             let store = ObservationStore::open_initialized().expect("store");
@@ -740,7 +694,7 @@ mod tests {
     #[test]
     fn evidence_projection_bounds_large_inventories_and_keeps_the_top_diagnostic() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run(
@@ -910,7 +864,7 @@ mod tests {
     #[test]
     fn evidence_projection_continues_selected_directory_diagnostics_by_handle() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run(
@@ -1107,8 +1061,9 @@ mod tests {
     #[test]
     fn evidence_command_derives_a_manifest_when_no_producer_attached_one() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let _public_artifact_base = EnvGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
+            let _public_artifact_base =
+                homeboy_core::test_support::EnvVarGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
             let artifact_root = home.path().join("agent-readable-artifacts");
             homeboy::core::set_artifact_root_override(Some(artifact_root));
             let store = ObservationStore::open_initialized().expect("store");
@@ -1162,8 +1117,9 @@ mod tests {
     #[test]
     fn evidence_command_surfaces_static_html_preview_entrypoints() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let _public_artifact_base = EnvGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
+            let _public_artifact_base =
+                homeboy_core::test_support::EnvVarGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
             let artifact_root = home.path().join("agent-readable-artifacts");
             homeboy::core::set_artifact_root_override(Some(artifact_root));
             let store = ObservationStore::open_initialized().expect("store");
@@ -1207,10 +1163,10 @@ mod tests {
     #[test]
     fn evidence_command_marks_directory_artifacts_as_published_without_local_paths() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let artifact_root = home.path().join("agent-readable-artifacts");
             homeboy::core::set_artifact_root_override(Some(artifact_root));
-            let _public_artifact_base = EnvGuard::set(
+            let _public_artifact_base = homeboy_core::test_support::EnvVarGuard::set(
                 PUBLIC_ARTIFACT_BASE_URL_ENV,
                 "https://artifacts.example.test/homeboy",
             );
@@ -1254,7 +1210,7 @@ mod tests {
     #[test]
     fn evidence_links_reject_unvalidated_local_urls() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run(
@@ -1290,7 +1246,7 @@ mod tests {
     #[test]
     fn evidence_surfaces_generic_matrix_summary_artifact() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run(
@@ -1359,7 +1315,7 @@ mod tests {
     #[test]
     fn evidence_failure_summary_does_not_mark_running_run_failed() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run(
@@ -1430,8 +1386,9 @@ mod tests {
     #[test]
     fn evidence_includes_related_lab_fuzz_results_for_runner_failure() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let _public_artifact_base = EnvGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
+            let _public_artifact_base =
+                homeboy_core::test_support::EnvVarGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
             let artifact_root = home.path().join("agent-readable-artifacts");
             homeboy::core::set_artifact_root_override(Some(artifact_root));
             let store = ObservationStore::open_initialized().expect("store");

--- a/crates/homeboy-cli/src/commands/runs/findings.rs
+++ b/crates/homeboy-cli/src/commands/runs/findings.rs
@@ -181,25 +181,6 @@ mod tests {
 
     use super::*;
 
-    struct XdgGuard(Option<String>);
-
-    impl XdgGuard {
-        fn unset() -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::remove_var("XDG_DATA_HOME");
-            Self(prior)
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
-    }
-
     fn labeled_run(store: &ObservationStore, label: &str) -> String {
         store
             .start_run(
@@ -241,7 +222,7 @@ mod tests {
         // alias, and filtering on the resolved id is what makes the lookup
         // return the run's findings instead of an empty list.
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run_id = labeled_run(&store, "findings-label");
             record_finding(&store, &run_id);
@@ -270,7 +251,7 @@ mod tests {
         // Behavior preservation: the facade tries the exact record id first, so
         // the pre-existing contract is unchanged.
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run_id = labeled_run(&store, "findings-exact");
             record_finding(&store, &run_id);
@@ -296,7 +277,7 @@ mod tests {
     #[test]
     fn findings_report_the_facade_missing_run_error() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let _store = ObservationStore::open_initialized().expect("store");
             // `RunsOutput` is not `Debug`, so match rather than `expect_err`.
             let error = match findings(

--- a/crates/homeboy-cli/src/commands/runs/hotspots.rs
+++ b/crates/homeboy-cli/src/commands/runs/hotspots.rs
@@ -784,25 +784,6 @@ mod tests {
         }
     }
 
-    struct XdgGuard(Option<String>);
-
-    impl XdgGuard {
-        fn unset() -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::remove_var("XDG_DATA_HOME");
-            Self(prior)
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
-    }
-
     fn sample_run(kind: &str, component_id: &str, rig_id: &str) -> NewRunRecord {
         NewRunRecord::builder(kind)
             .component_id(component_id)
@@ -859,7 +840,7 @@ mod tests {
     #[test]
     fn skipped_directory_fuzz_artifact_points_to_retrieval_command() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run("bench", "homeboy", "studio"))
@@ -906,7 +887,7 @@ mod tests {
         // batched artifact read must key on the resolved record id — keying on
         // the caller-supplied label would silently yield zero artifacts.
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(
@@ -959,7 +940,7 @@ mod tests {
         // The facade's missing-run error carries runner guidance the private
         // helper never produced. Preserve the stable argument/message contract.
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             // `RunsOutput` is not `Debug`, so match rather than `expect_err`.
             let error = match runs_hotspots(
                 &test_store(),

--- a/crates/homeboy-cli/src/commands/runs/reconcile.rs
+++ b/crates/homeboy-cli/src/commands/runs/reconcile.rs
@@ -520,25 +520,6 @@ mod tests {
     use homeboy::core::observation::{NewRunRecord, RunRecord};
     use homeboy::test_support::with_isolated_home;
 
-    struct XdgGuard(Option<String>);
-
-    impl XdgGuard {
-        fn unset() -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::remove_var("XDG_DATA_HOME");
-            Self(prior)
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
-    }
-
     fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
         NewRunRecord::builder(kind)
             .component_id(component_id)
@@ -588,7 +569,7 @@ mod tests {
     #[test]
     fn reconcile_marks_dead_owner_stale_and_preserves_artifacts() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run(
@@ -635,7 +616,7 @@ mod tests {
     #[test]
     fn reconcile_keeps_fresh_ownerless_running_records_running() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             store
                 .import_run(&ownerless_running_run(
@@ -670,7 +651,7 @@ mod tests {
     #[test]
     fn reconcile_keeps_a_recent_runner_backed_running_record_running() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             store
                 .import_run(&phantom_handoff_run("recent-handoff-run", minutes_ago(90)))
@@ -696,7 +677,7 @@ mod tests {
     #[test]
     fn authoritative_terminal_runner_job_outranks_live_daemon_owner() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let mut run = phantom_handoff_run("terminal-runner-job", minutes_ago(1));
             run.metadata_json = serde_json::json!({
@@ -744,7 +725,7 @@ mod tests {
     #[test]
     fn authoritative_active_runner_job_remains_running() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let mut run = phantom_handoff_run(
                 "active-runner-job",
@@ -774,7 +755,7 @@ mod tests {
     #[test]
     fn unavailable_runner_job_status_remains_fail_closed() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let mut run = phantom_handoff_run(
                 "unavailable-runner-job",
@@ -812,7 +793,7 @@ mod tests {
     #[test]
     fn reconcile_marks_a_runner_backed_running_record_stale_past_the_ceiling() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             store
                 .import_run(&phantom_handoff_run(
@@ -885,7 +866,7 @@ mod tests {
     #[test]
     fn targeted_reconcile_preserves_a_terminal_refresh() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run(
@@ -916,7 +897,7 @@ mod tests {
     #[test]
     fn reconcile_preserves_run_dir_child_metadata_when_parent_was_killed() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run_dir = home.path().join("homeboy-run-fixture");
             let children_dir = run_dir.join(run_dir::files::EXTENSION_CHILDREN_DIR);
@@ -973,7 +954,7 @@ mod tests {
     #[test]
     fn reconcile_dry_run_reports_without_mutating() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run("trace", "homeboy", "studio", Value::Null))
@@ -1001,7 +982,7 @@ mod tests {
     #[test]
     fn reconcile_dry_run_leaves_unrelated_running_records_unchanged() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let selected = store
                 .start_run(sample_run(
@@ -1049,7 +1030,7 @@ mod tests {
     #[test]
     fn reconcile_apply_changes_only_selected_candidate_ids() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let selected = store
                 .start_run(sample_run(
@@ -1105,7 +1086,7 @@ mod tests {
     #[test]
     fn live_owned_child_run_remains_running_when_parent_reports_no_active_jobs() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
                 .start_run(sample_run(

--- a/crates/homeboy-cli/src/commands/runs/tests/export_import.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/export_import.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use super::super::{export_runs, import_runs, RunsExportArgs, RunsImportArgs, RunsOutput};
-use super::{sample_run, XdgGuard};
+use super::sample_run;
 
 /// The observation store the enclosing isolated home installs.
 ///
@@ -29,7 +29,7 @@ fn read_bundle_test_json<T: for<'de> Deserialize<'de>>(path: &Path) -> T {
 #[test]
 fn export_one_run_writes_directory_bundle() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -68,7 +68,7 @@ fn export_one_run_writes_directory_bundle() {
 #[test]
 fn export_includes_findings_and_test_failures() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("test", "homeboy", "studio", Value::Null))
@@ -133,7 +133,7 @@ fn export_includes_findings_and_test_failures() {
 #[test]
 fn export_since_writes_multiple_runs() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let first = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -165,7 +165,7 @@ fn export_since_writes_multiple_runs() {
 #[test]
 fn export_embeds_local_file_artifact_bytes() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -203,7 +203,7 @@ fn export_embeds_local_file_artifact_bytes() {
 #[test]
 fn export_rewrites_unproven_remote_artifact_paths_as_metadata_only() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -248,7 +248,7 @@ fn export_rewrites_unproven_remote_artifact_paths_as_metadata_only() {
 #[test]
 fn export_trace_spans_when_present() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("trace", "homeboy", "studio", Value::Null))
@@ -283,7 +283,7 @@ fn export_trace_spans_when_present() {
 #[test]
 fn import_into_empty_db_and_reimport_is_idempotent() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let bundle = home.path().join("portable-bundle");
         let run_id = {
             let store = ObservationStore::open_initialized().expect("store");
@@ -368,7 +368,7 @@ fn import_into_empty_db_and_reimport_is_idempotent() {
 #[test]
 fn malformed_bundle_validation_fails_clearly() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let bundle = home.path().join("bad-bundle");
         std::fs::create_dir_all(&bundle).expect("bundle dir");
         std::fs::write(bundle.join("manifest.json"), "not json").expect("manifest");
@@ -391,7 +391,7 @@ fn malformed_bundle_validation_fails_clearly() {
 #[test]
 fn conflicting_existing_rows_fail_clearly() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -30,53 +30,6 @@ use homeboy::test_support::{
 };
 use serde_json::Value;
 
-struct XdgGuard(Option<String>);
-
-struct EnvGuard {
-    key: &'static str,
-    prior: Option<String>,
-}
-
-impl XdgGuard {
-    fn unset() -> Self {
-        let prior = std::env::var("XDG_DATA_HOME").ok();
-        std::env::remove_var("XDG_DATA_HOME");
-        Self(prior)
-    }
-}
-
-impl Drop for XdgGuard {
-    fn drop(&mut self) {
-        match &self.0 {
-            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
-    }
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let prior = std::env::var(key).ok();
-        std::env::set_var(key, value);
-        Self { key, prior }
-    }
-
-    fn unset(key: &'static str) -> Self {
-        let prior = std::env::var(key).ok();
-        std::env::remove_var(key);
-        Self { key, prior }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match &self.prior {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
-        }
-    }
-}
-
 fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
     NewRunRecord::builder(kind)
         .component_id(component_id)
@@ -92,7 +45,7 @@ fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> 
 #[test]
 fn run_list_filters_kind_component_rig_and_status() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let bench = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -145,7 +98,7 @@ fn run_list_filters_kind_component_rig_and_status() {
 #[test]
 fn run_list_reads_durable_record_without_reconciliation() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         store
             .import_run(&dead_owned_run("dead-owned-run"))
@@ -212,7 +165,7 @@ fn run_list_reads_durable_record_without_reconciliation() {
 #[test]
 fn run_list_does_not_classify_terminal_runs_as_stale() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         for status in [
             RunStatus::Pass,
@@ -340,7 +293,7 @@ fn run_list_collapses_runner_execution_mirrors_by_default() {
     // lineage. The default projection returns one canonical row and reports the
     // collapsed mirror count; --include-mirrors exposes every underlying row.
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let lineage = lab_lineage_metadata("homeboy-lab", "job-9629");
         let caller = store
@@ -396,7 +349,7 @@ fn run_list_collapses_runner_execution_mirrors_by_default() {
 #[test]
 fn run_list_applies_command_and_id_filters() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let keep = store
             .start_run(
@@ -456,7 +409,7 @@ fn run_list_applies_command_and_id_filters() {
 #[test]
 fn run_list_rediscovers_lab_agent_task_lineage_from_canonical_metadata() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let metadata = serde_json::json!({
             "lab": { "runner_id": "homeboy-lab", "remote_job_id": "job-11958" },
@@ -536,7 +489,7 @@ fn run_list_rediscovers_lab_agent_task_lineage_from_canonical_metadata() {
 #[test]
 fn run_discovery_uses_named_provenance_and_normalized_workspace_boundaries() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         store
             .import_run(&RunRecord {
@@ -648,7 +601,7 @@ fn run_discovery_uses_named_provenance_and_normalized_workspace_boundaries() {
 #[test]
 fn run_discovery_walks_beyond_legacy_prefetch_prefix() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         for index in 0..5 {
             store
@@ -698,7 +651,7 @@ fn run_discovery_walks_beyond_legacy_prefetch_prefix() {
 #[test]
 fn runs_reconcile_explicitly_reconciles_owned_dead_running_runs() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         store
             .import_run(&dead_owned_run("dead-owned-run"))
@@ -741,7 +694,7 @@ fn runs_reconcile_explicitly_reconciles_owned_dead_running_runs() {
 #[test]
 fn runs_reconcile_immediately_terminalizes_dead_deploy_observation_owner() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let mut child = std::process::Command::new("sh")
             .args(["-c", "sleep 0.05"])
@@ -791,7 +744,7 @@ fn runs_reconcile_immediately_terminalizes_dead_deploy_observation_owner() {
 #[test]
 fn run_show_includes_metadata_and_artifacts() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -824,9 +777,10 @@ fn run_show_includes_metadata_and_artifacts() {
 #[test]
 fn runs_dossier_aggregates_failure_env_refs_artifacts_and_commands() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
-        let _public_artifact_base =
-            EnvGuard::unset(homeboy::core::artifacts::PUBLIC_ARTIFACT_BASE_URL_ENV);
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
+        let _public_artifact_base = homeboy_core::test_support::EnvVarGuard::unset(
+            homeboy::core::artifacts::PUBLIC_ARTIFACT_BASE_URL_ENV,
+        );
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -943,7 +897,7 @@ fn runs_dossier_loads_artifacts_for_a_durable_run_label() {
 #[test]
 fn run_show_reads_owned_dead_running_run_without_mutating_it() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         store
             .import_run(&dead_owned_run("dead-owned-run"))
@@ -960,7 +914,7 @@ fn run_show_reads_owned_dead_running_run_without_mutating_it() {
 #[test]
 fn runs_env_explains_redacted_lab_env_resolution() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -1047,7 +1001,7 @@ fn runs_env_explains_redacted_lab_env_resolution() {
 #[test]
 fn runs_env_refuses_unredacted_env_resolution() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -1080,7 +1034,7 @@ fn runs_env_refuses_unredacted_env_resolution() {
 #[test]
 fn artifacts_command_reports_paths() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("trace", "homeboy", "studio", Value::Null))
@@ -1110,7 +1064,7 @@ fn artifacts_command_reports_paths() {
 #[test]
 fn artifacts_command_reports_url_artifacts() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -1136,7 +1090,7 @@ fn artifacts_command_reports_url_artifacts() {
 #[test]
 fn runner_job_artifact_listing_includes_related_sibling_lab_run_artifacts() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let job_id = "job-123";
         let runner_run = RunRecord {
@@ -1194,7 +1148,7 @@ fn runner_job_artifact_listing_includes_related_sibling_lab_run_artifacts() {
 #[test]
 fn runner_job_artifact_listing_includes_related_lab_run_artifacts() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let job_id = "job-123";
         let runner_run = RunRecord {
@@ -1278,7 +1232,7 @@ fn runner_job_artifact_listing_includes_related_lab_run_artifacts() {
 #[test]
 fn bench_artifact_listing_does_not_include_sibling_lab_run_artifacts() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let job_id = "job-123";
         let requested_run = RunRecord {
@@ -1345,7 +1299,7 @@ fn bench_artifact_listing_does_not_include_sibling_lab_run_artifacts() {
 #[test]
 fn runner_job_show_keeps_local_evidence_when_refresh_runner_is_unavailable() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = RunRecord {
             id: "runner-exec-missing-lab-job-123".to_string(),
@@ -1382,7 +1336,7 @@ fn runner_job_show_keeps_local_evidence_when_refresh_runner_is_unavailable() {
 #[test]
 fn runner_job_artifacts_keep_local_evidence_when_refresh_runner_is_unavailable() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = RunRecord {
             id: "runner-exec-missing-lab-job-456".to_string(),
@@ -1424,8 +1378,8 @@ fn runner_job_artifacts_keep_local_evidence_when_refresh_runner_is_unavailable()
 #[test]
 fn artifacts_command_marks_directory_publication_status_and_command() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
-        let _artifact_url = EnvGuard::set(
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
+        let _artifact_url = homeboy_core::test_support::EnvVarGuard::set(
             homeboy::core::artifacts::PUBLIC_ARTIFACT_BASE_URL_ENV,
             "https://artifacts.example.test/homeboy",
         );
@@ -1465,7 +1419,7 @@ fn artifacts_command_marks_directory_publication_status_and_command() {
 #[test]
 fn artifacts_command_lists_copy_paste_get_commands_with_names() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -1538,7 +1492,7 @@ fn artifacts_command_lists_copy_paste_get_commands_with_names() {
 #[test]
 fn artifact_get_copies_registered_file_without_raw_path_lookup() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -1592,7 +1546,7 @@ fn artifact_get_copies_registered_file_without_raw_path_lookup() {
 #[test]
 fn artifact_get_field_selector_projects_only_requested_fields() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -1645,7 +1599,7 @@ fn artifact_get_field_selector_projects_only_requested_fields() {
 #[test]
 fn show_run_field_selector_projects_run_detail_fields() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -1668,7 +1622,7 @@ fn show_run_field_selector_projects_run_detail_fields() {
 #[test]
 fn artifact_get_fetches_nested_publication_artifact_store_ref() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
@@ -1739,7 +1693,7 @@ fn artifact_get_fetches_nested_publication_artifact_store_ref() {
 #[test]
 fn artifacts_index_and_fetch_nested_visual_summary_refs_from_public_urls() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run(
@@ -1819,9 +1773,9 @@ fn artifacts_index_and_fetch_nested_visual_summary_refs_from_public_urls() {
 #[test]
 fn artifacts_command_derives_viewer_links_from_public_artifact_url_metadata() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let public_artifact_base = serve_public_artifact_base(200, 2);
-        let _artifact_url = EnvGuard::set(
+        let _artifact_url = homeboy_core::test_support::EnvVarGuard::set(
             homeboy::core::artifacts::PUBLIC_ARTIFACT_BASE_URL_ENV,
             &public_artifact_base,
         );
@@ -1918,9 +1872,9 @@ fn artifacts_command_derives_viewer_links_from_public_artifact_url_metadata() {
 #[test]
 fn artifacts_command_suppresses_viewer_links_when_public_url_is_unreachable() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let public_artifact_base = serve_public_artifact_base(404, 2);
-        let _artifact_url = EnvGuard::set(
+        let _artifact_url = homeboy_core::test_support::EnvVarGuard::set(
             homeboy::core::artifacts::PUBLIC_ARTIFACT_BASE_URL_ENV,
             &public_artifact_base,
         );
@@ -1968,7 +1922,7 @@ fn artifacts_command_suppresses_viewer_links_when_public_url_is_unreachable() {
 #[test]
 fn findings_commands_list_and_show_records() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("lint", "homeboy", "studio", Value::Null))
@@ -2019,7 +1973,7 @@ fn findings_commands_list_and_show_records() {
 #[test]
 fn latest_run_command_returns_newest_matching_run() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let old = store
             .start_run(sample_run("lint", "homeboy", "studio", Value::Null))
@@ -2053,7 +2007,7 @@ fn latest_run_command_returns_newest_matching_run() {
 #[test]
 fn latest_finding_command_uses_latest_matching_run() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let old_run = store
             .start_run(sample_run("lint", "homeboy", "studio", Value::Null))
@@ -2113,7 +2067,7 @@ fn latest_finding_command_uses_latest_matching_run() {
 #[test]
 fn bench_history_orders_and_filters_by_scenario() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let old = store
             .start_run(sample_run(
@@ -2186,7 +2140,7 @@ fn bench_history_orders_and_filters_by_scenario() {
 #[test]
 fn missing_and_mismatched_run_ids_return_clear_errors() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let trace = store
             .start_run(sample_run("trace", "homeboy", "studio", Value::Null))

--- a/crates/homeboy-cli/src/commands/test.rs
+++ b/crates/homeboy-cli/src/commands/test.rs
@@ -1542,36 +1542,9 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
-    struct XdgGuard {
-        prior: Option<String>,
-    }
-
     struct EnvVarGuard {
         name: &'static str,
         prior: Option<String>,
-    }
-
-    impl XdgGuard {
-        fn unset() -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::remove_var("XDG_DATA_HOME");
-            Self { prior }
-        }
-
-        fn set(value: &std::path::Path) -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::set_var("XDG_DATA_HOME", value);
-            Self { prior }
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            match &self.prior {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
     }
 
     impl EnvVarGuard {
@@ -1944,7 +1917,7 @@ mod tests {
     #[test]
     fn test_observation_start_persists_run_record() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
 
             let observation = start_test_observation("homeboy", home.path(), &args, "test", None)
@@ -1986,7 +1959,7 @@ mod tests {
     #[test]
     fn test_observation_keeps_run_dir_out_of_initial_metadata() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
             let run_dir = RunDir::create().expect("run dir");
 
@@ -2008,7 +1981,7 @@ mod tests {
     #[test]
     fn injected_artifact_store_failure_terminalizes_collection_and_cleans_scratch() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
             let runner = ObservedWorkflowRunner::create("test homeboy").expect("runner");
             let scratch_path = runner.run_dir().path().to_path_buf();
@@ -2107,7 +2080,7 @@ mod tests {
     #[test]
     fn test_observation_persists_test_failures_and_analysis_clusters() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
             let observation = start_test_observation("homeboy", home.path(), &args, "test", None)
                 .expect("observation should start");
@@ -2194,7 +2167,7 @@ mod tests {
     #[test]
     fn test_observation_attaches_validation_command_output() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
             let run_dir = RunDir::create().expect("run dir");
             let stdout = homeboy::core::validation_progress::write_command_artifact(
@@ -2269,7 +2242,7 @@ mod tests {
     #[test]
     fn failing_test_persists_declared_artifacts_and_records_missing_provenance() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
             let run_dir = RunDir::create().expect("run dir");
             let files = run_dir.path().join("files");
@@ -2437,7 +2410,7 @@ mod tests {
     #[test]
     fn delayed_passing_counts_only_pass_when_the_runner_succeeded() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
 
             for (runner_exit_code, expected_status, expected_exit_code) in
@@ -2592,7 +2565,7 @@ mod tests {
     #[test]
     fn interrupted_test_observation_persists_parseable_partial_child_evidence() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let args = sample_args();
             let run_dir = RunDir::create().expect("run dir");
             std::fs::write(
@@ -2667,7 +2640,8 @@ mod tests {
         with_isolated_home(|home| {
             let bad_data_home = home.path().join("not-a-dir");
             fs::write(&bad_data_home, "file blocks observation dir").expect("write marker");
-            let _xdg = XdgGuard::set(&bad_data_home);
+            let _xdg =
+                homeboy_core::test_support::EnvVarGuard::set("XDG_DATA_HOME", &bad_data_home);
             let _data_dir =
                 EnvVarGuard::set(homeboy::core::paths::HOMEBOY_DATA_DIR_ENV, &bad_data_home);
 

--- a/crates/homeboy-core/src/observation/runs_service/tests.rs
+++ b/crates/homeboy-core/src/observation/runs_service/tests.rs
@@ -9,25 +9,6 @@ use crate::test_support::with_isolated_home;
 use serde_json::Value;
 use std::sync::{mpsc, Mutex};
 
-struct XdgGuard(Option<String>);
-
-impl XdgGuard {
-    fn unset() -> Self {
-        let prior = std::env::var("XDG_DATA_HOME").ok();
-        std::env::remove_var("XDG_DATA_HOME");
-        Self(prior)
-    }
-}
-
-impl Drop for XdgGuard {
-    fn drop(&mut self) {
-        match &self.0 {
-            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
-    }
-}
-
 fn sample_run(kind: &str) -> NewRunRecord {
     NewRunRecord::builder(kind)
         .component_id("homeboy")
@@ -43,7 +24,7 @@ fn sample_run(kind: &str) -> NewRunRecord {
 #[test]
 fn require_run_returns_validation_error_for_missing_run() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let err = require_run(&store, "missing-run").expect_err("missing");
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
@@ -54,7 +35,7 @@ fn require_run_returns_validation_error_for_missing_run() {
 #[test]
 fn terminal_retention_is_dry_run_by_default_and_deletes_owned_lifecycle_on_apply() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let terminal = store
             .start_run(sample_run("agent-task"))
@@ -141,7 +122,7 @@ fn terminal_retention_is_dry_run_by_default_and_deletes_owned_lifecycle_on_apply
 #[test]
 fn terminal_retention_counts_only_the_runs_it_actually_deleted() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
 
         // Two aged terminal runs. One holds an artifact that cleanup must
@@ -225,7 +206,7 @@ fn missing_run_guidance_prints_runner_routed_retrieval_commands() {
 #[test]
 fn list_artifacts_for_run_enriches_url_artifact_links() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store.start_run(sample_run("bench")).expect("run");
         store
@@ -247,7 +228,7 @@ fn list_artifacts_for_run_enriches_url_artifact_links() {
 #[test]
 fn load_run_with_artifacts_uses_the_resolved_canonical_run_id() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(
@@ -277,7 +258,7 @@ fn load_run_with_artifacts_uses_the_resolved_canonical_run_id() {
 #[test]
 fn resolve_artifact_for_run_rejects_unknown_artifact_id() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store.start_run(sample_run("bench")).expect("run");
         let err = resolve_artifact_for_run(&store, &run.id, "missing-artifact")
@@ -293,7 +274,7 @@ fn resolve_artifact_for_run_rejects_unknown_artifact_id() {
 #[test]
 fn resolve_artifact_for_run_unknown_id_lists_available_names() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store.start_run(sample_run("bench")).expect("run");
         let source = home.path().join("bench-results.json");
@@ -317,7 +298,7 @@ fn resolve_artifact_for_run_unknown_id_lists_available_names() {
 #[test]
 fn copy_local_file_artifact_writes_bytes_and_reports_metadata() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store.start_run(sample_run("bench")).expect("run");
         let source = home.path().join("bench-results.json");
@@ -597,7 +578,7 @@ fn match_run_label_resolves_label_from_command_id_and_metadata() {
 #[test]
 fn resolve_run_id_or_label_returns_local_run_id_unchanged() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store.start_run(sample_run("bench.matrix")).expect("run");
         let resolved = resolve_run_id_or_label(&store, &run.id).expect("resolve existing run id");
@@ -608,7 +589,7 @@ fn resolve_run_id_or_label_returns_local_run_id_unchanged() {
 #[test]
 fn require_run_resolves_requested_run_id_metadata_alias() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(
@@ -699,7 +680,7 @@ fn require_run_reads_terminal_lab_review_alias_while_runner_probe_is_stalled() {
         .expect("provider test lock");
 
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let label = "runner-exec-review-homeboy-lab-terminal-job";
         let run = RunRecord {
@@ -763,7 +744,7 @@ fn require_run_reads_terminal_lab_review_alias_while_runner_probe_is_stalled() {
 #[test]
 fn list_artifacts_for_run_resolves_requested_run_id_alias() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(
@@ -792,7 +773,7 @@ fn list_artifacts_for_run_resolves_requested_run_id_alias() {
 #[test]
 fn require_run_rejects_ambiguous_requested_run_id_alias() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let first = store
             .start_run(
@@ -862,7 +843,7 @@ fn lab_labeled_run(id: &str, kind: &str, label: &str, job_id: &str) -> RunRecord
 #[test]
 fn require_run_resolves_lab_label_to_caller_across_mirrors() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let caller = lab_labeled_run("caller", "fuzz", "shared-label", "job-1");
         store.upsert_imported_run(&caller).expect("caller");
@@ -880,7 +861,7 @@ fn require_run_resolves_lab_label_to_caller_across_mirrors() {
 #[test]
 fn require_run_keeps_unrelated_lab_label_collision_ambiguous() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let caller = lab_labeled_run("caller", "fuzz", "shared-label", "job-1");
         let collision = lab_labeled_run("collision", "fuzz", "shared-label", "job-2");

--- a/crates/homeboy-core/src/observation/store/findings.rs
+++ b/crates/homeboy-core/src/observation/store/findings.rs
@@ -292,25 +292,6 @@ mod tests {
     use super::*;
     use crate::test_support::with_isolated_home;
 
-    struct XdgGuard(Option<String>);
-
-    impl XdgGuard {
-        fn unset() -> Self {
-            let prior = std::env::var("XDG_DATA_HOME").ok();
-            std::env::remove_var("XDG_DATA_HOME");
-            Self(prior)
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-        }
-    }
-
     fn new_run() -> NewRunRecord {
         NewRunRecord::builder("lint")
             .component_id("homeboy")
@@ -338,7 +319,7 @@ mod tests {
     #[test]
     fn test_record_finding() {
         with_isolated_home(|_| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store.start_run(new_run()).expect("start");
 
@@ -353,7 +334,7 @@ mod tests {
     #[test]
     fn test_record_findings() {
         with_isolated_home(|_| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store.start_run(new_run()).expect("start");
 
@@ -373,7 +354,7 @@ mod tests {
     #[test]
     fn test_record_findings_rejects_unknown_run_before_insert() {
         with_isolated_home(|_| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
 
             let result = store.record_findings(&[
@@ -392,7 +373,7 @@ mod tests {
     #[test]
     fn test_record_findings_requires_one_run_per_batch() {
         with_isolated_home(|_| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let first = store.start_run(new_run()).expect("first run");
             let second = store.start_run(new_run()).expect("second run");
@@ -413,7 +394,7 @@ mod tests {
     #[test]
     fn test_list_findings() {
         with_isolated_home(|_| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store.start_run(new_run()).expect("start");
             store
@@ -438,7 +419,7 @@ mod tests {
     #[test]
     fn test_latest_finding_uses_filters_and_deterministic_tie_break() {
         with_isolated_home(|_| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store.start_run(new_run()).expect("start");
             let old = store

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1928,6 +1928,19 @@ impl EnvVarGuard {
             prior,
         }
     }
+
+    /// Remove `name` for the guard's lifetime, restoring any prior value.
+    ///
+    /// Tests that assert a fallback path need the variable absent rather than
+    /// set, which is the half every hand-rolled copy of this guard existed for.
+    pub fn unset(name: &str) -> Self {
+        let prior = std::env::var_os(name);
+        unsafe { std::env::remove_var(name) };
+        Self {
+            name: name.to_string(),
+            prior,
+        }
+    }
 }
 
 impl Drop for EnvVarGuard {

--- a/tests/agent_task_promotion_provider.rs
+++ b/tests/agent_task_promotion_provider.rs
@@ -117,7 +117,7 @@ fn promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_i
     .to_string();
 
     let report = homeboy::agents::agent_task_promotion::promote(
-        homeboy::agents::agent_task_promotion::AgentTaskPromotionOptions {
+        homeboy::agents::agent_task_promotion::AgentTaskPromotionRequest {
             source,
             source_run_id: Some(run_id.clone()),
             source_path: None,

--- a/tests/commands/bench/observation_artifact_test.rs
+++ b/tests/commands/bench/observation_artifact_test.rs
@@ -8,14 +8,14 @@ use homeboy_core::extension::bench::artifact::BenchArtifact;
 use homeboy_core::extension::bench::result_types::BenchRunMetadata;
 use homeboy_core::extension::bench::{BenchRunExecution, BenchRunWorkflowResult};
 
-use super::tests::{bench_args, bench_results, XdgGuard};
+use super::tests::{bench_args, bench_results};
 use super::{finish_success, start, BenchObservationStart};
 use crate::test_support::with_isolated_home;
 
 #[test]
 fn bench_observation_reports_missing_and_blocked_artifacts() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
         fs::write(run_dir.path().join("promoted.json"), b"{}").expect("promoted artifact");
@@ -120,7 +120,7 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
 #[test]
 fn bench_observation_keeps_retained_artifact_when_public_alias_returns_404() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let public_alias = serve_public_alias(404);
         let prior_public_base = std::env::var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL").ok();
         std::env::set_var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL", &public_alias);
@@ -211,7 +211,7 @@ fn serve_public_alias(status: u16) -> String {
 #[test]
 fn bench_observation_rejects_url_only_artifacts_as_terminal_evidence() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
         let mut results = bench_results("homeboy", "cold", 42.0);
@@ -272,7 +272,7 @@ fn bench_observation_rejects_url_only_artifacts_as_terminal_evidence() {
 #[test]
 fn bench_observation_promotes_required_directory_with_tree_identity() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
         let directory = run_dir.path().join("artifacts/visual");
@@ -339,7 +339,7 @@ fn bench_observation_promotes_required_directory_with_tree_identity() {
 #[test]
 fn bench_observation_resolves_shared_state_mount_artifacts() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
 

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -63,27 +63,6 @@ fn test_run_analysis_job() {
     assert_eq!(output.output["argv"][1], "lint");
 }
 
-struct XdgGuard {
-    prior: Option<String>,
-}
-
-impl XdgGuard {
-    fn unset() -> Self {
-        let prior = std::env::var("XDG_DATA_HOME").ok();
-        std::env::remove_var("XDG_DATA_HOME");
-        Self { prior }
-    }
-}
-
-impl Drop for XdgGuard {
-    fn drop(&mut self) {
-        match &self.prior {
-            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
-    }
-}
-
 #[test]
 fn routes_component_endpoints() {
     assert_eq!(
@@ -1635,7 +1614,7 @@ fn control_plane_run_id_is_bounded_before_the_record_lookup() {
 #[test]
 fn activity_endpoint_exposes_activity_report_and_show() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("test", "homeboy", "studio"))
@@ -1961,7 +1940,7 @@ fn generic_job_cancel_is_idempotent_without_duplicating_events() {
 #[test]
 fn runs_list_includes_active_runner_jobs() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         ObservationStore::open_initialized().expect("store");
         let store = JobStore::default();
         let job = store
@@ -2044,7 +2023,7 @@ fn runs_list_includes_active_runner_jobs() {
 #[test]
 fn active_runner_job_run_lookup_preserves_daemon_identity_when_hydration_is_partial() {
     with_isolated_home(|_| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let observations = ObservationStore::open_initialized().expect("store");
 
         for (run_id, persisted) in [
@@ -2123,7 +2102,7 @@ fn active_runner_job_run_lookup_preserves_daemon_identity_when_hydration_is_part
 #[test]
 fn test_handle() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let bench = store
             .start_run(sample_run("bench", "homeboy", "studio"))
@@ -2212,7 +2191,7 @@ fn test_handle() {
 #[test]
 fn run_artifacts_keeps_legacy_http_clients_exhaustive_and_pages_explicit_requests() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "artifact-pagination"))
@@ -2249,7 +2228,7 @@ fn run_artifacts_keeps_legacy_http_clients_exhaustive_and_pages_explicit_request
 #[test]
 fn runs_list_reconciles_old_ownerless_running_records_before_responding() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let mut run = sample_imported_running_run("agent-task", "homeboy", "homeboy-lab");
         run.id = "legacy-ownerless-run".to_string();
@@ -2283,7 +2262,7 @@ fn runs_list_reconciles_old_ownerless_running_records_before_responding() {
 #[test]
 fn artifact_content_serves_encoded_artifact_store_locator() {
     with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio"))
@@ -2344,7 +2323,7 @@ fn artifact_content_serves_encoded_artifact_store_locator() {
 #[test]
 fn artifact_content_serves_percent_encoded_stored_artifact_ids() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::unset();
+        let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio"))

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -24,69 +24,15 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, Barrier};
 use std::time::{Duration, Instant};
 
-struct XdgGuard {
-    prior: Option<String>,
-}
-
-struct EnvGuard {
-    key: &'static str,
-    prior: Option<String>,
-}
-
-impl XdgGuard {
-    fn unset() -> Self {
-        let prior = std::env::var("XDG_DATA_HOME").ok();
-        std::env::remove_var("XDG_DATA_HOME");
-        Self { prior }
-    }
-}
-
-impl Drop for XdgGuard {
-    fn drop(&mut self) {
-        match &self.prior {
-            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
-    }
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: String) -> Self {
-        let prior = std::env::var(key).ok();
-        std::env::set_var(key, value);
-        Self { key, prior }
-    }
-
-    /// Clear a variable for the guard's lifetime.
-    ///
-    /// Needed for the XDG-layout assertions below: `with_isolated_home` sets
-    /// `HOMEBOY_DATA_DIR`, and `homeboy_data()` checks it *before* consulting
-    /// `XDG_DATA_HOME` -- so an `XdgGuard` alone cannot reach the path it is
-    /// setting up. Same drift documented in #11919.
-    fn unset(key: &'static str) -> Self {
-        let prior = std::env::var(key).ok();
-        std::env::remove_var(key);
-        Self { key, prior }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match &self.prior {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
-        }
-    }
-}
-
 mod store_init_tests {
     use super::*;
 
     #[test]
     fn test_status() {
         with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let _data_dir = EnvGuard::unset(crate::paths::HOMEBOY_DATA_DIR_ENV);
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
+            let _data_dir =
+                homeboy_core::test_support::EnvVarGuard::unset(crate::paths::HOMEBOY_DATA_DIR_ENV);
 
             let status = store::status().expect("status");
 
@@ -122,7 +68,8 @@ mod store_init_tests {
     #[test]
     fn test_database_path() {
         with_isolated_home(|home| {
-            let _data_dir = EnvGuard::unset(crate::paths::HOMEBOY_DATA_DIR_ENV);
+            let _data_dir =
+                homeboy_core::test_support::EnvVarGuard::unset(crate::paths::HOMEBOY_DATA_DIR_ENV);
 
             let path = store::database_path().expect("db path");
 
@@ -813,7 +760,7 @@ mod run_context_tests {
     #[test]
     fn start_run_records_subprocess_source_snapshot_metadata() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("init store");
             let snapshot = serde_json::json!({
                 "runner_id": "lab",
@@ -825,7 +772,10 @@ mod run_context_tests {
                 "sync_excludes": ["node_modules/"]
             });
 
-            let _env = EnvGuard::set(SOURCE_SNAPSHOT_METADATA_ENV, snapshot.to_string());
+            let _env = homeboy_core::test_support::EnvVarGuard::set(
+                SOURCE_SNAPSHOT_METADATA_ENV,
+                snapshot.to_string(),
+            );
             let run = store
                 .start_run(sample_run("test", "homeboy"))
                 .expect("start run");
@@ -837,7 +787,7 @@ mod run_context_tests {
     #[test]
     fn start_run_records_subprocess_lab_offload_metadata() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("init store");
             let lab = serde_json::json!({
                 "source": "automatic",
@@ -847,7 +797,10 @@ mod run_context_tests {
                 "fallback_reason": "runner connect timed out after 3s"
             });
 
-            let _env = EnvGuard::set(LAB_OFFLOAD_METADATA_ENV, lab.to_string());
+            let _env = homeboy_core::test_support::EnvVarGuard::set(
+                LAB_OFFLOAD_METADATA_ENV,
+                lab.to_string(),
+            );
             let run = store
                 .start_run(sample_run("test", "homeboy"))
                 .expect("start run");
@@ -859,14 +812,19 @@ mod run_context_tests {
     #[test]
     fn start_run_prefers_typed_context_over_subprocess_environment() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("init store");
             let env_snapshot = serde_json::json!({ "runner_id": "env" });
             let explicit_snapshot = serde_json::json!({ "runner_id": "typed" });
             let explicit_lab = serde_json::json!({ "status": "fallback", "source": "typed" });
-            let _env_snapshot =
-                EnvGuard::set(SOURCE_SNAPSHOT_METADATA_ENV, env_snapshot.to_string());
-            let _env_lab = EnvGuard::set(LAB_OFFLOAD_METADATA_ENV, "{not json".to_string());
+            let _env_snapshot = homeboy_core::test_support::EnvVarGuard::set(
+                SOURCE_SNAPSHOT_METADATA_ENV,
+                env_snapshot.to_string(),
+            );
+            let _env_lab = homeboy_core::test_support::EnvVarGuard::set(
+                LAB_OFFLOAD_METADATA_ENV,
+                "{not json".to_string(),
+            );
 
             let run = store
                 .start_run(
@@ -886,11 +844,16 @@ mod run_context_tests {
     #[test]
     fn malformed_subprocess_environment_does_not_pollute_typed_context() {
         with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+            let _xdg = homeboy_core::test_support::EnvVarGuard::unset("XDG_DATA_HOME");
             let store = ObservationStore::open_initialized().expect("init store");
-            let _env_snapshot =
-                EnvGuard::set(SOURCE_SNAPSHOT_METADATA_ENV, "{not json".to_string());
-            let _env_lab = EnvGuard::set(LAB_OFFLOAD_METADATA_ENV, "{not json".to_string());
+            let _env_snapshot = homeboy_core::test_support::EnvVarGuard::set(
+                SOURCE_SNAPSHOT_METADATA_ENV,
+                "{not json".to_string(),
+            );
+            let _env_lab = homeboy_core::test_support::EnvVarGuard::set(
+                LAB_OFFLOAD_METADATA_ENV,
+                "{not json".to_string(),
+            );
 
             let run = store
                 .start_run_with_context(


### PR DESCRIPTION
## Summary
`homeboy_core::test_support::EnvVarGuard` already sets an environment variable and restores it on drop. Nine test modules had rewritten it anyway — six as `XdgGuard`, three as `EnvGuard` — and `commands/test.rs` had even redeclared a local type literally named `EnvVarGuard`.

**−667/+232, net 435 lines removed** across 22 files.

## Why they existed
The canonical guard only had `set`. Every copy existed because a test needed the variable *absent* — asserting a fallback path — so each one open-coded the same twelve-line unset-and-restore.

`EnvVarGuard::unset` closes that gap, and the copies collapse. That is one small addition to the shared helper against nine bespoke reimplementations, all of which had to get `Drop` right independently.

## What was deliberately left alone
Five `EnvGuard` copies also hold a `MutexGuard`, serialising tests that mutate the same variable. That is a different job from restoring a value and the shared guard does not do it, so they stay:

- `core/lab_routing.rs`, `core/artifact_origin.rs`, `core/artifact_links.rs`
- `cli/cli_runtime.rs`, `cli/commands/infra/route/tests/mod.rs`

Two more bake their key into the constructor with a different signature (`rig/local_artifact.rs`, `core/defaults.rs`) and were not worth reshaping for this.

Only the nine that were pure duplication are gone.

## Verification
`cargo check --workspace --tests --all-targets` is clean.

| suite | result |
|---|---|
| `homeboy-core` observation / http_api / store | **445 passed, 0 failed** |
| `homeboy-cli` runs / bench | **417 passed, 0 failed** |

Those are the modules that owned the deleted guards.

Related to #13227 (consolidate duplicated fixtures into shared `test_support`).

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode found the duplication by scanning for type names defined in more than one file, added the missing `unset` half to the shared guard, collapsed the nine pure copies, and ran the owning suites. Chris Huber directed the work and remains responsible for acceptance.