### PR TITLE
fix(agent-task): complete fanout preview readiness admission

### DIFF
--- a/crates/homeboy-agents/src/agent_task_controller_service/request.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/request.rs
@@ -52,6 +52,7 @@ pub fn controller_request_dispatch_command(
             tasks_json: optional_string(dispatch, "tasks_json"),
             provider_config: optional_string(dispatch, "provider_config"),
             client_context: optional_string(dispatch, "client_context"),
+            generated_fanout_context: false,
             // An absent key is "unspecified", not "one execution and no
             // rotation": the dispatch-plan layer resolves it against the
             // configured provider rotation (#11082).

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -361,6 +361,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
                 "resolved_runtime_identity": request.core.resolved_provider_policy
                     .as_ref()
                     .and_then(|policy| policy.runtime_identity.as_ref()),
+                "provider_readiness_generated_fanout_context": request.core.generated_fanout_context,
             }),
         });
     }
@@ -2224,6 +2225,7 @@ mod tests {
                 tasks_json: overrides.core.tasks_json,
                 provider_config: overrides.core.provider_config,
                 client_context: overrides.core.client_context,
+                generated_fanout_context: overrides.core.generated_fanout_context,
                 attempts: overrides.core.attempts,
                 same_provider_retries: overrides.core.same_provider_retries,
                 provider_rotations: overrides.core.provider_rotations,

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -155,7 +155,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
     )?);
 
     let client_context = dispatch_client_context(request)?;
-    let (mut provider_config, _) = dispatch_provider_config(
+    let (mut provider_config, mut generated_provider_client_context) = dispatch_provider_config(
         request,
         &repo,
         &component,
@@ -168,17 +168,14 @@ pub fn build_dispatch_plan_with_provider_requirements(
         .as_ref()
         .and_then(|route| route.provider_config.as_object())
     {
+        // A selected policy route owns its explicit context, even when the
+        // base config received a Homeboy-generated fanout context.
+        generated_provider_client_context &= !overrides.contains_key("client_context");
         provider_config
             .as_object_mut()
             .expect("dispatch provider config object")
             .extend(overrides.clone());
     }
-    // Policy-route configuration is authoritative for the selected provider.
-    // Its client context is caller-owned even when Homeboy generated the base.
-    let generated_provider_client_context = !provider_config
-        .as_object()
-        .expect("dispatch provider config object")
-        .contains_key("client_context");
     let policy_backend = initial_route
         .as_ref()
         .map(|route| route.backend.clone())
@@ -1311,6 +1308,34 @@ mod tests {
         assert_eq!(
             plan.tasks[0].metadata["provider_readiness_generated_fanout_context"],
             false
+        );
+    }
+
+    #[test]
+    fn generated_fanout_context_remains_marked_for_readiness_identity() {
+        let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+            prompt: Some("Cook with generated fanout context.".to_string()),
+            core: DispatchCoreInputs {
+                generated_fanout_context: true,
+                client_context: Some(
+                    serde_json::json!({
+                        "fanout": {
+                            "id": "shared-fanout",
+                            "semantics": "batch_cook",
+                            "cook_id": "generated-child"
+                        }
+                    })
+                    .to_string(),
+                ),
+                ..DispatchCoreInputs::default()
+            },
+            ..DispatchRequestOverrides::default()
+        }))
+        .expect("dispatch plan");
+
+        assert_eq!(
+            plan.tasks[0].metadata["provider_readiness_generated_fanout_context"],
+            true
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -155,7 +155,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
     )?);
 
     let client_context = dispatch_client_context(request)?;
-    let (mut provider_config, generated_provider_client_context) = dispatch_provider_config(
+    let (mut provider_config, _) = dispatch_provider_config(
         request,
         &repo,
         &component,
@@ -173,6 +173,12 @@ pub fn build_dispatch_plan_with_provider_requirements(
             .expect("dispatch provider config object")
             .extend(overrides.clone());
     }
+    // Policy-route configuration is authoritative for the selected provider.
+    // Its client context is caller-owned even when Homeboy generated the base.
+    let generated_provider_client_context = !provider_config
+        .as_object()
+        .expect("dispatch provider config object")
+        .contains_key("client_context");
     let policy_backend = initial_route
         .as_ref()
         .map(|route| route.backend.clone())
@@ -1261,6 +1267,50 @@ mod tests {
                 .filter_map(|entry| entry.model.as_deref())
                 .collect::<Vec<_>>(),
             ["model-two", "model-three"]
+        );
+    }
+
+    #[test]
+    fn policy_route_client_context_is_not_marked_as_generated_fanout_context() {
+        let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+            prompt: Some("Cook with the policy provider context.".to_string()),
+            core: DispatchCoreInputs {
+                generated_fanout_context: true,
+                resolved_provider_policy: Some(
+                    crate::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy {
+                        backend: "policy-backend".to_string(),
+                        selector: None,
+                        model: None,
+                        rotation: Some(AgentTaskProviderRotationPolicy {
+                            entries: vec![
+                                crate::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                                    provider_config: serde_json::json!({
+                                        "client_context": {"fanout": {"cook_id": "caller-owned"}}
+                                    }),
+                                    ..Default::default()
+                                },
+                            ],
+                            ..Default::default()
+                        }),
+                        rotation_starts_with_first_entry: true,
+                        retry: AgentTaskRetryPolicy::default(),
+                        liveness_timeout_ms: None,
+                        runtime_identity: None,
+                    },
+                ),
+                ..DispatchCoreInputs::default()
+            },
+            ..DispatchRequestOverrides::default()
+        }))
+        .expect("dispatch plan");
+
+        assert_eq!(
+            plan.tasks[0].executor.config["client_context"]["fanout"]["cook_id"],
+            "caller-owned"
+        );
+        assert_eq!(
+            plan.tasks[0].metadata["provider_readiness_generated_fanout_context"],
+            false
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -155,7 +155,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
     )?);
 
     let client_context = dispatch_client_context(request)?;
-    let mut provider_config = dispatch_provider_config(
+    let (mut provider_config, generated_provider_client_context) = dispatch_provider_config(
         request,
         &repo,
         &component,
@@ -361,7 +361,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
                 "resolved_runtime_identity": request.core.resolved_provider_policy
                     .as_ref()
                     .and_then(|policy| policy.runtime_identity.as_ref()),
-                "provider_readiness_generated_fanout_context": request.core.generated_fanout_context,
+                "provider_readiness_generated_fanout_context": request.core.generated_fanout_context && generated_provider_client_context,
             }),
         });
     }

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/provider_config.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/provider_config.rs
@@ -32,7 +32,7 @@ pub(crate) fn dispatch_provider_config(
     component: &Option<String>,
     workspace: Option<&DispatchWorkspaceTarget>,
     client_context: &Value,
-) -> Result<Value> {
+) -> Result<(Value, bool)> {
     let mut config = Value::Object(defaults::load_config().settings.into_iter().collect());
     if let Some(spec) = &request.core.provider_config {
         let raw = read_text_spec(spec, "provider-config")?;
@@ -71,6 +71,9 @@ pub(crate) fn dispatch_provider_config(
         ));
     }
     let map = config.as_object_mut().expect("provider config object");
+    // This is true only when the client context below is inserted by Homeboy.
+    // A caller or configured default may supply an independent provider context.
+    let generated_client_context = !map.contains_key("client_context");
     map.entry("repo".to_string())
         .or_insert_with(|| serde_json::json!(repo));
     map.entry("component_id".to_string())
@@ -91,7 +94,7 @@ pub(crate) fn dispatch_provider_config(
     map.entry("task_url".to_string())
         .or_insert_with(|| serde_json::json!(request.task_url));
 
-    Ok(config)
+    Ok((config, generated_client_context))
 }
 
 pub(crate) fn dispatch_component_contracts(

--- a/crates/homeboy-agents/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_service.rs
@@ -100,6 +100,9 @@ pub struct DispatchCoreInputs {
     pub provider_config: Option<String>,
     /// Opaque client context JSON object, `@file`, or `-` for stdin.
     pub client_context: Option<String>,
+    /// Internal provenance for Homeboy-generated batch fanout context. This is
+    /// retained in task metadata and is never included in provider config.
+    pub generated_fanout_context: bool,
     /// Total provider executions per task, including the first attempt.
     /// `None` means the caller did not ask for a value, so the configured
     /// provider rotation gets to fund its own reachability (#11082).

--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -115,10 +115,7 @@ pub use runtime_preflight_checks::{
     ensure_runtime_preflight_checks, evaluate_runtime_preflight_checks, RuntimePreflightConflict,
     RuntimePreflightReadiness,
 };
-pub(crate) use runtime_readiness::{
-    effective_provider_config, readiness_request_key,
-    readiness_verdict_with_credentials_and_deadline,
-};
+pub(crate) use runtime_readiness::{effective_provider_config, readiness_request_key};
 pub use runtime_readiness::{
     preflight_plan_provider_runtime_readiness_with_providers, ProviderRuntimeReadinessCache,
 };

--- a/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     effective_provider_config, executor::effective_provider_for_request,
-    provider_credential_readiness, readiness_verdict_with_credentials_and_deadline,
-    resolve_provider_for_backend, runtime_readiness::provider_requires_live_auth_validation,
+    provider_credential_readiness, resolve_provider_for_backend,
+    runtime_readiness::provider_requires_live_auth_validation,
     validate_provider_immediate_failure_patterns, AgentTaskProviderCatalog, ProviderResolution,
     ProviderRuntimeReadinessCache,
 };
@@ -226,6 +226,7 @@ fn evaluate_provider_dispatchability_with_config_and_credentials(
         cache,
         runtime_evidence_out,
         None,
+        false,
     )
 }
 
@@ -244,6 +245,7 @@ fn evaluate_provider_dispatchability_with_config_credentials_and_deadline(
     cache: &mut ProviderRuntimeReadinessCache,
     runtime_evidence_out: &mut Option<AgentTaskProviderRuntimeEvidence>,
     deadline_unix_ms: Option<u64>,
+    generated_fanout_context: bool,
 ) -> AgentTaskProviderDispatchability {
     let candidate_providers = catalog
         .providers()
@@ -354,15 +356,19 @@ fn evaluate_provider_dispatchability_with_config_credentials_and_deadline(
         },
     };
     let mut runtime_remediation = Vec::new();
-    let (runtime, runtime_evidence) =
-        if probe_runtime && model_ready && credentials.dispatchable && configuration.ready {
-            let config = effective_provider_config(config, model);
-            match readiness_verdict_with_credentials_and_deadline(
+    let (runtime, runtime_evidence) = if probe_runtime
+        && model_ready
+        && credentials.dispatchable
+        && configuration.ready
+    {
+        let config = effective_provider_config(config, model);
+        match super::runtime_readiness::readiness_verdict_with_credentials_and_deadline_for_generated_fanout_context(
                 provider,
                 &config,
                 credential_env,
                 cache,
                 deadline_unix_ms,
+                generated_fanout_context,
             ) {
                 Ok(verdict) => {
                     let remediation = (!verdict.remediation.trim().is_empty())
@@ -429,15 +435,15 @@ fn evaluate_provider_dispatchability_with_config_credentials_and_deadline(
                     )
                 }
             }
-        } else {
-            (
-                AgentTaskProviderDispatchabilityCheck {
-                    ready: !probe_runtime,
-                    reason: (!probe_runtime).then_some("not requested".to_string()),
-                },
-                None,
-            )
-        };
+    } else {
+        (
+            AgentTaskProviderDispatchabilityCheck {
+                ready: !probe_runtime,
+                reason: (!probe_runtime).then_some("not requested".to_string()),
+            },
+            None,
+        )
+    };
     // `runtime.ready` alone conflates two very different situations: a
     // provider-declared probe actually ran and passed, versus no probe being
     // declared at all (in which case `run_provider_readiness_invocation`
@@ -940,7 +946,12 @@ pub fn provider_runtime_readiness_cache_identity_for_plan(
             )
         })?;
     let config = effective_provider_config(&request.executor.config, request.executor.model());
-    super::runtime_readiness::readiness_cache_identity(&provider, &config, &credential_env)
+    super::runtime_readiness::readiness_cache_identity_for_generated_fanout_context(
+        &provider,
+        &config,
+        &credential_env,
+        task.metadata["provider_readiness_generated_fanout_context"] == true,
+    )
 }
 
 pub(crate) fn evaluate_request_dispatchability_with_credentials(
@@ -966,6 +977,7 @@ pub(crate) fn evaluate_request_dispatchability_with_credentials(
         cache,
         &mut runtime_evidence,
         request.limits.execution_deadline_unix_ms,
+        request.metadata["provider_readiness_generated_fanout_context"] == true,
     );
     EvaluatedRequestDispatchability {
         dispatchability,

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
@@ -1224,21 +1224,37 @@ mod tests {
         let script = root.path().join("owner-different-deadlines.js");
         std::fs::write(
             &script,
-            "const fs=require('fs');const count=process.argv[2];fs.appendFileSync(count,'probe\\n');setTimeout(()=>process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:true,classification:'ready',retryable:false,remediation:'',reason:'',cache_key:'shared',identity:{account:'shared'}})),200);",
+            "const fs=require('fs');const count=process.argv[2];fs.appendFileSync(count,'probe\\n');setTimeout(()=>process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:true,classification:'ready',retryable:false,remediation:'',reason:'',cache_key:'shared',identity:{account:'shared'}})),1000);",
         )
         .expect("readiness script");
         let provider = provider(&script, &count);
         let mut cache = ProviderRuntimeReadinessCache::default();
 
-        let short_deadline = crate::agent_task_timeout::now_unix_ms() + 25;
-        let error = readiness_verdict_with_credentials_and_deadline(
-            &provider,
-            &json!({"model":"same"}),
-            &[],
-            &mut cache,
-            Some(short_deadline),
-        )
-        .expect_err("short probe owner must time out locally");
+        let short_deadline = crate::agent_task_timeout::now_unix_ms() + 300;
+        let short_provider = provider.clone();
+        let mut short_cache = cache.clone();
+        let short = std::thread::spawn(move || {
+            readiness_verdict_with_credentials_and_deadline(
+                &short_provider,
+                &json!({"model":"same"}),
+                &[],
+                &mut short_cache,
+                Some(short_deadline),
+            )
+        });
+        let start_deadline = Instant::now() + Duration::from_secs(2);
+        while !count.exists() {
+            assert!(Instant::now() < start_deadline, "short probe did not start");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(
+            crate::agent_task_timeout::now_unix_ms() < short_deadline,
+            "short deadline expired before its probe started"
+        );
+        let error = short
+            .join()
+            .expect("short probe owner")
+            .expect_err("short probe owner must time out locally");
         assert_eq!(error.details["classification"], "timeout");
         assert_eq!(error.details["deadline_unix_ms"], short_deadline);
 

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
@@ -378,9 +378,32 @@ pub(crate) fn readiness_verdict_with_credentials_and_deadline(
     cache: &mut ProviderRuntimeReadinessCache,
     deadline_unix_ms: Option<u64>,
 ) -> Result<ProviderReadinessInvocationResult> {
+    readiness_verdict_with_credentials_and_deadline_for_generated_fanout_context(
+        provider,
+        config,
+        credential_env,
+        cache,
+        deadline_unix_ms,
+        false,
+    )
+}
+
+pub(crate) fn readiness_verdict_with_credentials_and_deadline_for_generated_fanout_context(
+    provider: &AgentTaskExecutorProvider,
+    config: &Value,
+    credential_env: &[(String, String)],
+    cache: &mut ProviderRuntimeReadinessCache,
+    deadline_unix_ms: Option<u64>,
+    generated_fanout_context: bool,
+) -> Result<ProviderReadinessInvocationResult> {
     let started = Instant::now();
     ensure_readiness_deadline("probe", deadline_unix_ms)?;
-    let request_key = readiness_cache_identity(provider, config, credential_env)?;
+    let request_key = readiness_cache_identity_for_generated_fanout_context(
+        provider,
+        config,
+        credential_env,
+        generated_fanout_context,
+    )?;
     ensure_readiness_deadline("cache_key", deadline_unix_ms)?;
     let mut registered_waiter = false;
     loop {
@@ -623,41 +646,7 @@ pub(crate) fn readiness_request_key(
     provider: &AgentTaskExecutorProvider,
     config: &Value,
 ) -> Result<String> {
-    let mut provider_config = config.as_object().cloned().unwrap_or_default();
-    normalize_generated_fanout_client_context(&mut provider_config);
-    let mut environment = provider
-        .readiness_invocation
-        .as_ref()
-        .and_then(|invocation| invocation.extra.get("env_allowlist"))
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(Value::as_str)
-        .map(str::to_string)
-        .collect::<Vec<_>>();
-    environment.extend(super::credential_readiness::provider_required_secret_env_names(provider));
-    environment.extend(["PATH".to_string(), "HOME".to_string()]);
-    environment.sort();
-    environment.dedup();
-    let environment = environment
-        .into_iter()
-        .map(|name| {
-            let value = std::env::var_os(&name)
-                .map(|value| value.to_string_lossy().into_owned())
-                .unwrap_or_default();
-            (name, value)
-        })
-        .collect::<Vec<_>>();
-    let value = json!({
-        "provider_id": provider.id,
-        "runtime_path": provider.runtime_path,
-        "invocation": provider.readiness_invocation,
-        "effective_config": provider_config,
-        "environment": environment,
-    });
-    let encoded = serde_json::to_vec(&value)
-        .map_err(|error| Error::internal_json(error.to_string(), None))?;
-    Ok(content_hash::sha256_hex(&encoded))
+    readiness_request_key_for_generated_fanout_context(provider, config, false)
 }
 
 /// Child-specific fanout identity is orchestration metadata rather than a
@@ -687,17 +676,67 @@ fn normalize_generated_fanout_client_context(provider_config: &mut serde_json::M
 
 /// The complete process-local readiness cache identity. Callers that coalesce
 /// readiness work must use this rather than approximating a provider route.
-pub(crate) fn readiness_cache_identity(
+pub(crate) fn readiness_cache_identity_for_generated_fanout_context(
     provider: &AgentTaskExecutorProvider,
     config: &Value,
     credential_env: &[(String, String)],
+    generated_fanout_context: bool,
 ) -> Result<String> {
-    let base_key = readiness_request_key(provider, config)?;
+    let base_key = readiness_request_key_for_generated_fanout_context(
+        provider,
+        config,
+        generated_fanout_context,
+    )?;
     let credential_identity = credential_env
         .iter()
         .map(|(name, value)| (name, content_hash::sha256_hex(value.as_bytes())))
         .collect::<Vec<_>>();
     let encoded = serde_json::to_vec(&(base_key, credential_identity))
+        .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    Ok(content_hash::sha256_hex(&encoded))
+}
+
+fn readiness_request_key_for_generated_fanout_context(
+    provider: &AgentTaskExecutorProvider,
+    config: &Value,
+    generated_fanout_context: bool,
+) -> Result<String> {
+    let mut provider_config = config.as_object().cloned().unwrap_or_default();
+    if generated_fanout_context {
+        normalize_generated_fanout_client_context(&mut provider_config);
+    }
+    let environment = provider
+        .readiness_invocation
+        .as_ref()
+        .and_then(|invocation| invocation.extra.get("env_allowlist"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .chain(super::credential_readiness::provider_required_secret_env_names(provider))
+        .chain(["PATH".to_string(), "HOME".to_string()])
+        .collect::<Vec<_>>();
+    let mut environment = environment;
+    environment.sort();
+    environment.dedup();
+    let environment = environment
+        .into_iter()
+        .map(|name| {
+            let value = std::env::var_os(&name)
+                .map(|value| value.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            (name, value)
+        })
+        .collect::<Vec<_>>();
+    let value = json!({
+        "provider_id": provider.id,
+        "runtime_path": provider.runtime_path,
+        "invocation": provider.readiness_invocation,
+        "effective_config": provider_config,
+        "environment": environment,
+    });
+    let encoded = serde_json::to_vec(&value)
         .map_err(|error| Error::internal_json(error.to_string(), None))?;
     Ok(content_hash::sha256_hex(&encoded))
 }
@@ -903,7 +942,7 @@ mod tests {
 
         for (cook_id, to_worktree) in [("first", "homeboy@first"), ("second", "homeboy@second")] {
             assert!(
-                readiness_verdict(
+                readiness_verdict_with_credentials_and_deadline_for_generated_fanout_context(
                     &provider,
                     &json!({
                         "model": "ready",
@@ -918,7 +957,10 @@ mod tests {
                             },
                         },
                     }),
+                    &[],
                     &mut cache,
+                    None,
+                    true,
                 )
                 .expect("readiness verdict")
                 .ready
@@ -926,6 +968,34 @@ mod tests {
         }
 
         assert_eq!(std::fs::read_to_string(count).expect("probe count"), "1");
+    }
+
+    #[test]
+    fn caller_fanout_shape_without_the_internal_marker_remains_distinct() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let count = root.path().join("count");
+        let provider = provider(&readiness_script(root.path()), &count);
+        let mut cache = ProviderRuntimeReadinessCache::default();
+
+        for cook_id in ["first", "second"] {
+            assert!(
+                readiness_verdict(
+                    &provider,
+                    &json!({
+                        "model": "ready",
+                        "client_context": { "fanout": {
+                            "id": "shared-fanout", "semantics": "batch_cook",
+                            "cook_id": cook_id,
+                        }},
+                    }),
+                    &mut cache,
+                )
+                .expect("readiness verdict")
+                .ready
+            );
+        }
+
+        assert_eq!(std::fs::read_to_string(count).expect("probe count"), "2");
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -1388,6 +1388,14 @@ impl AgentTaskScheduleSupport {
             }
         }
         if let Some(overrides) = entry.provider_config.as_object() {
+            if overrides.contains_key("client_context") {
+                if !request.metadata.is_object() {
+                    request.metadata = Value::Object(serde_json::Map::new());
+                }
+                // A rotation route explicitly owns its replacement context.
+                request.metadata["provider_readiness_generated_fanout_context"] =
+                    Value::Bool(false);
+            }
             if !overrides.is_empty() {
                 if !executor.config.is_object() {
                     executor.config = Value::Object(serde_json::Map::new());

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -507,6 +507,70 @@ mod provider_rotation_tests {
     }
 
     #[test]
+    fn fallback_client_context_clears_generated_fanout_readiness_provenance() {
+        let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
+        let observed = Arc::clone(&executor.observed);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].metadata = json!({
+            "provider_readiness_generated_fanout_context": true
+        });
+        plan.tasks[0].executor.config = json!({
+            "client_context": {"fanout": {"cook_id": "generated-child"}}
+        });
+        plan.options.rotation = Some(rotation_policy(vec![AgentTaskProviderRotationEntry {
+            backend: Some("fallback-backend".to_string()),
+            provider_config: json!({
+                "client_context": {"account": "caller-owned-fallback"}
+            }),
+            ..Default::default()
+        }]));
+        enable_rotation(&mut plan);
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        let observed = observed.lock().expect("observed requests");
+        assert_eq!(
+            observed[1].executor.config["client_context"]["account"],
+            "caller-owned-fallback"
+        );
+        assert_eq!(
+            observed[1].metadata["provider_readiness_generated_fanout_context"],
+            false
+        );
+    }
+
+    #[test]
+    fn fallback_without_client_context_retains_generated_fanout_readiness_provenance() {
+        let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
+        let observed = Arc::clone(&executor.observed);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].metadata = json!({
+            "provider_readiness_generated_fanout_context": true
+        });
+        plan.tasks[0].executor.config = json!({
+            "client_context": {"fanout": {"cook_id": "generated-child"}}
+        });
+        plan.options.rotation = Some(rotation_policy(vec![AgentTaskProviderRotationEntry {
+            backend: Some("fallback-backend".to_string()),
+            provider_config: json!({"provider": "fallback-provider"}),
+            ..Default::default()
+        }]));
+        enable_rotation(&mut plan);
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        let observed = observed.lock().expect("observed requests");
+        assert_eq!(
+            observed[1].metadata["provider_readiness_generated_fanout_context"],
+            true
+        );
+    }
+
+    #[test]
     fn timeout_candidate_converges_before_failed_rotation() {
         retained_timeout_candidate_converges_before_rotation();
     }

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -4173,19 +4173,18 @@ fn preview_provider_dispatchability_evidence(
         // preview admission is for the selected provider route, not every
         // future task in that Cook; admitting the full plan would probe the
         // same route again before execution-side deduplication applies.
-        // Share a verdict only when the selected provider would use the same
-        // runtime-readiness cache entry, including effective config and secret
-        // value identities.
+        let admitted_plan = homeboy::agents::agent_task_provider::admit_plan_provider_dispatchability_with_providers(
+            &route.plan,
+            catalog,
+            &mut readiness_cache,
+        )?;
+        // Admission binds any viable fallback route. Derive coalescing identity
+        // from that selected route so an unavailable primary cannot block it.
         let route_key =
-            provider::provider_runtime_readiness_cache_identity_for_plan(catalog, &route.plan)?;
+            provider::provider_runtime_readiness_cache_identity_for_plan(catalog, &admitted_plan)?;
         let admission = if let Some(admission) = admitted_routes.get(&route_key) {
             admission.clone()
         } else {
-            let admitted_plan = homeboy::agents::agent_task_provider::admit_plan_provider_dispatchability_with_providers(
-                &route.plan,
-                catalog,
-                &mut readiness_cache,
-            )?;
             let task = admitted_plan.tasks.first().ok_or_else(|| {
                 Error::internal_unexpected("compiled fanout cook has no provider task")
             })?;
@@ -10306,14 +10305,14 @@ fi
                     "prompt": "fix the first issue",
                     "to_worktree": "homeboy@configured-preview-first",
                     "backend": "configured",
-                    "provider_config": "{\"client_context\":{\"account\":\"first\"}}",
+                    "provider_config": "{\"client_context\":{\"fanout\":{\"account\":\"first\"}}}",
                     "verify": ["true"]
                 }, {
                     "cook_id": "second",
                     "prompt": "fix the second issue",
                     "to_worktree": "homeboy@configured-preview-second",
                     "backend": "configured",
-                    "provider_config": "{\"client_context\":{\"account\":\"second\"}}",
+                    "provider_config": "{\"client_context\":{\"fanout\":{\"account\":\"second\"}}}",
                     "verify": ["true"]
                 }]
             }),
@@ -10338,6 +10337,103 @@ fi
         assert_eq!(
             std::fs::read_to_string(invoked).expect("readiness count"),
             "2"
+        );
+    }
+
+    #[test]
+    fn preview_readiness_admits_and_coalesces_a_selected_fallback_route() {
+        let root = tempfile::tempdir().expect("fixture directory");
+        let invoked = root.path().join("invoked");
+        let catalog = AgentTaskProviderCatalog {
+            providers: vec![
+                serde_json::from_value(serde_json::json!({
+                    "id": "unready-primary",
+                    "backend": "missing-primary",
+                    "readiness_invocation": {
+                        "argv": [
+                            "sh",
+                            "-c",
+                            "printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":false,\"classification\":\"account\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"primary unavailable\",\"cache_key\":\"primary\",\"identity\":{}}'"
+                        ],
+                        "timeout_ms": 5_000
+                    }
+                }))
+                .expect("provider fixture"),
+                serde_json::from_value(serde_json::json!({
+                "id": "ready-fallback",
+                "backend": "ready-fallback",
+                "readiness_invocation": {
+                    "argv": [
+                        "sh",
+                        "-c",
+                        format!(
+                            "count=$(cat {0} 2>/dev/null || printf 0); printf '%s' \"$((count + 1))\" > {0}; printf '%s' '{{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":true,\"classification\":\"ready\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"\",\"cache_key\":\"ready\",\"identity\":{{}}}}'",
+                            invoked.display()
+                        )
+                    ],
+                    "timeout_ms": 5_000
+                }
+            }))
+            .expect("provider fixture"),
+            ],
+            ..AgentTaskProviderCatalog::default()
+        };
+        let mut invocation_args = args();
+        invocation_args.backend = Some("missing-primary".to_string());
+        invocation_args.selector = None;
+        let plan = BatchCookFanoutPlan::from_value(
+            json!({
+                "schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
+                "fanout_id": "fallback-preview",
+                "cooks": [{
+                    "cook_id": "first",
+                    "prompt": "fix the first issue",
+                    "to_worktree": "homeboy@fallback-preview-first",
+                    "backend": "missing-primary",
+                    "verify": ["true"]
+                }, {
+                    "cook_id": "second",
+                    "prompt": "fix the second issue",
+                    "to_worktree": "homeboy@fallback-preview-second",
+                    "backend": "missing-primary",
+                    "verify": ["true"]
+                }]
+            }),
+            &invocation_args,
+        )
+        .expect("fanout plan");
+        let mut static_routes = preview_provider_selection_evidence(
+            &plan,
+            &catalog,
+            &json!({"fanout_id": plan.fanout_id}),
+        )
+        .expect("static routes");
+        for route in &mut static_routes.routes {
+            route.plan.options.rotation = Some(
+                homeboy::agents::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                    entries: vec![
+                        homeboy::agents::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                            backend: Some("ready-fallback".to_string()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+            );
+        }
+
+        let evidence = preview_provider_dispatchability_evidence(
+            &static_routes,
+            &catalog,
+            &json!({"fanout_id": plan.fanout_id}),
+        )
+        .expect("ready fallback admits each child");
+
+        assert_eq!(evidence["children"][0]["admission"]["state"], "completed");
+        assert_eq!(evidence["children"][1]["admission"]["state"], "completed");
+        assert_eq!(
+            std::fs::read_to_string(invoked).expect("readiness count"),
+            "1"
         );
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -4166,9 +4166,6 @@ fn preview_provider_dispatchability_evidence(
     let mut admitted_routes: BTreeMap<String, Value> = BTreeMap::new();
     let mut children = Vec::with_capacity(static_routes.routes.len());
     for route in &static_routes.routes {
-        let static_task = route.plan.tasks.first().ok_or_else(|| {
-            Error::internal_unexpected("compiled fanout cook has no provider task")
-        })?;
         // The compiled Cook may contain controller follow-up tasks. This
         // preview admission is for the selected provider route, not every
         // future task in that Cook; admitting the full plan would probe the
@@ -4178,6 +4175,9 @@ fn preview_provider_dispatchability_evidence(
             catalog,
             &mut readiness_cache,
         )?;
+        let admitted_task = admitted_plan.tasks.first().ok_or_else(|| {
+            Error::internal_unexpected("compiled fanout cook has no provider task")
+        })?;
         // Admission binds any viable fallback route. Derive coalescing identity
         // from that selected route so an unavailable primary cannot block it.
         let route_key =
@@ -4185,14 +4185,11 @@ fn preview_provider_dispatchability_evidence(
         let admission = if let Some(admission) = admitted_routes.get(&route_key) {
             admission.clone()
         } else {
-            let task = admitted_plan.tasks.first().ok_or_else(|| {
-                Error::internal_unexpected("compiled fanout cook has no provider task")
-            })?;
             let admission = serde_json::json!({
                 "state": "completed",
                 "owner": "provider_runtime_readiness",
-                "deadline_unix_ms": task.limits.execution_deadline_unix_ms,
-                "routing": task.metadata.get("provider_readiness_routing").cloned().unwrap_or(Value::Null),
+                "deadline_unix_ms": admitted_task.limits.execution_deadline_unix_ms,
+                "routing": admitted_task.metadata.get("provider_readiness_routing").cloned().unwrap_or(Value::Null),
             });
             admitted_routes.insert(route_key, admission.clone());
             admission
@@ -4200,9 +4197,9 @@ fn preview_provider_dispatchability_evidence(
         children.push(serde_json::json!({
             "cook_id": route.cook_id,
             "executor": {
-                "backend": static_task.executor.backend,
-                "selector": static_task.executor.selector,
-                "model": static_task.executor.model(),
+                "backend": admitted_task.executor.backend,
+                "selector": admitted_task.executor.selector,
+                "model": admitted_task.executor.model(),
             },
             "admission": admission,
         }));
@@ -10353,7 +10350,7 @@ fi
                         "argv": [
                             "sh",
                             "-c",
-                            "printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":false,\"classification\":\"account\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"primary unavailable\",\"cache_key\":\"primary\",\"identity\":{}}'"
+                            "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":false,\"classification\":\"account\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"primary unavailable\",\"cache_key\":\"primary\",\"identity\":{}}'"
                         ],
                         "timeout_ms": 5_000
                     }
@@ -10367,7 +10364,7 @@ fi
                         "sh",
                         "-c",
                         format!(
-                            "count=$(cat {0} 2>/dev/null || printf 0); printf '%s' \"$((count + 1))\" > {0}; printf '%s' '{{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":true,\"classification\":\"ready\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"\",\"cache_key\":\"ready\",\"identity\":{{}}}}'",
+                            "count=$(cat {0} 2>/dev/null || printf 0); printf '%s' \"$((count + 1))\" > {0}; cat >/dev/null; printf '%s' '{{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":true,\"classification\":\"ready\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"\",\"cache_key\":\"ready\",\"identity\":{{}}}}'",
                             invoked.display()
                         )
                     ],
@@ -10432,8 +10429,17 @@ fi
         assert_eq!(evidence["children"][0]["admission"]["state"], "completed");
         assert_eq!(evidence["children"][1]["admission"]["state"], "completed");
         assert_eq!(
+            evidence["children"][0]["executor"]["backend"],
+            "ready-fallback"
+        );
+        assert_eq!(
+            evidence["children"][1]["executor"]["backend"],
+            "ready-fallback"
+        );
+        assert_eq!(
             std::fs::read_to_string(invoked).expect("readiness count"),
-            "1"
+            "1",
+            "both children must coalesce onto one fallback readiness probe"
         );
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1776,6 +1776,7 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher_and_placement(
         attempt_dispatcher,
         None,
         placement,
+        provider::ProviderRuntimeReadinessCache::default(),
     )
 }
 
@@ -1784,6 +1785,7 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
     attempt_dispatcher: &CookAttemptDispatcherFactory,
     claim: Option<(String, bool)>,
     placement: Placement,
+    mut readiness_cache: provider::ProviderRuntimeReadinessCache,
 ) -> CmdResult<Value> {
     let gate_workspace = batch_plan_gate_workspace(&plan)?;
     let gate_contract_validation = validate_batch_gate_contracts(&plan, gate_workspace.as_deref())?;
@@ -1798,15 +1800,19 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
             claim_id.clone(),
             fanout_command(placement, "status", &plan.fanout_id),
         )?;
-        persist_batch_cook_recipes(&plan, |options| {
+        persist_batch_cook_recipes_with_readiness_cache(&plan, &mut readiness_cache, |options| {
             record_gate_contract_validation(options, &gate_contract_validation);
             options.provider_transport.attempt_dispatcher = Some(attempt_dispatcher(options));
         })?;
         let ready_plan = plan.ready_plan()?;
-        let cooks = compile_batch_cooks(&ready_plan, |options| {
-            record_gate_contract_validation(options, &gate_contract_validation);
-            options.provider_transport.attempt_dispatcher = Some(attempt_dispatcher(options));
-        })?;
+        let cooks = compile_batch_cooks_with_readiness_cache(
+            &ready_plan,
+            &mut readiness_cache,
+            |options| {
+                record_gate_contract_validation(options, &gate_contract_validation);
+                options.provider_transport.attempt_dispatcher = Some(attempt_dispatcher(options));
+            },
+        )?;
         let concurrency = batch_concurrency(&plan, &cooks);
         let result = batch::start_fanout_run_batch(&plan.fanout_id, &claim_id).and_then(|()| {
             agent_task_service::run_cook_batch_with_control(
@@ -1843,6 +1849,7 @@ fn run_batch_cook_fanout_plan_with_placement(
         Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
         None,
         placement,
+        provider::ProviderRuntimeReadinessCache::default(),
     )
 }
 
@@ -1851,6 +1858,7 @@ fn run_batch_cook_fanout_plan_with_executor_claim(
     executor: SharedAgentTaskExecutor,
     claim: Option<(String, bool)>,
     placement: Placement,
+    mut readiness_cache: provider::ProviderRuntimeReadinessCache,
 ) -> CmdResult<Value> {
     let gate_workspace = batch_plan_gate_workspace(&plan)?;
     let gate_contract_validation = validate_batch_gate_contracts(&plan, gate_workspace.as_deref())?;
@@ -1865,13 +1873,17 @@ fn run_batch_cook_fanout_plan_with_executor_claim(
             claim_id.clone(),
             fanout_command(placement, "status", &plan.fanout_id),
         )?;
-        persist_batch_cook_recipes(&plan, |options| {
+        persist_batch_cook_recipes_with_readiness_cache(&plan, &mut readiness_cache, |options| {
             record_gate_contract_validation(options, &gate_contract_validation);
         })?;
         let ready_plan = plan.ready_plan()?;
-        let cooks = compile_batch_cooks(&ready_plan, |options| {
-            record_gate_contract_validation(options, &gate_contract_validation);
-        })?;
+        let cooks = compile_batch_cooks_with_readiness_cache(
+            &ready_plan,
+            &mut readiness_cache,
+            |options| {
+                record_gate_contract_validation(options, &gate_contract_validation);
+            },
+        )?;
         let concurrency = batch_concurrency(&plan, &cooks);
         let result = batch::start_fanout_run_batch(&plan.fanout_id, &claim_id).and_then(|()| {
             agent_task_service::run_cook_batch_with_control(
@@ -2308,7 +2320,16 @@ fn persist_batch_cook_recipes(
     plan: &BatchCookFanoutPlan,
     configure: impl Fn(&mut CookRequest),
 ) -> Result<()> {
-    for options in compile_batch_cooks(plan, configure)? {
+    let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
+    persist_batch_cook_recipes_with_readiness_cache(plan, &mut readiness_cache, configure)
+}
+
+fn persist_batch_cook_recipes_with_readiness_cache(
+    plan: &BatchCookFanoutPlan,
+    readiness_cache: &mut provider::ProviderRuntimeReadinessCache,
+    configure: impl Fn(&mut CookRequest),
+) -> Result<()> {
+    for options in compile_batch_cooks_with_readiness_cache(plan, readiness_cache, configure)? {
         agent_task_service::persist_initial_recipe(&options)?;
     }
     Ok(())
@@ -2342,8 +2363,16 @@ fn compile_batch_cooks(
     plan: &BatchCookFanoutPlan,
     configure: impl Fn(&mut CookRequest),
 ) -> Result<Vec<CookRequest>> {
-    let harvest_context = batch_harvest_context()?;
     let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
+    compile_batch_cooks_with_readiness_cache(plan, &mut readiness_cache, configure)
+}
+
+fn compile_batch_cooks_with_readiness_cache(
+    plan: &BatchCookFanoutPlan,
+    readiness_cache: &mut provider::ProviderRuntimeReadinessCache,
+    configure: impl Fn(&mut CookRequest),
+) -> Result<Vec<CookRequest>> {
+    let harvest_context = batch_harvest_context()?;
     plan.cooks
         .iter()
         .map(|cook| {
@@ -2351,7 +2380,7 @@ fn compile_batch_cooks(
             let mut options = agent_task_service::compile_cook_attempt_with_readiness_cache(
                 invocation.options,
                 invocation.dispatch,
-                &mut readiness_cache,
+                readiness_cache,
             )?;
             if !cook.repository_identity.is_null() {
                 options.identity.initial_plan.metadata["cook_repository_identity"] =
@@ -2688,11 +2717,16 @@ fn cook_batch_inner(
         }
         None
     };
+    let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
     if can_run {
         // Compare the exact workspace-bound recipe that provider execution will
         // persist, not the handle-only planning form created before worktree
         // materialization.
-        if let Err(error) = preflight_batch_cook_recipes(&plan, attempt_dispatcher) {
+        if let Err(error) = preflight_batch_cook_recipes_with_readiness_cache(
+            &plan,
+            attempt_dispatcher,
+            &mut readiness_cache,
+        ) {
             record_batch_preflight_failure(
                 claim.as_ref().map(|(claim_id, _)| claim_id.as_str()),
                 &plan,
@@ -2709,12 +2743,14 @@ fn cook_batch_inner(
                 dispatcher,
                 claim.clone(),
                 placement,
+                readiness_cache,
             )?,
             None => run_batch_cook_fanout_plan_with_executor_claim(
                 plan.clone(),
                 Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
                 claim.clone(),
                 placement,
+                readiness_cache,
             )?,
         };
         Some(serde_json::json!({ "exit_code": exit_code, "result": value }))
@@ -3138,7 +3174,7 @@ fn cook_batch_dry_run_with_deadline(
     let plan_ref = batch_plan_reference(&plan)?;
     let provider_selection_plan = plan.clone();
     let provider_selection_plan_ref = plan_ref.clone();
-    let _provider_selection = planner.run_bounded(
+    let static_routes = planner.run_bounded(
         "provider_selection",
         "static provider selection",
         move || {
@@ -3182,7 +3218,7 @@ fn cook_batch_dry_run_with_deadline(
     planner.record_live_progress("started", Some("provider-owned readiness admission"));
     let provider_dispatchability = (|| {
         let catalog = AgentTaskProviderCatalog::discover();
-        preview_provider_dispatchability_evidence(&plan, &catalog, &plan_ref)
+        preview_provider_dispatchability_evidence(&static_routes, &catalog, &plan_ref)
     })()
     .map_err(|error| {
         planner.record_live_progress("failed", Some("provider-owned readiness admission"));
@@ -3200,7 +3236,7 @@ fn cook_batch_dry_run_with_deadline(
             "preflight": {
                 "default_branch": args.base_resolution.clone(),
                 "provider_readiness_command": provider_readiness_command(&args),
-                "provider_selection": provider_selection_preflight(&args),
+                "provider_selection": static_routes.evidence,
                 "provider_dispatchability": provider_dispatchability,
                 "deferred_live_checks": ["workspace_materialization"],
                 "placement": fanout_placement_preflight(plan.placement.as_ref()),
@@ -3999,10 +4035,22 @@ fn preflight_batch_cook_recipes(
     plan: &BatchCookFanoutPlan,
     attempt_dispatcher: Option<&CookAttemptDispatcherFactory>,
 ) -> Result<()> {
+    let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
+    preflight_batch_cook_recipes_with_readiness_cache(
+        plan,
+        attempt_dispatcher,
+        &mut readiness_cache,
+    )
+}
+
+fn preflight_batch_cook_recipes_with_readiness_cache(
+    plan: &BatchCookFanoutPlan,
+    attempt_dispatcher: Option<&CookAttemptDispatcherFactory>,
+    mut readiness_cache: &mut provider::ProviderRuntimeReadinessCache,
+) -> Result<()> {
     // Planning and dry-run callers may only have a managed worktree handle.
     // Validate immutable recipe inputs without resolving that handle as a live
     // workspace; execution validates the materialized workspace separately.
-    let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
     for cook in &plan.cooks {
         let invocation = cook.to_cook_invocation(plan)?;
         // Preflight must construct the same initial plan that Cook persists.
@@ -4025,13 +4073,24 @@ fn preflight_batch_cook_recipes(
 /// Project static provider selection without a live admission. This runs under
 /// `DryRunPlanner`; the returned route is then admitted once outside that
 /// planner by [`preview_provider_dispatchability_evidence`].
+struct PreviewStaticRoutePlans {
+    evidence: Value,
+    routes: Vec<PreviewStaticRoutePlan>,
+}
+
+struct PreviewStaticRoutePlan {
+    cook_id: String,
+    plan: AgentTaskPlan,
+}
+
 fn preview_provider_selection_evidence(
     plan: &BatchCookFanoutPlan,
     catalog: &AgentTaskProviderCatalog,
     plan_ref: &Value,
-) -> Result<Value> {
+) -> Result<PreviewStaticRoutePlans> {
     let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
     let mut children = Vec::with_capacity(plan.cooks.len());
+    let mut routes = Vec::with_capacity(plan.cooks.len());
     for cook in &plan.cooks {
         let mut invocation = cook.to_cook_invocation(plan)?;
         // Generated fanout cooks carry a future worktree handle. Provider
@@ -4047,7 +4106,20 @@ fn preview_provider_selection_evidence(
                 catalog,
                 &mut readiness_cache,
             )?;
-        let task = options.identity.initial_plan.tasks.first().ok_or_else(|| {
+        let mut route_plan = options.identity.initial_plan;
+        route_plan.tasks.truncate(1);
+        if let Some(deadline) = current_cook_deadline() {
+            route_plan.options.execution_budget.deadline_unix_ms = Some(
+                route_plan
+                    .options
+                    .execution_budget
+                    .deadline_unix_ms
+                    .map_or(deadline.deadline_unix_ms(), |existing| {
+                        existing.min(deadline.deadline_unix_ms())
+                    }),
+            );
+        }
+        let task = route_plan.tasks.first().ok_or_else(|| {
             Error::internal_unexpected("compiled fanout cook has no provider task")
         })?;
         children.push(serde_json::json!({
@@ -4059,83 +4131,58 @@ fn preview_provider_selection_evidence(
             },
             "admission": { "state": "pending", "owner": "provider_runtime_readiness" },
         }));
+        routes.push(PreviewStaticRoutePlan {
+            cook_id: cook.cook_id.clone(),
+            plan: route_plan,
+        });
     }
     let checked_at_unix_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64;
-    Ok(serde_json::json!({
-        "schema": "homeboy/agent-task-fanout-provider-selection/v1",
-        "state": "pending",
-        "plan_ref": plan_ref,
-        "checked_at_unix_ms": checked_at_unix_ms,
-        "freshness_window_seconds": Value::Null,
-        "revalidate_before_execution": false,
-        "children": children,
-    }))
+    Ok(PreviewStaticRoutePlans {
+        evidence: serde_json::json!({
+            "schema": "homeboy/agent-task-fanout-provider-selection/v1",
+            "state": "pending",
+            "plan_ref": plan_ref,
+            "checked_at_unix_ms": checked_at_unix_ms,
+            "freshness_window_seconds": Value::Null,
+            "revalidate_before_execution": false,
+            "children": children,
+        }),
+        routes,
+    })
 }
 
 /// Admit each statically selected route exactly once. The caller binds the
 /// batch deadline before entering this function, which propagates it to the
 /// provider readiness cache wait and contained process tree.
 fn preview_provider_dispatchability_evidence(
-    plan: &BatchCookFanoutPlan,
+    static_routes: &PreviewStaticRoutePlans,
     catalog: &AgentTaskProviderCatalog,
     plan_ref: &Value,
 ) -> Result<Value> {
     let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
     let mut admitted_routes: BTreeMap<String, Value> = BTreeMap::new();
-    let mut children = Vec::with_capacity(plan.cooks.len());
-    for cook in &plan.cooks {
-        let mut invocation = cook.to_cook_invocation(plan)?;
-        if cook.cwd.is_none() && cook.workspace.is_none() {
-            invocation.dispatch.workspace = None;
-        }
-        let mut static_options =
-            agent_task_service::compile_cook_attempt_static_with_catalog_and_readiness_cache(
-                invocation.options,
-                invocation.dispatch,
-                catalog,
-                &mut readiness_cache,
-            )?;
-        if let Some(deadline) = current_cook_deadline() {
-            let budget = &mut static_options
-                .identity
-                .initial_plan
-                .options
-                .execution_budget;
-            budget.deadline_unix_ms = Some(
-                budget
-                    .deadline_unix_ms
-                    .map_or(deadline.deadline_unix_ms(), |existing| {
-                        existing.min(deadline.deadline_unix_ms())
-                    }),
-            );
-        }
-        let static_task = static_options
-            .identity
-            .initial_plan
-            .tasks
-            .first()
-            .ok_or_else(|| {
-                Error::internal_unexpected("compiled fanout cook has no provider task")
-            })?;
+    let mut children = Vec::with_capacity(static_routes.routes.len());
+    for route in &static_routes.routes {
+        let static_task = route.plan.tasks.first().ok_or_else(|| {
+            Error::internal_unexpected("compiled fanout cook has no provider task")
+        })?;
         // The compiled Cook may contain controller follow-up tasks. This
         // preview admission is for the selected provider route, not every
         // future task in that Cook; admitting the full plan would probe the
         // same route again before execution-side deduplication applies.
-        let mut route_plan = static_options.identity.initial_plan.clone();
-        route_plan.tasks.truncate(1);
         // Share a verdict only when the selected provider would use the same
         // runtime-readiness cache entry, including effective config and secret
         // value identities.
         let route_key =
-            provider::provider_runtime_readiness_cache_identity_for_plan(catalog, &route_plan)?;
+            provider::provider_runtime_readiness_cache_identity_for_plan(catalog, &route.plan)?;
         let admission = if let Some(admission) = admitted_routes.get(&route_key) {
             admission.clone()
         } else {
             let admitted_plan = homeboy::agents::agent_task_provider::admit_plan_provider_dispatchability_with_providers(
-                &route_plan,
+                &route.plan,
                 catalog,
                 &mut readiness_cache,
             )?;
@@ -4152,7 +4199,7 @@ fn preview_provider_dispatchability_evidence(
             admission
         };
         children.push(serde_json::json!({
-            "cook_id": cook.cook_id,
+            "cook_id": route.cook_id,
             "executor": {
                 "backend": static_task.executor.backend,
                 "selector": static_task.executor.selector,
@@ -5025,6 +5072,7 @@ impl BatchCookSpec {
                 tasks_json: None,
                 provider_config,
                 client_context: Some(merged_client_context(plan, self)),
+                generated_fanout_context: true,
                 attempts: Some(retry_budget.provider_executions),
                 same_provider_retries: Some(retry_budget.same_provider_remediations),
                 provider_rotations: Some(retry_budget.provider_rotations),
@@ -10104,8 +10152,13 @@ fi
                     + 3_000,
             )),
             || {
-                preview_provider_dispatchability_evidence(
+                let static_routes = preview_provider_selection_evidence(
                     &plan,
+                    &catalog,
+                    &json!({"fanout_id": plan.fanout_id}),
+                )?;
+                preview_provider_dispatchability_evidence(
+                    &static_routes,
                     &catalog,
                     &json!({"fanout_id": plan.fanout_id}),
                 )
@@ -10268,8 +10321,14 @@ fi
         )
         .expect("fanout plan");
 
-        let evidence = preview_provider_dispatchability_evidence(
+        let static_routes = preview_provider_selection_evidence(
             &plan,
+            &catalog,
+            &json!({"fanout_id": plan.fanout_id}),
+        )
+        .expect("static routes");
+        let evidence = preview_provider_dispatchability_evidence(
+            &static_routes,
             &catalog,
             &json!({"fanout_id": plan.fanout_id}),
         )
@@ -10325,8 +10384,13 @@ fi
                     + 3_000,
             )),
             || {
-                preview_provider_dispatchability_evidence(
+                let static_routes = preview_provider_selection_evidence(
                     &plan,
+                    &catalog,
+                    &json!({"fanout_id": plan.fanout_id}),
+                )?;
+                preview_provider_dispatchability_evidence(
+                    &static_routes,
                     &catalog,
                     &json!({"fanout_id": plan.fanout_id}),
                 )

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -4182,18 +4182,24 @@ fn preview_provider_dispatchability_evidence(
         // from that selected route so an unavailable primary cannot block it.
         let route_key =
             provider::provider_runtime_readiness_cache_identity_for_plan(catalog, &admitted_plan)?;
-        let admission = if let Some(admission) = admitted_routes.get(&route_key) {
+        let mut admission = if let Some(admission) = admitted_routes.get(&route_key) {
             admission.clone()
         } else {
             let admission = serde_json::json!({
                 "state": "completed",
                 "owner": "provider_runtime_readiness",
                 "deadline_unix_ms": admitted_task.limits.execution_deadline_unix_ms,
-                "routing": admitted_task.metadata.get("provider_readiness_routing").cloned().unwrap_or(Value::Null),
             });
             admitted_routes.insert(route_key, admission.clone());
             admission
         };
+        // Readiness is shared by the selected route, but each child retains the
+        // route history that led to it.
+        admission["routing"] = admitted_task
+            .metadata
+            .get("provider_readiness_routing")
+            .cloned()
+            .unwrap_or(Value::Null);
         children.push(serde_json::json!({
             "cook_id": route.cook_id,
             "executor": {
@@ -10387,12 +10393,14 @@ fi
                     "prompt": "fix the first issue",
                     "to_worktree": "homeboy@fallback-preview-first",
                     "backend": "missing-primary",
+                    "model": "primary-model-one",
                     "verify": ["true"]
                 }, {
                     "cook_id": "second",
                     "prompt": "fix the second issue",
                     "to_worktree": "homeboy@fallback-preview-second",
                     "backend": "missing-primary",
+                    "model": "primary-model-two",
                     "verify": ["true"]
                 }]
             }),
@@ -10405,18 +10413,29 @@ fi
             &json!({"fanout_id": plan.fanout_id}),
         )
         .expect("static routes");
-        for route in &mut static_routes.routes {
-            route.plan.options.rotation = Some(
-                homeboy::agents::agent_task_scheduler::AgentTaskProviderRotationPolicy {
-                    entries: vec![
-                        homeboy::agents::agent_task_scheduler::AgentTaskProviderRotationEntry {
-                            backend: Some("ready-fallback".to_string()),
-                            ..Default::default()
-                        },
-                    ],
-                    ..Default::default()
-                },
-            );
+        for (route, primary_model) in static_routes
+            .routes
+            .iter_mut()
+            .zip(["primary-model-one", "primary-model-two"])
+        {
+            let task = route.plan.tasks.first_mut().expect("provider task");
+            task.executor.backend = "ready-fallback".to_string();
+            task.executor.selector = None;
+            task.executor.model = Some("fallback-model".to_string());
+            if let Some(selection) = task.executor.runtime_selection.as_mut() {
+                selection.executor_backend = Some("ready-fallback".to_string());
+                selection.executor_provider_id = None;
+                selection.model = Some("fallback-model".to_string());
+            }
+            task.metadata["provider_readiness_routing"] = json!({
+                "skipped": [{
+                    "backend": "missing-primary",
+                    "model": primary_model,
+                    "state": "account_unavailable"
+                }]
+            });
+            task.metadata["provider_readiness_generated_fanout_context"] = json!(true);
+            route.plan.options.rotation = None;
         }
 
         let evidence = preview_provider_dispatchability_evidence(
@@ -10435,6 +10454,22 @@ fi
         assert_eq!(
             evidence["children"][1]["executor"]["backend"],
             "ready-fallback"
+        );
+        assert_eq!(
+            evidence["children"][0]["admission"]["routing"]["skipped"][0]["model"],
+            "primary-model-one"
+        );
+        assert_eq!(
+            evidence["children"][1]["admission"]["routing"]["skipped"][0]["model"],
+            "primary-model-two"
+        );
+        assert_eq!(
+            evidence["children"][0]["executor"]["model"],
+            "fallback-model"
+        );
+        assert_eq!(
+            evidence["children"][1]["executor"]["model"],
+            "fallback-model"
         );
         assert_eq!(
             std::fs::read_to_string(invoked).expect("readiness count"),

--- a/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
@@ -125,6 +125,7 @@ impl From<DispatchCoreArgs> for DispatchCoreInputs {
             tasks_json: args.tasks_json,
             provider_config: args.provider_config,
             client_context: args.client_context,
+            generated_fanout_context: false,
             attempts: args.attempts,
             same_provider_retries: args.same_provider_retries,
             provider_rotations: args.provider_rotations,


### PR DESCRIPTION
## Summary

- share provider readiness admission across equivalent generated fanout children
- admit and report the selected fallback executor while preserving each child’s routing history
- keep caller, configured, policy-route, and fallback client contexts distinct from Homeboy-generated fanout context
- carry one bounded readiness cache through preview and execution preflight

This restores the remaining acceptance criteria from #14478 after #14496 merged before its final correction commits.

## Verification

- `cargo test -p homeboy-cli preview_readiness_ --lib`
- focused provider provenance, fallback rotation, cache identity, deadline, and singleflight tests
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- independent read-only review: no findings

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode implemented and iteratively reviewed the provider-admission corrections under Chris Huber’s direction; focused tests and independent review were used to verify the final branch.