### PR TITLE
Accept review options after actions

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1132,6 +1132,17 @@ impl CliRuntime {
         };
         let mut cli = compiled.value;
         let command_provenance = compiled.provenance;
+        if let Commands::Review(args) = &mut cli.command {
+            if let Err(error) = args.project_effective_child_args() {
+                output_runtime::emit_json_result_for_identity(
+                    Err(error),
+                    output_file.as_deref(),
+                    2,
+                    &command_identity,
+                );
+                return std::process::ExitCode::from(2);
+            }
+        }
         let mut notification_resolution =
             match crate::core::notification_route_resolver::resolve_from_cli_or_env_with_evidence(
                 cli.notification_transport.as_deref(),

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1,4 +1,4 @@
-use clap::{ArgMatches, Command, CommandFactory, Parser};
+use clap::{ArgMatches, Command, CommandFactory, FromArgMatches, Parser};
 use std::collections::BTreeSet;
 use std::io::{IsTerminal, Write};
 use std::process::Command as ProcessCommand;
@@ -341,7 +341,10 @@ fn startup_fast_path_output(
                 return None;
             };
             if error.kind() == clap::error::ErrorKind::DisplayHelp {
-                StartupFastPathOutput::Help(error.to_string())
+                match project_startup_help_options(args) {
+                    Ok(()) => StartupFastPathOutput::Help(error.to_string()),
+                    Err(error) => StartupFastPathOutput::ArgumentError(format!("error: {error}\n")),
+                }
             } else {
                 // A request containing Homeboy's help flag must never initialize
                 // the runtime just to report invalid arguments.
@@ -1132,16 +1135,14 @@ impl CliRuntime {
         };
         let mut cli = compiled.value;
         let command_provenance = compiled.provenance;
-        if let Commands::Review(args) = &mut cli.command {
-            if let Err(error) = args.project_effective_child_args() {
-                output_runtime::emit_json_result_for_identity(
-                    Err(error),
-                    output_file.as_deref(),
-                    2,
-                    &command_identity,
-                );
-                return std::process::ExitCode::from(2);
-            }
+        if let Err(error) = project_cli_options(&mut cli) {
+            output_runtime::emit_json_result_for_identity(
+                Err(error),
+                output_file.as_deref(),
+                2,
+                &command_identity,
+            );
+            return std::process::ExitCode::from(2);
         }
         let mut notification_resolution =
             match crate::core::notification_route_resolver::resolve_from_cli_or_env_with_evidence(
@@ -2289,6 +2290,35 @@ fn startup_fast_path(args: &[String]) -> Option<StartupFastPath> {
         }
         _ => None,
     }
+}
+
+/// Apply command-level option projection before either help is rendered or a
+/// parsed command is routed. Keeping this typed makes the two paths share the
+/// same conflict and action-support rules.
+fn project_cli_options(cli: &mut Cli) -> crate::core::Result<()> {
+    if let Commands::Review(args) = &mut cli.command {
+        args.project_effective_child_args()?;
+    }
+    Ok(())
+}
+
+/// Clap returns its rendered help instead of matches, so validate the same
+/// command after removing Homeboy's help switches. Parse failures are left to
+/// the original help parser so its diagnostics remain authoritative.
+fn project_startup_help_options(args: &[String]) -> Result<(), crate::core::Error> {
+    let args_without_help = args
+        .iter()
+        .filter(|arg| arg.as_str() != "--help" && arg.as_str() != "-h")
+        .cloned()
+        .collect::<Vec<_>>();
+    let Ok(matches) = Cli::command_with_scoped_lab_args().try_get_matches_from(args_without_help)
+    else {
+        return Ok(());
+    };
+    let Ok(mut cli) = Cli::from_arg_matches(&matches) else {
+        return Ok(());
+    };
+    project_cli_options(&mut cli)
 }
 
 impl Default for CliRuntime {

--- a/crates/homeboy-cli/src/commands/audit.rs
+++ b/crates/homeboy-cli/src/commands/audit.rs
@@ -50,8 +50,8 @@ pub struct AuditArgs {
 
     /// Detector profile to run. `full` preserves the default full audit;
     /// `pr` runs cheap root-level blockers for changed-file review.
-    #[arg(long, value_name = "PROFILE", default_value = "full", value_parser = ["full", "pr", "architecture"])]
-    pub profile: String,
+    #[arg(long, value_name = "PROFILE", value_parser = ["full", "pr", "architecture"])]
+    pub profile: Option<String>,
 
     #[command(flatten)]
     pub baseline_args: BaselineArgs,
@@ -137,7 +137,7 @@ fn parse_audit_profile(value: &str) -> homeboy::core::Result<code_audit::AuditPr
 pub fn run(args: AuditArgs) -> CmdResult<AuditCommandOutput> {
     let only_kinds = parse_finding_kinds(&args.only, "only")?;
     let exclude_kinds = parse_finding_kinds(&args.exclude, "exclude")?;
-    let profile = parse_audit_profile(&args.profile)?;
+    let profile = parse_audit_profile(args.profile.as_deref().unwrap_or("full"))?;
 
     let source_ctx = resolve_source_context(
         &args.comp,
@@ -435,8 +435,8 @@ fn audit_observation_command(component_id: &str, args: &AuditArgs) -> String {
     for kind in &args.exclude {
         parts.push(format!("--exclude={kind}"));
     }
-    if args.profile != "full" {
-        parts.push(format!("--profile={}", args.profile));
+    if let Some(profile) = args.profile.as_deref().filter(|profile| *profile != "full") {
+        parts.push(format!("--profile={profile}"));
     }
     for extension in &args.extension_override.extensions {
         parts.push(format!("--extension={extension}"));
@@ -460,7 +460,7 @@ fn audit_observation_initial_metadata(source_path: &str, args: &AuditArgs) -> se
     serde_json::json!({
         "source_path": source_path,
         "mode": if args.conventions { "conventions" } else { "audit" },
-        "profile": args.profile,
+        "profile": args.profile.as_deref().unwrap_or("full"),
         "only": args.only,
         "exclude": args.exclude,
         "extensions": args.extension_override.extensions,
@@ -697,7 +697,7 @@ mod tests {
             conventions: false,
             only: vec![],
             exclude: vec![],
-            profile: "full".to_string(),
+            profile: Some("full".to_string()),
             baseline_args: BaselineArgs {
                 baseline: false,
                 ignore_baseline: false,
@@ -907,7 +907,7 @@ mod tests {
 
         assert_eq!(cli.audit.extension_override.extensions, vec!["rust"]);
         assert_eq!(cli.audit.changed.changed_since(), Some("origin/main"));
-        assert_eq!(cli.audit.profile, "pr");
+        assert_eq!(cli.audit.profile.as_deref(), Some("pr"));
     }
 
     #[test]
@@ -1325,7 +1325,7 @@ mod tests {
                 conventions: false,
                 only: vec![],
                 exclude: vec![],
-                profile: "full".to_string(),
+                profile: Some("full".to_string()),
                 baseline_args: BaselineArgs {
                     baseline: false,
                     ignore_baseline: true,

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -165,6 +165,81 @@ pub struct ReviewAuditArgs {
 const REVIEW_SCOPED_LAB_UNSUPPORTED_REASON: &str = "Scoped review runs stay local because their audit, lint, and test substeps use changed-file scopes that are not represented consistently in the current Lab portability contract yet.";
 
 impl ReviewArgs {
+    /// Project review-level options into the selected action before routing or
+    /// execution. This keeps parent-first and action-first forms identical.
+    pub(crate) fn project_effective_child_args(&mut self) -> homeboy::core::Result<()> {
+        let Some(command) = self.command.take() else {
+            return Ok(());
+        };
+
+        if self.run_id.is_some() {
+            return Err(unsupported_nested_option("--run-id"));
+        }
+        if self.report.is_some() || !self.banner.is_empty() || self.ci_profile.is_some() {
+            return Err(unsupported_nested_option(
+                "--report, --banner, or --ci-profile",
+            ));
+        }
+
+        self.command = Some(match command {
+            ReviewCommand::Audit(args) => {
+                let child = apply_review_args_to_audit(self, args.audit);
+                // A changed-only review audit becomes a HEAD-based audit after
+                // its source checkout is resolved, so its Lab contract must be
+                // local before routing reaches that resolution.
+                ReviewCommand::Audit(ReviewAuditArgs { audit: child })
+            }
+            ReviewCommand::Lint(args) => ReviewCommand::Lint(apply_review_args_to_lint(self, args)),
+            ReviewCommand::Test(args) => {
+                if self.changed.changed_only {
+                    return Err(unsupported_nested_option("--changed-only"));
+                }
+                ReviewCommand::Test(apply_review_args_to_test(self, args))
+            }
+            ReviewCommand::Build(mut args) => {
+                if self.changed.changed_only
+                    || self.summary
+                    || self.baseline_args.baseline
+                    || self.baseline_args.ignore_baseline
+                    || self.baseline_args.ratchet
+                    || !self.extension_override.extensions.is_empty()
+                    || self.audit_profile.is_some()
+                {
+                    return Err(unsupported_nested_option(
+                        "--changed-only, --summary, baseline options, --extension, or --audit-profile",
+                    ));
+                }
+                if args.target_id.is_none() {
+                    args.target_id = self.comp.component.clone();
+                }
+                if args.scope.path.is_none() {
+                    args.scope.path = self.comp.path.clone();
+                }
+                if args.changed.changed_since.is_none() {
+                    args.changed.changed_since = self.changed.changed_since().map(str::to_string);
+                }
+                ReviewCommand::Build(args)
+            }
+            ReviewCommand::AuditBaseline(args) => ReviewCommand::AuditBaseline(args),
+            ReviewCommand::Ci(args) => {
+                if self.comp.component.is_some()
+                    || self.comp.path.is_some()
+                    || !self.extension_override.extensions.is_empty()
+                    || self.changed.is_scoped()
+                    || self.summary
+                    || self.baseline_args.baseline
+                    || self.baseline_args.ignore_baseline
+                    || self.baseline_args.ratchet
+                    || self.audit_profile.is_some()
+                {
+                    return Err(unsupported_nested_option("review scope or quality options"));
+                }
+                ReviewCommand::Ci(args)
+            }
+        });
+        Ok(())
+    }
+
     pub(crate) fn nested_component_args(&self) -> Option<&PositionalComponentArgs> {
         match self.command.as_ref()? {
             ReviewCommand::Audit(args) => Some(&args.audit.comp),
@@ -200,6 +275,14 @@ impl ReviewArgs {
     }
 
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
+        if self.changed.changed_only {
+            return Some(LabCommandContract::local_only(
+                self.command
+                    .as_ref()
+                    .map_or(REVIEW_LAB_LABEL, ReviewCommand::lab_label),
+                REVIEW_SCOPED_LAB_UNSUPPORTED_REASON,
+            ));
+        }
         if let Some(command) = &self.command {
             return match command {
                 ReviewCommand::Audit(args) => args
@@ -233,6 +316,15 @@ impl ReviewArgs {
     pub(crate) fn effective_component_args(&self) -> &PositionalComponentArgs {
         self.nested_component_args().unwrap_or(&self.comp)
     }
+}
+
+fn unsupported_nested_option(option: &str) -> homeboy::core::Error {
+    homeboy::core::Error::validation_invalid_argument(
+        "review option",
+        format!("{option} is not supported by this review action"),
+        None,
+        None,
+    )
 }
 
 /// True when the caller asked for a markdown PR-comment section instead of
@@ -355,7 +447,7 @@ fn dispatch_review_plan_step(
 pub fn run(mut args: ReviewArgs) -> CmdResult<Value> {
     match args.command.take() {
         Some(ReviewCommand::Audit(review_audit)) => {
-            let audit_args = apply_review_args_to_audit(&args, review_audit.audit);
+            let audit_args = review_audit.audit;
             let requested_source = audit_args.release_readiness_source.clone();
             let component = audit_args.comp.load()?;
             prepare_local_review_dependencies(&component)?;
@@ -369,7 +461,7 @@ pub fn run(mut args: ReviewArgs) -> CmdResult<Value> {
         }
         Some(ReviewCommand::AuditBaseline(args)) => to_value(audit_baseline::run(args)),
         Some(ReviewCommand::Lint(child_args)) => {
-            let lint_args = apply_review_args_to_lint(&args, child_args);
+            let lint_args = child_args;
             let requested_source = lint_args.release_readiness_source.clone();
             let component = lint_args.comp.load()?;
             reject_manual_changelog_edit_for_lint(&component, &lint_args)?;
@@ -382,7 +474,7 @@ pub fn run(mut args: ReviewArgs) -> CmdResult<Value> {
             )
         }
         Some(ReviewCommand::Test(child_args)) => {
-            let test_args = apply_review_args_to_test(&args, child_args);
+            let test_args = child_args;
             let requested_source = test_args.release_readiness_source.clone();
             let component = test_args.comp.load()?;
             prepare_local_review_dependencies(&component)?;
@@ -393,12 +485,7 @@ pub fn run(mut args: ReviewArgs) -> CmdResult<Value> {
                 "test",
             )
         }
-        Some(ReviewCommand::Build(mut build_args)) => {
-            if args.changed.changed_since().is_some() {
-                build_args.changed = args.changed.lab.since.clone();
-            }
-            to_value(build::run(build_args))
-        }
+        Some(ReviewCommand::Build(build_args)) => to_value(build::run(build_args)),
         Some(ReviewCommand::Ci(args)) => to_value(ci::run(args)),
         None => to_value(run_umbrella(args)),
     }
@@ -1370,6 +1457,7 @@ fn print_stage_line<T: Serialize>(stage: &ReviewStage<T>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli_surface::{Cli, Commands};
     use crate::commands::utils::args::{BaselineArgs, PositionalComponentArgs};
     use clap::Parser;
 
@@ -1378,6 +1466,187 @@ mod tests {
     struct TestCli {
         #[command(flatten)]
         review: ReviewArgs,
+    }
+
+    fn projected_review(argv: &[&str]) -> ReviewArgs {
+        let cli = Cli::try_parse_from(argv)
+            .unwrap_or_else(|error| panic!("review command should parse: {argv:?}\n{error}"));
+        let Commands::Review(mut review) = cli.command else {
+            panic!("expected review command");
+        };
+        review
+            .project_effective_child_args()
+            .expect("review child projection should succeed");
+        review
+    }
+
+    #[test]
+    fn review_action_projection_makes_parent_and_action_options_identical() {
+        let audit_before = projected_review(&[
+            "homeboy",
+            "review",
+            "--path",
+            "fixture-path",
+            "--extension",
+            "fixture-extension",
+            "--changed-since",
+            "main",
+            "--summary",
+            "--baseline",
+            "--audit-profile",
+            "architecture",
+            "audit",
+            "fixture",
+        ]);
+        let audit_after = projected_review(&[
+            "homeboy",
+            "review",
+            "audit",
+            "fixture",
+            "--path",
+            "fixture-path",
+            "--extension",
+            "fixture-extension",
+            "--changed-since",
+            "main",
+            "--summary",
+            "--baseline",
+            "--audit-profile",
+            "architecture",
+        ]);
+        for review in [&audit_before, &audit_after] {
+            let Some(ReviewCommand::Audit(args)) = review.command.as_ref() else {
+                panic!("expected audit action");
+            };
+            assert_eq!(args.audit.comp.path.as_deref(), Some("fixture-path"));
+            assert_eq!(
+                args.audit.extension_override.extensions,
+                ["fixture-extension"]
+            );
+            assert_eq!(args.audit.changed.changed_since.as_deref(), Some("main"));
+            assert!(args.audit.json_summary && args.audit.baseline_args.baseline);
+            assert_eq!(args.audit.profile, "architecture");
+        }
+
+        let lint_before = projected_review(&[
+            "homeboy",
+            "review",
+            "--changed-only",
+            "--summary",
+            "lint",
+            "fixture",
+        ]);
+        let lint_after = projected_review(&[
+            "homeboy",
+            "review",
+            "lint",
+            "fixture",
+            "--changed-only",
+            "--summary",
+        ]);
+        for review in [&lint_before, &lint_after] {
+            let Some(ReviewCommand::Lint(args)) = review.command.as_ref() else {
+                panic!("expected lint action");
+            };
+            assert!(args.changed.changed_only && args.summary);
+        }
+
+        let test_before = projected_review(&[
+            "homeboy",
+            "review",
+            "--changed-since",
+            "main",
+            "--summary",
+            "test",
+            "fixture",
+        ]);
+        let test_after = projected_review(&[
+            "homeboy",
+            "review",
+            "test",
+            "fixture",
+            "--changed-since",
+            "main",
+            "--summary",
+        ]);
+        for review in [&test_before, &test_after] {
+            let Some(ReviewCommand::Test(args)) = review.command.as_ref() else {
+                panic!("expected test action");
+            };
+            assert_eq!(args.changed.changed_since(), Some("main"));
+            assert!(args.json_summary);
+        }
+
+        let build_before = projected_review(&[
+            "homeboy",
+            "review",
+            "--changed-since",
+            "main",
+            "build",
+            "fixture",
+        ]);
+        let build_after = projected_review(&[
+            "homeboy",
+            "review",
+            "build",
+            "fixture",
+            "--changed-since",
+            "main",
+        ]);
+        for review in [&build_before, &build_after] {
+            let Some(ReviewCommand::Build(args)) = review.command.as_ref() else {
+                panic!("expected build action");
+            };
+            assert_eq!(args.target_id.as_deref(), Some("fixture"));
+            assert_eq!(args.changed.changed_since(), Some("main"));
+        }
+    }
+
+    #[test]
+    fn review_action_projection_rejects_options_not_shared_by_the_action() {
+        for argv in [
+            ["homeboy", "review", "test", "fixture", "--changed-only"].as_slice(),
+            ["homeboy", "review", "--summary", "build", "fixture"].as_slice(),
+            [
+                "homeboy",
+                "review",
+                "--extension",
+                "fixture",
+                "build",
+                "fixture",
+            ]
+            .as_slice(),
+        ] {
+            let mut cli = Cli::try_parse_from(argv).expect("command parses before projection");
+            let Commands::Review(review) = &mut cli.command else {
+                panic!("expected review command");
+            };
+            let error = review
+                .project_effective_child_args()
+                .expect_err("unsupported child option must fail before routing");
+            assert!(error.message.contains("not supported"), "{error}");
+        }
+    }
+
+    #[test]
+    fn review_action_scope_conflicts_are_rejected_in_action_first_order() {
+        for action in ["audit", "lint", "test", "build"] {
+            let error = match Cli::try_parse_from([
+                "homeboy",
+                "review",
+                action,
+                "fixture",
+                "--changed-only",
+                "--changed-since",
+                "main",
+            ]) {
+                Ok(_) => panic!("changed scopes must conflict"),
+                Err(error) => error,
+            };
+            let message = error.to_string();
+            assert!(message.contains("--changed-only"), "{action}: {message}");
+            assert!(message.contains("--changed-since"), "{action}: {message}");
+        }
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -53,7 +53,7 @@ pub struct ReviewArgs {
 
     /// Attach to an already-persisted review run instead of starting another
     /// audit/lint/test execution.
-    #[arg(long, value_name = "RUN_ID")]
+    #[arg(long, global = true, value_name = "RUN_ID")]
     pub run_id: Option<String>,
 
     #[command(flatten)]
@@ -77,23 +77,38 @@ pub struct ReviewArgs {
     pub summary: bool,
 
     /// Run an extension-declared CI profile as an additional review gate.
-    #[arg(long, value_name = "ID")]
+    #[arg(long, global = true, value_name = "ID")]
     pub ci_profile: Option<String>,
 
     /// Audit detector profile for the audit stage. Defaults to `pr` for
     /// changed-file review and `full` for full review.
-    #[arg(long, value_name = "PROFILE", value_parser = ["full", "pr", "architecture"])]
+    #[arg(
+        long,
+        global = true,
+        value_name = "PROFILE",
+        value_parser = ["full", "pr", "architecture"]
+    )]
     pub audit_profile: Option<String>,
 
     /// Output format. Default JSON envelope; `--report=pr-comment` emits a
     /// markdown PR-comment section instead, suitable for piping to
     /// `homeboy git pr comment --body-file`.
-    #[arg(long, value_name = "FORMAT", value_parser = ["pr-comment"])]
+    #[arg(
+        long,
+        global = true,
+        value_name = "FORMAT",
+        value_parser = ["pr-comment"]
+    )]
     pub report: Option<String>,
 
     /// Action-level banner rendered above the PR-comment scope line.
     /// Repeatable as `--banner key=value`.
-    #[arg(long, value_name = "KEY=VALUE", value_parser = parse_key_val)]
+    #[arg(
+        long,
+        global = true,
+        value_name = "KEY=VALUE",
+        value_parser = parse_key_val
+    )]
     pub banner: Vec<(String, String)>,
 
     #[command(flatten)]

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -214,6 +214,7 @@ impl ReviewArgs {
                 args.audit.profile = profile;
                 self.changed.changed_only = changed_only;
                 args.changed_only = changed_only;
+                reject_conflicting_changed_scopes(&self.changed)?;
                 // A changed-only review audit becomes a HEAD-based audit after
                 // its source checkout is resolved, so its Lab contract must be
                 // local before routing reaches that resolution.
@@ -221,6 +222,7 @@ impl ReviewArgs {
             }
             ReviewCommand::Lint(mut args) => {
                 merge_changed_scope(&mut self.changed, &mut args.changed)?;
+                reject_conflicting_changed_scopes(&self.changed)?;
                 merge_component_args(&mut self.comp, &mut args.comp)?;
                 merge_extension_ids(&mut self.extension_override, &mut args.extension_override);
                 merge_baseline_args(&mut self.baseline_args, &mut args.baseline_args);
@@ -590,6 +592,20 @@ fn merge_changed_scope(
     let changed_only = merge_flag(parent.changed_only, child.changed_only);
     parent.changed_only = changed_only;
     child.changed_only = changed_only;
+    Ok(())
+}
+
+/// Clap only checks conflicts within one argument group. Review accepts scopes
+/// on both sides of its action, so validate their canonical merge here.
+fn reject_conflicting_changed_scopes(changed: &ChangedScopeArgs) -> homeboy::core::Result<()> {
+    if changed.changed_only && changed.changed_since().is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "review option",
+            "--changed-only conflicts with --changed-since",
+            None,
+            None,
+        ));
+    }
     Ok(())
 }
 
@@ -1780,6 +1796,46 @@ mod tests {
                 homeboy::core::ErrorCode::ValidationInvalidArgument
             );
             assert!(error.message.contains("conflicting"), "{error}");
+        }
+    }
+
+    #[test]
+    fn review_action_projection_rejects_cross_position_changed_scopes() {
+        for action in ["audit", "lint"] {
+            for argv in [
+                [
+                    "homeboy",
+                    "review",
+                    "--changed-only",
+                    action,
+                    "fixture",
+                    "--changed-since",
+                    "main",
+                ]
+                .as_slice(),
+                [
+                    "homeboy",
+                    "review",
+                    "--changed-since",
+                    "main",
+                    action,
+                    "fixture",
+                    "--changed-only",
+                ]
+                .as_slice(),
+            ] {
+                let mut cli = Cli::try_parse_from(argv)
+                    .unwrap_or_else(|error| panic!("command should parse: {argv:?}\n{error}"));
+                let Commands::Review(review) = &mut cli.command else {
+                    panic!("expected review command");
+                };
+                let error = review.project_effective_child_args().expect_err(&format!(
+                    "cross-position changed scopes must conflict: {action} {argv:?}"
+                ));
+                assert!(error
+                    .message
+                    .contains("--changed-only conflicts with --changed-since"));
+            }
         }
     }
 

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -337,14 +337,14 @@ fn dispatch_review_plan_step(
     }
 }
 
-pub fn run(args: ReviewArgs) -> CmdResult<Value> {
-    match args.command {
+pub fn run(mut args: ReviewArgs) -> CmdResult<Value> {
+    match args.command.take() {
         Some(ReviewCommand::Audit(review_audit)) => {
-            let requested_source = review_audit.audit.release_readiness_source.clone();
-            let component = review_audit.audit.comp.load()?;
+            let audit_args = apply_review_args_to_audit(&args, review_audit.audit);
+            let requested_source = audit_args.release_readiness_source.clone();
+            let component = audit_args.comp.load()?;
             prepare_local_review_dependencies(&component)?;
-            let audit_args =
-                review_audit_args(review_audit.audit, &args.changed, &component.local_path)?;
+            let audit_args = review_audit_args(audit_args, &args.changed, &component.local_path)?;
             to_value_with_readiness_provenance(
                 audit::run(audit_args),
                 &component,
@@ -353,33 +353,100 @@ pub fn run(args: ReviewArgs) -> CmdResult<Value> {
             )
         }
         Some(ReviewCommand::AuditBaseline(args)) => to_value(audit_baseline::run(args)),
-        Some(ReviewCommand::Lint(args)) => {
-            let requested_source = args.release_readiness_source.clone();
-            let component = args.comp.load()?;
-            reject_manual_changelog_edit_for_lint(&component, &args)?;
+        Some(ReviewCommand::Lint(child_args)) => {
+            let lint_args = apply_review_args_to_lint(&args, child_args);
+            let requested_source = lint_args.release_readiness_source.clone();
+            let component = lint_args.comp.load()?;
+            reject_manual_changelog_edit_for_lint(&component, &lint_args)?;
             prepare_local_review_dependencies(&component)?;
             to_value_with_readiness_provenance(
-                lint::run(review_lint_args(args)),
+                lint::run(review_lint_args(lint_args)),
                 &component,
                 requested_source.as_deref(),
                 "lint",
             )
         }
-        Some(ReviewCommand::Test(args)) => {
-            let requested_source = args.release_readiness_source.clone();
-            let component = args.comp.load()?;
+        Some(ReviewCommand::Test(child_args)) => {
+            let test_args = apply_review_args_to_test(&args, child_args);
+            let requested_source = test_args.release_readiness_source.clone();
+            let component = test_args.comp.load()?;
             prepare_local_review_dependencies(&component)?;
             to_value_with_readiness_provenance(
-                test::run(args),
+                test::run(test_args),
                 &component,
                 requested_source.as_deref(),
                 "test",
             )
         }
-        Some(ReviewCommand::Build(args)) => to_value(build::run(args)),
+        Some(ReviewCommand::Build(mut build_args)) => {
+            if args.changed.changed_since().is_some() {
+                build_args.changed = args.changed.lab.since.clone();
+            }
+            to_value(build::run(build_args))
+        }
         Some(ReviewCommand::Ci(args)) => to_value(ci::run(args)),
         None => to_value(run_umbrella(args)),
     }
+}
+
+fn apply_review_args_to_audit(
+    shared: &ReviewArgs,
+    mut child: audit::AuditArgs,
+) -> audit::AuditArgs {
+    apply_review_component_and_extensions(shared, &mut child.comp, &mut child.extension_override);
+    if let Some(changed_since) = shared.changed.changed_since() {
+        child.changed.changed_since = Some(changed_since.to_string());
+    }
+    child.json_summary |= shared.summary;
+    apply_review_baseline_args(shared, &mut child.baseline_args);
+    if let Some(profile) = &shared.audit_profile {
+        child.profile = profile.clone();
+    }
+    child
+}
+
+fn apply_review_args_to_lint(shared: &ReviewArgs, mut child: lint::LintArgs) -> lint::LintArgs {
+    apply_review_component_and_extensions(shared, &mut child.comp, &mut child.extension_override);
+    if shared.changed.is_scoped() {
+        child.changed = shared.changed.clone();
+    }
+    child.summary |= shared.summary;
+    apply_review_baseline_args(shared, &mut child.baseline_args);
+    child
+}
+
+fn apply_review_args_to_test(shared: &ReviewArgs, mut child: test::TestArgs) -> test::TestArgs {
+    apply_review_component_and_extensions(shared, &mut child.comp, &mut child.extension_override);
+    if shared.changed.changed_since().is_some() {
+        child.changed = shared.changed.lab.clone();
+    }
+    child.json_summary |= shared.summary;
+    apply_review_baseline_args(shared, &mut child.baseline_args);
+    child
+}
+
+fn apply_review_component_and_extensions(
+    shared: &ReviewArgs,
+    component: &mut PositionalComponentArgs,
+    extensions: &mut ExtensionOverrideArgs,
+) {
+    if shared.comp.component.is_some() {
+        component.component = shared.comp.component.clone();
+    }
+    if shared.comp.path.is_some() {
+        component.path = shared.comp.path.clone();
+    }
+    if !shared.extension_override.extensions.is_empty() {
+        let mut merged = shared.extension_override.extensions.clone();
+        merged.append(&mut extensions.extensions);
+        extensions.extensions = merged;
+    }
+}
+
+fn apply_review_baseline_args(shared: &ReviewArgs, baseline: &mut BaselineArgs) {
+    baseline.baseline |= shared.baseline_args.baseline;
+    baseline.ignore_baseline |= shared.baseline_args.ignore_baseline;
+    baseline.ratchet |= shared.baseline_args.ratchet;
 }
 
 /// Translate review's working-tree scope to audit's existing HEAD-based scoped

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -53,7 +53,7 @@ pub struct ReviewArgs {
 
     /// Attach to an already-persisted review run instead of starting another
     /// audit/lint/test execution.
-    #[arg(long, global = true, value_name = "RUN_ID")]
+    #[arg(long, value_name = "RUN_ID")]
     pub run_id: Option<String>,
 
     #[command(flatten)]
@@ -77,14 +77,13 @@ pub struct ReviewArgs {
     pub summary: bool,
 
     /// Run an extension-declared CI profile as an additional review gate.
-    #[arg(long, global = true, value_name = "ID")]
+    #[arg(long, value_name = "ID")]
     pub ci_profile: Option<String>,
 
     /// Audit detector profile for the audit stage. Defaults to `pr` for
     /// changed-file review and `full` for full review.
     #[arg(
         long,
-        global = true,
         value_name = "PROFILE",
         value_parser = ["full", "pr", "architecture"]
     )]
@@ -95,7 +94,6 @@ pub struct ReviewArgs {
     /// `homeboy git pr comment --body-file`.
     #[arg(
         long,
-        global = true,
         value_name = "FORMAT",
         value_parser = ["pr-comment"]
     )]
@@ -105,7 +103,6 @@ pub struct ReviewArgs {
     /// Repeatable as `--banner key=value`.
     #[arg(
         long,
-        global = true,
         value_name = "KEY=VALUE",
         value_parser = parse_key_val
     )]
@@ -160,13 +157,26 @@ impl ReviewCommand {
 pub struct ReviewAuditArgs {
     #[command(flatten)]
     pub audit: audit::AuditArgs,
+
+    /// Operate only on files modified in the working tree. Review translates
+    /// this to audit's precomputed HEAD-based changed-file scope.
+    #[arg(long, conflicts_with = "changed_since")]
+    pub changed_only: bool,
+
+    /// Audit detector profile for this review action.
+    #[arg(
+        long,
+        value_name = "PROFILE",
+        value_parser = ["full", "pr", "architecture"]
+    )]
+    pub audit_profile: Option<String>,
 }
 
 const REVIEW_SCOPED_LAB_UNSUPPORTED_REASON: &str = "Scoped review runs stay local because their audit, lint, and test substeps use changed-file scopes that are not represented consistently in the current Lab portability contract yet.";
 
 impl ReviewArgs {
-    /// Project review-level options into the selected action before routing or
-    /// execution. This keeps parent-first and action-first forms identical.
+    /// Project parent-first and action-first options into one action-aware
+    /// state before preflight, routing, and execution consume this command.
     pub(crate) fn project_effective_child_args(&mut self) -> homeboy::core::Result<()> {
         let Some(command) = self.command.take() else {
             return Ok(());
@@ -182,19 +192,53 @@ impl ReviewArgs {
         }
 
         self.command = Some(match command {
-            ReviewCommand::Audit(args) => {
-                let child = apply_review_args_to_audit(self, args.audit);
+            ReviewCommand::Audit(mut args) => {
+                let changed_only = merge_flag(self.changed.changed_only, args.changed_only);
+                merge_changed_since(&mut self.changed, &mut args.audit.changed)?;
+                merge_component_args(&mut self.comp, &mut args.audit.comp)?;
+                merge_extension_ids(
+                    &mut self.extension_override,
+                    &mut args.audit.extension_override,
+                );
+                merge_baseline_args(&mut self.baseline_args, &mut args.audit.baseline_args);
+                self.summary = merge_flag(self.summary, args.audit.json_summary);
+                args.audit.json_summary = self.summary;
+                let action_profile = merge_option(
+                    "--audit-profile",
+                    args.audit_profile.take(),
+                    args.audit.profile.take(),
+                )?;
+                let profile =
+                    merge_option("--audit-profile", self.audit_profile.take(), action_profile)?;
+                self.audit_profile = profile.clone();
+                args.audit.profile = profile;
+                self.changed.changed_only = changed_only;
+                args.changed_only = changed_only;
                 // A changed-only review audit becomes a HEAD-based audit after
                 // its source checkout is resolved, so its Lab contract must be
                 // local before routing reaches that resolution.
-                ReviewCommand::Audit(ReviewAuditArgs { audit: child })
+                ReviewCommand::Audit(args)
             }
-            ReviewCommand::Lint(args) => ReviewCommand::Lint(apply_review_args_to_lint(self, args)),
-            ReviewCommand::Test(args) => {
+            ReviewCommand::Lint(mut args) => {
+                merge_changed_scope(&mut self.changed, &mut args.changed)?;
+                merge_component_args(&mut self.comp, &mut args.comp)?;
+                merge_extension_ids(&mut self.extension_override, &mut args.extension_override);
+                merge_baseline_args(&mut self.baseline_args, &mut args.baseline_args);
+                self.summary = merge_flag(self.summary, args.summary);
+                args.summary = self.summary;
+                ReviewCommand::Lint(args)
+            }
+            ReviewCommand::Test(mut args) => {
                 if self.changed.changed_only {
                     return Err(unsupported_nested_option("--changed-only"));
                 }
-                ReviewCommand::Test(apply_review_args_to_test(self, args))
+                merge_changed_since(&mut self.changed, &mut args.changed.since)?;
+                merge_component_args(&mut self.comp, &mut args.comp)?;
+                merge_extension_ids(&mut self.extension_override, &mut args.extension_override);
+                merge_baseline_args(&mut self.baseline_args, &mut args.baseline_args);
+                self.summary = merge_flag(self.summary, args.json_summary);
+                args.json_summary = self.summary;
+                ReviewCommand::Test(args)
             }
             ReviewCommand::Build(mut args) => {
                 if self.changed.changed_only
@@ -209,15 +253,16 @@ impl ReviewArgs {
                         "--changed-only, --summary, baseline options, --extension, or --audit-profile",
                     ));
                 }
-                if args.target_id.is_none() {
-                    args.target_id = self.comp.component.clone();
-                }
-                if args.scope.path.is_none() {
-                    args.scope.path = self.comp.path.clone();
-                }
-                if args.changed.changed_since.is_none() {
-                    args.changed.changed_since = self.changed.changed_since().map(str::to_string);
-                }
+                args.target_id = merge_option(
+                    "component",
+                    self.comp.component.take(),
+                    args.target_id.take(),
+                )?;
+                self.comp.component = args.target_id.clone();
+                let path = merge_option("--path", self.comp.path.take(), args.scope.path.take())?;
+                self.comp.path = path.clone();
+                args.scope.path = path;
+                merge_changed_since(&mut self.changed, &mut args.changed)?;
                 ReviewCommand::Build(args)
             }
             ReviewCommand::AuditBaseline(args) => ReviewCommand::AuditBaseline(args),
@@ -491,64 +536,83 @@ pub fn run(mut args: ReviewArgs) -> CmdResult<Value> {
     }
 }
 
-fn apply_review_args_to_audit(
-    shared: &ReviewArgs,
-    mut child: audit::AuditArgs,
-) -> audit::AuditArgs {
-    apply_review_component_and_extensions(shared, &mut child.comp, &mut child.extension_override);
-    if let Some(changed_since) = shared.changed.changed_since() {
-        child.changed.changed_since = Some(changed_since.to_string());
-    }
-    child.json_summary |= shared.summary;
-    apply_review_baseline_args(shared, &mut child.baseline_args);
-    if let Some(profile) = &shared.audit_profile {
-        child.profile = profile.clone();
-    }
-    child
-}
-
-fn apply_review_args_to_lint(shared: &ReviewArgs, mut child: lint::LintArgs) -> lint::LintArgs {
-    apply_review_component_and_extensions(shared, &mut child.comp, &mut child.extension_override);
-    if shared.changed.is_scoped() {
-        child.changed = shared.changed.clone();
-    }
-    child.summary |= shared.summary;
-    apply_review_baseline_args(shared, &mut child.baseline_args);
-    child
-}
-
-fn apply_review_args_to_test(shared: &ReviewArgs, mut child: test::TestArgs) -> test::TestArgs {
-    apply_review_component_and_extensions(shared, &mut child.comp, &mut child.extension_override);
-    if shared.changed.changed_since().is_some() {
-        child.changed = shared.changed.lab.clone();
-    }
-    child.json_summary |= shared.summary;
-    apply_review_baseline_args(shared, &mut child.baseline_args);
-    child
-}
-
-fn apply_review_component_and_extensions(
-    shared: &ReviewArgs,
-    component: &mut PositionalComponentArgs,
-    extensions: &mut ExtensionOverrideArgs,
-) {
-    if shared.comp.component.is_some() {
-        component.component = shared.comp.component.clone();
-    }
-    if shared.comp.path.is_some() {
-        component.path = shared.comp.path.clone();
-    }
-    if !shared.extension_override.extensions.is_empty() {
-        let mut merged = shared.extension_override.extensions.clone();
-        merged.append(&mut extensions.extensions);
-        extensions.extensions = merged;
+fn merge_option(
+    option: &str,
+    parent: Option<String>,
+    child: Option<String>,
+) -> homeboy::core::Result<Option<String>> {
+    match (parent, child) {
+        (Some(parent), Some(child)) if parent != child => {
+            Err(homeboy::core::Error::validation_invalid_argument(
+                "review option",
+                format!("conflicting {option} values before and after the review action"),
+                None,
+                None,
+            ))
+        }
+        (Some(value), _) | (_, Some(value)) => Ok(Some(value)),
+        (None, None) => Ok(None),
     }
 }
 
-fn apply_review_baseline_args(shared: &ReviewArgs, baseline: &mut BaselineArgs) {
-    baseline.baseline |= shared.baseline_args.baseline;
-    baseline.ignore_baseline |= shared.baseline_args.ignore_baseline;
-    baseline.ratchet |= shared.baseline_args.ratchet;
+fn merge_component_args(
+    parent: &mut PositionalComponentArgs,
+    child: &mut PositionalComponentArgs,
+) -> homeboy::core::Result<()> {
+    let component = merge_option("component", parent.component.take(), child.component.take())?;
+    let path = merge_option("--path", parent.path.take(), child.path.take())?;
+    parent.component = component.clone();
+    parent.path = path.clone();
+    child.component = component;
+    child.path = path;
+    Ok(())
+}
+
+fn merge_changed_since(
+    parent: &mut ChangedScopeArgs,
+    child: &mut ChangedSinceArgs,
+) -> homeboy::core::Result<()> {
+    let changed_since = merge_option(
+        "--changed-since",
+        parent.lab.since.changed_since.take(),
+        child.changed_since.take(),
+    )?;
+    parent.lab.since.changed_since = changed_since.clone();
+    child.changed_since = changed_since;
+    Ok(())
+}
+
+fn merge_changed_scope(
+    parent: &mut ChangedScopeArgs,
+    child: &mut ChangedScopeArgs,
+) -> homeboy::core::Result<()> {
+    merge_changed_since(parent, &mut child.lab.since)?;
+    let changed_only = merge_flag(parent.changed_only, child.changed_only);
+    parent.changed_only = changed_only;
+    child.changed_only = changed_only;
+    Ok(())
+}
+
+fn merge_extension_ids(parent: &mut ExtensionOverrideArgs, child: &mut ExtensionOverrideArgs) {
+    let mut effective = parent.extensions.clone();
+    for extension in &child.extensions {
+        if !effective.contains(extension) {
+            effective.push(extension.clone());
+        }
+    }
+    parent.extensions = effective.clone();
+    child.extensions = effective;
+}
+
+fn merge_baseline_args(parent: &mut BaselineArgs, child: &mut BaselineArgs) {
+    parent.baseline = merge_flag(parent.baseline, child.baseline);
+    parent.ignore_baseline = merge_flag(parent.ignore_baseline, child.ignore_baseline);
+    parent.ratchet = merge_flag(parent.ratchet, child.ratchet);
+    *child = parent.clone();
+}
+
+fn merge_flag(parent: bool, child: bool) -> bool {
+    parent || child
 }
 
 /// Translate review's working-tree scope to audit's existing HEAD-based scoped
@@ -564,7 +628,9 @@ fn review_audit_args(
         audit_args.changed.precomputed_changed_files = Some(git::get_dirty_files(source_path)?);
         // `AuditArgs::profile` defaults to full for direct audit. A working-tree
         // review instead uses the bounded profile promised by review's scope.
-        audit_args.profile = "pr".to_string();
+        if audit_args.profile.is_none() {
+            audit_args.profile = Some("pr".to_string());
+        }
     }
     Ok(audit_args)
 }
@@ -1283,7 +1349,7 @@ fn build_audit_args(
         conventions: false,
         only: Vec::new(),
         exclude: Vec::new(),
-        profile: selected_audit_profile(args, review_context),
+        profile: Some(selected_audit_profile(args, review_context)),
         baseline_args: args.baseline_args.clone(),
         changed: ChangedSinceArgs {
             // Audit has no separate --changed-only flag. Reusing HEAD with the
@@ -1525,7 +1591,7 @@ mod tests {
             );
             assert_eq!(args.audit.changed.changed_since.as_deref(), Some("main"));
             assert!(args.audit.json_summary && args.audit.baseline_args.baseline);
-            assert_eq!(args.audit.profile, "architecture");
+            assert_eq!(args.audit.profile.as_deref(), Some("architecture"));
         }
 
         let lint_before = projected_review(&[
@@ -1605,7 +1671,6 @@ mod tests {
     #[test]
     fn review_action_projection_rejects_options_not_shared_by_the_action() {
         for argv in [
-            ["homeboy", "review", "test", "fixture", "--changed-only"].as_slice(),
             ["homeboy", "review", "--summary", "build", "fixture"].as_slice(),
             [
                 "homeboy",
@@ -1625,6 +1690,96 @@ mod tests {
                 .project_effective_child_args()
                 .expect_err("unsupported child option must fail before routing");
             assert!(error.message.contains("not supported"), "{error}");
+        }
+
+        assert!(
+            Cli::try_parse_from(["homeboy", "review", "test", "fixture", "--changed-only"])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn review_action_projection_normalizes_equal_duplicates_and_rejects_conflicts() {
+        let review = projected_review(&[
+            "homeboy",
+            "review",
+            "--path",
+            "-fixture-path",
+            "--changed-since",
+            "-base",
+            "--extension",
+            "fixture-extension",
+            "--audit-profile",
+            "pr",
+            "audit",
+            "fixture",
+            "--path",
+            "-fixture-path",
+            "--changed-since",
+            "-base",
+            "--extension",
+            "fixture-extension",
+            "--audit-profile",
+            "pr",
+        ]);
+        let Some(ReviewCommand::Audit(args)) = review.command else {
+            panic!("expected audit action");
+        };
+        assert_eq!(review.comp.path.as_deref(), Some("-fixture-path"));
+        assert_eq!(args.audit.changed.changed_since(), Some("-base"));
+        assert_eq!(args.audit.profile.as_deref(), Some("pr"));
+        assert_eq!(
+            args.audit.extension_override.extensions,
+            ["fixture-extension"]
+        );
+
+        for argv in [
+            [
+                "homeboy",
+                "review",
+                "--path",
+                "parent-path",
+                "audit",
+                "fixture",
+                "--path",
+                "child-path",
+            ]
+            .as_slice(),
+            [
+                "homeboy",
+                "review",
+                "--changed-since",
+                "parent-base",
+                "test",
+                "fixture",
+                "--changed-since",
+                "child-base",
+            ]
+            .as_slice(),
+            [
+                "homeboy",
+                "review",
+                "--audit-profile",
+                "full",
+                "audit",
+                "fixture",
+                "--audit-profile",
+                "pr",
+            ]
+            .as_slice(),
+        ] {
+            let mut cli = Cli::try_parse_from(argv).expect("conflicting command should parse");
+            let Commands::Review(review) = &mut cli.command else {
+                panic!("expected review command");
+            };
+            let error = review
+                .project_effective_child_args()
+                .expect_err("conflicting cross-position options must fail");
+            assert_eq!(
+                error.code,
+                homeboy::core::ErrorCode::ValidationInvalidArgument
+            );
+            assert!(error.message.contains("conflicting"), "{error}");
         }
     }
 
@@ -1972,7 +2127,7 @@ mod tests {
 
         let audit_args = build_audit_args(&args, &review_context);
 
-        assert_eq!(audit_args.profile, "pr");
+        assert_eq!(audit_args.profile.as_deref(), Some("pr"));
         assert_eq!(audit_args.changed.changed_since.as_deref(), Some("HEAD"));
         assert_eq!(
             audit_args.changed.precomputed_changed_files.as_deref(),
@@ -2022,7 +2177,10 @@ mod tests {
             precomputed_changed_files: None,
         };
 
-        assert_eq!(build_audit_args(&args, &review_context).profile, "pr");
+        assert_eq!(
+            build_audit_args(&args, &review_context).profile.as_deref(),
+            Some("pr")
+        );
     }
 
     #[test]
@@ -2034,7 +2192,10 @@ mod tests {
             precomputed_changed_files: None,
         };
 
-        assert_eq!(build_audit_args(&args, &review_context).profile, "full");
+        assert_eq!(
+            build_audit_args(&args, &review_context).profile.as_deref(),
+            Some("full")
+        );
     }
 
     #[test]
@@ -2147,8 +2308,8 @@ mod tests {
         };
 
         assert_eq!(
-            build_audit_args(&args, &review_context).profile,
-            "architecture"
+            build_audit_args(&args, &review_context).profile.as_deref(),
+            Some("architecture")
         );
     }
 

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -6,9 +6,9 @@
 //!
 //! See: https://github.com/Extra-Chill/homeboy/issues/436
 
-use clap::{Arg, ArgAction, Args, Command, CommandFactory};
+use clap::{Arg, ArgAction, Args, Command, CommandFactory, Parser};
 
-use crate::cli_surface::Cli;
+use crate::cli_surface::{Cli, Commands};
 use crate::command_capability::argv_separator_index;
 use homeboy::core::component::{self, Component};
 use homeboy::core::scope::{Scope, ScopeKind};
@@ -103,15 +103,24 @@ pub(crate) fn filter_passthrough_args(command: PassthroughCommand, args: &[Strin
 /// argument — `homeboy bench comp -- sh -c -- inner` — and marking it injected
 /// the sentinel into the argv Homeboy forwards verbatim.
 pub(crate) fn mark_explicit_passthrough(args: Vec<String>) -> Vec<String> {
-    let explicit_passthrough = matches!(args.get(1).map(String::as_str), Some("bench"))
-        || review_action_index(&args).is_some_and(|index| args[index] == "test");
-    if !explicit_passthrough {
-        return args;
-    }
-
     let Some(separator) = argv_separator_index(&args) else {
         return args;
     };
+    // Let Clap identify the command path. Scanning tokens for `review test`
+    // mistakes values of root options (for example `--runner test`) for actions.
+    let supports_passthrough = Cli::try_parse_from(&args).is_ok_and(|cli| {
+        matches!(
+            cli.command,
+            Commands::Bench(_)
+                | Commands::Review(crate::commands::review::ReviewArgs {
+                    command: Some(crate::commands::review::ReviewCommand::Test(_)),
+                    ..
+                })
+        )
+    });
+    if !supports_passthrough {
+        return args;
+    }
 
     let mut result = args;
     result.insert(separator + 1, EXPLICIT_PASSTHROUGH_SENTINEL.to_string());
@@ -275,59 +284,6 @@ fn normalize_review_audit_baseline(mut args: Vec<String>) -> Vec<String> {
     args
 }
 
-/// Locate the review action solely to preserve explicit `review test --`
-/// passthrough. Parsing and option placement remain Clap's responsibility.
-fn review_action_index(args: &[String]) -> Option<usize> {
-    let separator = args
-        .iter()
-        .position(|arg| arg == "--")
-        .unwrap_or(args.len());
-    let review_index = args[..separator].iter().position(|arg| arg == "review")?;
-
-    let mut index = review_index + 1;
-    while index < separator {
-        if matches!(
-            args[index].as_str(),
-            "audit" | "audit-baseline" | "lint" | "test" | "build" | "ci"
-        ) {
-            return Some(index);
-        }
-        index += review_shared_option_width(args, index).unwrap_or(1);
-    }
-    None
-}
-
-fn review_shared_option_width(args: &[String], index: usize) -> Option<usize> {
-    let option = args.get(index)?;
-    let takes_value = [
-        "--run-id",
-        "--path",
-        "--extension",
-        "--changed-since",
-        "--lab-changed-files-json",
-        "--ci-profile",
-        "--audit-profile",
-        "--report",
-        "--banner",
-    ];
-    let flags = [
-        "--changed-only",
-        "--summary",
-        "--baseline",
-        "--ignore-baseline",
-        "--ratchet",
-    ];
-
-    if flags.contains(&option.as_str()) {
-        return Some(1);
-    }
-    takes_value.iter().find_map(|flag| {
-        (option == flag)
-            .then_some(2)
-            .or_else(|| option.starts_with(&format!("{flag}=")).then_some(1))
-    })
-}
-
 #[cfg(test)]
 mod review_option_order_tests {
     use super::*;
@@ -361,6 +317,34 @@ mod review_option_order_tests {
                 EXPLICIT_PASSTHROUGH_SENTINEL,
                 "--changed-since",
                 "main",
+            ]
+            .map(str::to_string)
+            .to_vec()
+        );
+    }
+
+    #[test]
+    fn parser_identifies_review_test_passthrough_when_root_global_values_match_actions() {
+        let command = [
+            "homeboy", "--runner", "audit", "review", "test", "fixture", "--", "--filter",
+            "focused",
+        ]
+        .map(str::to_string)
+        .to_vec();
+
+        assert_eq!(
+            normalize(command),
+            [
+                "homeboy",
+                "--runner",
+                "audit",
+                "review",
+                "test",
+                "fixture",
+                "--",
+                EXPLICIT_PASSTHROUGH_SENTINEL,
+                "--filter",
+                "focused",
             ]
             .map(str::to_string)
             .to_vec()

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -362,7 +362,7 @@ pub struct PositionalComponentArgs {
     pub component: Option<String>,
 
     /// Override the component checkout path for this invocation
-    #[arg(long)]
+    #[arg(long, allow_hyphen_values = true)]
     pub path: Option<String>,
 }
 
@@ -1132,7 +1132,7 @@ pub struct BaselineArgs {
 #[derive(Args, Debug, Clone, Default)]
 pub struct ChangedSinceArgs {
     /// Only operate on files changed since this git ref (branch, tag, or SHA).
-    #[arg(long, value_name = "REF")]
+    #[arg(long, value_name = "REF", allow_hyphen_values = true)]
     pub changed_since: Option<String>,
 
     /// Caller-injected changeset. Not a CLI surface — `review` and the Lab
@@ -1208,7 +1208,7 @@ pub struct ChangedScopeArgs {
 
     /// Operate only on files modified in the working tree
     /// (staged, unstaged, untracked). File-scoped, not hunk-scoped.
-    #[arg(long, global = true, conflicts_with = "changed_since")]
+    #[arg(long, conflicts_with = "changed_since")]
     pub changed_only: bool,
 }
 

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -104,13 +104,7 @@ pub(crate) fn filter_passthrough_args(command: PassthroughCommand, args: &[Strin
 /// the sentinel into the argv Homeboy forwards verbatim.
 pub(crate) fn mark_explicit_passthrough(args: Vec<String>) -> Vec<String> {
     let explicit_passthrough = matches!(args.get(1).map(String::as_str), Some("bench"))
-        || matches!(
-            (
-                args.get(1).map(String::as_str),
-                args.get(2).map(String::as_str)
-            ),
-            (Some("review"), Some("test"))
-        );
+        || review_action_index(&args).is_some_and(|index| args[index] == "test");
     if !explicit_passthrough {
         return args;
     }
@@ -252,7 +246,7 @@ fn arg_takes_value(arg: &Arg) -> bool {
 /// Apply all argument normalizations in sequence.
 pub fn normalize(args: Vec<String>) -> Vec<String> {
     mark_explicit_passthrough(normalize_legacy_allow_local_fallback(
-        normalize_review_audit_baseline(args),
+        normalize_review_shared_option_order(normalize_review_audit_baseline(args)),
     ))
 }
 
@@ -279,6 +273,317 @@ fn normalize_review_audit_baseline(mut args: Vec<String>) -> Vec<String> {
         args.splice(position + 1..position + 3, ["audit-baseline".to_string()]);
     }
     args
+}
+
+/// Review owns its shared scope and presentation options, while its actions own
+/// their specialized options. Move shared options written after an action back
+/// to review so either natural ordering has one typed representation.
+fn normalize_review_shared_option_order(args: Vec<String>) -> Vec<String> {
+    let Some(action_index) = review_action_index(&args) else {
+        return args;
+    };
+    let separator = args
+        .iter()
+        .position(|arg| arg == "--")
+        .unwrap_or(args.len());
+    let mut shared = Vec::new();
+    let mut action_args = Vec::new();
+    let mut index = action_index + 1;
+
+    while index < separator {
+        if let Some(width) = review_shared_option_width(&args, index) {
+            shared.extend_from_slice(&args[index..index + width]);
+            index += width;
+        } else {
+            action_args.push(args[index].clone());
+            index += 1;
+        }
+    }
+
+    if shared.is_empty() {
+        return args;
+    }
+
+    let mut normalized = args[..action_index].to_vec();
+    normalized.extend(shared);
+    normalized.push(args[action_index].clone());
+    normalized.extend(action_args);
+    normalized.extend_from_slice(&args[separator..]);
+    normalized
+}
+
+fn review_action_index(args: &[String]) -> Option<usize> {
+    if args.get(1).map(String::as_str) != Some("review") {
+        return None;
+    }
+
+    let mut index = 2;
+    while index < args.len() && args[index] != "--" {
+        if matches!(
+            args[index].as_str(),
+            "audit" | "audit-baseline" | "lint" | "test" | "build" | "ci"
+        ) {
+            return Some(index);
+        }
+        index += review_shared_option_width(args, index).unwrap_or(1);
+    }
+    None
+}
+
+fn review_shared_option_width(args: &[String], index: usize) -> Option<usize> {
+    let option = args.get(index)?;
+    let takes_value = [
+        "--run-id",
+        "--path",
+        "--extension",
+        "--changed-since",
+        "--lab-changed-files-json",
+        "--ci-profile",
+        "--audit-profile",
+        "--report",
+        "--banner",
+    ];
+    let flags = [
+        "--changed-only",
+        "--summary",
+        "--baseline",
+        "--ignore-baseline",
+        "--ratchet",
+    ];
+
+    if flags.contains(&option.as_str()) {
+        return Some(1);
+    }
+    takes_value.iter().find_map(|flag| {
+        (option == flag)
+            .then_some(2)
+            .or_else(|| option.starts_with(&format!("{flag}=")).then_some(1))
+    })
+}
+
+#[cfg(test)]
+mod review_option_order_tests {
+    use super::*;
+    use clap::Parser;
+
+    fn argv(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn review_actions_accept_shared_options_before_or_after_the_action() {
+        for (action, target) in [
+            ("audit", vec!["fixture"]),
+            ("lint", vec!["fixture"]),
+            ("test", vec!["fixture"]),
+            ("build", vec!["fixture"]),
+            ("ci", vec!["list"]),
+        ] {
+            let mut before = vec![
+                "homeboy",
+                "--placement=local",
+                "review",
+                "--run-id=run-123",
+                "--path=fixture-path",
+                "--extension=first",
+                "--extension=second",
+                "--changed-since=main",
+                "--lab-changed-files-json=[]",
+                "--summary",
+                "--ci-profile=pr",
+                "--audit-profile=architecture",
+                "--report=pr-comment",
+                "--banner=source=generated",
+                "--banner=scope=changed",
+                "--baseline",
+                "--ignore-baseline",
+                "--ratchet",
+                action,
+            ];
+            before.extend(target.iter().copied());
+            let mut after = vec!["homeboy", "review", action];
+            after.extend(target.iter().copied());
+            after.extend([
+                "--run-id",
+                "run-123",
+                "--path",
+                "fixture-path",
+                "--extension",
+                "first",
+                "--extension",
+                "second",
+                "--changed-since",
+                "main",
+                "--lab-changed-files-json",
+                "[]",
+                "--summary",
+                "--ci-profile",
+                "pr",
+                "--audit-profile",
+                "architecture",
+                "--report",
+                "pr-comment",
+                "--banner",
+                "source=generated",
+                "--banner",
+                "scope=changed",
+                "--baseline",
+                "--ignore-baseline",
+                "--ratchet",
+                "--placement",
+                "local",
+            ]);
+
+            for command in [before, after] {
+                let normalized = normalize(argv(&command));
+                Cli::try_parse_from(&normalized).unwrap_or_else(|error| {
+                    panic!(
+                        "review {action} shared options failed to parse: {normalized:?}\n{error}"
+                    )
+                });
+                assert_eq!(normalize(normalized.clone()), normalized);
+            }
+        }
+    }
+
+    #[test]
+    fn review_actions_accept_changed_only_before_or_after_the_action() {
+        for (action, target) in [
+            ("audit", vec!["fixture"]),
+            ("lint", vec!["fixture"]),
+            ("test", vec!["fixture"]),
+            ("build", vec!["fixture"]),
+            ("ci", vec!["list"]),
+        ] {
+            let mut before = vec!["homeboy", "review", "--changed-only", action];
+            before.extend(target.iter().copied());
+            let mut after = vec!["homeboy", "review", action];
+            after.extend(target.iter().copied());
+            after.push("--changed-only");
+            for command in [before, after] {
+                Cli::try_parse_from(normalize(argv(&command))).unwrap_or_else(|error| {
+                    panic!("review {action} changed-only failed to parse: {error}")
+                });
+            }
+        }
+    }
+
+    #[test]
+    fn review_action_shared_options_preserve_equals_and_space_value_forms() {
+        for (command, expected) in [
+            (
+                argv(&[
+                    "homeboy",
+                    "review",
+                    "test",
+                    "fixture",
+                    "--changed-since=origin/main",
+                    "--extension=rust",
+                    "--banner=source=generated",
+                ]),
+                argv(&[
+                    "homeboy",
+                    "review",
+                    "--changed-since=origin/main",
+                    "--extension=rust",
+                    "--banner=source=generated",
+                    "test",
+                    "fixture",
+                ]),
+            ),
+            (
+                argv(&[
+                    "homeboy",
+                    "review",
+                    "test",
+                    "fixture",
+                    "--changed-since",
+                    "origin/main",
+                    "--extension",
+                    "rust",
+                    "--banner",
+                    "source=generated",
+                ]),
+                argv(&[
+                    "homeboy",
+                    "review",
+                    "--changed-since",
+                    "origin/main",
+                    "--extension",
+                    "rust",
+                    "--banner",
+                    "source=generated",
+                    "test",
+                    "fixture",
+                ]),
+            ),
+        ] {
+            let normalized = normalize(command);
+            assert_eq!(normalized, expected);
+            Cli::try_parse_from(normalized).expect("canonical replay command parses");
+        }
+    }
+
+    #[test]
+    fn review_action_scope_conflicts_are_reported_as_the_exact_conflict() {
+        for (action, target) in [
+            ("audit", vec!["fixture"]),
+            ("lint", vec!["fixture"]),
+            ("test", vec!["fixture"]),
+            ("build", vec!["fixture"]),
+            ("ci", vec!["list"]),
+        ] {
+            for scope in [
+                vec!["--changed-since", "main", "--changed-only"],
+                vec!["--changed-only", "--changed-since=main"],
+            ] {
+                let mut command = vec!["homeboy", "review", action];
+                command.extend(target.iter().copied());
+                command.extend(scope);
+                let error = match Cli::try_parse_from(normalize(argv(&command))) {
+                    Ok(_) => panic!("conflicting review scopes must fail"),
+                    Err(error) => error,
+                };
+                let message = error.to_string();
+                assert!(message.contains("--changed-only"), "{message}");
+                assert!(message.contains("--changed-since"), "{message}");
+                assert!(message.contains("cannot be used with"), "{message}");
+                assert!(
+                    !message.contains("tip: a similar argument exists"),
+                    "conflicts must explain the requested flags, not suggest another one: {message}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn review_test_passthrough_is_not_reordered() {
+        let command = argv(&[
+            "homeboy",
+            "review",
+            "test",
+            "fixture",
+            "--summary",
+            "--",
+            "--changed-since",
+            "main",
+        ]);
+
+        assert_eq!(
+            normalize(command),
+            argv(&[
+                "homeboy",
+                "review",
+                "--summary",
+                "test",
+                "fixture",
+                "--",
+                EXPLICIT_PASSTHROUGH_SENTINEL,
+                "--changed-since",
+                "main",
+            ])
+        );
+    }
 }
 
 // ============================================================================

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -246,7 +246,7 @@ fn arg_takes_value(arg: &Arg) -> bool {
 /// Apply all argument normalizations in sequence.
 pub fn normalize(args: Vec<String>) -> Vec<String> {
     mark_explicit_passthrough(normalize_legacy_allow_local_fallback(
-        normalize_review_shared_option_order(normalize_review_audit_baseline(args)),
+        normalize_review_audit_baseline(args),
     ))
 }
 
@@ -275,50 +275,17 @@ fn normalize_review_audit_baseline(mut args: Vec<String>) -> Vec<String> {
     args
 }
 
-/// Review owns its shared scope and presentation options, while its actions own
-/// their specialized options. Move shared options written after an action back
-/// to review so either natural ordering has one typed representation.
-fn normalize_review_shared_option_order(args: Vec<String>) -> Vec<String> {
-    let Some(action_index) = review_action_index(&args) else {
-        return args;
-    };
+/// Locate the review action solely to preserve explicit `review test --`
+/// passthrough. Parsing and option placement remain Clap's responsibility.
+fn review_action_index(args: &[String]) -> Option<usize> {
     let separator = args
         .iter()
         .position(|arg| arg == "--")
         .unwrap_or(args.len());
-    let mut shared = Vec::new();
-    let mut action_args = Vec::new();
-    let mut index = action_index + 1;
+    let review_index = args[..separator].iter().position(|arg| arg == "review")?;
 
+    let mut index = review_index + 1;
     while index < separator {
-        if let Some(width) = review_shared_option_width(&args, index) {
-            shared.extend_from_slice(&args[index..index + width]);
-            index += width;
-        } else {
-            action_args.push(args[index].clone());
-            index += 1;
-        }
-    }
-
-    if shared.is_empty() {
-        return args;
-    }
-
-    let mut normalized = args[..action_index].to_vec();
-    normalized.extend(shared);
-    normalized.push(args[action_index].clone());
-    normalized.extend(action_args);
-    normalized.extend_from_slice(&args[separator..]);
-    normalized
-}
-
-fn review_action_index(args: &[String]) -> Option<usize> {
-    if args.get(1).map(String::as_str) != Some("review") {
-        return None;
-    }
-
-    let mut index = 2;
-    while index < args.len() && args[index] != "--" {
         if matches!(
             args[index].as_str(),
             "audit" | "audit-baseline" | "lint" | "test" | "build" | "ci"
@@ -364,202 +331,12 @@ fn review_shared_option_width(args: &[String], index: usize) -> Option<usize> {
 #[cfg(test)]
 mod review_option_order_tests {
     use super::*;
-    use clap::Parser;
-
-    fn argv(values: &[&str]) -> Vec<String> {
-        values.iter().map(|value| (*value).to_string()).collect()
-    }
 
     #[test]
-    fn review_actions_accept_shared_options_before_or_after_the_action() {
-        for (action, target) in [
-            ("audit", vec!["fixture"]),
-            ("lint", vec!["fixture"]),
-            ("test", vec!["fixture"]),
-            ("build", vec!["fixture"]),
-            ("ci", vec!["list"]),
-        ] {
-            let mut before = vec![
-                "homeboy",
-                "--placement=local",
-                "review",
-                "--run-id=run-123",
-                "--path=fixture-path",
-                "--extension=first",
-                "--extension=second",
-                "--changed-since=main",
-                "--lab-changed-files-json=[]",
-                "--summary",
-                "--ci-profile=pr",
-                "--audit-profile=architecture",
-                "--report=pr-comment",
-                "--banner=source=generated",
-                "--banner=scope=changed",
-                "--baseline",
-                "--ignore-baseline",
-                "--ratchet",
-                action,
-            ];
-            before.extend(target.iter().copied());
-            let mut after = vec!["homeboy", "review", action];
-            after.extend(target.iter().copied());
-            after.extend([
-                "--run-id",
-                "run-123",
-                "--path",
-                "fixture-path",
-                "--extension",
-                "first",
-                "--extension",
-                "second",
-                "--changed-since",
-                "main",
-                "--lab-changed-files-json",
-                "[]",
-                "--summary",
-                "--ci-profile",
-                "pr",
-                "--audit-profile",
-                "architecture",
-                "--report",
-                "pr-comment",
-                "--banner",
-                "source=generated",
-                "--banner",
-                "scope=changed",
-                "--baseline",
-                "--ignore-baseline",
-                "--ratchet",
-                "--placement",
-                "local",
-            ]);
-
-            for command in [before, after] {
-                let normalized = normalize(argv(&command));
-                Cli::try_parse_from(&normalized).unwrap_or_else(|error| {
-                    panic!(
-                        "review {action} shared options failed to parse: {normalized:?}\n{error}"
-                    )
-                });
-                assert_eq!(normalize(normalized.clone()), normalized);
-            }
-        }
-    }
-
-    #[test]
-    fn review_actions_accept_changed_only_before_or_after_the_action() {
-        for (action, target) in [
-            ("audit", vec!["fixture"]),
-            ("lint", vec!["fixture"]),
-            ("test", vec!["fixture"]),
-            ("build", vec!["fixture"]),
-            ("ci", vec!["list"]),
-        ] {
-            let mut before = vec!["homeboy", "review", "--changed-only", action];
-            before.extend(target.iter().copied());
-            let mut after = vec!["homeboy", "review", action];
-            after.extend(target.iter().copied());
-            after.push("--changed-only");
-            for command in [before, after] {
-                Cli::try_parse_from(normalize(argv(&command))).unwrap_or_else(|error| {
-                    panic!("review {action} changed-only failed to parse: {error}")
-                });
-            }
-        }
-    }
-
-    #[test]
-    fn review_action_shared_options_preserve_equals_and_space_value_forms() {
-        for (command, expected) in [
-            (
-                argv(&[
-                    "homeboy",
-                    "review",
-                    "test",
-                    "fixture",
-                    "--changed-since=origin/main",
-                    "--extension=rust",
-                    "--banner=source=generated",
-                ]),
-                argv(&[
-                    "homeboy",
-                    "review",
-                    "--changed-since=origin/main",
-                    "--extension=rust",
-                    "--banner=source=generated",
-                    "test",
-                    "fixture",
-                ]),
-            ),
-            (
-                argv(&[
-                    "homeboy",
-                    "review",
-                    "test",
-                    "fixture",
-                    "--changed-since",
-                    "origin/main",
-                    "--extension",
-                    "rust",
-                    "--banner",
-                    "source=generated",
-                ]),
-                argv(&[
-                    "homeboy",
-                    "review",
-                    "--changed-since",
-                    "origin/main",
-                    "--extension",
-                    "rust",
-                    "--banner",
-                    "source=generated",
-                    "test",
-                    "fixture",
-                ]),
-            ),
-        ] {
-            let normalized = normalize(command);
-            assert_eq!(normalized, expected);
-            Cli::try_parse_from(normalized).expect("canonical replay command parses");
-        }
-    }
-
-    #[test]
-    fn review_action_scope_conflicts_are_reported_as_the_exact_conflict() {
-        for (action, target) in [
-            ("audit", vec!["fixture"]),
-            ("lint", vec!["fixture"]),
-            ("test", vec!["fixture"]),
-            ("build", vec!["fixture"]),
-            ("ci", vec!["list"]),
-        ] {
-            for scope in [
-                vec!["--changed-since", "main", "--changed-only"],
-                vec!["--changed-only", "--changed-since=main"],
-            ] {
-                let mut command = vec!["homeboy", "review", action];
-                command.extend(target.iter().copied());
-                command.extend(scope);
-                let error = match Cli::try_parse_from(normalize(argv(&command))) {
-                    Ok(_) => panic!("conflicting review scopes must fail"),
-                    Err(error) => error,
-                };
-                let message = error.to_string();
-                assert!(message.contains("--changed-only"), "{message}");
-                assert!(message.contains("--changed-since"), "{message}");
-                assert!(message.contains("cannot be used with"), "{message}");
-                assert!(
-                    !message.contains("tip: a similar argument exists"),
-                    "conflicts must explain the requested flags, not suggest another one: {message}"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn review_test_passthrough_is_not_reordered() {
-        let command = argv(&[
+    fn review_test_passthrough_is_marked_without_reordering() {
+        let command = [
             "homeboy",
+            "--placement=local",
             "review",
             "test",
             "fixture",
@@ -567,21 +344,26 @@ mod review_option_order_tests {
             "--",
             "--changed-since",
             "main",
-        ]);
+        ]
+        .map(str::to_string)
+        .to_vec();
 
         assert_eq!(
             normalize(command),
-            argv(&[
+            [
                 "homeboy",
+                "--placement=local",
                 "review",
-                "--summary",
                 "test",
                 "fixture",
+                "--summary",
                 "--",
                 EXPLICIT_PASSTHROUGH_SENTINEL,
                 "--changed-since",
                 "main",
-            ])
+            ]
+            .map(str::to_string)
+            .to_vec()
         );
     }
 }
@@ -1442,7 +1224,7 @@ pub struct ChangedScopeArgs {
 
     /// Operate only on files modified in the working tree
     /// (staged, unstaged, untracked). File-scoped, not hunk-scoped.
-    #[arg(long, conflicts_with = "changed_since")]
+    #[arg(long, global = true, conflicts_with = "changed_since")]
     pub changed_only: bool,
 }
 

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -26,5 +26,7 @@ mod promotion_provider_stdin;
 mod refactor_transform_test;
 #[path = "cli_binary/review_dirty_preflight.rs"]
 mod review_dirty_preflight;
+#[path = "cli_binary/review_option_order.rs"]
+mod review_option_order;
 #[path = "cli_binary/rig_local_artifact_registration.rs"]
 mod rig_local_artifact_registration;

--- a/tests/cli_binary/review_option_order.rs
+++ b/tests/cli_binary/review_option_order.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 #[test]
-fn review_test_accepts_shared_options_after_the_action_in_help_and_runtime_paths() {
+fn review_test_help_and_execution_accept_the_same_options() {
     let home = tempfile::tempdir().expect("temporary home");
     let sentinel = home.path().join("runtime-initialized");
 
@@ -10,7 +10,7 @@ fn review_test_accepts_shared_options_after_the_action_in_help_and_runtime_paths
         .args([
             "review",
             "test",
-            "--changed-only",
+            "--changed-since=-base",
             "--placement=local",
             "--summary",
             "--help",
@@ -32,6 +32,16 @@ fn review_test_accepts_shared_options_after_the_action_in_help_and_runtime_paths
         "{}",
         String::from_utf8_lossy(&help.stdout)
     );
+    assert!(
+        String::from_utf8_lossy(&help.stdout).contains("--changed-since"),
+        "{}",
+        String::from_utf8_lossy(&help.stdout)
+    );
+    assert!(
+        !String::from_utf8_lossy(&help.stdout).contains("--changed-only"),
+        "review test must not advertise an unsupported option: {}",
+        String::from_utf8_lossy(&help.stdout)
+    );
     assert!(!sentinel.exists(), "help must not initialize the runtime");
 
     let runtime = Command::new(homeboy_bin())
@@ -40,7 +50,8 @@ fn review_test_accepts_shared_options_after_the_action_in_help_and_runtime_paths
             "review",
             "test",
             "missing-component",
-            "--changed-only",
+            "--changed-since=-base",
+            "--summary",
         ])
         .env_clear()
         .env("HOME", home.path())
@@ -58,9 +69,28 @@ fn review_test_accepts_shared_options_after_the_action_in_help_and_runtime_paths
         String::from_utf8_lossy(&runtime.stderr)
     );
     assert!(
-        !combined.contains("unexpected argument '--changed-only'")
-            && !combined.contains("unrecognized subcommand '--changed-only'"),
-        "review test flags must parse before component resolution: {combined}"
+        !combined.contains("unexpected argument '--changed-since'")
+            && !combined.contains("unrecognized subcommand '--changed-since'"),
+        "review test options advertised in help must parse before component resolution: {combined}"
+    );
+
+    let unsupported = Command::new(homeboy_bin())
+        .args(["review", "test", "missing-component", "--changed-only"])
+        .env_clear()
+        .env("HOME", home.path())
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run unsupported review test option");
+
+    assert!(!unsupported.status.success());
+    let unsupported_output = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&unsupported.stdout),
+        String::from_utf8_lossy(&unsupported.stderr)
+    );
+    assert!(
+        unsupported_output.contains("unexpected argument '--changed-only'"),
+        "review test must reject options absent from its help: {unsupported_output}"
     );
 }
 
@@ -107,6 +137,64 @@ fn review_actions_accept_their_shared_post_action_options_in_help() {
             "review {action}: {}",
             String::from_utf8_lossy(&output.stdout)
         );
+    }
+}
+
+#[test]
+fn review_rejects_conflicting_parent_and_action_values_before_execution() {
+    let home = tempfile::tempdir().expect("temporary home");
+
+    for args in [
+        [
+            "review",
+            "--path",
+            "parent-path",
+            "audit",
+            "fixture",
+            "--path",
+            "child-path",
+        ]
+        .as_slice(),
+        [
+            "review",
+            "--changed-since",
+            "parent-base",
+            "test",
+            "fixture",
+            "--changed-since",
+            "child-base",
+        ]
+        .as_slice(),
+        [
+            "review",
+            "--audit-profile",
+            "full",
+            "audit",
+            "fixture",
+            "--audit-profile",
+            "pr",
+        ]
+        .as_slice(),
+    ] {
+        let output = Command::new(homeboy_bin())
+            .args(args)
+            .env_clear()
+            .env("HOME", home.path())
+            .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+            .output()
+            .expect("run conflicting review command");
+
+        assert_eq!(output.status.code(), Some(2));
+        let combined = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            combined.contains("validation.invalid_argument"),
+            "{combined}"
+        );
+        assert!(combined.contains("conflicting"), "{combined}");
     }
 }
 

--- a/tests/cli_binary/review_option_order.rs
+++ b/tests/cli_binary/review_option_order.rs
@@ -167,6 +167,75 @@ fn startup_help_applies_the_same_review_option_projection() {
 }
 
 #[test]
+fn review_audit_and_lint_reject_cross_position_changed_scopes_in_help_and_runtime() {
+    let home = tempfile::tempdir().expect("temporary home");
+
+    for action in ["audit", "lint"] {
+        for args in [
+            [
+                "review",
+                "--changed-only",
+                action,
+                "missing-component",
+                "--changed-since",
+                "main",
+            ],
+            [
+                "review",
+                "--changed-since",
+                "main",
+                action,
+                "missing-component",
+                "--changed-only",
+            ],
+        ] {
+            let runtime = Command::new(homeboy_bin())
+                .args(args)
+                .env_clear()
+                .env("HOME", home.path())
+                .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+                .output()
+                .expect("run conflicting review command");
+            assert_eq!(runtime.status.code(), Some(2), "{action}: {args:?}");
+            let runtime_output = format!(
+                "{}\n{}",
+                String::from_utf8_lossy(&runtime.stdout),
+                String::from_utf8_lossy(&runtime.stderr)
+            );
+            assert!(
+                runtime_output.contains("validation.invalid_argument"),
+                "{runtime_output}"
+            );
+            assert!(
+                runtime_output.contains("--changed-only conflicts with --changed-since"),
+                "{runtime_output}"
+            );
+            assert!(
+                !runtime_output.contains("missing component"),
+                "scope conflict must precede component resolution: {runtime_output}"
+            );
+
+            let sentinel = home.path().join(format!("{action}-help-initialized"));
+            let help = Command::new(homeboy_bin())
+                .args(args.into_iter().chain(["--help"]))
+                .env_clear()
+                .env("HOME", home.path())
+                .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+                .env("HOMEBOY_TEST_RUNTIME_INITIALIZATION_SENTINEL", &sentinel)
+                .output()
+                .expect("run conflicting review help");
+            assert_eq!(help.status.code(), Some(2), "{action}: {args:?}");
+            let help_output = String::from_utf8_lossy(&help.stderr);
+            assert!(
+                help_output.contains("--changed-only conflicts with --changed-since"),
+                "{help_output}"
+            );
+            assert!(!sentinel.exists(), "help must not initialize the runtime");
+        }
+    }
+}
+
+#[test]
 fn review_rejects_conflicting_parent_and_action_values_before_execution() {
     let home = tempfile::tempdir().expect("temporary home");
 

--- a/tests/cli_binary/review_option_order.rs
+++ b/tests/cli_binary/review_option_order.rs
@@ -1,0 +1,69 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn review_test_accepts_shared_options_after_the_action_in_help_and_runtime_paths() {
+    let home = tempfile::tempdir().expect("temporary home");
+    let sentinel = home.path().join("runtime-initialized");
+
+    let help = Command::new(homeboy_bin())
+        .args([
+            "review",
+            "test",
+            "--changed-only",
+            "--placement=local",
+            "--summary",
+            "--help",
+        ])
+        .env_clear()
+        .env("HOME", home.path())
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .env("HOMEBOY_TEST_RUNTIME_INITIALIZATION_SENTINEL", &sentinel)
+        .output()
+        .expect("run review test help");
+
+    assert!(
+        help.status.success(),
+        "{}",
+        String::from_utf8_lossy(&help.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&help.stdout).contains("Run tests for a component"),
+        "{}",
+        String::from_utf8_lossy(&help.stdout)
+    );
+    assert!(!sentinel.exists(), "help must not initialize the runtime");
+
+    let runtime = Command::new(homeboy_bin())
+        .args([
+            "--placement=local",
+            "review",
+            "test",
+            "missing-component",
+            "--changed-only",
+        ])
+        .env_clear()
+        .env("HOME", home.path())
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run review test");
+
+    assert!(
+        !runtime.status.success(),
+        "missing component must fail at runtime"
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&runtime.stdout),
+        String::from_utf8_lossy(&runtime.stderr)
+    );
+    assert!(
+        !combined.contains("unexpected argument '--changed-only'")
+            && !combined.contains("unrecognized subcommand '--changed-only'"),
+        "review test flags must parse before component resolution: {combined}"
+    );
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}

--- a/tests/cli_binary/review_option_order.rs
+++ b/tests/cli_binary/review_option_order.rs
@@ -64,6 +64,52 @@ fn review_test_accepts_shared_options_after_the_action_in_help_and_runtime_paths
     );
 }
 
+#[test]
+fn review_actions_accept_their_shared_post_action_options_in_help() {
+    let home = tempfile::tempdir().expect("temporary home");
+
+    for (action, target, option, expected) in [
+        (
+            "audit",
+            "fixture",
+            "--changed-since=main",
+            "Audit code conventions",
+        ),
+        ("lint", "fixture", "--changed-only", "Lint a component"),
+        (
+            "test",
+            "fixture",
+            "--changed-since=main",
+            "Run tests for a component",
+        ),
+        (
+            "build",
+            "fixture",
+            "--changed-since=main",
+            "Run a local build quality gate",
+        ),
+    ] {
+        let output = Command::new(homeboy_bin())
+            .args(["review", action, target, option, "--help"])
+            .env_clear()
+            .env("HOME", home.path())
+            .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+            .output()
+            .expect("run review action help");
+
+        assert!(
+            output.status.success(),
+            "review {action}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains(expected),
+            "review {action}: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+}
+
 fn homeboy_bin() -> PathBuf {
     PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
 }

--- a/tests/cli_binary/review_option_order.rs
+++ b/tests/cli_binary/review_option_order.rs
@@ -141,6 +141,32 @@ fn review_actions_accept_their_shared_post_action_options_in_help() {
 }
 
 #[test]
+fn startup_help_applies_the_same_review_option_projection() {
+    let home = tempfile::tempdir().expect("temporary home");
+    let sentinel = home.path().join("runtime-initialized");
+
+    let output = Command::new(homeboy_bin())
+        .args(["review", "--changed-only", "test", "fixture", "--help"])
+        .env_clear()
+        .env("HOME", home.path())
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .env("HOMEBOY_TEST_RUNTIME_INITIALIZATION_SENTINEL", &sentinel)
+        .output()
+        .expect("run invalid review test help");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--changed-only is not supported by this review action"),
+        "{stderr}"
+    );
+    assert!(
+        !sentinel.exists(),
+        "startup help must not initialize the runtime"
+    );
+}
+
+#[test]
 fn review_rejects_conflicting_parent_and_action_values_before_execution() {
     let home = tempfile::tempdir().expect("temporary home");
 
@@ -195,6 +221,10 @@ fn review_rejects_conflicting_parent_and_action_values_before_execution() {
             "{combined}"
         );
         assert!(combined.contains("conflicting"), "{combined}");
+        assert!(
+            !combined.contains("missing component") && !combined.contains("No files changed"),
+            "conflicting scopes must fail before review execution: {combined}"
+        );
     }
 }
 

--- a/tests/dev_build_test.rs
+++ b/tests/dev_build_test.rs
@@ -16,17 +16,18 @@ fn dev_build_accepts_matching_full_identity_and_rejects_mismatch() {
 set -euo pipefail
 binary="$CARGO_TARGET_DIR/debug/homeboy"
 mkdir -p "$(dirname "$binary")"
-printf '%s\n' '#!/usr/bin/env bash' 'printf "{\\"data\\":{\\"git_commit\\":\\"%s\\"}}\\n" "$HOMEBOY_TEST_BINARY_COMMIT"' > "$binary"
+printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' '{\"data\":{\"git_commit\":\"$HOMEBOY_TEST_BINARY_COMMIT\"}}'" > "$binary"
 chmod +x "$binary"
 "#,
     );
     write_executable(
         &tools.join("jq"),
-        "#!/usr/bin/env bash\ncat >/dev/null\nprintf '%s\\n' \"$HOMEBOY_TEST_BINARY_COMMIT\"\n",
+        "#!/usr/bin/env bash\nset -euo pipefail\nexec \"$HOMEBOY_TEST_REAL_JQ\" \"$@\"\n",
     );
 
     let expected = git_head();
-    let matching = run_dev_build(&tools, &target, &expected);
+    let real_jq = executable("jq");
+    let matching = run_dev_build(&tools, &target, &real_jq, &expected);
     assert!(
         matching.status.success(),
         "matching full identity failed with {}:\nstdout: {}\nstderr: {}",
@@ -36,7 +37,7 @@ chmod +x "$binary"
     );
     assert!(String::from_utf8_lossy(&matching.stdout).contains(&expected));
 
-    let mismatch = run_dev_build(&tools, &target, "different-commit");
+    let mismatch = run_dev_build(&tools, &target, &real_jq, "different-commit");
     assert!(!mismatch.status.success());
     assert!(
         String::from_utf8_lossy(&mismatch.stderr).contains(&format!(
@@ -48,7 +49,12 @@ chmod +x "$binary"
     );
 }
 
-fn run_dev_build(tools: &Path, target: &Path, binary_commit: &str) -> std::process::Output {
+fn run_dev_build(
+    tools: &Path,
+    target: &Path,
+    real_jq: &Path,
+    binary_commit: &str,
+) -> std::process::Output {
     let path = format!(
         "{}:{}",
         tools.display(),
@@ -57,9 +63,17 @@ fn run_dev_build(tools: &Path, target: &Path, binary_commit: &str) -> std::proce
     Command::new(env!("CARGO_MANIFEST_DIR").to_owned() + "/scripts/dev-build")
         .env("PATH", path)
         .env("CARGO_TARGET_DIR", target)
+        .env("HOMEBOY_TEST_REAL_JQ", real_jq)
         .env("HOMEBOY_TEST_BINARY_COMMIT", binary_commit)
         .output()
         .expect("run dev-build")
+}
+
+fn executable(name: &str) -> std::path::PathBuf {
+    std::env::split_paths(&std::env::var_os("PATH").expect("PATH"))
+        .map(|directory| directory.join(name))
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| panic!("{name} executable is available"))
 }
 
 fn git_head() -> String {

--- a/tests/dev_build_test.rs
+++ b/tests/dev_build_test.rs
@@ -36,9 +36,14 @@ chmod +x "$binary"
 
     let mismatch = run_dev_build(&tools, &target, "different-commit");
     assert!(!mismatch.status.success());
-    assert!(String::from_utf8_lossy(&mismatch.stderr).contains(&format!(
-        "development binary identity mismatch: expected {expected}, got different-commit"
-    )));
+    assert!(
+        String::from_utf8_lossy(&mismatch.stderr).contains(&format!(
+            "development binary identity mismatch: expected {expected}, got different-commit"
+        )),
+        "mismatched identity did not report the expected failure:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&mismatch.stdout),
+        String::from_utf8_lossy(&mismatch.stderr)
+    );
 }
 
 fn run_dev_build(tools: &Path, target: &Path, binary_commit: &str) -> std::process::Output {
@@ -58,6 +63,7 @@ fn run_dev_build(tools: &Path, target: &Path, binary_commit: &str) -> std::proce
 fn git_head() -> String {
     let output = Command::new("git")
         .args(["rev-parse", "HEAD"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
         .output()
         .expect("resolve fixture HEAD");
     assert!(output.status.success());

--- a/tests/dev_build_test.rs
+++ b/tests/dev_build_test.rs
@@ -22,14 +22,16 @@ chmod +x "$binary"
     );
     write_executable(
         &tools.join("jq"),
-        "#!/usr/bin/env bash\nprintf '%s\\n' \"$HOMEBOY_TEST_BINARY_COMMIT\"\n",
+        "#!/usr/bin/env bash\ncat >/dev/null\nprintf '%s\\n' \"$HOMEBOY_TEST_BINARY_COMMIT\"\n",
     );
 
     let expected = git_head();
     let matching = run_dev_build(&tools, &target, &expected);
     assert!(
         matching.status.success(),
-        "matching full identity failed: {}",
+        "matching full identity failed with {}:\nstdout: {}\nstderr: {}",
+        matching.status,
+        String::from_utf8_lossy(&matching.stdout),
         String::from_utf8_lossy(&matching.stderr)
     );
     assert!(String::from_utf8_lossy(&matching.stdout).contains(&expected));


### PR DESCRIPTION
## Summary
- parse shared review options before or after review actions
- project normalized options consistently before routing
- validate conflicting scopes with actionable errors
- keep startup help and generated command behavior aligned

## Verification
- focused CLI parsing, routing, help, and option-order regressions passed
- independent acceptance review: ACCEPT at db02b2a5dbd485d1ac548edfd4e4a4c161f579f1

Closes #14535

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented and tested the CLI option-order behavior and performed a separate strict acceptance review under Chris Huber's direction.