### PR TITLE
refactor(engine-primitives): share the conservative shell arg quoter

### DIFF
--- a/crates/homeboy-engine-primitives/src/shell.rs
+++ b/crates/homeboy-engine-primitives/src/shell.rs
@@ -74,6 +74,21 @@ fn split_respecting_quotes(input: &str) -> Vec<String> {
     result
 }
 
+/// Quote a shell argument, leaving conservatively safe words bare.
+///
+/// Unlike [`quote_arg`], which quotes anything containing a shell metacharacter,
+/// this keeps unquoted only an explicit allowlist. Command builders that render
+/// readable remote commands use it so a plain path or flag stays legible.
+pub fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 pub fn quote_path(path: &str) -> String {
     format!("'{}'", escape_single_quote_content(path))
 }

--- a/crates/homeboy-lab-runner/src/extension_materialization.rs
+++ b/crates/homeboy-lab-runner/src/extension_materialization.rs
@@ -801,8 +801,8 @@ pub(crate) fn dev_extension_lifecycle(
         cleanup_intent: Default::default(),
         cleanup_command: Some(format!(
             "homeboy runner dev-sync {} --extensions {}=<path>",
-            shell_arg(runner_id),
-            shell_arg(extension_id)
+            shell::quote_path(runner_id),
+            shell::quote_path(extension_id)
         )),
         status: ResourceLifecycleResourceStatus::Active,
         migration_provenance: None,
@@ -890,10 +890,6 @@ fn shell_command(command: &[String]) -> String {
         .map(|arg| shell::quote_arg(arg))
         .collect::<Vec<_>>()
         .join(" ")
-}
-
-fn shell_arg(value: &str) -> String {
-    shell::quote_path(value)
 }
 
 #[cfg(test)]

--- a/crates/homeboy-lab-runner/src/shell_quote.rs
+++ b/crates/homeboy-lab-runner/src/shell_quote.rs
@@ -7,16 +7,6 @@
 //! inputs. Several lab-runner command builders relied on the allowlist behavior;
 //! this consolidates the previously copy-pasted definitions into one place
 //! without changing what gets quoted.
-pub(crate) fn shell_arg(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
-    {
-        return value.to_string();
-    }
-    format!("'{}'", value.replace('\'', "'\\''"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -44,3 +34,5 @@ mod tests {
         assert_eq!(shell_arg(""), "");
     }
 }
+
+pub(crate) use homeboy_engine_primitives::shell::shell_arg;

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -271,8 +271,8 @@ fn package_evidence_from_metadata(id: &str, metadata: RigSourceMetadata) -> RigP
     let refresh_command = (!freshness_verified).then(|| {
         format!(
             "homeboy rig install {} --id {} --reinstall",
-            shell_arg(&metadata.source),
-            shell_arg(id)
+            homeboy_engine_primitives::shell::shell_arg(&metadata.source),
+            homeboy_engine_primitives::shell::shell_arg(id)
         )
     });
 
@@ -295,16 +295,6 @@ fn package_evidence_from_metadata(id: &str, metadata: RigSourceMetadata) -> RigP
         freshness_message,
         refresh_command,
     }
-}
-
-fn shell_arg(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
-    {
-        return value.to_string();
-    }
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 /// Byte-compare the contents of two files.


### PR DESCRIPTION
## Summary
`shell_arg` had **five** definitions across two crates, and they did not agree on which characters are safe to leave unquoted:

| definition | safe set |
|---|---|
| `rig/src/lib.rs` | `- _ . / : =` |
| `lab-runner/src/shell_quote.rs` | `- _ . / : =` |
| `lab-runner/src/lab/offload/fallback_commands.rs` | `- _ . / : @` |
| `lab-runner/src/upgrade_runners/commands.rs` | `/ . _ - : @ =` |
| `lab-runner/src/extension_materialization.rs` | *(3-line alias for `shell::quote_path`)* |

Five functions with one name and three different opinions about shell safety, in a codebase whose main job is building remote commands.

## This PR: the three with no behaviour question
- The two **byte-identical** definitions (`rig`, `shell_quote`) now come from `homeboy_engine_primitives::shell::shell_arg`, beside the existing `quote_arg`.
- The **alias** in `extension_materialization` called `shell::quote_path` and nothing else; its three call sites now say so directly.

No output changes for any of them.

## Deliberately left for a separate decision
`fallback_commands` (`@`, no `=`) and `upgrade_runners` (`@` and `=`) genuinely differ from the shared set. Folding them in changes what gets quoted, which is a behaviour change on remote command construction and deserves its own review rather than riding along in a duplication cleanup. `upgrade_runners` alone has 29 call sites.

Recorded here so the remaining divergence is visible rather than buried in five copies.

## Note on the wider surface
`quote_arg` — a metacharacter denylist rather than an allowlist — already has **439** call sites against `shell_arg`'s 164. The long-term answer is probably one quoter, not two, but that is a much larger behavioural change than this.

## Verification
`cargo check --workspace --tests` clean.

| suite | result |
|---|---|
| `homeboy-rig` + `homeboy-engine-primitives` | **739 passed, 0 failed** |
| `lab-runner` extension_materialization / shell / upgrade_runners / offload | 316 passed, 1 failed |

That single failure, `upgrade_runners::tests::part_a::upgrade_reporting_and_reconciliation_omit_unverified_persisted_refresh_refs`, fails identically on a baseline worktree at the same commit.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode found this by hashing function bodies to locate verbatim copies across files, consolidated the three that carry no behaviour question, and confirmed the one failure is pre-existing. Chris Huber directed the work and remains responsible for acceptance.