### PR TITLE
refactor(cli): build the runs fixture once

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/artifact_index_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/artifact_index_tests.rs
@@ -35,18 +35,7 @@ impl Drop for PublicArtifactBaseGuard {
     }
 }
 
-fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-    NewRunRecord::builder(kind)
-        .component_id(component_id)
-        .command(format!("homeboy {kind} {component_id}"))
-        .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
-        .homeboy_version("test-version")
-        .git_sha(Some("abc123".to_string()))
-        .rig_id(rig_id)
-        .metadata(metadata)
-        .build()
-}
-
+use crate::commands::runs::test_support::sample_run;
 #[test]
 fn runs_list_rig_filter_surfaces_compact_artifact_index() {
     with_isolated_home(|home| {

--- a/crates/homeboy-cli/src/commands/runs/bench/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/bench/mod.rs
@@ -556,18 +556,7 @@ mod tests {
     use homeboy::core::observation::NewRunRecord;
     use homeboy::test_support::with_isolated_home;
 
-    fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-        NewRunRecord::builder(kind)
-            .component_id(component_id)
-            .command(format!("homeboy {kind} {component_id}"))
-            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
-            .homeboy_version("test-version")
-            .git_sha(Some("abc123".to_string()))
-            .rig_id(rig_id)
-            .metadata(metadata)
-            .build()
-    }
-
+    use crate::commands::runs::test_support::sample_run;
     #[test]
     fn bench_compare_reports_deltas_and_missing_metrics() {
         with_isolated_home(|_home| {

--- a/crates/homeboy-cli/src/commands/runs/bundle_import_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/bundle_import_tests.rs
@@ -356,18 +356,7 @@ fn runs_export_import_preserves_directory_artifact_as_checksumed_archive() {
     });
 }
 
-fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-    NewRunRecord::builder(kind)
-        .component_id(component_id)
-        .command(format!("homeboy {kind} {component_id}"))
-        .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
-        .homeboy_version("test-version")
-        .git_sha(Some("abc123".to_string()))
-        .rig_id(rig_id)
-        .metadata(metadata)
-        .build()
-}
-
+use crate::commands::runs::test_support::sample_run;
 fn read_bundle_test_json<T: for<'de> Deserialize<'de>>(path: &Path) -> T {
     serde_json::from_str(&std::fs::read_to_string(path).expect("read json")).expect("json")
 }

--- a/crates/homeboy-cli/src/commands/runs/compare.rs
+++ b/crates/homeboy-cli/src/commands/runs/compare.rs
@@ -284,18 +284,7 @@ mod tests {
     use homeboy::core::observation::{NewRunRecord, RunStatus};
     use homeboy::test_support::with_isolated_home;
 
-    fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-        NewRunRecord::builder(kind)
-            .component_id(component_id)
-            .command(format!("homeboy {kind} {component_id}"))
-            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
-            .homeboy_version("test-version")
-            .git_sha(Some("abc123".to_string()))
-            .rig_id(rig_id)
-            .metadata(metadata)
-            .build()
-    }
-
+    use crate::commands::runs::test_support::sample_run;
     #[test]
     fn runs_compare_filters_history_and_reports_selected_metrics() {
         with_isolated_home(|_home| {

--- a/crates/homeboy-cli/src/commands/runs/distribution.rs
+++ b/crates/homeboy-cli/src/commands/runs/distribution.rs
@@ -224,18 +224,7 @@ mod tests {
     use homeboy::core::observation::{NewRunRecord, RunStatus};
     use homeboy::test_support::with_isolated_home;
 
-    fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-        NewRunRecord::builder(kind)
-            .component_id(component_id)
-            .command(format!("homeboy {kind} {component_id}"))
-            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
-            .homeboy_version("test-version")
-            .git_sha(Some("abc123".to_string()))
-            .rig_id(rig_id)
-            .metadata(metadata)
-            .build()
-    }
-
+    use crate::commands::runs::test_support::sample_run;
     #[test]
     fn distribution_counts_scalar_metadata_values() {
         with_isolated_home(|_home| {

--- a/crates/homeboy-cli/src/commands/runs/evidence.rs
+++ b/crates/homeboy-cli/src/commands/runs/evidence.rs
@@ -288,18 +288,7 @@ mod tests {
     };
     use super::*;
 
-    fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-        NewRunRecord::builder(kind)
-            .component_id(component_id)
-            .command(format!("homeboy {kind} {component_id}"))
-            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
-            .homeboy_version("test-version")
-            .git_sha(Some("abc123".to_string()))
-            .rig_id(rig_id)
-            .metadata(metadata)
-            .build()
-    }
-
+    use crate::commands::runs::test_support::sample_run;
     #[test]
     fn evidence_command_reports_registry_artifacts_retention_and_failure_summary() {
         with_isolated_home(|home| {

--- a/crates/homeboy-cli/src/commands/runs/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/mod.rs
@@ -7,6 +7,9 @@
 //! - per-concern submodules (`bench`, `bundle`, `compare`, ...) own the rest.
 
 #[cfg(test)]
+pub(crate) mod test_support;
+
+#[cfg(test)]
 mod artifact_index_tests;
 mod bench;
 mod bundle;

--- a/crates/homeboy-cli/src/commands/runs/reconcile.rs
+++ b/crates/homeboy-cli/src/commands/runs/reconcile.rs
@@ -520,18 +520,7 @@ mod tests {
     use homeboy::core::observation::{NewRunRecord, RunRecord};
     use homeboy::test_support::with_isolated_home;
 
-    fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-        NewRunRecord::builder(kind)
-            .component_id(component_id)
-            .command(format!("homeboy {kind} {component_id}"))
-            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
-            .homeboy_version("test-version")
-            .git_sha(Some("abc123".to_string()))
-            .rig_id(rig_id)
-            .metadata(metadata)
-            .build()
-    }
-
+    use crate::commands::runs::test_support::sample_run;
     fn ownerless_running_run(id: &str, started_at: String) -> RunRecord {
         RunRecord {
             id: id.to_string(),

--- a/crates/homeboy-cli/src/commands/runs/test_support.rs
+++ b/crates/homeboy-cli/src/commands/runs/test_support.rs
@@ -1,0 +1,25 @@
+//! Shared fixtures for `homeboy runs` tests.
+
+use homeboy::core::observation::NewRunRecord;
+use serde_json::Value;
+
+/// A run record fixture with fixed provenance.
+///
+/// Eight `runs` submodules needed the same record, so it is built once here
+/// rather than restated per file.
+pub(super) fn sample_run(
+    kind: &str,
+    component_id: &str,
+    rig_id: &str,
+    metadata: Value,
+) -> NewRunRecord {
+    NewRunRecord::builder(kind)
+        .component_id(component_id)
+        .command(format!("homeboy {kind} {component_id}"))
+        .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+        .homeboy_version("test-version")
+        .git_sha(Some("abc123".to_string()))
+        .rig_id(rig_id)
+        .metadata(metadata)
+        .build()
+}

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -30,18 +30,7 @@ use homeboy::test_support::{
 };
 use serde_json::Value;
 
-fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-    NewRunRecord::builder(kind)
-        .component_id(component_id)
-        .command(format!("homeboy {kind} {component_id}"))
-        .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
-        .homeboy_version("test-version")
-        .git_sha(Some("abc123".to_string()))
-        .rig_id(rig_id)
-        .metadata(metadata)
-        .build()
-}
-
+use crate::commands::runs::test_support::sample_run;
 #[test]
 fn run_list_filters_kind_component_rig_and_status() {
     with_isolated_home(|_home| {


### PR DESCRIPTION
Eight `homeboy runs` submodules each declared a byte-identical `sample_run` fixture:

```
artifact_index_tests.rs   bench/mod.rs   bundle_import_tests.rs
compare.rs   distribution.rs   evidence.rs   reconcile.rs   tests/mod.rs
```

Same signature, same builder chain, same fixed provenance (`/tmp/homeboy-fixture`, `test-version`, `abc123`). Now one `runs::test_support`.

**−96/+11.**

## Not collapsed
Four more `sample_run` definitions in the same tree take different arguments or build a different record, so they stay: `corpus_tests.rs`, `hotspots.rs`, `fuzz_compare.rs`, and the one in `commands/fuzz/inspect.rs`. Only the exact-duplicate set moved.

## Verification
`cargo check --workspace --tests --all-targets` clean.

```
Summary [52.409s] 244 tests run: 244 passed, 2673 skipped
```

Every `runs::` test passes.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode found this by hashing normalized function bodies, confirmed which copies were exact duplicates before collapsing, and ran the owning module. Chris Huber directed the work and remains responsible for acceptance.