### PR TITLE
fix(code-audit): block-comment openers take precedence over doc line prefixes

### DIFF
--- a/crates/homeboy-code-audit/src/conventions/tests.rs
+++ b/crates/homeboy-code-audit/src/conventions/tests.rs
@@ -1098,6 +1098,64 @@ fn namespace_mismatch_detected_in_convention() {
 }
 
 #[test]
+fn namespace_conforming_file_not_reported() {
+    // Regression test companion for #14527.
+    //
+    // Inverse of `namespace_mismatch_detected_in_convention`: a file whose
+    // fingerprint carries exactly the expected namespace (as the fixed
+    // producer now yields for a file declaring its namespace after a long
+    // docblock) must be conforming — never reported as "Missing namespace
+    // declaration". A convention deviation may only be synthesized from an
+    // accurate fingerprint; a file the producer could not fingerprint at all
+    // is dropped upstream (`fingerprint_content` returns None) and never
+    // reaches this comparison.
+    let fingerprints = vec![
+        FileFingerprint {
+            relative_path: "abilities/CreateFlow.php".to_string(),
+            language: Language::Php,
+            methods: vec!["execute".to_string()],
+            type_name: Some("CreateFlow".to_string()),
+            namespace: Some("SamplePlugin\\Abilities\\Flow".to_string()),
+            ..Default::default()
+        },
+        FileFingerprint {
+            relative_path: "abilities/UpdateFlow.php".to_string(),
+            language: Language::Php,
+            methods: vec!["execute".to_string()],
+            type_name: Some("UpdateFlow".to_string()),
+            namespace: Some("SamplePlugin\\Abilities\\Flow".to_string()),
+            ..Default::default()
+        },
+        FileFingerprint {
+            relative_path: "abilities/DeleteFlow.php".to_string(),
+            language: Language::Php,
+            methods: vec!["execute".to_string()],
+            type_name: Some("DeleteFlow".to_string()),
+            namespace: Some("SamplePlugin\\Abilities\\Flow".to_string()), // declares the expected namespace
+            ..Default::default()
+        },
+    ];
+
+    let convention = discover_conventions("Flow", "abilities/*", &fingerprints).unwrap();
+
+    assert_eq!(
+        convention.expected_namespace,
+        Some("SamplePlugin\\Abilities\\Flow".to_string())
+    );
+    assert!(
+        convention.outliers.is_empty(),
+        "A file declaring exactly the expected namespace must not produce deviations. Got: {:?}",
+        convention
+            .outliers
+            .iter()
+            .flat_map(|o| &o.deviations)
+            .map(|d| &d.description)
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(convention.conforming.len(), 3);
+}
+
+#[test]
 fn missing_import_not_flagged_for_same_namespace_reference() {
     // Regression test for #1135 (case 2).
     //

--- a/crates/homeboy-code-audit/src/core_fingerprint/tests.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/tests.rs
@@ -736,6 +736,66 @@ fn namespace_with_php_reserved_word_segment_is_extracted() {
 }
 
 #[test]
+fn namespace_after_long_docblock_is_extracted() {
+    // Regression test for #14527 (real-world case:
+    // data-machine-events inc/Abilities/AbilityCategories.php).
+    //
+    // The file declares exactly the expected namespace on line 12, after a
+    // long file docblock. The audit reported "Missing namespace declaration"
+    // because the grammar engine consumed the `/**` opener as a line comment
+    // (doc prefix), never opened the block state, and classified the
+    // docblock interior as code — where prose apostrophes opened phantom
+    // multi-line strings that swallowed the namespace line.
+    let Some(grammar) = php_grammar() else {
+        eprintln!("Skipping — wordpress grammar not available");
+        return;
+    };
+
+    let content = "<?php\n/**\n * Ability Categories\n *\n * Centralized registration of Data Machine Events ability categories.\n * Follows the same pattern as Data Machine core's AbilityCategories.\n *\n * @package DataMachineEvents\\Abilities\n * @since 0.29.0\n */\n\nnamespace DataMachineEvents\\Abilities;\n\ndefined( 'ABSPATH' ) || exit;\n\nclass AbilityCategories {\n    public static function register(): void {\n    }\n}\n";
+
+    let fp = fingerprint_from_grammar(content, &grammar, "inc/Abilities/AbilityCategories.php")
+        .expect("fingerprint should succeed");
+
+    assert_eq!(
+        fp.namespace.as_deref(),
+        Some("DataMachineEvents\\Abilities"),
+        "Namespace declared after a long docblock must be extracted. Got: {:?}",
+        fp.namespace
+    );
+}
+
+#[test]
+fn method_after_docblock_with_apostrophes_is_extracted() {
+    // Regression test for #14527 (real-world case: data-machine-events
+    // inc/Cli/Check/CheckDuplicatesCommand.php defines `__invoke` at line 79,
+    // yet the audit reported "Missing method: __invoke").
+    //
+    // WP-CLI command docblocks contain prose with apostrophes ("weren't",
+    // "doesn't"). When the docblock was misparsed as code, each apostrophe
+    // opened a phantom multi-line string that swallowed the method signature
+    // that followed — here the ENTIRE method list came back empty.
+    let Some(grammar) = php_grammar() else {
+        eprintln!("Skipping — wordpress grammar not available");
+        return;
+    };
+
+    let content = "<?php\nnamespace DataMachineEvents\\Cli\\Check;\n\nclass CheckDuplicatesCommand {\n    /**\n     * Check for duplicate events that weren't caught during import.\n     *\n     * ## OPTIONS\n     *\n     * [--scope=<scope>]\n     * : Which events to scan. Doesn't include past events by default.\n     *\n     * @param array $args       Positional arguments.\n     * @param array $assoc_args Named arguments.\n     */\n    public function __invoke( array $args, array $assoc_args ): void {\n        $scope = $assoc_args['scope'] ?? 'upcoming';\n    }\n}\n";
+
+    let fp = fingerprint_from_grammar(
+        content,
+        &grammar,
+        "inc/Cli/Check/CheckDuplicatesCommand.php",
+    )
+    .expect("fingerprint should succeed");
+
+    assert!(
+        fp.methods.contains(&"__invoke".to_string()),
+        "Method declared after a docblock containing apostrophes must be extracted. Got: {:?}",
+        fp.methods
+    );
+}
+
+#[test]
 fn namespace_with_leading_whitespace_is_extracted() {
     // Regression test for #1134 (real-world case).
     //

--- a/crates/homeboy-engine-primitives/src/grammar/mod.rs
+++ b/crates/homeboy-engine-primitives/src/grammar/mod.rs
@@ -317,6 +317,121 @@ mod tests {
         assert_eq!(lines[4].region, Region::Code);
     }
 
+    /// PHP-style grammar mirroring real-world extension configs where the doc
+    /// prefix (`/**`) is a prefix of the block-comment opener (`/*`).
+    fn php_docblock_grammar() -> Grammar {
+        Grammar {
+            language: LanguageMeta {
+                id: "php".to_string(),
+                extensions: vec!["php".to_string()],
+                import_parser: None,
+            },
+            comments: CommentSyntax {
+                line: vec!["//".to_string(), "#".to_string()],
+                block: vec![("/*".to_string(), "*/".to_string())],
+                doc: vec!["/**".to_string()],
+            },
+            strings: StringSyntax {
+                quotes: vec!["\"".to_string(), "'".to_string()],
+                escape: "\\".to_string(),
+                multiline: vec![],
+            },
+            blocks: BlockSyntax::default(),
+            contract: None,
+            fingerprint: FingerprintGrammar::default(),
+            patterns: {
+                let mut p = HashMap::new();
+                p.insert(
+                    "method".to_string(),
+                    ConceptPattern {
+                        regex: r"(?:(?:public|protected|private|static|abstract|final)\s+)*function\s+(\w+)\s*\(([^)]*)\)".to_string(),
+                        captures: captures(&[("name", 1), ("params", 2)]),
+                        context: "any".to_string(),
+                        skip_comments: true,
+                        skip_strings: true,
+                        require_capture: None,
+                    },
+                );
+                p.insert(
+                    "namespace".to_string(),
+                    ConceptPattern {
+                        regex: r"^\s*namespace\s+([\w\\]+)\s*;".to_string(),
+                        captures: captures(&[("name", 1)]),
+                        context: "top_level".to_string(),
+                        skip_comments: true,
+                        skip_strings: true,
+                        require_capture: None,
+                    },
+                );
+                p
+            },
+        }
+    }
+
+    #[test]
+    fn docblock_opener_wins_over_doc_line_prefix() {
+        // Regression test for #14527.
+        //
+        // A `/**` doc-block opener must not be consumed as a line comment by
+        // the doc-prefix check. When it was, the block state never opened, the
+        // docblock interior was classified as code, and prose apostrophes
+        // ("doesn't", "file's") opened phantom multi-line strings that
+        // swallowed the namespace and method declarations that followed.
+        let grammar = php_docblock_grammar();
+        let content = "<?php\n/**\n * Docblock prose with an apostrophe: doesn't.\n *\n * @package X\\Y\n */\n\nnamespace X\\Y;\n";
+        let lines = walk_lines(content, &grammar);
+
+        assert_eq!(
+            lines[1].region,
+            Region::BlockComment,
+            "`/**` opens a block comment"
+        );
+        assert_eq!(lines[2].region, Region::BlockComment);
+        assert_eq!(lines[3].region, Region::BlockComment);
+        assert_eq!(
+            lines[5].region,
+            Region::BlockComment,
+            "`*/` line is block comment"
+        );
+        assert_eq!(lines[7].region, Region::Code, "namespace line is code");
+    }
+
+    #[test]
+    fn namespace_after_docblock_with_apostrophes_is_extracted() {
+        // Regression test for #14527 (real-world case: data-machine-events
+        // inc/Abilities/AbilityCategories.php declared exactly the expected
+        // namespace, yet the audit reported "Missing namespace declaration"
+        // because the docblock above it was misparsed).
+        let grammar = php_docblock_grammar();
+        let content = "<?php\n/**\n * Centralized registration.\n *\n * Follows the same pattern as the core's AbilityCategories.\n *\n * @package DataMachineEvents\\Abilities\n */\n\nnamespace DataMachineEvents\\Abilities;\n\nclass AbilityCategories {}\n";
+
+        let symbols = extract(content, &grammar);
+        let ns = namespace(&symbols);
+
+        assert_eq!(
+            ns.as_deref(),
+            Some("DataMachineEvents\\Abilities"),
+            "Namespace declared after a docblock containing apostrophes should be extracted"
+        );
+    }
+
+    #[test]
+    fn method_after_docblock_with_apostrophes_is_extracted() {
+        // Regression test for #14527 (real-world case: CLI command docblocks
+        // contain WP-CLI option prose with apostrophes; the method signature
+        // after the docblock was swallowed by a phantom string state).
+        let grammar = php_docblock_grammar();
+        let content = "<?php\nclass CheckDuplicatesCommand {\n    /**\n     * Check for duplicate events that weren't caught during import.\n     *\n     * @param array $args Positional arguments.\n     */\n    public function __invoke( array $args ): void {\n        $scope = $args['scope'] ?? 'upcoming';\n    }\n}\n";
+
+        let symbols = extract(content, &grammar);
+        let names = method_names(&symbols);
+
+        assert!(
+            names.contains(&"__invoke".to_string()),
+            "Method declared after a docblock containing apostrophes should be extracted. Got: {names:?}"
+        );
+    }
+
     #[test]
     fn depth_skips_braces_in_strings() {
         let content = "let x = \"{ not a block }\";\nlet y = 1;\n";

--- a/crates/homeboy-engine-primitives/src/grammar/parser.rs
+++ b/crates/homeboy-engine-primitives/src/grammar/parser.rs
@@ -141,25 +141,13 @@ pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<Context
                 regular_string_quote = None;
             }
             Region::StringLiteral
-        } else if in_block_comment {
-            // Check if block comment ends on this line
-            if let Some(pos) = trimmed.find(block_comment_end.as_str()) {
-                // Comment ends partway through this line
-                in_block_comment = false;
-                let after = &trimmed[pos + block_comment_end.len()..].trim();
-                if after.is_empty() {
-                    Region::BlockComment
-                } else {
-                    // Mixed line — treat as code (conservative)
-                    Region::Code
-                }
-            } else {
-                Region::BlockComment
-            }
-        } else if is_line_comment(trimmed, &grammar.comments) {
-            Region::LineComment
         } else {
-            // Check for block comment start
+            // Outside any string: block comments take precedence over
+            // line/doc comment prefixes. A `/**` doc-block opener must not be
+            // consumed as a line comment — that leaves the block's interior
+            // classified as code, where prose apostrophes ("doesn't", "file's")
+            // open phantom multi-line strings that swallow the real namespace
+            // and method declarations that follow (#14527).
             for (open, close) in &grammar.comments.block {
                 if trimmed.starts_with(open.as_str())
                     && (!trimmed.contains(close.as_str()) || trimmed.ends_with(open.as_str()))
@@ -169,7 +157,22 @@ pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<Context
                 }
             }
             if in_block_comment {
-                Region::BlockComment
+                // Check if block comment ends on this line
+                if let Some(pos) = trimmed.find(block_comment_end.as_str()) {
+                    // Comment ends partway through this line
+                    in_block_comment = false;
+                    let after = &trimmed[pos + block_comment_end.len()..].trim();
+                    if after.is_empty() {
+                        Region::BlockComment
+                    } else {
+                        // Mixed line — treat as code (conservative)
+                        Region::Code
+                    }
+                } else {
+                    Region::BlockComment
+                }
+            } else if is_line_comment(trimmed, &grammar.comments) {
+                Region::LineComment
             } else {
                 // Scan only the code portion: a trailing `// the post's title`
                 // must not open a single-quoted string that swallows every


### PR DESCRIPTION
Closes #14527

## Root cause

`walk_lines()` in the grammar engine checked doc/line-comment prefixes before block-comment openers (`crates/homeboy-engine-primitives/src/grammar/parser.rs`): a line beginning with `/**` matched the grammar's `doc = ["/**"]` entry in `is_line_comment()` and was consumed as a single-line comment, so the block-comment state never opened. Every subsequent docblock interior line (` * Doesn't match X`) was classified as `Region::Code`, where the walker's multi-line string tracking saw prose apostrophes as an unterminated `'` string and swallowed the following real code — including `namespace` declarations and method signatures. `fingerprint_from_grammar()` therefore produced fingerprints with `namespace: None` and the affected methods missing, and `check_conventions()` (`crates/homeboy-code-audit/src/conventions/mod.rs:321`, `:256-270`) reported them as `NamespaceMismatch` / `MissingMethod` deviations. The PHP grammar itself, the extension fingerprint script, and the comparison logic were all correct — the loss happened in region classification, upstream of all of them.

The five flagged files are reproduced exactly by fingerprinting the real sources with the installed WordPress grammar (`inc/Abilities/AbilityCategories.php` → `namespace=None`; `inc/Cli/Check/CheckDuplicatesCommand.php` → `methods=[]`, etc.), and all five extract correctly after the one-line precedence fix. Files whose docblocks contained no apostrophe (e.g. `CheckMissingVenueAddressesCommand` namespace case) failed through a second-order effect: an earlier phantom string, once opened by an apostrophe elsewhere in the file, swallowed the declaration line.

## Producer/fallback behavior

- **Before:** grammar path (extension `grammar.toml`) is preferred; the extension fingerprint script is a fallback used only when no grammar handles the extension. The fallback was not the problem — the grammar path itself returned a *silently wrong* fingerprint (computed, but missing members), which the convention comparison cannot distinguish from a genuine violation.
- **After:** same producer selection, but the grammar path now classifies docblocks correctly, so its output is accurate. No suppression lists, no finding-kind exclusions, no gate changes.

Per the principle from the issue: **a fingerprint that could not be computed must never be reported as a convention deviation.** That contract already holds structurally — a file whose fingerprint cannot be computed at all returns `None` from `fingerprint_content()` and is dropped before `discover_conventions()` (pinned by the existing `fingerprint_extension_content_returns_none_without_claimed_extension` test and the new `namespace_conforming_file_not_reported` test) — and this fix removes the remaining way a *computed* fingerprint could be silently wrong: parser misclassification. "Analyzer failed" and "code violates convention" are now genuinely distinct states.

## Audit before/after (`homeboy review audit data-machine-events --placement local`, component `1ba8800`)

Five false positives — **before → after**:

| Audit deviation | Before | After |
|---|---|---|
| `inc/Abilities/AbilityCategories.php` — Missing namespace declaration (expected `DataMachineEvents\Abilities`) | reported | **gone** |
| `inc/Cli/Check/CheckMissingVenueAddressesCommand.php` — Missing namespace declaration | reported | **gone** |
| `inc/Cli/Check/CheckDuplicatesCommand.php` — Missing method `__invoke` | reported | **gone** |
| `inc/Steps/.../Extractors/VenuePilotExtractor.php` — Missing method `canExtract` | reported | **gone** |
| `inc/Steps/.../Paginators/JsonApiPaginator.php` — Missing method `getNextPageUrl` | reported | **gone** |

Three additional same-cause false positives (verified present in source, swallowed by the same phantom-string mechanism) also cleared: `CheckOrphanPipelinesCommand.php` (`__invoke`), `UpdateEventCommand.php` (`__invoke`), `DiceFmAuth.php` (`__construct`). Total deviations dropped 18 → 10.

True findings survive — no false-negative trade:

- `inc/Cli/SettingsCommand.php` — Missing method `__invoke`: still reported (file has no `__invoke`)
- `inc/Blocks/Calendar/Cache/CacheInvalidator.php` — Missing method `invalidate`: still reported (file has no `invalidate`)
- All non-fingerprint-heuristic findings unchanged: `EventScraperTest`/`mapEvent`, `DetailPageFetcher` (`enrich`/`shouldEnrich`/`provides`), and the three `naming_mismatch` findings.

Run status remains `failed` because genuine convention drift remains to triage — this PR fixes the detector, not the gate.

## Gates

- `cargo fmt --all --check` — pass
- `cargo clippy -p homeboy-engine-primitives -p homeboy-code-audit --all-targets` — zero new warnings vs clean `main` baseline (74/74 and 0/0); note raw `clippy -- -D warnings` also fails on a pre-existing `large_enum_variant` in `homeboy-runner-contract` (dependency crate, untouched here)
- `cargo test -p homeboy-engine-primitives -p homeboy-code-audit` — all green except two pre-existing, environment-dependent failures verified on a clean checkout of `main` (`command::tests::controller_loss_reaps_the_release_mutation_process_group`, `detectors::artifact_portability::tests::homeboy_config_declares_homeboy_run_marker`). `cargo-nextest` is not installed on this host; `cargo test` used per the issue's fallback clause.
- Full audit repro re-run: results above.

## Related regressions

- **#1134 (closed, reserved-word namespace segments):** covered — `namespace_with_php_reserved_word_segment_is_extracted` still passes; this fix is orthogonal (region classification, not the namespace regex).
- **Docblock/indented-namespace class (`core_fingerprint/tests.rs:744+`):** covered and extended — `namespace_with_leading_whitespace_is_extracted` still passes, and the new tests (`namespace_after_long_docblock_is_extracted`, `method_after_docblock_with_apostrophes_is_extracted`, plus the engine-level region tests) pin the docblock-position variant that #14527 exposed.
- **Known remaining gap, distinct cause:** `TicketmasterTest.php` is still reported missing `test` because its signature spans multiple lines (`public function test(` with parameters on following lines) and grammar patterns match per line. That is a multi-line-signature extraction limitation, pre-existing and unrelated to docblock parsing — worth a separate issue if the false positive matters.

Also filed while building this branch: #14532 (clean `main` does not compile — `ControlPlaneBlocker` initializer missed by #14492 in `crates/homeboy-agents/src/orchestration.rs:3905`). This branch inherits that breakage; the audit verification was run with a local, uncommitted three-line unblock of that initializer (not included in this PR).

## AI disclosure

This PR was authored by an AI coding agent (Extra Chill Bot minion) and is pending human review.
