### PR TITLE
chore: delete code the compiler proves is unreachable

### DIFF
--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -1643,13 +1643,6 @@ fn remove_with_store_until(
     }
 }
 
-fn remove_with_store_unlocked(
-    options: WorktreeRemoveOptions,
-    store_dir: &Path,
-) -> Result<WorktreeRemoveOutput> {
-    remove_with_store_unlocked_until(options, store_dir, None)
-}
-
 fn remove_with_store_unlocked_until(
     options: WorktreeRemoveOptions,
     store_dir: &Path,
@@ -1809,12 +1802,6 @@ fn workspace_claim_store_for_worktrees(
     ))
 }
 
-pub(super) fn branch_cleanup_report(
-    record: &TaskWorktreeRecord,
-) -> Result<WorktreeBranchCleanupReport> {
-    branch_cleanup_report_until(record, None)
-}
-
 fn branch_cleanup_report_until(
     record: &TaskWorktreeRecord,
     deadline: Option<std::time::Instant>,
@@ -1887,14 +1874,6 @@ fn branch_cleanup_report_until(
         },
         cleanup_command,
     })
-}
-
-fn apply_branch_cleanup(
-    record: &TaskWorktreeRecord,
-    report: WorktreeBranchCleanupReport,
-    allow_unmerged_branch: bool,
-) -> Result<WorktreeBranchCleanupReport> {
-    apply_branch_cleanup_until(record, report, allow_unmerged_branch, None)
 }
 
 fn apply_branch_cleanup_until(
@@ -2042,24 +2021,12 @@ fn safety_report_until(
 
 const LIVE_CWD_REASON: &str = "refuses to remove the caller's live current working directory";
 
-pub(super) fn is_dirty(path: &Path) -> Result<bool> {
-    Ok(
-        !git::run_git(path, &["status", "--porcelain=v1"], "git status")?
-            .trim()
-            .is_empty(),
-    )
-}
-
 fn is_dirty_until(path: &Path, deadline: Option<std::time::Instant>) -> Result<bool> {
     Ok(
         !run_inventory_git_until(path, &["status", "--porcelain=v1"], "git status", deadline)?
             .trim()
             .is_empty(),
     )
-}
-
-pub(super) fn unpushed_commit_count(path: &Path, base_ref: &str) -> Result<u32> {
-    unpushed_commit_count_until(path, base_ref, None)
 }
 
 fn unpushed_commit_count_until(

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -1841,17 +1841,6 @@ fn refresh_execution_route(
     ))
 }
 
-/// Refresh is a mutation path, so it first settles the generation ledger and
-/// then derives route selection from that exact post-reconcile status. The
-/// later pre-rotation job probe remains the fail-closed check for work that
-/// appears while materialization is in progress.
-fn reconciled_refresh_admission(runner_id: &str) -> Result<super::RunnerAdmissionSnapshot> {
-    reconciled_refresh_admission_in_roots(
-        &homeboy_core::paths::PathRoots::from_environment()?,
-        runner_id,
-    )
-}
-
 /// [`reconciled_refresh_admission`] against an explicitly injected root.
 fn reconciled_refresh_admission_in_roots(
     roots: &homeboy_core::paths::PathRoots,


### PR DESCRIPTION
Six functions with **zero references anywhere in the tree** — no production caller, no test caller. Confirmed both by `rustc`'s `dead_code` pass and by grep. **−44 lines.**

`homeboy-core/src/worktree/store_ops.rs`
- `remove_with_store_unlocked`
- `branch_cleanup_report`
- `apply_branch_cleanup`
- `is_dirty`
- `unpushed_commit_count`

`homeboy-lab-runner/src/homeboy_refresh.rs`
- `reconciled_refresh_admission` — my own orphan from #14408, left behind when the refresh path moved to the rooted variant

## Verification
`cargo check --workspace --all-targets` clean. `homeboy-core` worktree tests: **107 passed, 0 failed**.

## Separate finding: production code alive only through its own tests
Six more items warn as `never used` in the library build but do have callers — all of them tests. That means production code with no production caller, kept compiling by tests that exercise nothing else:

| item | only caller |
|---|---|
| `structured_sidecar::registry` | own tests |
| `worktree::store_ops::cleanup_with_store` | `worktree/tests.rs` (14 refs) |
| `fanout::persist_batch_cook_recipes` | own tests |
| `fanout::compile_batch_cooks` | own tests |
| `fanout::preflight_batch_cook_recipes` | own tests |
| `homeboy_refresh::acquire_runner_binary_promotion{,_with}` | `tests/part_b.rs` |

Removing those means removing their tests too, which is a coverage decision rather than a cleanup, so I left them. The last two are also mine from #14408: production now calls the rooted variants, and `part_b` uses the ambient wrappers only as a convenient way to obtain a lease.

Recorded so the set is visible rather than sitting behind warnings.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode collected the workspace `dead_code` warnings, separated genuinely unreachable code from code kept alive by its own tests, and deleted only the former. Chris Huber directed the work and remains responsible for acceptance.