### PR TITLE
fix(git): complete shared fetch authority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
 name = "homeboy-engine-primitives"
 version = "0.1.0"
 dependencies = [
+ "fs4",
  "homeboy-error",
  "homeboy-paths",
  "inventory",

--- a/crates/homeboy-core/src/git/changes.rs
+++ b/crates/homeboy-core/src/git/changes.rs
@@ -232,36 +232,38 @@ fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
 
     eprintln!("Shallow clone detected — deepening to resolve merge base for {git_ref}");
     let repository = Path::new(path);
-    let remote = resolve_default_remote(repository);
+    let (remote, reference) = remote_and_ref(path, git_ref);
+    let tracking_ref = reference.strip_prefix("refs/heads/").unwrap_or(&reference);
+    let refspec = format!("{reference}:refs/remotes/{remote}/{tracking_ref}");
     let deadline = Instant::now() + Duration::from_secs(30);
-    let _ = fetch_remote_tracking_refs_until(
+    fetch_remote_tracking_refs_until(
         repository,
-        &["fetch", &remote, git_ref, "--depth=50"],
+        &["fetch", &remote, &refspec, "--depth=50"],
         "git fetch changed-since ref",
         &[],
         deadline,
-    );
+    )?;
     for depth in ["50", "200"] {
-        let _ = fetch_remote_tracking_refs_until(
+        fetch_remote_tracking_refs_until(
             repository,
             &["fetch", "--deepen", depth],
             "git deepen changed-since history",
             &[],
             deadline,
-        );
+        )?;
         if has_merge_base(path, git_ref) {
             eprintln!("Merge base found after deepening by {depth} commits");
             return Ok(());
         }
     }
     eprintln!("Merge base not found with depth 200, unshallowing repository");
-    let _ = fetch_remote_tracking_refs_until(
+    fetch_remote_tracking_refs_until(
         repository,
         &["fetch", "--unshallow"],
         "git unshallow changed-since history",
         &[],
         deadline,
-    );
+    )?;
     if has_merge_base(path, git_ref) {
         eprintln!("Merge base found after full unshallow");
         Ok(())
@@ -270,6 +272,27 @@ fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
             "Cannot resolve merge base for {git_ref} even after full unshallow — the ref may not exist in the remote"
         )))
     }
+}
+
+fn remote_and_ref(path: &str, git_ref: &str) -> (String, String) {
+    let remote_ref = git_ref.strip_prefix("refs/remotes/").unwrap_or(git_ref);
+    if let Some((remote, reference)) = remote_ref.split_once('/') {
+        let remotes = execute_git(path, &["remote"])
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| {
+                String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .map(str::trim)
+                    .any(|name| name == remote)
+            })
+            .unwrap_or(false);
+        if !reference.is_empty() && remotes {
+            return (remote.to_string(), reference.to_string());
+        }
+    }
+
+    (resolve_default_remote(Path::new(path)), git_ref.to_string())
 }
 
 fn is_shallow_repo(path: &str) -> bool {

--- a/crates/homeboy-core/src/git/changes.rs
+++ b/crates/homeboy-core/src/git/changes.rs
@@ -677,6 +677,71 @@ mod tests {
         assert!(files.contains(&"untracked.txt".to_string()));
     }
 
+    #[test]
+    fn resolve_merge_base_deepens_remote_qualified_ref_through_named_remote() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let source = dir.path().join("source");
+        let remote = dir.path().join("remote.git");
+        let checkout = dir.path().join("checkout");
+        fs::create_dir(&source).expect("create source");
+        let source_path = source.to_str().expect("utf-8 source path");
+        init_repo_with_initial_commit(source_path);
+        git(source_path, &["checkout", "-qb", "feature"]);
+        fs::write(source.join("feature.txt"), "feature\n").expect("write feature commit");
+        git(source_path, &["add", "."]);
+        git(source_path, &["commit", "-qm", "feature"]);
+        git(
+            source_path,
+            &[
+                "init",
+                "--bare",
+                "-q",
+                remote.to_str().expect("utf-8 remote path"),
+            ],
+        );
+        git(
+            source_path,
+            &[
+                "remote",
+                "add",
+                "upstream",
+                remote.to_str().expect("utf-8 remote path"),
+            ],
+        );
+        git(source_path, &["push", "-q", "upstream", "main", "feature"]);
+
+        let clone = Command::new("git")
+            .args([
+                "clone",
+                "--depth=1",
+                "--branch",
+                "feature",
+                &format!("file://{}", remote.display()),
+                checkout.to_str().expect("utf-8 checkout path"),
+            ])
+            .output()
+            .expect("clone shallow checkout");
+        assert!(clone.status.success(), "shallow clone must succeed");
+        let checkout_path = checkout.to_str().expect("utf-8 checkout path");
+        git(checkout_path, &["remote", "rename", "origin", "upstream"]);
+        git(
+            checkout_path,
+            &["remote", "add", "origin", "file:///missing/origin.git"],
+        );
+        git(
+            checkout_path,
+            &["config", "branch.feature.remote", "origin"],
+        );
+        git(
+            checkout_path,
+            &["config", "branch.feature.merge", "refs/heads/feature"],
+        );
+
+        let merge_base = resolve_merge_base(checkout_path, "upstream/main")
+            .expect("resolve through upstream rather than branch origin");
+        assert!(!merge_base.is_empty());
+    }
+
     fn init_repo_with_initial_commit(path: &str) {
         for args in [
             ["init", "-q", "-b", "main"].as_slice(),

--- a/crates/homeboy-core/src/git/changes.rs
+++ b/crates/homeboy-core/src/git/changes.rs
@@ -246,7 +246,7 @@ fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
     for depth in ["50", "200"] {
         fetch_remote_tracking_refs_until(
             repository,
-            &["fetch", "--deepen", depth],
+            &["fetch", &remote, "--deepen", depth],
             "git deepen changed-since history",
             &[],
             deadline,
@@ -259,7 +259,7 @@ fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
     eprintln!("Merge base not found with depth 200, unshallowing repository");
     fetch_remote_tracking_refs_until(
         repository,
-        &["fetch", "--unshallow"],
+        &["fetch", &remote, "--unshallow"],
         "git unshallow changed-since history",
         &[],
         deadline,

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -96,8 +96,8 @@ pub use primitives::{
     fetch_remote_tracking_refs_until, get_component_path_prefix, get_git_root,
     get_git_root_with_timeout, git_probe_path, has_staged_changes, is_workdir_clean_or_not_git,
     pull_repo, resolve_default_remote, run_git, run_git_output, run_git_output_with_env,
-    run_git_output_with_env_timeout, run_git_with_env, run_git_with_env_timeout, stage_all,
-    update_to_remote_default_branch,
+    run_git_output_with_env_timeout, run_git_remote_tracking_operation_until, run_git_with_env,
+    run_git_with_env_timeout, stage_all, update_to_remote_default_branch,
 };
 pub use primitives::{is_git_repo, is_tracked_path};
 pub use primitives_query::{

--- a/crates/homeboy-core/src/git/primitives.rs
+++ b/crates/homeboy-core/src/git/primitives.rs
@@ -1366,7 +1366,7 @@ mod tests {
             with_remote_tracking_authority_until(
                 &holder_repository,
                 "test lock holder",
-                Instant::now() + Duration::from_secs(2),
+                Instant::now() + Duration::from_secs(5),
                 |_| {
                     locked.send(()).unwrap();
                     released.recv().expect("release authority");
@@ -1381,12 +1381,12 @@ mod tests {
         let error = fetch_and_merge_upstream_ff_only(
             repository,
             Instant::now() + Duration::from_millis(50),
-        )
-        .expect_err("authority wait exhausts the pull deadline");
-        assert!(started.elapsed() < Duration::from_millis(250));
-        assert!(error.message.contains("deadline"));
+        );
 
         release.send(()).expect("release holder");
         holder.join().unwrap();
+        let error = error.expect_err("authority wait exhausts the pull deadline");
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(error.message.contains("deadline"));
     }
 }

--- a/crates/homeboy-core/src/git/primitives.rs
+++ b/crates/homeboy-core/src/git/primitives.rs
@@ -5,7 +5,6 @@ use std::time::{Duration, Instant};
 use crate::engine::command;
 use crate::error::{Error, GitCommandFailedDetails, Result};
 
-use super::primitives_query::current_branch;
 use super::with_remote_tracking_authority_until;
 
 fn git_command_display(args: &[&str]) -> String {
@@ -300,34 +299,53 @@ pub fn fetch_and_merge_upstream_ff_only(
     git_root: &Path,
     deadline: Instant,
 ) -> Result<std::process::Output> {
-    let branch = current_branch(git_root)
-        .ok_or_else(|| Error::git_command_failed("resolve current branch for git pull"))?;
-    let remote = run_git(
-        git_root,
-        &["config", "--get", &format!("branch.{branch}.remote")],
-        "git upstream remote",
-    )?
-    .trim()
-    .to_string();
-    let upstream_ref = run_git(
-        git_root,
-        &["config", "--get", &format!("branch.{branch}.merge")],
-        "git upstream ref",
-    )?
-    .trim()
-    .to_string();
-    fetch_remote_tracking_refs_until(
-        git_root,
-        &["fetch", &remote, &upstream_ref],
-        &format!("git fetch {remote} {upstream_ref}"),
-        &[],
-        deadline,
-    )?;
-    run_git_output(
-        git_root,
-        &["merge", "--ff-only", "FETCH_HEAD"],
-        "git merge --ff-only",
-    )
+    with_remote_tracking_authority_until(git_root, "git pull", deadline, |_| {
+        let branch = git_stdout_until(
+            git_root,
+            &["symbolic-ref", "--quiet", "--short", "HEAD"],
+            "resolve current branch for git pull",
+            deadline,
+        )?;
+        let remote = git_stdout_until(
+            git_root,
+            &["config", "--get", &format!("branch.{branch}.remote")],
+            "git upstream remote",
+            deadline,
+        )?;
+        let upstream_ref = git_stdout_until(
+            git_root,
+            &["config", "--get", &format!("branch.{branch}.merge")],
+            "git upstream ref",
+            deadline,
+        )?;
+        run_git_with_env_timeout(
+            git_root,
+            &["fetch", &remote, &upstream_ref],
+            &format!("git fetch {remote} {upstream_ref}"),
+            &[],
+            remaining_timeout(deadline)?,
+        )?;
+        run_git_output_with_env_timeout(
+            git_root,
+            &["merge", "--ff-only", "FETCH_HEAD"],
+            "git merge --ff-only",
+            &[],
+            remaining_timeout(deadline)?,
+        )
+    })
+}
+
+/// Run a fetch-capable Git operation while holding the linked-worktree
+/// remote-tracking authority for its full duration.
+pub fn run_git_remote_tracking_operation_until(
+    git_root: &Path,
+    args: &[&str],
+    context: &str,
+    deadline: Instant,
+) -> Result<std::process::Output> {
+    with_remote_tracking_authority_until(git_root, context, deadline, |_| {
+        run_git_output_with_env_timeout(git_root, args, context, &[], remaining_timeout(deadline)?)
+    })
 }
 
 /// Run a git command in a repository and return raw output without treating
@@ -468,54 +486,150 @@ pub fn default_branch_name(path: &Path) -> Option<String> {
 
 /// Update a clean linked repo to the latest remote default-branch revision.
 pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
-    let remote = resolve_default_remote(git_root);
-    let old_branch = current_branch(git_root);
     let deadline = Instant::now() + Duration::from_secs(30);
-    fetch_remote_tracking_refs_until(
-        git_root,
-        &["fetch", &remote],
-        &format!("git fetch {remote}"),
-        &[],
-        deadline,
-    )?;
-    if let Some(remote_branch) = default_remote_branch(git_root) {
-        let local_branch = remote_branch
-            .strip_prefix(&format!("{remote}/"))
-            .unwrap_or(&remote_branch)
-            .to_string();
-
-        if old_branch.as_deref() != Some(local_branch.as_str())
-            && run_git(
+    with_remote_tracking_authority_until(git_root, "update remote default branch", deadline, |_| {
+        let remote = resolve_default_remote_until(git_root, deadline)?;
+        let remote_branch = default_remote_branch_until(git_root, &remote, deadline)?;
+        let (target_remote, target_ref, local_branch) = match remote_branch {
+            Some(branch) => {
+                let branch_name = branch
+                    .rsplit_once('/')
+                    .map(|(_, name)| name)
+                    .unwrap_or(&branch);
+                (
+                    remote,
+                    format!("refs/heads/{branch_name}"),
+                    Some(branch_name.to_string()),
+                )
+            }
+            None => {
+                let (remote, reference) = configured_upstream_until(git_root, deadline)?;
+                (remote, reference, None)
+            }
+        };
+        run_git_with_env_timeout(
+            git_root,
+            &["fetch", &target_remote, &target_ref],
+            &format!("git fetch {target_remote} {target_ref}"),
+            &[],
+            remaining_timeout(deadline)?,
+        )?;
+        if let Some(local_branch) = local_branch {
+            if run_git_with_env_timeout(
                 git_root,
                 &["switch", &local_branch],
                 "git switch default branch",
+                &[],
+                remaining_timeout(deadline)?,
             )
             .is_err()
-        {
-            run_git(
-                git_root,
-                &["switch", "--detach", &remote_branch],
-                "git switch detached default branch",
-            )?;
+            {
+                run_git_with_env_timeout(
+                    git_root,
+                    &["switch", "--detach", "FETCH_HEAD"],
+                    "git switch detached default branch",
+                    &[],
+                    remaining_timeout(deadline)?,
+                )?;
+            }
         }
-        // `pull` fetches again after the authoritative fetch above. Merge the
-        // already-fetched tracking ref instead so linked worktrees do not race.
-        run_git(
+        run_git_with_env_timeout(
             git_root,
-            &["merge", "--ff-only", &remote_branch],
+            &["merge", "--ff-only", "FETCH_HEAD"],
             "git merge default branch --ff-only",
+            &[],
+            remaining_timeout(deadline)?,
         )?;
-    } else {
-        // The authority fetch above already refreshed this branch's tracking
-        // ref. Do not call the pull helper here because it would fetch again.
-        run_git(
-            git_root,
-            &["merge", "--ff-only", "@{upstream}"],
-            "git merge upstream --ff-only",
-        )?;
-    }
+        Ok(())
+    })
+}
 
-    Ok(())
+fn remaining_timeout(deadline: Instant) -> Result<Duration> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .ok_or_else(|| Error::git_command_failed("git operation deadline exhausted"))
+}
+
+fn git_stdout_until(
+    git_root: &Path,
+    args: &[&str],
+    context: &str,
+    deadline: Instant,
+) -> Result<String> {
+    run_git_with_env_timeout(git_root, args, context, &[], remaining_timeout(deadline)?)
+        .map(|value| value.trim().to_string())
+}
+
+fn resolve_default_remote_until(git_root: &Path, deadline: Instant) -> Result<String> {
+    let remotes = git_stdout_until(git_root, &["remote"], "git remote", deadline)?;
+    let remotes: Vec<_> = remotes
+        .lines()
+        .filter(|remote| !remote.is_empty())
+        .collect();
+    if remotes.contains(&"origin") {
+        Ok("origin".to_string())
+    } else if let [remote] = remotes.as_slice() {
+        Ok((*remote).to_string())
+    } else {
+        Ok("origin".to_string())
+    }
+}
+
+fn default_remote_branch_until(
+    git_root: &Path,
+    remote: &str,
+    deadline: Instant,
+) -> Result<Option<String>> {
+    let head_ref = format!("refs/remotes/{remote}/HEAD");
+    let output = run_git_output_with_env_timeout(
+        git_root,
+        &["symbolic-ref", "--quiet", "--short", &head_ref],
+        "git default remote branch",
+        &[],
+        remaining_timeout(deadline)?,
+    )?;
+    if output.status.success() {
+        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !value.is_empty() {
+            return Ok(Some(value));
+        }
+    }
+    for branch in ["main", "trunk", "master"] {
+        let candidate = format!("{remote}/{branch}");
+        let output = run_git_output_with_env_timeout(
+            git_root,
+            &["rev-parse", "--verify", "--quiet", &candidate],
+            "git rev-parse",
+            &[],
+            remaining_timeout(deadline)?,
+        )?;
+        if output.status.success() {
+            return Ok(Some(candidate));
+        }
+    }
+    Ok(None)
+}
+
+fn configured_upstream_until(git_root: &Path, deadline: Instant) -> Result<(String, String)> {
+    let branch = git_stdout_until(
+        git_root,
+        &["symbolic-ref", "--quiet", "--short", "HEAD"],
+        "resolve current branch for configured upstream",
+        deadline,
+    )?;
+    let remote = git_stdout_until(
+        git_root,
+        &["config", "--get", &format!("branch.{branch}.remote")],
+        "git upstream remote",
+        deadline,
+    )?;
+    let reference = git_stdout_until(
+        git_root,
+        &["config", "--get", &format!("branch.{branch}.merge")],
+        "git upstream ref",
+        deadline,
+    )?;
+    Ok((remote, reference))
 }
 
 /// List all git-tracked markdown files in a directory.
@@ -624,6 +738,7 @@ mod tests {
     use std::thread;
 
     use super::*;
+    use crate::git::primitives_query::current_branch;
 
     use crate::test_support::run_git_command as git;
 
@@ -1000,7 +1115,18 @@ mod tests {
                 checkout.to_str().unwrap(),
             ],
         );
-        git(&checkout, &["remote", "set-head", "origin", "-d"]);
+        // Preferable origin is unavailable and has no conventional default;
+        // the configured non-origin upstream must be selected before fetching.
+        git(&checkout, &["remote", "rename", "origin", "upstream"]);
+        git(
+            &checkout,
+            &[
+                "remote",
+                "add",
+                "origin",
+                tmp.path().join("missing-origin.git").to_str().unwrap(),
+            ],
+        );
         let fetches = tmp.path().join("fetches");
         let upload_pack = tmp.path().join("count-upload-pack");
         std::fs::write(
@@ -1020,7 +1146,7 @@ mod tests {
             &checkout,
             &[
                 "config",
-                "remote.origin.uploadpack",
+                "remote.upstream.uploadpack",
                 upload_pack.to_str().unwrap(),
             ],
         );
@@ -1160,5 +1286,52 @@ mod tests {
             .expect("contender completes after authority release")
             .expect_err("missing remote fails");
         contender.join().unwrap();
+    }
+
+    #[test]
+    fn fetch_and_merge_upstream_uses_the_caller_deadline_for_authority_wait() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repository = dir.path();
+        git(repository, &["init", "-q", "-b", "main"]);
+        git(repository, &["config", "user.email", "t@x.test"]);
+        git(repository, &["config", "user.name", "T"]);
+        std::fs::write(repository.join("f.txt"), "x\n").unwrap();
+        git(repository, &["add", "."]);
+        git(repository, &["commit", "-qm", "initial"]);
+        git(repository, &["config", "branch.main.remote", "origin"]);
+        git(
+            repository,
+            &["config", "branch.main.merge", "refs/heads/main"],
+        );
+
+        let (locked, ready) = mpsc::channel();
+        let (release, released) = mpsc::channel();
+        let holder_repository = repository.to_path_buf();
+        let holder = thread::spawn(move || {
+            with_remote_tracking_authority_until(
+                &holder_repository,
+                "test lock holder",
+                Instant::now() + Duration::from_secs(2),
+                |_| {
+                    locked.send(()).unwrap();
+                    released.recv().expect("release authority");
+                    Ok(())
+                },
+            )
+            .unwrap();
+        });
+        ready.recv().expect("authority acquired");
+
+        let started = Instant::now();
+        let error = fetch_and_merge_upstream_ff_only(
+            repository,
+            Instant::now() + Duration::from_millis(50),
+        )
+        .expect_err("authority wait exhausts the pull deadline");
+        assert!(started.elapsed() < Duration::from_millis(250));
+        assert!(error.message.contains("deadline"));
+
+        release.send(()).expect("release holder");
+        holder.join().unwrap();
     }
 }

--- a/crates/homeboy-core/src/git/primitives.rs
+++ b/crates/homeboy-core/src/git/primitives.rs
@@ -489,12 +489,11 @@ pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
     let deadline = Instant::now() + Duration::from_secs(30);
     with_remote_tracking_authority_until(git_root, "update remote default branch", deadline, |_| {
         let remote = resolve_default_remote_until(git_root, deadline)?;
-        let remote_branch = default_remote_branch_until(git_root, &remote, deadline)?;
+        let remote_branch = remote_default_branch_until(git_root, &remote, deadline)?;
         let (target_remote, target_ref, local_branch) = match remote_branch {
             Some(branch) => {
                 let branch_name = branch
-                    .rsplit_once('/')
-                    .map(|(_, name)| name)
+                    .strip_prefix(&format!("{remote}/"))
                     .unwrap_or(&branch);
                 (
                     remote,
@@ -575,39 +574,33 @@ fn resolve_default_remote_until(git_root: &Path, deadline: Instant) -> Result<St
     }
 }
 
-fn default_remote_branch_until(
+/// Resolve the remote's live HEAD symref without relying on cached
+/// remote-tracking refs, which may belong to a previous remote URL or default.
+fn remote_default_branch_until(
     git_root: &Path,
     remote: &str,
     deadline: Instant,
 ) -> Result<Option<String>> {
-    let head_ref = format!("refs/remotes/{remote}/HEAD");
     let output = run_git_output_with_env_timeout(
         git_root,
-        &["symbolic-ref", "--quiet", "--short", &head_ref],
-        "git default remote branch",
+        &["ls-remote", "--symref", remote, "HEAD"],
+        "git remote default branch",
         &[],
         remaining_timeout(deadline)?,
     )?;
-    if output.status.success() {
-        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !value.is_empty() {
-            return Ok(Some(value));
-        }
-    }
-    for branch in ["main", "trunk", "master"] {
-        let candidate = format!("{remote}/{branch}");
-        let output = run_git_output_with_env_timeout(
-            git_root,
-            &["rev-parse", "--verify", "--quiet", &candidate],
-            "git rev-parse",
-            &[],
-            remaining_timeout(deadline)?,
-        )?;
-        if output.status.success() {
-            return Ok(Some(candidate));
-        }
-    }
-    Ok(None)
+    Ok(output
+        .status
+        .success()
+        .then(|| {
+            String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .find_map(|line| {
+                    line.strip_prefix("ref: refs/heads/")
+                        .and_then(|line| line.strip_suffix("\tHEAD"))
+                        .map(|branch| format!("{remote}/{branch}"))
+                })
+        })
+        .flatten())
 }
 
 fn configured_upstream_until(git_root: &Path, deadline: Instant) -> Result<(String, String)> {
@@ -798,14 +791,12 @@ mod tests {
             &["hang"],
             "test hung Git phase",
             &[],
-            Duration::from_millis(50),
+            Duration::from_millis(250),
         )
         .expect_err("hung Git alias should time out");
 
         assert!(started.elapsed() < Duration::from_secs(2));
-        assert!(err.details["stderr"]
-            .as_str()
-            .is_some_and(|detail| detail.contains("timed out")));
+        assert!(err.message.contains("timed out"));
         let pid: i32 = std::fs::read_to_string(&child_pid)
             .expect("hung child records its pid")
             .trim()
@@ -962,6 +953,70 @@ mod tests {
             std::fs::read_to_string(fetches).unwrap().lines().count(),
             1,
             "the update must merge the authority-fetched tracking ref without a second fetch"
+        );
+    }
+
+    #[test]
+    fn update_to_remote_default_branch_uses_live_remote_head_with_slash_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = tmp.path().join("remote.git");
+        let seed = tmp.path().join("seed");
+        let checkout = tmp.path().join("checkout");
+        git(
+            tmp.path(),
+            &["init", "--bare", "-b", "main", remote.to_str().unwrap()],
+        );
+        git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                seed.to_str().unwrap(),
+            ],
+        );
+        git(&seed, &["config", "user.email", "t@x.test"]);
+        git(&seed, &["config", "user.name", "T"]);
+        std::fs::write(seed.join("f.txt"), "main\n").unwrap();
+        git(&seed, &["add", "."]);
+        git(&seed, &["commit", "-qm", "main"]);
+        git(&seed, &["push", "-q", "origin", "main"]);
+        git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                checkout.to_str().unwrap(),
+            ],
+        );
+
+        git(&seed, &["switch", "-qc", "release/2026"]);
+        std::fs::write(seed.join("f.txt"), "release\n").unwrap();
+        git(&seed, &["commit", "-qam", "release"]);
+        git(&seed, &["push", "-q", "origin", "release/2026"]);
+        git(
+            &remote,
+            &["symbolic-ref", "HEAD", "refs/heads/release/2026"],
+        );
+        let expected = run_git(&seed, &["rev-parse", "HEAD"], "release head").unwrap();
+        assert_eq!(
+            remote_default_branch_until(
+                &checkout,
+                "origin",
+                Instant::now() + Duration::from_secs(2)
+            )
+            .unwrap()
+            .as_deref(),
+            Some("origin/release/2026")
+        );
+
+        update_to_remote_default_branch(&checkout).expect("update live default branch");
+
+        assert_eq!(
+            run_git(&checkout, &["rev-parse", "HEAD"], "checkout head").unwrap(),
+            expected,
+            "the cached origin/main HEAD must not override the remote's current default"
         );
     }
 

--- a/crates/homeboy-core/src/git/primitives.rs
+++ b/crates/homeboy-core/src/git/primitives.rs
@@ -113,7 +113,7 @@ pub fn pull_repo(repo_dir: &Path) -> Result<()> {
     let output = fetch_and_merge_upstream_ff_only(repo_dir, deadline)?;
     ensure_git_success(
         repo_dir,
-        &["merge", "--ff-only", "@{upstream}"],
+        &["merge", "--ff-only", "FETCH_HEAD"],
         "git merge --ff-only",
         &output,
     )?;
@@ -300,16 +300,32 @@ pub fn fetch_and_merge_upstream_ff_only(
     git_root: &Path,
     deadline: Instant,
 ) -> Result<std::process::Output> {
-    fetch_remote_tracking_refs_until(git_root, &["fetch"], "git fetch", &[], deadline)?;
-    let upstream = run_git(
+    let branch = current_branch(git_root)
+        .ok_or_else(|| Error::git_command_failed("resolve current branch for git pull"))?;
+    let remote = run_git(
         git_root,
-        &["rev-parse", "--abbrev-ref", "@{upstream}"],
-        "git upstream",
+        &["config", "--get", &format!("branch.{branch}.remote")],
+        "git upstream remote",
+    )?
+    .trim()
+    .to_string();
+    let upstream_ref = run_git(
+        git_root,
+        &["config", "--get", &format!("branch.{branch}.merge")],
+        "git upstream ref",
+    )?
+    .trim()
+    .to_string();
+    fetch_remote_tracking_refs_until(
+        git_root,
+        &["fetch", &remote, &upstream_ref],
+        &format!("git fetch {remote} {upstream_ref}"),
+        &[],
+        deadline,
     )?;
-    let upstream = upstream.trim();
     run_git_output(
         git_root,
-        &["merge", "--ff-only", upstream],
+        &["merge", "--ff-only", "FETCH_HEAD"],
         "git merge --ff-only",
     )
 }
@@ -490,12 +506,12 @@ pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
             "git merge default branch --ff-only",
         )?;
     } else {
-        let output = fetch_and_merge_upstream_ff_only(git_root, deadline)?;
-        ensure_git_success(
+        // The authority fetch above already refreshed this branch's tracking
+        // ref. Do not call the pull helper here because it would fetch again.
+        run_git(
             git_root,
             &["merge", "--ff-only", "@{upstream}"],
-            "git merge --ff-only",
-            &output,
+            "git merge upstream --ff-only",
         )?;
     }
 
@@ -835,6 +851,194 @@ mod tests {
     }
 
     #[test]
+    fn pull_repo_fetches_configured_non_default_upstream_with_restricted_refspec() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let origin = tmp.path().join("origin.git");
+        let upstream = tmp.path().join("upstream.git");
+        let seed = tmp.path().join("seed");
+        let checkout = tmp.path().join("checkout");
+        git(
+            tmp.path(),
+            &["init", "--bare", "-b", "main", origin.to_str().unwrap()],
+        );
+        git(
+            tmp.path(),
+            &["init", "--bare", "-b", "topic", upstream.to_str().unwrap()],
+        );
+        git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                origin.to_str().unwrap(),
+                seed.to_str().unwrap(),
+            ],
+        );
+        git(&seed, &["config", "user.email", "t@x.test"]);
+        git(&seed, &["config", "user.name", "T"]);
+        std::fs::write(seed.join("f.txt"), "one\n").unwrap();
+        git(&seed, &["add", "."]);
+        git(&seed, &["commit", "-qm", "initial"]);
+        git(&seed, &["push", "-q", "origin", "main"]);
+        git(
+            &seed,
+            &["remote", "add", "upstream", upstream.to_str().unwrap()],
+        );
+        git(&seed, &["switch", "-qc", "topic"]);
+        std::fs::write(seed.join("f.txt"), "two\n").unwrap();
+        git(&seed, &["commit", "-qam", "topic"]);
+        git(&seed, &["push", "-q", "upstream", "topic"]);
+        let expected = run_git(&seed, &["rev-parse", "HEAD"], "seed head").unwrap();
+        git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                origin.to_str().unwrap(),
+                checkout.to_str().unwrap(),
+            ],
+        );
+        git(
+            &checkout,
+            &["remote", "add", "upstream", upstream.to_str().unwrap()],
+        );
+        git(&checkout, &["config", "branch.main.remote", "upstream"]);
+        git(
+            &checkout,
+            &["config", "branch.main.merge", "refs/heads/topic"],
+        );
+        git(
+            &checkout,
+            &[
+                "config",
+                "remote.upstream.fetch",
+                "+refs/heads/main:refs/remotes/upstream/main",
+            ],
+        );
+        git(
+            &checkout,
+            &["remote", "set-url", "origin", "missing-origin.git"],
+        );
+        let fetches = tmp.path().join("fetches");
+        let upload_pack = tmp.path().join("count-upload-pack");
+        std::fs::write(
+            &upload_pack,
+            format!(
+                "#!/bin/sh\nprintf fetch >> {}\nexec git upload-pack \"$@\"\n",
+                fetches.display()
+            ),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&upload_pack, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        git(
+            &checkout,
+            &[
+                "config",
+                "remote.upstream.uploadpack",
+                upload_pack.to_str().unwrap(),
+            ],
+        );
+
+        pull_repo(&checkout).expect("pull configured upstream");
+
+        assert_eq!(
+            run_git(&checkout, &["rev-parse", "HEAD"], "checkout head").unwrap(),
+            expected
+        );
+        assert!(
+            run_git(
+                &checkout,
+                &[
+                    "rev-parse",
+                    "--verify",
+                    "--quiet",
+                    "refs/remotes/upstream/topic"
+                ],
+                "upstream tracking ref",
+            )
+            .is_err(),
+            "the restricted fetch refspec must leave the topic without a tracking ref"
+        );
+        assert_eq!(std::fs::read_to_string(fetches).unwrap().lines().count(), 1);
+    }
+
+    #[test]
+    fn update_to_remote_default_branch_fallback_merges_without_a_second_fetch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = tmp.path().join("remote.git");
+        let seed = tmp.path().join("seed");
+        let checkout = tmp.path().join("checkout");
+        git(
+            tmp.path(),
+            &["init", "--bare", "-b", "feature", remote.to_str().unwrap()],
+        );
+        git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                seed.to_str().unwrap(),
+            ],
+        );
+        git(&seed, &["config", "user.email", "t@x.test"]);
+        git(&seed, &["config", "user.name", "T"]);
+        std::fs::write(seed.join("f.txt"), "one\n").unwrap();
+        git(&seed, &["add", "."]);
+        git(&seed, &["commit", "-qm", "initial"]);
+        git(&seed, &["push", "-q", "origin", "feature"]);
+        git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                checkout.to_str().unwrap(),
+            ],
+        );
+        git(&checkout, &["remote", "set-head", "origin", "-d"]);
+        let fetches = tmp.path().join("fetches");
+        let upload_pack = tmp.path().join("count-upload-pack");
+        std::fs::write(
+            &upload_pack,
+            format!(
+                "#!/bin/sh\nprintf fetch >> {}\nexec git upload-pack \"$@\"\n",
+                fetches.display()
+            ),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&upload_pack, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        git(
+            &checkout,
+            &[
+                "config",
+                "remote.origin.uploadpack",
+                upload_pack.to_str().unwrap(),
+            ],
+        );
+        std::fs::write(seed.join("f.txt"), "two\n").unwrap();
+        git(&seed, &["commit", "-qam", "advance"]);
+        git(&seed, &["push", "-q", "origin", "feature"]);
+        let expected = run_git(&seed, &["rev-parse", "HEAD"], "seed head").unwrap();
+
+        update_to_remote_default_branch(&checkout).expect("fallback update");
+
+        assert_eq!(
+            run_git(&checkout, &["rev-parse", "HEAD"], "checkout head").unwrap(),
+            expected
+        );
+        assert_eq!(std::fs::read_to_string(fetches).unwrap().lines().count(), 1);
+    }
+
+    #[test]
     fn update_to_remote_default_branch_detaches_when_the_local_default_branch_is_missing() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = tmp.path().join("remote.git");
@@ -892,6 +1096,7 @@ mod tests {
 
     #[test]
     fn update_to_remote_default_branch_waits_for_remote_tracking_authority() {
+        let _env_lock = crate::test_support::env_lock();
         let dir = tempfile::tempdir().expect("tempdir");
         let repository = dir.path();
         git(repository, &["init", "-q", "-b", "main"]);

--- a/crates/homeboy-core/src/git/remote_tracking_authority.rs
+++ b/crates/homeboy-core/src/git/remote_tracking_authority.rs
@@ -1,19 +1,6 @@
-use std::collections::HashMap;
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
-use std::thread;
+use crate::error::Result;
+use std::path::Path;
 use std::time::{Duration, Instant};
-
-use fs4::fs_std::FileExt;
-
-use crate::error::{Error, Result};
-
-const WAIT_INTERVAL: Duration = Duration::from_millis(50);
-const LOCK_FILE: &str = "homeboy-remote-tracking.lock";
-
-static AUTHORITIES: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
 
 /// Serialize Homeboy operations that can update remote-tracking refs for one
 /// repository. Linked worktrees share a Git common directory, while unrelated
@@ -24,171 +11,17 @@ pub fn with_remote_tracking_authority_until<T>(
     deadline: Instant,
     action: impl FnOnce(Duration) -> Result<T>,
 ) -> Result<T> {
-    report_authority_attempt();
-    let common_dir = git_common_dir(repository)?;
-    let authority = {
-        let mut authorities = AUTHORITIES
-            .get_or_init(|| Mutex::new(HashMap::new()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        authorities
-            .entry(common_dir.clone())
-            .or_insert_with(|| Arc::new(Mutex::new(())))
-            .clone()
-    };
-    let _process_guard = acquire_process_guard(&authority, &common_dir, operation, deadline)?;
-    let lock_path = common_dir.join(LOCK_FILE);
-    let mut lock = OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .open(&lock_path)
-        .map_err(|error| authority_error(operation, &common_dir, &lock_path, None, error))?;
-    acquire_file_guard(&mut lock, &common_dir, &lock_path, operation, deadline)?;
-    action(remaining(
-        deadline,
-        operation,
-        &common_dir,
-        &lock_path,
-        None,
-    )?)
+    homeboy_engine_primitives::git_remote_tracking_authority::with_remote_tracking_authority_until(
+        repository, operation, deadline, action,
+    )
 }
-
-fn git_common_dir(repository: &Path) -> Result<PathBuf> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
-        .current_dir(repository)
-        .output()
-        .map_err(|error| Error::git_command_failed(error.to_string()))?;
-    if !output.status.success() {
-        return Err(Error::git_command_failed(format!(
-            "resolve Git common directory for {}",
-            repository.display()
-        )));
-    }
-    let common_dir = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
-    fs::canonicalize(&common_dir).map_err(|error| Error::git_command_failed(error.to_string()))
-}
-
-fn acquire_process_guard<'a>(
-    authority: &'a Mutex<()>,
-    common_dir: &Path,
-    operation: &str,
-    deadline: Instant,
-) -> Result<std::sync::MutexGuard<'a, ()>> {
-    let mut reported_wait = false;
-    loop {
-        match authority.try_lock() {
-            Ok(guard) => return Ok(guard),
-            Err(std::sync::TryLockError::Poisoned(poisoned)) => return Ok(poisoned.into_inner()),
-            Err(std::sync::TryLockError::WouldBlock) if Instant::now() < deadline => {
-                if !reported_wait {
-                    crate::log_status!(
-                        "git",
-                        "phase=remote_tracking_wait operation={} common_dir={} owner=local_process",
-                        operation,
-                        common_dir.display()
-                    );
-                    reported_wait = true;
-                }
-                thread::sleep(WAIT_INTERVAL)
-            }
-            Err(std::sync::TryLockError::WouldBlock) => {
-                return Err(authority_error(
-                    operation,
-                    common_dir,
-                    &common_dir.join(LOCK_FILE),
-                    Some("another Homeboy operation in this process".to_string()),
-                    timed_out_error(),
-                ));
-            }
-        }
-    }
-}
-
-fn acquire_file_guard(
-    lock: &mut File,
-    common_dir: &Path,
-    lock_path: &Path,
-    operation: &str,
-    deadline: Instant,
-) -> Result<()> {
-    let mut reported_wait = false;
-    loop {
-        match lock.try_lock_exclusive() {
-            Ok(true) => {
-                let owner = format!("pid={} operation={}\n", std::process::id(), operation);
-                lock.set_len(0)
-                    .and_then(|()| lock.write_all(owner.as_bytes()))
-                    .and_then(|()| lock.sync_data())
-                    .map_err(|error| {
-                        authority_error(operation, common_dir, lock_path, None, error)
-                    })?;
-                return Ok(());
-            }
-            Ok(false) | Err(_) if Instant::now() < deadline => {
-                report_authority_attempt();
-                if !reported_wait {
-                    let owner = fs::read_to_string(lock_path)
-                        .ok()
-                        .map(|value| value.trim().to_string())
-                        .filter(|value| !value.is_empty())
-                        .unwrap_or_else(|| "unknown owner".to_string());
-                    crate::log_status!(
-                        "git",
-                        "phase=remote_tracking_wait operation={} common_dir={} owner={}",
-                        operation,
-                        common_dir.display(),
-                        owner
-                    );
-                    reported_wait = true;
-                }
-                thread::sleep(WAIT_INTERVAL)
-            }
-            Ok(false) => {
-                let error = timed_out_error();
-                let owner = fs::read_to_string(lock_path)
-                    .ok()
-                    .map(|value| value.trim().to_string());
-                return Err(authority_error(
-                    operation, common_dir, lock_path, owner, error,
-                ));
-            }
-            Err(error) if Instant::now() >= deadline => {
-                let owner = fs::read_to_string(lock_path)
-                    .ok()
-                    .map(|value| value.trim().to_string());
-                return Err(authority_error(
-                    operation, common_dir, lock_path, owner, error,
-                ));
-            }
-            Err(error) => {
-                let owner = fs::read_to_string(lock_path)
-                    .ok()
-                    .map(|value| value.trim().to_string());
-                return Err(authority_error(
-                    operation, common_dir, lock_path, owner, error,
-                ));
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-fn report_authority_attempt() {
-    if let Some(path) = std::env::var_os("HOMEB0Y_REMOTE_TRACKING_FETCH_LOCK_ATTEMPTED") {
-        std::fs::write(path, "attempted\n").expect("write remote-tracking lock attempt");
-    }
-}
-
-#[cfg(not(test))]
-fn report_authority_attempt() {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::process::Command;
     use std::sync::mpsc;
+    use std::thread;
 
     fn git(path: &Path, args: &[&str]) {
         assert!(Command::new("git")
@@ -477,38 +310,4 @@ mod tests {
             .expect("first thread")
             .expect("first authority");
     }
-}
-
-fn remaining(
-    deadline: Instant,
-    operation: &str,
-    common_dir: &Path,
-    lock_path: &Path,
-    owner: Option<String>,
-) -> Result<Duration> {
-    deadline
-        .checked_duration_since(Instant::now())
-        .ok_or_else(|| authority_error(operation, common_dir, lock_path, owner, timed_out_error()))
-}
-
-fn timed_out_error() -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::TimedOut, "authority deadline exhausted")
-}
-
-fn authority_error(
-    operation: &str,
-    common_dir: &Path,
-    lock_path: &Path,
-    owner: Option<String>,
-    error: std::io::Error,
-) -> Error {
-    let owner = owner
-        .filter(|owner| !owner.is_empty())
-        .unwrap_or_else(|| "unknown owner".to_string());
-    Error::git_command_failed(format!(
-        "{operation} exhausted its caller deadline waiting for remote-tracking authority at {} (owner: {}; lock: {}): {error}",
-        common_dir.display(),
-        owner,
-        lock_path.display(),
-    ))
 }

--- a/crates/homeboy-engine-primitives/Cargo.toml
+++ b/crates/homeboy-engine-primitives/Cargo.toml
@@ -26,6 +26,7 @@ toml = "1.0.3"
 regex = "1.11"
 libc = "0.2"
 sha2 = "0.10.9"
+fs4 = "0.13"
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/crates/homeboy-engine-primitives/src/git_changes.rs
+++ b/crates/homeboy-engine-primitives/src/git_changes.rs
@@ -13,6 +13,7 @@
 //! primitives base rather than all of `homeboy-core` for changed-file scoping.
 
 use std::collections::BTreeSet;
+use std::path::Path;
 use std::process::{Command, Output};
 use std::time::{Duration, Instant};
 
@@ -29,7 +30,16 @@ fn execute_git(path: &str, args: &[&str]) -> std::io::Result<Output> {
 /// Run Git until `deadline`, terminating its process group if a transport or
 /// credential helper stalls.
 fn execute_git_until(path: &str, args: &[&str], deadline: Instant) -> Result<Output> {
-    let mut process = Command::new("git");
+    execute_git_until_with_program(path, args, deadline, Path::new("git"))
+}
+
+fn execute_git_until_with_program(
+    path: &str,
+    args: &[&str],
+    deadline: Instant,
+    program: &Path,
+) -> Result<Output> {
+    let mut process = Command::new(program);
     process
         .args(args)
         .current_dir(path)
@@ -325,35 +335,35 @@ mod tests {
 
         let dir = tempfile::TempDir::new().expect("tempdir");
         let path = dir.path().to_str().expect("utf-8 path");
-        execute_git(path, &["init", "-q"]).expect("initialize repository");
-        let remote = dir.path().join("remote.git");
-        execute_git(path, &["init", "--bare", "-q", remote.to_str().unwrap()])
-            .expect("initialize remote");
-        execute_git(path, &["remote", "add", "origin", remote.to_str().unwrap()])
-            .expect("configure remote");
-        let upload_pack = dir.path().join("hang-upload-pack");
-        std::fs::write(&upload_pack, "#!/bin/sh\nsleep 10 &\nwait\n").expect("write helper");
-        std::fs::set_permissions(&upload_pack, std::fs::Permissions::from_mode(0o755))
-            .expect("make helper executable");
-        execute_git(
-            path,
-            &[
-                "config",
-                "remote.origin.uploadpack",
-                upload_pack.to_str().unwrap(),
-            ],
-        )
-        .expect("configure upload-pack helper");
+        let git = dir.path().join("git");
+        let pid_file = dir.path().join("descendant.pid");
+        let script = format!(
+            "#!/bin/sh\nsleep 30 &\necho $! > {}\nwait\n",
+            crate::shell::quote_path(&pid_file.display().to_string())
+        );
+        std::fs::write(&git, script).expect("write stalled git");
+        std::fs::set_permissions(&git, std::fs::Permissions::from_mode(0o755))
+            .expect("make stalled git executable");
 
         let started = Instant::now();
-        let error = execute_git_until(
+        let error = execute_git_until_with_program(
             path,
             &["fetch", "origin"],
-            Instant::now() + Duration::from_millis(250),
+            Instant::now() + Duration::from_secs(1),
+            &git,
         )
         .expect_err("stalled fetch must exhaust its deadline");
 
         assert!(started.elapsed() < Duration::from_secs(2));
         assert!(error.message.contains("deadline exhausted"));
+        let descendant_pid = std::fs::read_to_string(&pid_file)
+            .expect("descendant pid")
+            .trim()
+            .parse::<u32>()
+            .expect("numeric descendant pid");
+        assert!(
+            !command::process_is_running(descendant_pid),
+            "deadline left descendant {descendant_pid} runnable"
+        );
     }
 }

--- a/crates/homeboy-engine-primitives/src/git_changes.rs
+++ b/crates/homeboy-engine-primitives/src/git_changes.rs
@@ -166,7 +166,19 @@ fn has_merge_base(path: &str, git_ref: &str) -> bool {
 /// Resolve the default remote of a repository: prefer `origin`, else a sole
 /// remote, else fall back to `origin`.
 fn resolve_default_remote(path: &str) -> String {
-    let remotes: Vec<String> = execute_git(path, &["remote"])
+    let remotes = remote_names(path);
+
+    if remotes.iter().any(|remote| remote == "origin") {
+        return "origin".to_string();
+    }
+    if let [only] = remotes.as_slice() {
+        return only.clone();
+    }
+    "origin".to_string()
+}
+
+fn remote_names(path: &str) -> Vec<String> {
+    execute_git(path, &["remote"])
         .ok()
         .filter(|out| out.status.success())
         .map(|out| {
@@ -177,15 +189,32 @@ fn resolve_default_remote(path: &str) -> String {
                 .map(str::to_string)
                 .collect()
         })
-        .unwrap_or_default();
+        .unwrap_or_default()
+}
 
-    if remotes.iter().any(|remote| remote == "origin") {
-        return "origin".to_string();
+fn remote_and_ref(path: &str, git_ref: &str) -> (String, String) {
+    let remote_ref = git_ref.strip_prefix("refs/remotes/").unwrap_or(git_ref);
+    if let Some((remote, reference)) = remote_ref.split_once('/') {
+        if !reference.is_empty() && remote_names(path).iter().any(|name| name == remote) {
+            return (remote.to_string(), reference.to_string());
+        }
     }
-    if let [only] = remotes.as_slice() {
-        return only.clone();
+
+    (resolve_default_remote(path), git_ref.to_string())
+}
+
+fn fetch_until(path: &str, args: &[&str], deadline: Instant) -> Result<()> {
+    let output = execute_git_until(path, args, deadline)?;
+    if output.status.success() {
+        return Ok(());
     }
-    "origin".to_string()
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(Error::git_command_failed(format!(
+        "git {} failed: {}",
+        args.join(" "),
+        stderr.trim()
+    )))
 }
 
 /// In shallow clones, the merge base between a ref and HEAD may not be
@@ -222,12 +251,14 @@ pub fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
         deadline,
         |_| {
             // Fetch the ref itself if it's not already present.
-            let remote = resolve_default_remote(path);
-            let _ = execute_git_until(path, &["fetch", &remote, git_ref, "--depth=50"], deadline)?;
+            let (remote, reference) = remote_and_ref(path, git_ref);
+            let tracking_ref = reference.strip_prefix("refs/heads/").unwrap_or(&reference);
+            let refspec = format!("{reference}:refs/remotes/{remote}/{tracking_ref}");
+            fetch_until(path, &["fetch", &remote, &refspec, "--depth=50"], deadline)?;
 
             // Progressive deepening: try increasingly generous depths.
             for depth in &["50", "200"] {
-                let _ = execute_git_until(path, &["fetch", "--deepen", depth], deadline)?;
+                fetch_until(path, &["fetch", "--deepen", depth], deadline)?;
                 if has_merge_base(path, git_ref) {
                     eprintln!("Merge base found after deepening by {depth} commits");
                     return Ok(());
@@ -236,7 +267,7 @@ pub fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
 
             // Last resort: full unshallow.
             eprintln!("Merge base not found with depth 200, unshallowing repository");
-            let _ = execute_git_until(path, &["fetch", "--unshallow"], deadline)?;
+            fetch_until(path, &["fetch", "--unshallow"], deadline)?;
 
             if has_merge_base(path, git_ref) {
                 eprintln!("Merge base found after full unshallow");
@@ -328,6 +359,128 @@ mod tests {
             !files.contains(&"deleted.txt".to_string()),
             "deleted file excluded: {files:?}"
         );
+    }
+
+    #[test]
+    fn remote_qualified_refs_use_their_configured_remote() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().to_str().expect("utf-8 path");
+        execute_git(path, &["init", "-q"]).expect("initialize repository");
+        execute_git(
+            path,
+            &["remote", "add", "origin", "https://origin.invalid/repo.git"],
+        )
+        .expect("configure origin");
+        execute_git(
+            path,
+            &[
+                "remote",
+                "add",
+                "upstream",
+                "https://upstream.invalid/repo.git",
+            ],
+        )
+        .expect("configure upstream");
+
+        assert_eq!(
+            remote_and_ref(path, "upstream/main"),
+            ("upstream".to_string(), "main".to_string())
+        );
+        assert_eq!(
+            remote_and_ref(path, "refs/remotes/upstream/main"),
+            ("upstream".to_string(), "main".to_string())
+        );
+    }
+
+    #[test]
+    fn shallow_clone_fetches_remote_qualified_ref_from_its_named_remote() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let source = dir.path().join("source");
+        let remote = dir.path().join("remote.git");
+        let checkout = dir.path().join("checkout");
+        std::fs::create_dir(&source).expect("create source");
+        let source_path = source.to_str().expect("utf-8 source path");
+        execute_git(source_path, &["init", "-q", "-b", "main"]).expect("initialize source");
+        execute_git(source_path, &["config", "user.email", "test@example.com"])
+            .expect("configure author email");
+        execute_git(source_path, &["config", "user.name", "test"]).expect("configure author name");
+        std::fs::write(source.join("base.txt"), "base\n").expect("write base commit");
+        execute_git(source_path, &["add", "."]).expect("stage base commit");
+        execute_git(source_path, &["commit", "-qm", "base"]).expect("commit base");
+        execute_git(source_path, &["switch", "-qc", "feature"]).expect("create feature branch");
+        std::fs::write(source.join("feature.txt"), "feature\n").expect("write feature commit");
+        execute_git(source_path, &["add", "."]).expect("stage feature commit");
+        execute_git(source_path, &["commit", "-qm", "feature"]).expect("commit feature");
+        execute_git(
+            source_path,
+            &[
+                "init",
+                "--bare",
+                "-q",
+                remote.to_str().expect("utf-8 remote path"),
+            ],
+        )
+        .expect("initialize remote");
+        execute_git(
+            source_path,
+            &[
+                "remote",
+                "add",
+                "upstream",
+                remote.to_str().expect("utf-8 remote path"),
+            ],
+        )
+        .expect("configure upstream remote");
+        execute_git(source_path, &["push", "-q", "upstream", "main", "feature"])
+            .expect("push source branches");
+
+        let clone = Command::new("git")
+            .args([
+                "clone",
+                "--depth=1",
+                "--branch",
+                "feature",
+                &format!("file://{}", remote.display()),
+                checkout.to_str().expect("utf-8 checkout path"),
+            ])
+            .output()
+            .expect("clone shallow checkout");
+        assert!(clone.status.success(), "shallow clone must succeed");
+        let checkout_path = checkout.to_str().expect("utf-8 checkout path");
+        execute_git(checkout_path, &["remote", "rename", "origin", "upstream"])
+            .expect("rename checkout remote");
+        execute_git(
+            checkout_path,
+            &["remote", "add", "origin", "file:///missing/origin.git"],
+        )
+        .expect("configure default remote");
+
+        ensure_ancestry_for_ref(checkout_path, "upstream/main")
+            .expect("fetch named remote ref and resolve merge base");
+        assert!(has_merge_base(checkout_path, "upstream/main"));
+    }
+
+    #[test]
+    fn failed_fetch_status_is_returned_as_an_error() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().to_str().expect("utf-8 path");
+        execute_git(path, &["init", "-q"]).expect("initialize repository");
+        execute_git(
+            path,
+            &["remote", "add", "origin", "file:///missing/repository.git"],
+        )
+        .expect("configure missing remote");
+
+        let error = fetch_until(
+            path,
+            &["fetch", "origin", "main", "--depth=50"],
+            Instant::now() + Duration::from_secs(5),
+        )
+        .expect_err("a failed fetch status must be returned");
+
+        assert!(error
+            .message
+            .contains("git fetch origin main --depth=50 failed"));
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-engine-primitives/src/git_changes.rs
+++ b/crates/homeboy-engine-primitives/src/git_changes.rs
@@ -393,7 +393,9 @@ mod tests {
     }
 
     #[test]
-    fn shallow_clone_fetches_remote_qualified_ref_from_its_named_remote() {
+    fn shallow_clone_fetches_and_unshallows_remote_qualified_ref_from_its_named_remote() {
+        use std::io::Write;
+
         let dir = tempfile::TempDir::new().expect("tempdir");
         let source = dir.path().join("source");
         let remote = dir.path().join("remote.git");
@@ -408,9 +410,46 @@ mod tests {
         execute_git(source_path, &["add", "."]).expect("stage base commit");
         execute_git(source_path, &["commit", "-qm", "base"]).expect("commit base");
         execute_git(source_path, &["switch", "-qc", "feature"]).expect("create feature branch");
-        std::fs::write(source.join("feature.txt"), "feature\n").expect("write feature commit");
-        execute_git(source_path, &["add", "."]).expect("stage feature commit");
-        execute_git(source_path, &["commit", "-qm", "feature"]).expect("commit feature");
+        let parent = String::from_utf8_lossy(
+            &execute_git(source_path, &["rev-parse", "HEAD"])
+                .expect("resolve feature parent")
+                .stdout,
+        )
+        .trim()
+        .to_string();
+        // The 50 and 200 deepen steps cannot reach this feature's base.
+        let mut history = String::new();
+        for index in 1..=300 {
+            let message = format!("feature {index}");
+            let previous = if index == 1 {
+                parent.clone()
+            } else {
+                format!(":{}", index - 1)
+            };
+            history.push_str(&format!(
+                "commit refs/heads/feature\nmark :{index}\nauthor test <test@example.com> 0 +0000\ncommitter test <test@example.com> 0 +0000\ndata {}\n{message}\nfrom {previous}\n\n",
+                message.len()
+            ));
+        }
+        let mut importer = Command::new("git")
+            .args(["fast-import", "--quiet"])
+            .current_dir(source_path)
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+            .expect("start feature history importer");
+        importer
+            .stdin
+            .take()
+            .expect("feature history importer stdin")
+            .write_all(history.as_bytes())
+            .expect("write feature history");
+        assert!(
+            importer
+                .wait()
+                .expect("wait for feature history importer")
+                .success(),
+            "import feature history"
+        );
         execute_git(
             source_path,
             &[

--- a/crates/homeboy-engine-primitives/src/git_changes.rs
+++ b/crates/homeboy-engine-primitives/src/git_changes.rs
@@ -30,14 +30,14 @@ fn execute_git(path: &str, args: &[&str]) -> std::io::Result<Output> {
 /// Run Git until `deadline`, terminating its process group if a transport or
 /// credential helper stalls.
 fn execute_git_until(path: &str, args: &[&str], deadline: Instant) -> Result<Output> {
-    execute_git_until_with_program(path, args, deadline, Path::new("git"))
+    execute_git_until_with_program(path, args, Path::new("git"), || deadline)
 }
 
 fn execute_git_until_with_program(
     path: &str,
     args: &[&str],
-    deadline: Instant,
     program: &Path,
+    deadline: impl FnOnce() -> Instant,
 ) -> Result<Output> {
     let mut process = Command::new(program);
     process
@@ -50,6 +50,7 @@ fn execute_git_until_with_program(
     let mut child = process
         .spawn()
         .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    let deadline = deadline();
     let mut timed_out = false;
     let output = command::wait_with_bounded_output_until_cancelled(
         &mut child,
@@ -261,6 +262,7 @@ fn parse_diff_output(stdout: &[u8]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::thread;
 
     #[test]
     fn get_files_changed_since_includes_dirty_and_untracked_files() {
@@ -336,25 +338,31 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let path = dir.path().to_str().expect("utf-8 path");
         let git = dir.path().join("git");
+        let ready_file = dir.path().join("helper-ready");
+        let release_file = dir.path().join("start-stall");
         let pid_file = dir.path().join("descendant.pid");
         let script = format!(
-            "#!/bin/sh\nsleep 30 &\necho $! > {}\nwait\n",
+            "#!/bin/sh\ntouch {}\nwhile [ ! -f {} ]; do sleep 0.01; done\nsleep 30 &\necho $! > {}\nwait\n",
+            crate::shell::quote_path(&ready_file.display().to_string()),
+            crate::shell::quote_path(&release_file.display().to_string()),
             crate::shell::quote_path(&pid_file.display().to_string())
         );
         std::fs::write(&git, script).expect("write stalled git");
         std::fs::set_permissions(&git, std::fs::Permissions::from_mode(0o755))
             .expect("make stalled git executable");
 
-        let started = Instant::now();
-        let error = execute_git_until_with_program(
-            path,
-            &["fetch", "origin"],
-            Instant::now() + Duration::from_secs(1),
-            &git,
-        )
+        let mut deadline_started = None;
+        let error = execute_git_until_with_program(path, &["fetch", "origin"], &git, || {
+            wait_for_file(&ready_file);
+            std::fs::write(&release_file, "start stalled helper").expect("release stalled helper");
+            wait_for_file(&pid_file);
+            let started = Instant::now();
+            deadline_started = Some(started);
+            started + Duration::from_secs(1)
+        })
         .expect_err("stalled fetch must exhaust its deadline");
 
-        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(deadline_started.expect("deadline started").elapsed() < Duration::from_secs(2));
         assert!(error.message.contains("deadline exhausted"));
         let descendant_pid = std::fs::read_to_string(&pid_file)
             .expect("descendant pid")
@@ -365,5 +373,18 @@ mod tests {
             !command::process_is_running(descendant_pid),
             "deadline left descendant {descendant_pid} runnable"
         );
+    }
+
+    #[cfg(unix)]
+    fn wait_for_file(path: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !path.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "stalled Git helper did not record {}",
+                path.display()
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
     }
 }

--- a/crates/homeboy-engine-primitives/src/git_changes.rs
+++ b/crates/homeboy-engine-primitives/src/git_changes.rs
@@ -258,7 +258,7 @@ pub fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
 
             // Progressive deepening: try increasingly generous depths.
             for depth in &["50", "200"] {
-                fetch_until(path, &["fetch", "--deepen", depth], deadline)?;
+                fetch_until(path, &["fetch", &remote, "--deepen", depth], deadline)?;
                 if has_merge_base(path, git_ref) {
                     eprintln!("Merge base found after deepening by {depth} commits");
                     return Ok(());
@@ -267,7 +267,7 @@ pub fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
 
             // Last resort: full unshallow.
             eprintln!("Merge base not found with depth 200, unshallowing repository");
-            fetch_until(path, &["fetch", "--unshallow"], deadline)?;
+            fetch_until(path, &["fetch", &remote, "--unshallow"], deadline)?;
 
             if has_merge_base(path, git_ref) {
                 eprintln!("Merge base found after full unshallow");
@@ -454,6 +454,16 @@ mod tests {
             &["remote", "add", "origin", "file:///missing/origin.git"],
         )
         .expect("configure default remote");
+        execute_git(
+            checkout_path,
+            &["config", "branch.feature.remote", "origin"],
+        )
+        .expect("configure unusable branch remote");
+        execute_git(
+            checkout_path,
+            &["config", "branch.feature.merge", "refs/heads/feature"],
+        )
+        .expect("configure tracked branch");
 
         ensure_ancestry_for_ref(checkout_path, "upstream/main")
             .expect("fetch named remote ref and resolve merge base");

--- a/crates/homeboy-engine-primitives/src/git_changes.rs
+++ b/crates/homeboy-engine-primitives/src/git_changes.rs
@@ -14,8 +14,11 @@
 
 use std::collections::BTreeSet;
 use std::process::{Command, Output};
+use std::time::{Duration, Instant};
 
 use homeboy_error::{Error, Result};
+
+use crate::git_remote_tracking_authority::with_remote_tracking_authority_until;
 
 /// Run a git subcommand in `path`, returning the raw process output.
 fn execute_git(path: &str, args: &[&str]) -> std::io::Result<Output> {
@@ -167,32 +170,38 @@ pub fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
     }
 
     eprintln!("Shallow clone detected — deepening to resolve merge base for {git_ref}");
+    with_remote_tracking_authority_until(
+        std::path::Path::new(path),
+        "deepen shallow clone",
+        Instant::now() + Duration::from_secs(30),
+        |_| {
+            // Fetch the ref itself if it's not already present.
+            let remote = resolve_default_remote(path);
+            let _ = execute_git(path, &["fetch", &remote, git_ref, "--depth=50"]);
 
-    // Fetch the ref itself if it's not already present.
-    let remote = resolve_default_remote(path);
-    let _ = execute_git(path, &["fetch", &remote, git_ref, "--depth=50"]);
+            // Progressive deepening: try increasingly generous depths.
+            for depth in &["50", "200"] {
+                let _ = execute_git(path, &["fetch", "--deepen", depth]);
+                if has_merge_base(path, git_ref) {
+                    eprintln!("Merge base found after deepening by {depth} commits");
+                    return Ok(());
+                }
+            }
 
-    // Progressive deepening: try increasingly generous depths.
-    for depth in &["50", "200"] {
-        let _ = execute_git(path, &["fetch", "--deepen", depth]);
-        if has_merge_base(path, git_ref) {
-            eprintln!("Merge base found after deepening by {depth} commits");
-            return Ok(());
-        }
-    }
+            // Last resort: full unshallow.
+            eprintln!("Merge base not found with depth 200, unshallowing repository");
+            let _ = execute_git(path, &["fetch", "--unshallow"]);
 
-    // Last resort: full unshallow.
-    eprintln!("Merge base not found with depth 200, unshallowing repository");
-    let _ = execute_git(path, &["fetch", "--unshallow"]);
-
-    if has_merge_base(path, git_ref) {
-        eprintln!("Merge base found after full unshallow");
-        Ok(())
-    } else {
-        Err(Error::git_command_failed(format!(
-            "Cannot resolve merge base for {git_ref} even after full unshallow — the ref may not exist in the remote"
-        )))
-    }
+            if has_merge_base(path, git_ref) {
+                eprintln!("Merge base found after full unshallow");
+                Ok(())
+            } else {
+                Err(Error::git_command_failed(format!(
+                    "Cannot resolve merge base for {git_ref} even after full unshallow — the ref may not exist in the remote"
+                )))
+            }
+        },
+    )
 }
 
 /// Parse newline-delimited `git diff --name-only` output into a file list.

--- a/crates/homeboy-engine-primitives/src/git_changes.rs
+++ b/crates/homeboy-engine-primitives/src/git_changes.rs
@@ -18,11 +18,45 @@ use std::time::{Duration, Instant};
 
 use homeboy_error::{Error, Result};
 
+use crate::command;
 use crate::git_remote_tracking_authority::with_remote_tracking_authority_until;
 
 /// Run a git subcommand in `path`, returning the raw process output.
 fn execute_git(path: &str, args: &[&str]) -> std::io::Result<Output> {
     Command::new("git").args(args).current_dir(path).output()
+}
+
+/// Run Git until `deadline`, terminating its process group if a transport or
+/// credential helper stalls.
+fn execute_git_until(path: &str, args: &[&str], deadline: Instant) -> Result<Output> {
+    let mut process = Command::new("git");
+    process
+        .args(args)
+        .current_dir(path)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    command::isolate_process_tree(&mut process);
+    let mut child = process
+        .spawn()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    let mut timed_out = false;
+    let output = command::wait_with_bounded_output_until_cancelled(
+        &mut child,
+        command::DEFAULT_CAPTURE_LIMIT_BYTES,
+        || {
+            timed_out = Instant::now() >= deadline;
+            timed_out
+        },
+    )
+    .map_err(|error| Error::git_command_failed(error.to_string()))?
+    .into_output();
+    if timed_out {
+        return Err(Error::git_command_failed(
+            "git shallow-clone fetch deadline exhausted; terminated child process group",
+        ));
+    }
+    Ok(output)
 }
 
 /// Get the files that changed on the current branch relative to `git_ref`.
@@ -170,18 +204,19 @@ pub fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
     }
 
     eprintln!("Shallow clone detected — deepening to resolve merge base for {git_ref}");
+    let deadline = Instant::now() + Duration::from_secs(30);
     with_remote_tracking_authority_until(
         std::path::Path::new(path),
         "deepen shallow clone",
-        Instant::now() + Duration::from_secs(30),
+        deadline,
         |_| {
             // Fetch the ref itself if it's not already present.
             let remote = resolve_default_remote(path);
-            let _ = execute_git(path, &["fetch", &remote, git_ref, "--depth=50"]);
+            let _ = execute_git_until(path, &["fetch", &remote, git_ref, "--depth=50"], deadline)?;
 
             // Progressive deepening: try increasingly generous depths.
             for depth in &["50", "200"] {
-                let _ = execute_git(path, &["fetch", "--deepen", depth]);
+                let _ = execute_git_until(path, &["fetch", "--deepen", depth], deadline)?;
                 if has_merge_base(path, git_ref) {
                     eprintln!("Merge base found after deepening by {depth} commits");
                     return Ok(());
@@ -190,7 +225,7 @@ pub fn ensure_ancestry_for_ref(path: &str, git_ref: &str) -> Result<()> {
 
             // Last resort: full unshallow.
             eprintln!("Merge base not found with depth 200, unshallowing repository");
-            let _ = execute_git(path, &["fetch", "--unshallow"]);
+            let _ = execute_git_until(path, &["fetch", "--unshallow"], deadline)?;
 
             if has_merge_base(path, git_ref) {
                 eprintln!("Merge base found after full unshallow");
@@ -281,5 +316,44 @@ mod tests {
             !files.contains(&"deleted.txt".to_string()),
             "deleted file excluded: {files:?}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deadline_terminates_a_stalled_git_process_group() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().to_str().expect("utf-8 path");
+        execute_git(path, &["init", "-q"]).expect("initialize repository");
+        let remote = dir.path().join("remote.git");
+        execute_git(path, &["init", "--bare", "-q", remote.to_str().unwrap()])
+            .expect("initialize remote");
+        execute_git(path, &["remote", "add", "origin", remote.to_str().unwrap()])
+            .expect("configure remote");
+        let upload_pack = dir.path().join("hang-upload-pack");
+        std::fs::write(&upload_pack, "#!/bin/sh\nsleep 10 &\nwait\n").expect("write helper");
+        std::fs::set_permissions(&upload_pack, std::fs::Permissions::from_mode(0o755))
+            .expect("make helper executable");
+        execute_git(
+            path,
+            &[
+                "config",
+                "remote.origin.uploadpack",
+                upload_pack.to_str().unwrap(),
+            ],
+        )
+        .expect("configure upload-pack helper");
+
+        let started = Instant::now();
+        let error = execute_git_until(
+            path,
+            &["fetch", "origin"],
+            Instant::now() + Duration::from_millis(250),
+        )
+        .expect_err("stalled fetch must exhaust its deadline");
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(error.message.contains("deadline exhausted"));
     }
 }

--- a/crates/homeboy-engine-primitives/src/git_remote_tracking_authority.rs
+++ b/crates/homeboy-engine-primitives/src/git_remote_tracking_authority.rs
@@ -56,13 +56,13 @@ pub fn with_remote_tracking_authority_until<T>(
 }
 
 fn git_common_dir(repository: &Path, deadline: Instant) -> Result<PathBuf> {
-    git_common_dir_with_program(repository, deadline, Path::new("git"))
+    git_common_dir_with_program(repository, Path::new("git"), || deadline)
 }
 
 fn git_common_dir_with_program(
     repository: &Path,
-    deadline: Instant,
     program: &Path,
+    deadline: impl FnOnce() -> Instant,
 ) -> Result<PathBuf> {
     let mut git = Command::new(program);
     git.args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
@@ -74,6 +74,7 @@ fn git_common_dir_with_program(
     let mut child = git
         .spawn()
         .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    let deadline = deadline();
     let mut timed_out = false;
     let output = command::wait_with_bounded_output_until_cancelled(
         &mut child,
@@ -105,6 +106,7 @@ fn git_common_dir_with_program(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::thread;
 
     #[cfg(unix)]
     #[test]
@@ -112,22 +114,32 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::TempDir::new().expect("tempdir");
+        let ready_file = dir.path().join("helper-ready");
+        let release_file = dir.path().join("start-stall");
         let pid_file = dir.path().join("descendant.pid");
         let git = dir.path().join("git");
         let script = format!(
-            "#!/bin/sh\nsleep 30 &\necho $! > {}\nwait\n",
-            crate::shell::quote_path(&pid_file.display().to_string())
+            "#!/bin/sh\ntouch {}\nwhile [ ! -f {} ]; do sleep 0.01; done\nsleep 30 &\necho $! > {}\nwait\n",
+            crate::shell::quote_path(&ready_file.display().to_string()),
+            crate::shell::quote_path(&release_file.display().to_string()),
+            crate::shell::quote_path(&pid_file.display().to_string()),
         );
         fs::write(&git, script).expect("write stalled git");
         fs::set_permissions(&git, fs::Permissions::from_mode(0o755))
             .expect("make stalled git executable");
 
-        let started = Instant::now();
-        let error =
-            git_common_dir_with_program(dir.path(), Instant::now() + Duration::from_secs(1), &git)
-                .expect_err("stalled common-directory probe must exhaust its deadline");
+        let mut deadline_started = None;
+        let error = git_common_dir_with_program(dir.path(), &git, || {
+            wait_for_file(&ready_file);
+            fs::write(&release_file, "start stalled helper").expect("release stalled helper");
+            wait_for_file(&pid_file);
+            let started = Instant::now();
+            deadline_started = Some(started);
+            started + Duration::from_secs(1)
+        })
+        .expect_err("stalled common-directory probe must exhaust its deadline");
 
-        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(deadline_started.expect("deadline started").elapsed() < Duration::from_secs(2));
         assert!(error.message.contains("deadline exhausted"));
         let descendant_pid = fs::read_to_string(&pid_file)
             .expect("descendant pid")
@@ -138,6 +150,19 @@ mod tests {
             !command::process_is_running(descendant_pid),
             "deadline left descendant {descendant_pid} runnable"
         );
+    }
+
+    #[cfg(unix)]
+    fn wait_for_file(path: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !path.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "stalled Git helper did not record {}",
+                path.display()
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
     }
 }
 

--- a/crates/homeboy-engine-primitives/src/git_remote_tracking_authority.rs
+++ b/crates/homeboy-engine-primitives/src/git_remote_tracking_authority.rs
@@ -2,12 +2,15 @@ use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use fs4::fs_std::FileExt;
 use homeboy_error::{Error, Result};
+
+use crate::command;
 
 const WAIT_INTERVAL: Duration = Duration::from_millis(50);
 const LOCK_FILE: &str = "homeboy-remote-tracking.lock";
@@ -23,7 +26,7 @@ pub fn with_remote_tracking_authority_until<T>(
     action: impl FnOnce(Duration) -> Result<T>,
 ) -> Result<T> {
     report_authority_attempt();
-    let common_dir = git_common_dir(repository)?;
+    let common_dir = git_common_dir(repository, deadline)?;
     let authority = {
         let mut authorities = AUTHORITIES
             .get_or_init(|| Mutex::new(HashMap::new()))
@@ -52,12 +55,41 @@ pub fn with_remote_tracking_authority_until<T>(
     )?)
 }
 
-fn git_common_dir(repository: &Path) -> Result<PathBuf> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+fn git_common_dir(repository: &Path, deadline: Instant) -> Result<PathBuf> {
+    git_common_dir_with_program(repository, deadline, Path::new("git"))
+}
+
+fn git_common_dir_with_program(
+    repository: &Path,
+    deadline: Instant,
+    program: &Path,
+) -> Result<PathBuf> {
+    let mut git = Command::new(program);
+    git.args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
         .current_dir(repository)
-        .output()
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command::isolate_process_tree(&mut git);
+    let mut child = git
+        .spawn()
         .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    let mut timed_out = false;
+    let output = command::wait_with_bounded_output_until_cancelled(
+        &mut child,
+        command::DEFAULT_CAPTURE_LIMIT_BYTES,
+        || {
+            timed_out = Instant::now() >= deadline;
+            timed_out
+        },
+    )
+    .map_err(|error| Error::git_command_failed(error.to_string()))?
+    .into_output();
+    if timed_out {
+        return Err(Error::git_command_failed(
+            "resolve Git common directory deadline exhausted; terminated child process group",
+        ));
+    }
     if !output.status.success() {
         return Err(Error::git_command_failed(format!(
             "resolve Git common directory for {}",
@@ -68,6 +100,45 @@ fn git_common_dir(repository: &Path) -> Result<PathBuf> {
         String::from_utf8_lossy(&output.stdout).trim(),
     ))
     .map_err(|error| Error::git_command_failed(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn common_directory_probe_deadline_reaps_stalled_git_process_group() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let pid_file = dir.path().join("descendant.pid");
+        let git = dir.path().join("git");
+        let script = format!(
+            "#!/bin/sh\nsleep 30 &\necho $! > {}\nwait\n",
+            crate::shell::quote_path(&pid_file.display().to_string())
+        );
+        fs::write(&git, script).expect("write stalled git");
+        fs::set_permissions(&git, fs::Permissions::from_mode(0o755))
+            .expect("make stalled git executable");
+
+        let started = Instant::now();
+        let error =
+            git_common_dir_with_program(dir.path(), Instant::now() + Duration::from_secs(1), &git)
+                .expect_err("stalled common-directory probe must exhaust its deadline");
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(error.message.contains("deadline exhausted"));
+        let descendant_pid = fs::read_to_string(&pid_file)
+            .expect("descendant pid")
+            .trim()
+            .parse::<u32>()
+            .expect("numeric descendant pid");
+        assert!(
+            !command::process_is_running(descendant_pid),
+            "deadline left descendant {descendant_pid} runnable"
+        );
+    }
 }
 
 fn acquire_process_guard<'a>(

--- a/crates/homeboy-engine-primitives/src/git_remote_tracking_authority.rs
+++ b/crates/homeboy-engine-primitives/src/git_remote_tracking_authority.rs
@@ -1,0 +1,183 @@
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use fs4::fs_std::FileExt;
+use homeboy_error::{Error, Result};
+
+const WAIT_INTERVAL: Duration = Duration::from_millis(50);
+const LOCK_FILE: &str = "homeboy-remote-tracking.lock";
+
+static AUTHORITIES: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+
+/// Serialize operations that update remote-tracking refs for one repository.
+/// Linked worktrees share a Git common directory; unrelated repositories do not.
+pub fn with_remote_tracking_authority_until<T>(
+    repository: &Path,
+    operation: &str,
+    deadline: Instant,
+    action: impl FnOnce(Duration) -> Result<T>,
+) -> Result<T> {
+    report_authority_attempt();
+    let common_dir = git_common_dir(repository)?;
+    let authority = {
+        let mut authorities = AUTHORITIES
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        authorities
+            .entry(common_dir.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    };
+    let _process_guard = acquire_process_guard(&authority, &common_dir, operation, deadline)?;
+    let lock_path = common_dir.join(LOCK_FILE);
+    let mut lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| authority_error(operation, &common_dir, &lock_path, None, error))?;
+    acquire_file_guard(&mut lock, &common_dir, &lock_path, operation, deadline)?;
+    action(remaining(
+        deadline,
+        operation,
+        &common_dir,
+        &lock_path,
+        None,
+    )?)
+}
+
+fn git_common_dir(repository: &Path) -> Result<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .current_dir(repository)
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !output.status.success() {
+        return Err(Error::git_command_failed(format!(
+            "resolve Git common directory for {}",
+            repository.display()
+        )));
+    }
+    fs::canonicalize(PathBuf::from(
+        String::from_utf8_lossy(&output.stdout).trim(),
+    ))
+    .map_err(|error| Error::git_command_failed(error.to_string()))
+}
+
+fn acquire_process_guard<'a>(
+    authority: &'a Mutex<()>,
+    common_dir: &Path,
+    operation: &str,
+    deadline: Instant,
+) -> Result<std::sync::MutexGuard<'a, ()>> {
+    loop {
+        match authority.try_lock() {
+            Ok(guard) => return Ok(guard),
+            Err(std::sync::TryLockError::Poisoned(poisoned)) => return Ok(poisoned.into_inner()),
+            Err(std::sync::TryLockError::WouldBlock) if Instant::now() < deadline => {
+                thread::sleep(WAIT_INTERVAL)
+            }
+            Err(std::sync::TryLockError::WouldBlock) => {
+                return Err(authority_error(
+                    operation,
+                    common_dir,
+                    &common_dir.join(LOCK_FILE),
+                    Some("another Homeboy operation in this process".to_string()),
+                    timed_out_error(),
+                ))
+            }
+        }
+    }
+}
+
+fn acquire_file_guard(
+    lock: &mut File,
+    common_dir: &Path,
+    lock_path: &Path,
+    operation: &str,
+    deadline: Instant,
+) -> Result<()> {
+    loop {
+        match lock.try_lock_exclusive() {
+            Ok(true) => {
+                let owner = format!("pid={} operation={}\n", std::process::id(), operation);
+                lock.set_len(0)
+                    .and_then(|()| lock.write_all(owner.as_bytes()))
+                    .and_then(|()| lock.sync_data())
+                    .map_err(|error| {
+                        authority_error(operation, common_dir, lock_path, None, error)
+                    })?;
+                return Ok(());
+            }
+            Ok(false) | Err(_) if Instant::now() < deadline => {
+                report_authority_attempt();
+                thread::sleep(WAIT_INTERVAL);
+            }
+            Ok(false) => {
+                return Err(authority_error(
+                    operation,
+                    common_dir,
+                    lock_path,
+                    lock_owner(lock_path),
+                    timed_out_error(),
+                ))
+            }
+            Err(error) => {
+                return Err(authority_error(
+                    operation,
+                    common_dir,
+                    lock_path,
+                    lock_owner(lock_path),
+                    error,
+                ))
+            }
+        }
+    }
+}
+
+fn lock_owner(lock_path: &Path) -> Option<String> {
+    fs::read_to_string(lock_path)
+        .ok()
+        .map(|value| value.trim().to_string())
+}
+
+fn remaining(
+    deadline: Instant,
+    operation: &str,
+    common_dir: &Path,
+    lock_path: &Path,
+    owner: Option<String>,
+) -> Result<Duration> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .ok_or_else(|| authority_error(operation, common_dir, lock_path, owner, timed_out_error()))
+}
+
+fn timed_out_error() -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::TimedOut, "authority deadline exhausted")
+}
+
+fn authority_error(
+    operation: &str,
+    common_dir: &Path,
+    lock_path: &Path,
+    owner: Option<String>,
+    error: std::io::Error,
+) -> Error {
+    let owner = owner
+        .filter(|owner| !owner.is_empty())
+        .unwrap_or_else(|| "unknown owner".to_string());
+    Error::git_command_failed(format!("{operation} exhausted its caller deadline waiting for remote-tracking authority at {} (owner: {}; lock: {}): {error}", common_dir.display(), owner, lock_path.display()))
+}
+
+fn report_authority_attempt() {
+    if let Some(path) = std::env::var_os("HOMEB0Y_REMOTE_TRACKING_FETCH_LOCK_ATTEMPTED") {
+        let _ = std::fs::write(path, "attempted\n");
+    }
+}

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -19,6 +19,7 @@ pub mod edit_op;
 pub mod edit_op_apply;
 pub mod fs_index_lock;
 pub mod git_changes;
+pub mod git_remote_tracking_authority;
 pub mod grammar;
 pub mod identifier;
 pub mod language;

--- a/crates/homeboy-rig/src/pipeline/git_step.rs
+++ b/crates/homeboy-rig/src/pipeline/git_step.rs
@@ -4,6 +4,7 @@ use super::super::expand::expand_vars;
 use super::super::spec::{GitOp, RigSpec};
 use super::component::resolve_component_path;
 use homeboy_core::error::{Error, Result};
+use std::time::{Duration, Instant};
 
 pub(super) fn run_git_step(
     rig: &RigSpec,
@@ -29,7 +30,18 @@ pub(super) fn run_git_step(
     }
     let arg_refs: Vec<&str> = full_args.iter().map(String::as_str).collect();
 
-    let output = homeboy_core::git::execute_git_for_release(&path, &arg_refs).map_err(|e| {
+    let output = if matches!(op, GitOp::Fetch | GitOp::Pull) {
+        homeboy_core::git::run_git_remote_tracking_operation_until(
+            std::path::Path::new(&path),
+            &arg_refs,
+            &format!("rig git {}", full_args[0]),
+            Instant::now() + Duration::from_secs(30),
+        )
+    } else {
+        homeboy_core::git::execute_git_for_release(&path, &arg_refs)
+            .map_err(|error| Error::git_command_failed(error.to_string()))
+    }
+    .map_err(|e| {
         Error::rig_pipeline_failed(
             &rig.id,
             "git",


### PR DESCRIPTION
## Summary

- serialize remote-tracking mutations across linked worktrees and consume `FETCH_HEAD` atomically under authority
- honor configured upstreams and live slash-named default branches without implicit second fetches
- bound common-directory resolution, authority waits, fetches, shallow deepening, and descendant process trees with one absolute deadline
- route every remote-qualified shallow-history phase through the resolved remote and validate failed fetch statuses
- route rig fetch/pull operations through the shared authority

This restores the remaining acceptance criteria from #14479 after #14497 merged before its final correction commits.

## Verification

- focused configured-upstream, default-branch, authority serialization, deadline, and process-tree tests
- forced-unshallow multi-remote tests with an unusable `origin`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- independent read-only review: no findings

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode implemented and iteratively reviewed the shared fetch-authority corrections under Chris Huber’s direction; focused tests and independent review were used to verify the final branch.