### PR TITLE
refactor(trace): build the trace fixtures once per crate

### DIFF
--- a/crates/homeboy-cli/src/commands/trace.rs
+++ b/crates/homeboy-cli/src/commands/trace.rs
@@ -55,6 +55,8 @@ mod run_service;
 mod schedule;
 #[cfg(test)]
 mod test_fixture;
+#[cfg(test)]
+mod test_support;
 mod workload;
 
 use compare_bundle::run_compare_bundle;

--- a/crates/homeboy-cli/src/commands/trace/rig_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/rig_tests.rs
@@ -25,59 +25,7 @@ fn set_trace_rig_resources(home: &tempfile::TempDir, rig_id: &str, resources: se
     .expect("write rig");
 }
 
-fn trace_args_for_rig(rig_id: &str, component_id: &str, scenario_id: &str) -> TraceArgs {
-    TraceArgs {
-        command: None,
-        comp: PositionalComponentArgs {
-            component: Some(component_id.to_string()),
-            path: None,
-        },
-        component_arg: None,
-        scenario: Some(scenario_id.to_string()),
-        scenario_arg: None,
-        compare_after: None,
-        baseline_target: None,
-        candidate: None,
-        rig: Some(rig_id.to_string()),
-        profile: None,
-        profiles: false,
-        setting_args: SettingArgs::default(),
-        secret_env: Vec::new(),
-        json_summary: false,
-        report: None,
-        experiment: None,
-        repeat: 1,
-        aggregate: None,
-        schedule: TraceSchedule::Grouped,
-        focus_spans: Vec::new(),
-        metric_guardrails: Vec::new(),
-        spans: Vec::new(),
-        phases: Vec::new(),
-        attachments: Vec::new(),
-        phase_preset: None,
-        baseline_args: BaselineArgs::default(),
-        regression_threshold: extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
-        overlays: Vec::new(),
-        variants: Vec::new(),
-        matrix: TraceVariantMatrixMode::None,
-        axes: Vec::new(),
-        matrix_env: Vec::new(),
-        output_dir: None,
-        visual_compare: false,
-        visual_artifacts_dir: None,
-        visual_compare_provider: None,
-        visual_provider_args: Vec::new(),
-        visual_threshold: None,
-        keep_overlay: false,
-        stale: false,
-        force: false,
-        canonical: false,
-        allow_local_toolchain: true,
-        checkout_provenance: None,
-    }
-}
-
+use crate::commands::trace::test_support::trace_args_for_rig;
 #[test]
 fn rig_trace_run_fails_fast_on_active_default_namespace_resource_lease() {
     with_isolated_home(|home| {

--- a/crates/homeboy-cli/src/commands/trace/test_support.rs
+++ b/crates/homeboy-cli/src/commands/trace/test_support.rs
@@ -1,0 +1,62 @@
+//! Shared fixtures for `homeboy trace` tests.
+
+use super::test_fixture::{write_trace_extension, write_trace_rig, TRACE_FIXTURE_EXTENSION_ID};
+use super::workload::trace_workload_scenario_id;
+use super::*;
+use crate::test_support::with_isolated_home;
+use homeboy::core::component::ScopedExtensionConfig;
+use homeboy::rig::{self, ComponentSpec, RigSpec};
+use std::{collections::HashMap, fs};
+
+pub(super) fn trace_args_for_rig(rig_id: &str, component_id: &str, scenario_id: &str) -> TraceArgs {
+    TraceArgs {
+        command: None,
+        comp: PositionalComponentArgs {
+            component: Some(component_id.to_string()),
+            path: None,
+        },
+        component_arg: None,
+        scenario: Some(scenario_id.to_string()),
+        scenario_arg: None,
+        compare_after: None,
+        baseline_target: None,
+        candidate: None,
+        rig: Some(rig_id.to_string()),
+        profile: None,
+        profiles: false,
+        setting_args: SettingArgs::default(),
+        secret_env: Vec::new(),
+        json_summary: false,
+        report: None,
+        experiment: None,
+        repeat: 1,
+        aggregate: None,
+        schedule: TraceSchedule::Grouped,
+        focus_spans: Vec::new(),
+        metric_guardrails: Vec::new(),
+        spans: Vec::new(),
+        phases: Vec::new(),
+        attachments: Vec::new(),
+        phase_preset: None,
+        baseline_args: BaselineArgs::default(),
+        regression_threshold: extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        overlays: Vec::new(),
+        variants: Vec::new(),
+        matrix: TraceVariantMatrixMode::None,
+        axes: Vec::new(),
+        matrix_env: Vec::new(),
+        output_dir: None,
+        visual_compare: false,
+        visual_artifacts_dir: None,
+        visual_compare_provider: None,
+        visual_provider_args: Vec::new(),
+        visual_threshold: None,
+        keep_overlay: false,
+        stale: false,
+        force: false,
+        canonical: false,
+        allow_local_toolchain: true,
+        checkout_provenance: None,
+    }
+}

--- a/crates/homeboy-cli/src/commands/trace/tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/tests.rs
@@ -178,59 +178,7 @@ fn lab_dispatch_observation_persists_trace_run_before_remote_execution() {
     });
 }
 
-fn trace_args_for_rig(rig_id: &str, component_id: &str, scenario_id: &str) -> TraceArgs {
-    TraceArgs {
-        command: None,
-        comp: PositionalComponentArgs {
-            component: Some(component_id.to_string()),
-            path: None,
-        },
-        component_arg: None,
-        scenario: Some(scenario_id.to_string()),
-        scenario_arg: None,
-        compare_after: None,
-        baseline_target: None,
-        candidate: None,
-        rig: Some(rig_id.to_string()),
-        profile: None,
-        profiles: false,
-        setting_args: SettingArgs::default(),
-        secret_env: Vec::new(),
-        json_summary: false,
-        report: None,
-        experiment: None,
-        repeat: 1,
-        aggregate: None,
-        schedule: TraceSchedule::Grouped,
-        focus_spans: Vec::new(),
-        metric_guardrails: Vec::new(),
-        spans: Vec::new(),
-        phases: Vec::new(),
-        attachments: Vec::new(),
-        phase_preset: None,
-        baseline_args: BaselineArgs::default(),
-        regression_threshold: extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
-        overlays: Vec::new(),
-        variants: Vec::new(),
-        matrix: TraceVariantMatrixMode::None,
-        axes: Vec::new(),
-        matrix_env: Vec::new(),
-        output_dir: None,
-        visual_compare: false,
-        visual_artifacts_dir: None,
-        visual_compare_provider: None,
-        visual_provider_args: Vec::new(),
-        visual_threshold: None,
-        keep_overlay: false,
-        stale: false,
-        force: false,
-        canonical: false,
-        allow_local_toolchain: true,
-        checkout_provenance: None,
-    }
-}
-
+use crate::commands::trace::test_support::trace_args_for_rig;
 #[test]
 fn rig_trace_run_uses_rig_owned_workload_extension_without_component_link() {
     with_isolated_home(|home| {

--- a/crates/homeboy-core/src/extension/trace/canonicality.rs
+++ b/crates/homeboy-core/src/extension/trace/canonicality.rs
@@ -1050,42 +1050,7 @@ mod tests {
         }
     }
 
-    fn write_trace_extension(home: &Path, component: &Component) -> ExtensionExecutionContext {
-        let extension_id = "fixture-extension";
-        let extension_dir = home.join(".config/homeboy/extensions").join(extension_id);
-        std::fs::create_dir_all(&extension_dir).expect("extension dir");
-        std::fs::write(
-            extension_dir.join(format!("{extension_id}.json")),
-            serde_json::json!({
-                "name": "Fixture Extension",
-                "version": "0.0.0",
-                "trace": {
-                    "extension_script": "trace.js",
-                    "toolchain_provenance": [
-                        {
-                            "id": "fixture-toolchain",
-                            "label": "Fixture Toolchain",
-                            "env_keys": ["FIXTURE_TOOLCHAIN_BIN"]
-                        }
-                    ]
-                }
-            })
-            .to_string(),
-        )
-        .expect("extension manifest");
-        std::fs::write(extension_dir.join("trace.js"), "#!/usr/bin/env node\n").unwrap();
-
-        ExtensionExecutionContext {
-            component: component.clone(),
-            capability: ExtensionCapability::Trace,
-            extension_id: extension_id.to_string(),
-            extension_path: extension_dir,
-            script_path: "trace.js".to_string(),
-            settings: Vec::new(),
-            accepted_setting_keys: Vec::new(),
-        }
-    }
-
+    use crate::extension::trace::test_support::{test_run_args, write_trace_extension};
     fn init_git_repo(path: &std::path::Path) {
         git(path, &["init", "-b", "main"]);
         git(path, &["config", "user.email", "test@example.com"]);
@@ -1111,32 +1076,5 @@ mod tests {
             .status
             .success()
             .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
-    }
-
-    fn test_run_args(path: &std::path::Path) -> TraceRunWorkflowArgs {
-        TraceRunWorkflowArgs {
-            component_label: "example".to_string(),
-            component_id: "example".to_string(),
-            path_override: Some(path.to_string_lossy().to_string()),
-            settings: Vec::new(),
-            runner_inputs: TraceRunnerInputs::default(),
-            scenario_id: "missing".to_string(),
-            json_summary: false,
-            rig_id: None,
-            overlays: Vec::new(),
-            keep_overlay: false,
-            span_definitions: Vec::new(),
-            baseline_flags: BaselineFlags {
-                baseline: false,
-                ignore_baseline: true,
-                ratchet: false,
-            },
-            regression_threshold_percent:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-            regression_min_delta_ms:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
-            canonical_policy: TraceCanonicalPolicy::Development,
-            checkout_provenance: None,
-        }
     }
 }

--- a/crates/homeboy-core/src/extension/trace/mod.rs
+++ b/crates/homeboy-core/src/extension/trace/mod.rs
@@ -26,6 +26,8 @@ pub mod report;
 pub mod run;
 mod span_summary;
 pub mod spans;
+#[cfg(test)]
+pub(crate) mod test_support;
 
 use crate::extension::resolve::ExtensionExecutionContext;
 use homeboy_core::component::Component;

--- a/crates/homeboy-core/src/extension/trace/run/tests/workflow.rs
+++ b/crates/homeboy-core/src/extension/trace/run/tests/workflow.rs
@@ -458,45 +458,7 @@ fn test_component(path: &std::path::Path) -> Component {
     }
 }
 
-fn write_trace_extension(
-    home: &std::path::Path,
-    component: &Component,
-) -> ExtensionExecutionContext {
-    let extension_id = "fixture-extension";
-    let extension_dir = home.join(".config/homeboy/extensions").join(extension_id);
-    std::fs::create_dir_all(&extension_dir).expect("extension dir");
-    std::fs::write(
-        extension_dir.join(format!("{extension_id}.json")),
-        serde_json::json!({
-            "name": "Fixture Extension",
-            "version": "0.0.0",
-            "trace": {
-                "extension_script": "trace.js",
-                "toolchain_provenance": [
-                    {
-                        "id": "fixture-toolchain",
-                        "label": "Fixture Toolchain",
-                        "env_keys": ["FIXTURE_TOOLCHAIN_BIN"]
-                    }
-                ]
-            }
-        })
-        .to_string(),
-    )
-    .expect("extension manifest");
-    std::fs::write(extension_dir.join("trace.js"), "#!/usr/bin/env node\n").unwrap();
-
-    ExtensionExecutionContext {
-        component: component.clone(),
-        capability: ExtensionCapability::Trace,
-        extension_id: extension_id.to_string(),
-        extension_path: extension_dir,
-        script_path: "trace.js".to_string(),
-        settings: Vec::new(),
-        accepted_setting_keys: Vec::new(),
-    }
-}
-
+use crate::extension::trace::test_support::{test_run_args, write_trace_extension};
 fn init_git_repo(path: &std::path::Path) {
     git(path, &["init", "-b", "main"]);
     git(path, &["config", "user.email", "test@example.com"]);
@@ -507,29 +469,3 @@ fn init_git_repo(path: &std::path::Path) {
 }
 
 use crate::test_support::run_git_command as git;
-
-fn test_run_args(path: &std::path::Path) -> TraceRunWorkflowArgs {
-    TraceRunWorkflowArgs {
-        component_label: "example".to_string(),
-        component_id: "example".to_string(),
-        path_override: Some(path.to_string_lossy().to_string()),
-        settings: Vec::new(),
-        runner_inputs: TraceRunnerInputs::default(),
-        scenario_id: "missing".to_string(),
-        json_summary: false,
-        rig_id: None,
-        overlays: Vec::new(),
-        keep_overlay: false,
-        span_definitions: Vec::new(),
-        baseline_flags: BaselineFlags {
-            baseline: false,
-            ignore_baseline: true,
-            ratchet: false,
-        },
-        regression_threshold_percent:
-            crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        regression_min_delta_ms: crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
-        canonical_policy: TraceCanonicalPolicy::Development,
-        checkout_provenance: None,
-    }
-}

--- a/crates/homeboy-core/src/extension/trace/test_support.rs
+++ b/crates/homeboy-core/src/extension/trace/test_support.rs
@@ -1,0 +1,73 @@
+//! Shared fixtures for extension trace tests.
+
+use crate::extension::resolve::ExtensionExecutionContext;
+use crate::extension::trace::canonicality::TraceCanonicalPolicy;
+use crate::extension::trace::run::{TraceRunWorkflowArgs, TraceRunnerInputs};
+use homeboy_core::component::Component;
+use homeboy_engine_primitives::baseline::BaselineFlags;
+use homeboy_extension_contract::ExtensionCapability;
+
+pub(crate) fn write_trace_extension(
+    home: &std::path::Path,
+    component: &Component,
+) -> ExtensionExecutionContext {
+    let extension_id = "fixture-extension";
+    let extension_dir = home.join(".config/homeboy/extensions").join(extension_id);
+    std::fs::create_dir_all(&extension_dir).expect("extension dir");
+    std::fs::write(
+        extension_dir.join(format!("{extension_id}.json")),
+        serde_json::json!({
+            "name": "Fixture Extension",
+            "version": "0.0.0",
+            "trace": {
+                "extension_script": "trace.js",
+                "toolchain_provenance": [
+                    {
+                        "id": "fixture-toolchain",
+                        "label": "Fixture Toolchain",
+                        "env_keys": ["FIXTURE_TOOLCHAIN_BIN"]
+                    }
+                ]
+            }
+        })
+        .to_string(),
+    )
+    .expect("extension manifest");
+    std::fs::write(extension_dir.join("trace.js"), "#!/usr/bin/env node\n").unwrap();
+
+    ExtensionExecutionContext {
+        component: component.clone(),
+        capability: ExtensionCapability::Trace,
+        extension_id: extension_id.to_string(),
+        extension_path: extension_dir,
+        script_path: "trace.js".to_string(),
+        settings: Vec::new(),
+        accepted_setting_keys: Vec::new(),
+    }
+}
+
+pub(crate) fn test_run_args(path: &std::path::Path) -> TraceRunWorkflowArgs {
+    TraceRunWorkflowArgs {
+        component_label: "example".to_string(),
+        component_id: "example".to_string(),
+        path_override: Some(path.to_string_lossy().to_string()),
+        settings: Vec::new(),
+        runner_inputs: TraceRunnerInputs::default(),
+        scenario_id: "missing".to_string(),
+        json_summary: false,
+        rig_id: None,
+        overlays: Vec::new(),
+        keep_overlay: false,
+        span_definitions: Vec::new(),
+        baseline_flags: BaselineFlags {
+            baseline: false,
+            ignore_baseline: true,
+            ratchet: false,
+        },
+        regression_threshold_percent:
+            crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        canonical_policy: TraceCanonicalPolicy::Development,
+        checkout_provenance: None,
+    }
+}


### PR DESCRIPTION
Three trace fixtures were copy-pasted between sibling test modules. **−234/+8.**

### `homeboy-core`
`write_trace_extension` (34 lines) and `test_run_args` (25 lines) were byte-identical in `extension/trace/canonicality.rs` and `extension/trace/run/tests/workflow.rs`. Both now come from `extension::trace::test_support`.

### `homeboy-cli`
`trace_args_for_rig` (51 lines — the largest duplicate in the tree) was identical in `commands/trace/rig_tests.rs` and `commands/trace/tests.rs`. Now `commands::trace::test_support`.

A 51-line fixture maintained in two places is one edit away from two tests quietly asserting against different `TraceArgs`.

## Verification
`cargo check --workspace --tests --all-targets` clean.

| suite | result |
|---|---|
| `homeboy-core` trace | **133 passed, 0 failed** |
| `homeboy-cli` trace | **91 passed, 0 failed** |

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode located these by hashing normalized function bodies across the tree, and ran both owning suites. Chris Huber directed the work and remains responsible for acceptance.