### PR TITLE
chore: retire test-only wrappers onto the paths production uses

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -2313,17 +2313,6 @@ fn notify_batch_wave_complete(
     homeboy::agents::agent_task_notify::batch_terminal(report, fanout_id, None, None, exit_code);
 }
 
-/// Recipes are the durable restart boundary. Persist blocked dependents before
-/// dispatching any sibling so a later merge can release them through `resume`
-/// without reconstructing mutable operator input or re-planning a branch.
-fn persist_batch_cook_recipes(
-    plan: &BatchCookFanoutPlan,
-    configure: impl Fn(&mut CookRequest),
-) -> Result<()> {
-    let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
-    persist_batch_cook_recipes_with_readiness_cache(plan, &mut readiness_cache, configure)
-}
-
 fn persist_batch_cook_recipes_with_readiness_cache(
     plan: &BatchCookFanoutPlan,
     readiness_cache: &mut provider::ProviderRuntimeReadinessCache,
@@ -2357,14 +2346,6 @@ fn batch_harvest_context() -> Result<homeboy::agents::agent_task_scheduler::Harv
     } else {
         Ok(homeboy::agents::agent_task_scheduler::HarvestExecutionContext::default())
     }
-}
-
-fn compile_batch_cooks(
-    plan: &BatchCookFanoutPlan,
-    configure: impl Fn(&mut CookRequest),
-) -> Result<Vec<CookRequest>> {
-    let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
-    compile_batch_cooks_with_readiness_cache(plan, &mut readiness_cache, configure)
 }
 
 fn compile_batch_cooks_with_readiness_cache(
@@ -4029,18 +4010,6 @@ fn active_registered_worktree_path(handle: &str) -> Option<String> {
         .ok()
         .flatten()
         .map(|target| target.path.display().to_string())
-}
-
-fn preflight_batch_cook_recipes(
-    plan: &BatchCookFanoutPlan,
-    attempt_dispatcher: Option<&CookAttemptDispatcherFactory>,
-) -> Result<()> {
-    let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
-    preflight_batch_cook_recipes_with_readiness_cache(
-        plan,
-        attempt_dispatcher,
-        &mut readiness_cache,
-    )
 }
 
 fn preflight_batch_cook_recipes_with_readiness_cache(
@@ -7073,7 +7042,12 @@ mod tests {
             );
             homeboy::core::defaults::save_config(&config).expect("save configured rotation");
             let plan = test_batch_plan();
-            let compiled = compile_batch_cooks(&plan, |_| {}).expect("compile child policies");
+            let compiled = compile_batch_cooks_with_readiness_cache(
+                &plan,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+                |_| {},
+            )
+            .expect("compile child policies");
 
             for (cook, compiled) in plan.cooks.iter().zip(&compiled) {
                 let invocation = cook
@@ -7767,7 +7741,12 @@ fi
                 ("HOMEBOY_LAB_OFFLOAD_JSON", None),
             ]);
             let plan = test_batch_plan();
-            let cooks = compile_batch_cooks(&plan, |_| {}).expect("compile batch cooks");
+            let cooks = compile_batch_cooks_with_readiness_cache(
+                &plan,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+                |_| {},
+            )
+            .expect("compile batch cooks");
 
             assert_eq!(cooks.len(), 2);
             assert!(cooks
@@ -9458,7 +9437,12 @@ fi
             let mut loaded =
                 BatchCookFanoutPlan::from_value(serialized, &args()).expect("load persisted plan");
             loaded.apply_ai_tool_override(Some("OpenAI GPT-5.6 Terra via OpenCode"));
-            persist_batch_cook_recipes(&loaded, |_| {}).expect("persist child recipes");
+            persist_batch_cook_recipes_with_readiness_cache(
+                &loaded,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+                |_| {},
+            )
+            .expect("persist child recipes");
             for cook in &loaded.cooks {
                 let invocation = cook.to_cook_invocation(&loaded).expect("cook invocation");
                 assert_eq!(
@@ -9553,7 +9537,12 @@ fi
                 Some(root.as_path())
             );
 
-            let compiled = compile_batch_cooks(&plan, |_| {}).expect("compile before provider");
+            let compiled = compile_batch_cooks_with_readiness_cache(
+                &plan,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+                |_| {},
+            )
+            .expect("compile before provider");
             assert_eq!(
                 compiled[0].identity.initial_plan.tasks[0]
                     .workspace
@@ -9790,7 +9779,12 @@ fi
         with_isolated_home(|home| {
             install_fanout_agent_task_providers(home.path());
             let plan = test_batch_plan();
-            let compiled = compile_batch_cooks(&plan, |_| {}).expect("compile batch cooks");
+            let compiled = compile_batch_cooks_with_readiness_cache(
+                &plan,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+                |_| {},
+            )
+            .expect("compile batch cooks");
             let mut invocation = plan.cooks[0]
                 .to_cook_invocation(&plan)
                 .expect("cook invocation");
@@ -9799,14 +9793,22 @@ fi
             agent_task_service::persist_initial_recipe(&invocation.options)
                 .expect("persist initial recipe");
 
-            if let Err(error) = preflight_batch_cook_recipes(&plan, None) {
+            if let Err(error) = preflight_batch_cook_recipes_with_readiness_cache(
+                &plan,
+                None,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+            ) {
                 panic!("exact replay is incompatible: {error:?}");
             }
 
             let mut changed = plan;
             changed.cooks[0].title = Some("changed title".to_string());
-            preflight_batch_cook_recipes(&changed, None)
-                .expect("pre-execution finalization metadata can be corrected safely");
+            preflight_batch_cook_recipes_with_readiness_cache(
+                &changed,
+                None,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+            )
+            .expect("pre-execution finalization metadata can be corrected safely");
         });
     }
 
@@ -9816,8 +9818,18 @@ fi
             install_fanout_agent_task_providers(home.path());
             let plan = test_batch_plan();
 
-            persist_batch_cook_recipes(&plan, |_| {}).expect("persist local child recipes");
-            preflight_batch_cook_recipes(&plan, None).expect("preflight local recipes");
+            persist_batch_cook_recipes_with_readiness_cache(
+                &plan,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+                |_| {},
+            )
+            .expect("persist local child recipes");
+            preflight_batch_cook_recipes_with_readiness_cache(
+                &plan,
+                None,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+            )
+            .expect("preflight local recipes");
 
             for cook in &plan.cooks {
                 let recipe = agent_task_service::load_recipe(&cook.run_id()).expect("local recipe");
@@ -9848,13 +9860,26 @@ fi
                     >
             };
 
-            persist_batch_cook_recipes(&plan, |options| {
-                options.provider_transport.attempt_dispatcher = Some(dispatcher(options));
-            })
+            persist_batch_cook_recipes_with_readiness_cache(
+                &plan,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+                |options| {
+                    options.provider_transport.attempt_dispatcher = Some(dispatcher(options));
+                },
+            )
             .expect("persist Lab child recipes");
-            preflight_batch_cook_recipes(&plan, Some(&dispatcher))
-                .expect("preflight Lab recipes with their dispatcher");
-            let compiled = compile_batch_cooks(&plan, |_| {}).expect("compile child options");
+            preflight_batch_cook_recipes_with_readiness_cache(
+                &plan,
+                Some(&dispatcher),
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+            )
+            .expect("preflight Lab recipes with their dispatcher");
+            let compiled = compile_batch_cooks_with_readiness_cache(
+                &plan,
+                &mut provider::ProviderRuntimeReadinessCache::default(),
+                |_| {},
+            )
+            .expect("compile child options");
 
             for (cook, options) in plan.cooks.iter().zip(&compiled) {
                 let recipe = agent_task_service::load_recipe(&cook.run_id()).expect("Lab recipe");

--- a/crates/homeboy-core/src/structured_sidecar.rs
+++ b/crates/homeboy-core/src/structured_sidecar.rs
@@ -171,10 +171,6 @@ pub const REGISTRY: &[StructuredSidecarSchema] = &[
     },
 ];
 
-pub fn registry() -> &'static [StructuredSidecarSchema] {
-    REGISTRY
-}
-
 pub fn schema(key: &str) -> Option<&'static StructuredSidecarSchema> {
     REGISTRY.iter().find(|entry| entry.key == key)
 }
@@ -412,7 +408,7 @@ mod tests {
 
     #[test]
     fn registry_contains_current_core_sidecars() {
-        let keys: Vec<&str> = registry().iter().map(|entry| entry.key).collect();
+        let keys: Vec<&str> = REGISTRY.iter().map(|entry| entry.key).collect();
 
         for key in [
             "lint.findings",
@@ -454,7 +450,7 @@ mod tests {
 
     #[test]
     fn registry_keys_are_unique() {
-        let mut keys: Vec<&str> = registry().iter().map(|entry| entry.key).collect();
+        let mut keys: Vec<&str> = REGISTRY.iter().map(|entry| entry.key).collect();
         let total = keys.len();
         keys.sort_unstable();
         keys.dedup();
@@ -463,7 +459,7 @@ mod tests {
 
     #[test]
     fn empty_payload_matches_declared_shape() {
-        for entry in registry() {
+        for entry in REGISTRY {
             let empty = entry.empty_payload();
             match entry.shape {
                 StructuredSidecarShape::Array => assert!(empty.is_array(), "{}", entry.key),

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -1257,17 +1257,6 @@ pub fn refresh_homeboy_binary_in_roots(
     ))
 }
 
-fn acquire_runner_binary_promotion(
-    runner_id: &str,
-    candidate_commit: &str,
-) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
-    acquire_runner_binary_promotion_in_roots(
-        &homeboy_core::paths::PathRoots::from_environment()?,
-        runner_id,
-        candidate_commit,
-    )
-}
-
 /// [`acquire_runner_binary_promotion`] against an explicitly injected root.
 ///
 /// The promotion lease store is machine-global by default, so an isolated
@@ -1282,19 +1271,6 @@ fn acquire_runner_binary_promotion_in_roots(
         runner_id,
         candidate_commit,
         super::lab_selection::emit_runtime_promotion_wait,
-    )
-}
-
-fn acquire_runner_binary_promotion_with(
-    runner_id: &str,
-    candidate_commit: &str,
-    progress: impl FnMut(homeboy_core::runtime_promotion::RuntimePromotionWaitEvent),
-) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
-    acquire_runner_binary_promotion_with_in_root(
-        &homeboy_core::paths::runtime_promotion_dir()?,
-        runner_id,
-        candidate_commit,
-        progress,
     )
 }
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -503,7 +503,11 @@ fn ssh_bootstrap_success_promotes_verified_exact_sha_with_provenance() {
             &plan,
             || Ok(verified_bootstrap_output("abc123")),
             |path, _| {
-                let lease = acquire_runner_binary_promotion("lab-local", "abc123")?;
+                let lease = acquire_runner_binary_promotion_in_roots(
+                    &ambient_roots(),
+                    "lab-local",
+                    "abc123",
+                )?;
                 promote_verified_runner_binary_in_roots(&ambient_roots(), &lease, "lab-local", path)
                     .map(|fields| (fields, None))
             },
@@ -533,8 +537,12 @@ fn controller_binary_selection_reports_fresh_main_control_plane_fields() {
 
         assert_eq!(
             {
-                let lease = acquire_runner_binary_promotion("lab-local", "verified")
-                    .expect("promotion lease");
+                let lease = acquire_runner_binary_promotion_in_roots(
+                    &ambient_roots(),
+                    "lab-local",
+                    "verified",
+                )
+                .expect("promotion lease");
                 promote_verified_runner_binary_in_roots(
                     &ambient_roots(),
                     &lease,
@@ -547,7 +555,7 @@ fn controller_binary_selection_reports_fresh_main_control_plane_fields() {
         );
         assert_eq!(
             {
-                let lease = acquire_runner_binary_promotion("lab-local", "verified")
+                let lease = acquire_runner_binary_promotion_in_roots(&ambient_roots(), "lab-local", "verified")
                     .expect("promotion lease");
                 promote_verified_runner_binary_in_roots(
                 &ambient_roots(),
@@ -673,12 +681,17 @@ fn equivalent_refresh_waiter_reloads_the_owner_selection_after_promotion_handoff
         )
         .expect("create runner");
 
-        let owner = acquire_runner_binary_promotion("lab", "0123456789ab").expect("owner lease");
+        let owner =
+            acquire_runner_binary_promotion_in_roots(&ambient_roots(), "lab", "0123456789ab")
+                .expect("owner lease");
         let (queued_tx, queued_rx) = std::sync::mpsc::channel();
         let waiter = std::thread::spawn(move || {
-            let _lease = acquire_runner_binary_promotion_with("lab", "0123456789ab", |event| {
-                queued_tx.send(event).expect("report queued owner")
-            })?;
+            let _lease = acquire_runner_binary_promotion_with_in_root(
+                &homeboy_core::paths::runtime_promotion_dir_in_root(ambient_roots().data()),
+                "lab",
+                "0123456789ab",
+                |event| queued_tx.send(event).expect("report queued owner"),
+            )?;
             let status = crate::status("lab")?;
             refresh_promotion_authorities_in_roots(&ambient_roots(), "lab", &status)?;
             crate::load("lab")
@@ -714,12 +727,16 @@ fn divergent_refresh_candidate_is_rejected_while_owner_keeps_selection() {
             false,
         )
         .expect("create runner");
-        let owner = acquire_runner_binary_promotion("lab", "newer").expect("owner lease");
+        let owner = acquire_runner_binary_promotion_in_roots(&ambient_roots(), "lab", "newer")
+            .expect("owner lease");
 
         let error = std::thread::spawn(|| {
-            acquire_runner_binary_promotion_with("lab", "diverged", |_| {
-                panic!("divergent candidate must not queue")
-            })
+            acquire_runner_binary_promotion_with_in_root(
+                &homeboy_core::paths::runtime_promotion_dir_in_root(ambient_roots().data()),
+                "lab",
+                "diverged",
+                |_| panic!("divergent candidate must not queue"),
+            )
         })
         .join()
         .expect("divergent contender exits")
@@ -749,12 +766,16 @@ fn strict_ancestor_refresh_candidate_is_rejected_while_owner_keeps_selection() {
             false,
         )
         .expect("create runner");
-        let owner = acquire_runner_binary_promotion("lab", "descendant").expect("owner lease");
+        let owner = acquire_runner_binary_promotion_in_roots(&ambient_roots(), "lab", "descendant")
+            .expect("owner lease");
 
         let error = std::thread::spawn(|| {
-            acquire_runner_binary_promotion_with("lab", "ancestor", |_| {
-                panic!("strict ancestor candidate must not queue")
-            })
+            acquire_runner_binary_promotion_with_in_root(
+                &homeboy_core::paths::runtime_promotion_dir_in_root(ambient_roots().data()),
+                "lab",
+                "ancestor",
+                |_| panic!("strict ancestor candidate must not queue"),
+            )
         })
         .join()
         .expect("strict ancestor contender exits")


### PR DESCRIPTION
Follow-up to #14546, which recorded six items that the compiler reports as `never used` in the library build but which do have callers — all of them tests.

Each turned out to be the same shape: a thin wrapper that allocates a default and delegates, where **production calls the delegate directly and only tests call the wrapper**. So the tests were exercising a path production does not take.

Rather than delete the tests, they now call what production calls, and the wrappers are gone.

| wrapper | tests now call |
|---|---|
| `persist_batch_cook_recipes` | `..._with_readiness_cache` |
| `compile_batch_cooks` | `..._with_readiness_cache` |
| `preflight_batch_cook_recipes` | `..._with_readiness_cache` |
| `acquire_runner_binary_promotion` | `..._in_roots` |
| `acquire_runner_binary_promotion_with` | `..._with_in_root` |
| `structured_sidecar::registry()` | the `REGISTRY` const it returned |

Coverage is unchanged and now points at the real code path. The two promotion wrappers were my own leftovers from #14408.

## Left alone
`worktree::store_ops::cleanup_with_store` has the same shape — it delegates to `cleanup_with_store_page` with `limit: usize::MAX` — but rerouting its 14 test call sites means expanding each into a `WorktreeCleanupPageOptions` literal. That is a lot of test churn to retire one 15-line wrapper, so it stays and remains the single dead-code warning in the workspace.

## Verification
`cargo check --workspace --all-targets` clean apart from that one known warning.

| suite | baseline | this branch |
|---|---|---|
| `homeboy-lab-runner` homeboy_refresh | 100 passed, 2 failed | **101 passed, 1 failed** |
| `homeboy-core` structured_sidecar | — | **16 passed, 0 failed** |

The remaining refresh failure is the long-standing `part_a::materialize_failure_preserves_compiler_diagnostics_and_active_binary`. The second baseline failure is the known flaky `contending_refreshes...`.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced each warning to its callers, moved the tests onto the production path, deleted the wrappers, and compared against a baseline worktree. Chris Huber directed the work and remains responsible for acceptance.