### PR TITLE
Fix authoritative runner rebind disconnect

### DIFF
--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -218,6 +218,7 @@ pub(crate) fn disconnect_with_session_in_roots(
                 return partial_disconnect_report(runner_id, session.clone().into(), error.message)
             }
         };
+        let authoritative_rebind = authoritative_session.is_some();
         if let Some(authoritative_session) = authoritative_session {
             *session = authoritative_session.clone();
         }
@@ -232,7 +233,14 @@ pub(crate) fn disconnect_with_session_in_roots(
         let mut unresolved = Vec::new();
         for generation in generations {
             if generation.mode == RunnerTunnelMode::DirectSsh {
-                if let Err(error) = disconnect_remote_daemon(&generation, force) {
+                let stop = if authoritative_rebind {
+                    // A rebound lease belongs to the SSH authority, while this
+                    // retained session's local tunnel targets an older generation.
+                    verify_remote_daemon_stopped(&generation, force)
+                } else {
+                    disconnect_remote_daemon(&generation, force)
+                };
+                if let Err(error) = stop {
                     unresolved.push(serde_json::json!({
                         "lease_id": generation.remote_daemon_lease_id,
                         "pid": generation.remote_daemon_pid,


### PR DESCRIPTION
## Summary
- stop a reconciled authoritative direct-SSH daemon via the existing exact-owner SSH stop path
- retain endpoint-based disconnects for sessions that did not rebind

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner stale_generation_reconcile_uses_the_same_idle_observation_as_rotation --lib`
- `cargo test -p homeboy-lab-runner transport_drop_uses_bounded_ssh_stop_for_exact_live_owner --lib`
- `cargo test -p homeboy-lab-runner --lib` remains red for two baseline failures, each reproduced unchanged against `origin/main`:
  - `lab_runner_preparation_falls_back_for_stale_default_runtime_paths`
  - `stale_daemon_recovery_uses_only_an_exact_safe_typed_action`

Fixes #14510

## AI assistance
OpenAI GPT-5.6 Terra, using OpenCode, investigated the recovery path, implemented the scoped change, and ran the listed verification.