### PR TITLE
refactor(lab-runner): build the ssh fixtures once

### DIFF
--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -1109,23 +1109,7 @@ mod tests {
     use std::time::Duration;
     use tempfile::tempdir;
 
-    fn ssh_runner() -> Runner {
-        Runner {
-            id: "lab".to_string(),
-            kind: RunnerKind::Ssh,
-            server_id: Some("srv".to_string()),
-            workspace_root: Some("/srv/homeboy".to_string()),
-            settings: RunnerSettings {
-                daemon: true,
-                ..Default::default()
-            },
-            env: Default::default(),
-            secret_env: Default::default(),
-            resources: Default::default(),
-            policy: RunnerPolicy::default(),
-        }
-    }
-
+    pub(crate) use crate::test_support::ssh_runner;
     #[test]
     fn capability_preflight_uses_injected_homeboy_command() {
         let mut runner = ssh_runner();

--- a/crates/homeboy-lab-runner/src/connection/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/mod.rs
@@ -711,32 +711,7 @@ pub(super) fn sample_active_job(
     }
 }
 
-pub(super) fn direct_ssh_session(lease_id: &str) -> RunnerSession {
-    RunnerSession {
-        runner_id: "homeboy-lab".to_string(),
-        mode: RunnerTunnelMode::DirectSsh,
-        role: RunnerSessionRole::Controller,
-        server_id: Some("homeboy-lab".to_string()),
-        controller_id: None,
-        broker_url: None,
-        remote_daemon_address: Some("127.0.0.1:49152".to_string()),
-        local_port: Some(49153),
-        local_url: Some("http://127.0.0.1:49153".to_string()),
-        tunnel_pid: Some(1234),
-        tunnel_process_start_identity: None,
-        proxy_forward: None,
-        remote_daemon_pid: Some(4242),
-        remote_daemon_lease_id: Some(lease_id.to_string()),
-        homeboy_version: "test".to_string(),
-        homeboy_build_identity: Some("homeboy test+abc123".to_string()),
-        connected_at: Utc::now().to_rfc3339(),
-        worker_identity: None,
-        worker_pid: None,
-        last_seen_at: None,
-        leaseless_recovery_evidence: None,
-    }
-}
-
+pub(crate) use crate::test_support::direct_ssh_session;
 pub(super) fn remote_daemon_status_for_test(
     fresh: bool,
     reachable: bool,

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -807,32 +807,7 @@ mod tests {
     use std::sync::{atomic::Ordering, Arc};
     use std::thread;
 
-    fn direct_ssh_session(lease_id: &str) -> RunnerSession {
-        RunnerSession {
-            runner_id: "homeboy-lab".to_string(),
-            mode: RunnerTunnelMode::DirectSsh,
-            role: RunnerSessionRole::Controller,
-            server_id: Some("homeboy-lab".to_string()),
-            controller_id: None,
-            broker_url: None,
-            remote_daemon_address: Some("127.0.0.1:49152".to_string()),
-            local_port: Some(49153),
-            local_url: Some("http://127.0.0.1:49153".to_string()),
-            tunnel_pid: Some(1234),
-            tunnel_process_start_identity: None,
-            proxy_forward: None,
-            remote_daemon_pid: Some(4242),
-            remote_daemon_lease_id: Some(lease_id.to_string()),
-            homeboy_version: "test".to_string(),
-            homeboy_build_identity: Some("homeboy test+abc123".to_string()),
-            connected_at: Utc::now().to_rfc3339(),
-            worker_identity: None,
-            worker_pid: None,
-            last_seen_at: None,
-            leaseless_recovery_evidence: None,
-        }
-    }
-
+    pub(crate) use crate::test_support::direct_ssh_session;
     fn remote_daemon_status(
         reachable: bool,
         active_jobs: usize,

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -137,23 +137,7 @@ fn mirror_refresh_recovers_terminal_evidence_from_the_exact_retained_generation(
     );
 }
 
-fn ssh_runner() -> Runner {
-    Runner {
-        id: "lab".to_string(),
-        kind: RunnerKind::Ssh,
-        server_id: Some("srv".to_string()),
-        workspace_root: Some("/srv/homeboy".to_string()),
-        settings: RunnerSettings {
-            daemon: true,
-            ..Default::default()
-        },
-        env: Default::default(),
-        secret_env: Default::default(),
-        resources: Default::default(),
-        policy: RunnerPolicy::default(),
-    }
-}
-
+pub(crate) use crate::test_support::ssh_runner;
 fn terminal_runner_job() -> Job {
     Job {
         id: Uuid::new_v4(),

--- a/crates/homeboy-lab-runner/src/execution/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/mod.rs
@@ -17,23 +17,7 @@ mod prepare;
 mod redaction;
 mod secret_source;
 
-pub(super) fn ssh_runner() -> Runner {
-    Runner {
-        id: "lab".to_string(),
-        kind: RunnerKind::Ssh,
-        server_id: Some("srv".to_string()),
-        workspace_root: Some("/srv/homeboy".to_string()),
-        settings: RunnerSettings {
-            daemon: true,
-            ..Default::default()
-        },
-        env: Default::default(),
-        secret_env: Default::default(),
-        resources: Default::default(),
-        policy: RunnerPolicy::default(),
-    }
-}
-
+pub(crate) use crate::test_support::ssh_runner;
 pub(super) fn local_runner(workspace_root: String) -> Runner {
     Runner {
         id: "local".to_string(),

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -32,6 +32,8 @@ pub use homeboy_core::broker_auth::{
 };
 mod capabilities;
 mod cli_resolver;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub use cli_resolver::{
     resolve_agent_task_dispatch, resolve_command_label, resolve_lab_runner_hint,
     set_agent_task_dispatch_resolver, set_command_label_resolver, set_lab_runner_hint_provider,

--- a/crates/homeboy-lab-runner/src/test_support.rs
+++ b/crates/homeboy-lab-runner/src/test_support.rs
@@ -1,0 +1,50 @@
+//! Shared fixtures for lab-runner tests.
+
+use crate::{
+    Runner, RunnerKind, RunnerPolicy, RunnerSession, RunnerSessionRole, RunnerSettings,
+    RunnerTunnelMode,
+};
+use chrono::Utc;
+
+pub(crate) fn ssh_runner() -> Runner {
+    Runner {
+        id: "lab".to_string(),
+        kind: RunnerKind::Ssh,
+        server_id: Some("srv".to_string()),
+        workspace_root: Some("/srv/homeboy".to_string()),
+        settings: RunnerSettings {
+            daemon: true,
+            ..Default::default()
+        },
+        env: Default::default(),
+        secret_env: Default::default(),
+        resources: Default::default(),
+        policy: RunnerPolicy::default(),
+    }
+}
+
+pub(crate) fn direct_ssh_session(lease_id: &str) -> RunnerSession {
+    RunnerSession {
+        runner_id: "homeboy-lab".to_string(),
+        mode: RunnerTunnelMode::DirectSsh,
+        role: RunnerSessionRole::Controller,
+        server_id: Some("homeboy-lab".to_string()),
+        controller_id: None,
+        broker_url: None,
+        remote_daemon_address: Some("127.0.0.1:49152".to_string()),
+        local_port: Some(49153),
+        local_url: Some("http://127.0.0.1:49153".to_string()),
+        tunnel_pid: Some(1234),
+        tunnel_process_start_identity: None,
+        proxy_forward: None,
+        remote_daemon_pid: Some(4242),
+        remote_daemon_lease_id: Some(lease_id.to_string()),
+        homeboy_version: "test".to_string(),
+        homeboy_build_identity: Some("homeboy test+abc123".to_string()),
+        connected_at: Utc::now().to_rfc3339(),
+        worker_identity: None,
+        worker_pid: None,
+        last_seen_at: None,
+        leaseless_recovery_evidence: None,
+    }
+}


### PR DESCRIPTION
Two SSH fixtures were copy-pasted across `homeboy-lab-runner` test modules. **−103/+7.**

- **`ssh_runner`** — byte-identical in `capabilities.rs`, `evidence/tests/mod.rs` and `execution/tests/mod.rs`
- **`direct_ssh_session`** — byte-identical in `connection/tests/mod.rs` and `connection_stop_transport_recovery.rs`

Both now come from a new `crate::test_support`, which the crate did not previously have.

## Not collapsed
Two further `ssh_runner` definitions differ: `upgrade_runners/tests/mod.rs` takes `(id, homeboy_path)`, and `upgrade_runners/orchestration.rs` builds a different runner. Only the exact-duplicate set moved.

## Verification
`cargo check --workspace --tests --all-targets` clean. The owning modules against a baseline worktree at the same commit:

| | result |
|---|---|
| baseline | 399 run, 393 passed, 6 failed |
| this branch | 399 run, 393 passed, 6 failed |

Identical. Those six `connection::tests::recovery` failures are pre-existing on `main`.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode located these by hashing normalized function bodies, verified which copies were exact duplicates, and compared against a baseline worktree. Chris Huber directed the work and remains responsible for acceptance.