### PR TITLE
refactor(lab-runner): one daemon response envelope

### DIFF
--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -307,12 +307,6 @@ fn runner_authority_from_inventory(
     }
 }
 
-#[derive(Deserialize)]
-struct DaemonEnvelope {
-    success: bool,
-    data: Option<Value>,
-}
-
 fn workspace_claim_post(
     runner_id: &str,
     path: &str,
@@ -502,7 +496,7 @@ fn daemon_response(
     let body = body.map_err(|error| {
         workspace_claim_error(runner_id, format!("read daemon {path} response: {error}"))
     })?;
-    let envelope: DaemonEnvelope = serde_json::from_str(&body).map_err(|error| {
+    let envelope: crate::execution::DaemonEnvelope = serde_json::from_str(&body).map_err(|error| {
         workspace_claim_error(
             runner_id,
             format!("malformed daemon {path} response: {error}"),

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -496,12 +496,13 @@ fn daemon_response(
     let body = body.map_err(|error| {
         workspace_claim_error(runner_id, format!("read daemon {path} response: {error}"))
     })?;
-    let envelope: crate::execution::DaemonEnvelope = serde_json::from_str(&body).map_err(|error| {
-        workspace_claim_error(
-            runner_id,
-            format!("malformed daemon {path} response: {error}"),
-        )
-    })?;
+    let envelope: crate::execution::DaemonEnvelope =
+        serde_json::from_str(&body).map_err(|error| {
+            workspace_claim_error(
+                runner_id,
+                format!("malformed daemon {path} response: {error}"),
+            )
+        })?;
     if status != 200 || !envelope.success {
         return Err(workspace_claim_error(
             runner_id,

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -821,11 +821,15 @@ pub(crate) struct PreparedRunnerProcess {
     pub require_paths: Vec<String>,
 }
 
+/// The daemon's JSON response envelope.
+///
+/// Every daemon endpoint answers in this shape, so it is declared once here
+/// rather than restated per caller.
 #[derive(Debug, Deserialize)]
-pub(super) struct DaemonEnvelope {
-    pub(super) success: bool,
-    pub(super) data: Option<Value>,
-    pub(super) error: Option<Value>,
+pub(crate) struct DaemonEnvelope {
+    pub(crate) success: bool,
+    pub(crate) data: Option<Value>,
+    pub(crate) error: Option<Value>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Every daemon endpoint answers in the same JSON envelope, and `homeboy-lab-runner` declared that shape twice:

- `execution/mod.rs` — `{ success, data, error }`
- `continuation_provider.rs` — `{ success, data }`, the same envelope with the error arm dropped

The second is now gone; `continuation_provider` reads the one in `execution`, widened from `pub(super)` to `pub(crate)`. A caller that omits `error` cannot report why the daemon refused it, which is the kind of divergence a second copy invites.

The third `DaemonEnvelope`, in `homeboy-control-plane-client`, is `{ status, endpoint, body }` — an HTTP proxy envelope, not this one. Left alone.

## Verification
`cargo check -p homeboy-lab-runner --tests` clean. Continuation-provider and execution tests against a baseline worktree at the same commit:

| | result |
|---|---|
| baseline | 222 run, 218 passed, 4 failed |
| this branch | 222 run, 218 passed, 4 failed |

Identical; those four are pre-existing.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode found this by scanning for type names declared in more than one file, and verified against a baseline worktree. Chris Huber directed the work and remains responsible for acceptance.