### PR TITLE
Fix lifecycle-owned snapshot recovery projection

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -337,6 +337,9 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
         0
     };
     let mut value = serde_json::to_value(run).unwrap_or(Value::Null);
+    if let Ok(record) = agent_task_lifecycle::exact_record(&target.run_id) {
+        attach_lab_snapshot_failure_projection(&mut value, &record);
+    }
     if value["action_eligibility"]["actions"]
         .as_array()
         .is_some_and(|actions| {
@@ -1386,6 +1389,89 @@ fn lab_transport_repair_action_for_receipt(
     .with_kind(CommandNextActionKind::Repair)
 }
 
+/// Snapshot construction happens before a provider or runner owns work. Its
+/// producer deliberately records no command: only the durable lifecycle can
+/// decide whether this exact record admits a replay.
+fn lab_snapshot_recovery_projection(
+    record: &AgentTaskRunRecord,
+    retry: &RetryReplayAction,
+) -> Option<Value> {
+    let recovery = record
+        .metadata
+        .pointer("/pre_execution_failure/details/recovery")?;
+    if record
+        .metadata
+        .pointer("/pre_execution_failure/details/classification")?
+        .as_str()
+        != Some("snapshot_construction")
+        || recovery.get("owner").and_then(Value::as_str) != Some("durable_lifecycle")
+        || recovery.get("action").and_then(Value::as_str) != Some("project_lifecycle_recovery")
+    {
+        return None;
+    }
+    let reason = recovery.get("reason").and_then(Value::as_str)?;
+    let remediation = recovery.get("remediation").and_then(Value::as_str)?;
+    // Snapshot construction has no provider-side state to continue. A Cook
+    // therefore needs corrected inputs and a replacement lifecycle run, even
+    // when an older generic replay plan remains readable.
+    let cook_owned = record.metadata["cook_id"].is_string();
+    let (readiness, admission, action, projected_reason) = if cook_owned {
+        (
+            "unavailable",
+            json!({ "admitted": false, "reason": reason }),
+            None,
+            json!(reason),
+        )
+    } else {
+        (
+            retry.readiness,
+            retry.admission.clone(),
+            retry
+                .action
+                .as_ref()
+                .and_then(|action| action.action.clone()),
+            if retry.action.is_some() {
+                Value::Null
+            } else {
+                json!(reason)
+            },
+        )
+    };
+    Some(json!({
+        "owner": {
+            "run_id": record.run_id,
+            "lifecycle": if cook_owned { "cook" } else { "agent_task" },
+        },
+        "readiness": readiness,
+        "reason": projected_reason,
+        "admission": admission,
+        "action": action,
+        "remediation": remediation,
+    }))
+}
+
+fn attach_lab_snapshot_failure_projection(value: &mut Value, record: &AgentTaskRunRecord) {
+    let retry = retry_replay_action(record);
+    if let Some(projection) = lab_snapshot_recovery_projection(record, &retry) {
+        if projection["admission"]["admitted"] == false {
+            let reason = projection["admission"]["reason"].clone();
+            if let Some(actions) = value
+                .pointer_mut("/action_eligibility/actions")
+                .and_then(Value::as_array_mut)
+            {
+                for action in actions
+                    .iter_mut()
+                    .filter(|action| action["action"] == "retry")
+                {
+                    action["availability"] = json!("unavailable");
+                    action["reason"] = reason.clone();
+                }
+            }
+        }
+        value["lab_snapshot_failure"] = projection;
+    }
+}
+
 const DISCOVERY_NEXT_ACTION_LIMIT: usize = 8;
 
 fn attach_agent_task_discovery_actionable(value: &mut Value, active_command: Option<&str>) {
@@ -1769,7 +1855,15 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
             }));
         }
     }
-    let retry = retry_replay_action(&record);
+    let mut retry = retry_replay_action(&record);
+    let lab_snapshot_failure = lab_snapshot_recovery_projection(&record, &retry);
+    if let Some(reason) = lab_snapshot_failure
+        .as_ref()
+        .filter(|projection| projection["admission"]["admitted"] == false)
+        .and_then(|projection| projection["reason"].as_str())
+    {
+        retry = RetryReplayAction::unavailable(retry.owner.clone(), reason);
+    }
     let next_commands = diagnose_next_commands(
         &record,
         retry.action.as_ref(),
@@ -1793,11 +1887,13 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         "runner_diagnostic_probe": runner_diagnostic_probe,
         "continuation_admission": record.metadata.get("cook_continuation_admission"),
         "retry_replay": retry.projection(),
+        "lab_snapshot_failure": lab_snapshot_failure,
         "next_commands": next_commands,
     });
     if let Some(projection) = lab_transport_failure_projection(&record, run_id) {
         value["lab_transport_failure"] = projection;
     }
+    let has_lab_snapshot_failure = value["lab_snapshot_failure"].is_object();
     attach_durable_read_availability(&mut value, &durable_read.unavailable_sources);
     attach_cook_completion(&mut value, &record);
     if let Some(selection) = target.selection {
@@ -1828,6 +1924,7 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         runner_cancellation.is_some(),
         queued_runner_ownership.is_some(),
         current_lifecycle_diagnostic.is_some(),
+        has_lab_snapshot_failure,
     );
     let recovery_prefix =
         agent_task_service_direct::cook_recovery_command_prefix_for_record(&record);
@@ -1966,8 +2063,29 @@ fn attach_diagnose_actionable(
     runner_cancellation: bool,
     queued_runner_ownership: bool,
     current_lifecycle_denial: bool,
+    lab_snapshot_failure: bool,
 ) {
     let run_id = record.run_id.as_str();
+    if lab_snapshot_failure {
+        if let Value::Object(map) = value {
+            map.insert(
+                "next_action_basis".to_string(),
+                Value::String(DIAGNOSE_ACTION_BASIS_DIAGNOSIS.to_string()),
+            );
+        }
+        attach_actionable_metadata(
+            value,
+            CommandActionableMetadata {
+                run: Some(diagnose_run_ref(record, runner_id)),
+                refs: CommandResultRefs {
+                    agent_tasks: vec![agent_task_ref(run_id)],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        return;
+    }
     if let Some(action) = lab_transport_repair_action(record) {
         if let Value::Object(map) = value {
             map.insert(

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1389,9 +1389,9 @@ fn lab_transport_repair_action_for_receipt(
     .with_kind(CommandNextActionKind::Repair)
 }
 
-/// Snapshot construction happens before a provider or runner owns work. Its
-/// producer deliberately records no command: only the durable lifecycle can
-/// decide whether this exact record admits a replay.
+/// Snapshot construction happens before a provider or runner owns work. The
+/// recovery marker is compatibility-tolerant because persisted failures from
+/// before lifecycle projection carried the producer's stale command string.
 fn lab_snapshot_recovery_projection(
     record: &AgentTaskRunRecord,
     retry: &RetryReplayAction,
@@ -1399,53 +1399,53 @@ fn lab_snapshot_recovery_projection(
     let recovery = record
         .metadata
         .pointer("/pre_execution_failure/details/recovery")?;
-    if record
+    let snapshot_construction = record
         .metadata
         .pointer("/pre_execution_failure/details/classification")?
         .as_str()
-        != Some("snapshot_construction")
-        || recovery.get("owner").and_then(Value::as_str) != Some("durable_lifecycle")
-        || recovery.get("action").and_then(Value::as_str) != Some("project_lifecycle_recovery")
-    {
+        == Some("snapshot_construction");
+    let lifecycle_marker = matches!(
+        (
+            recovery.get("owner").and_then(Value::as_str),
+            recovery.get("action").and_then(Value::as_str),
+        ),
+        (
+            Some("durable_lifecycle"),
+            Some("project_lifecycle_recovery")
+        ) | (
+            Some("homeboy_snapshot_staging"),
+            Some("rebuild_snapshot_staging_and_replay_cook")
+        )
+    );
+    if !snapshot_construction || !lifecycle_marker {
         return None;
     }
-    let reason = recovery.get("reason").and_then(Value::as_str)?;
-    let remediation = recovery.get("remediation").and_then(Value::as_str)?;
-    // Snapshot construction has no provider-side state to continue. A Cook
-    // therefore needs corrected inputs and a replacement lifecycle run, even
-    // when an older generic replay plan remains readable.
-    let cook_owned = record.metadata["cook_id"].is_string();
-    let (readiness, admission, action, projected_reason) = if cook_owned {
-        (
-            "unavailable",
-            json!({ "admitted": false, "reason": reason }),
-            None,
-            json!(reason),
-        )
+    let remediation = recovery
+        .get("remediation")
+        .and_then(Value::as_str)
+        .unwrap_or("Correct the controller-side snapshot inputs before retrying or starting replacement lifecycle work.");
+    let reason = retry
+        .reason
+        .as_deref()
+        .or_else(|| recovery.get("reason").and_then(Value::as_str));
+    let owner = if let Some(cook_id) = record.metadata["cook_id"].as_str() {
+        json!({
+            "lifecycle": "cook",
+            "cook_id": cook_id,
+            "attempt_run_id": record.run_id,
+        })
     } else {
-        (
-            retry.readiness,
-            retry.admission.clone(),
-            retry
-                .action
-                .as_ref()
-                .and_then(|action| action.action.clone()),
-            if retry.action.is_some() {
-                Value::Null
-            } else {
-                json!(reason)
-            },
-        )
+        json!({
+            "lifecycle": "agent_task",
+            "run_id": record.run_id,
+        })
     };
     Some(json!({
-        "owner": {
-            "run_id": record.run_id,
-            "lifecycle": if cook_owned { "cook" } else { "agent_task" },
-        },
-        "readiness": readiness,
-        "reason": projected_reason,
-        "admission": admission,
-        "action": action,
+        "owner": owner,
+        "readiness": retry.readiness,
+        "reason": reason,
+        "admission": retry.admission,
+        "action": retry.action.as_ref().and_then(|action| action.action.clone()),
         "remediation": remediation,
     }))
 }
@@ -1453,21 +1453,6 @@ fn lab_snapshot_recovery_projection(
 fn attach_lab_snapshot_failure_projection(value: &mut Value, record: &AgentTaskRunRecord) {
     let retry = retry_replay_action(record);
     if let Some(projection) = lab_snapshot_recovery_projection(record, &retry) {
-        if projection["admission"]["admitted"] == false {
-            let reason = projection["admission"]["reason"].clone();
-            if let Some(actions) = value
-                .pointer_mut("/action_eligibility/actions")
-                .and_then(Value::as_array_mut)
-            {
-                for action in actions
-                    .iter_mut()
-                    .filter(|action| action["action"] == "retry")
-                {
-                    action["availability"] = json!("unavailable");
-                    action["reason"] = reason.clone();
-                }
-            }
-        }
         value["lab_snapshot_failure"] = projection;
     }
 }
@@ -1855,15 +1840,8 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
             }));
         }
     }
-    let mut retry = retry_replay_action(&record);
+    let retry = retry_replay_action(&record);
     let lab_snapshot_failure = lab_snapshot_recovery_projection(&record, &retry);
-    if let Some(reason) = lab_snapshot_failure
-        .as_ref()
-        .filter(|projection| projection["admission"]["admitted"] == false)
-        .and_then(|projection| projection["reason"].as_str())
-    {
-        retry = RetryReplayAction::unavailable(retry.owner.clone(), reason);
-    }
     let next_commands = diagnose_next_commands(
         &record,
         retry.action.as_ref(),
@@ -1893,7 +1871,6 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
     if let Some(projection) = lab_transport_failure_projection(&record, run_id) {
         value["lab_transport_failure"] = projection;
     }
-    let has_lab_snapshot_failure = value["lab_snapshot_failure"].is_object();
     attach_durable_read_availability(&mut value, &durable_read.unavailable_sources);
     attach_cook_completion(&mut value, &record);
     if let Some(selection) = target.selection {
@@ -1924,7 +1901,6 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         runner_cancellation.is_some(),
         queued_runner_ownership.is_some(),
         current_lifecycle_diagnostic.is_some(),
-        has_lab_snapshot_failure,
     );
     let recovery_prefix =
         agent_task_service_direct::cook_recovery_command_prefix_for_record(&record);
@@ -2063,29 +2039,8 @@ fn attach_diagnose_actionable(
     runner_cancellation: bool,
     queued_runner_ownership: bool,
     current_lifecycle_denial: bool,
-    lab_snapshot_failure: bool,
 ) {
     let run_id = record.run_id.as_str();
-    if lab_snapshot_failure {
-        if let Value::Object(map) = value {
-            map.insert(
-                "next_action_basis".to_string(),
-                Value::String(DIAGNOSE_ACTION_BASIS_DIAGNOSIS.to_string()),
-            );
-        }
-        attach_actionable_metadata(
-            value,
-            CommandActionableMetadata {
-                run: Some(diagnose_run_ref(record, runner_id)),
-                refs: CommandResultRefs {
-                    agent_tasks: vec![agent_task_ref(run_id)],
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        );
-        return;
-    }
     if let Some(action) = lab_transport_repair_action(record) {
         if let Value::Object(map) = value {
             map.insert(
@@ -4898,6 +4853,10 @@ fn persisted_cook_failure_diagnostic(record: &AgentTaskRunRecord) -> Option<Coll
                 }),
             });
         }
+        // Historical snapshot records include the producer's obsolete generic
+        // retry command. Durable recovery projection owns that command now, so
+        // retain the failure facts but never relay the stale hint as diagnosis.
+        let details = diagnostic_pre_execution_details(details);
         return Some(CollectedDiagnostic {
             task_id: "controller".to_string(),
             class: failure
@@ -4935,6 +4894,18 @@ fn persisted_cook_failure_diagnostic(record: &AgentTaskRunRecord) -> Option<Coll
             })
         }),
     })
+}
+
+fn diagnostic_pre_execution_details(details: &Value) -> Value {
+    let mut details = details.clone();
+    let is_snapshot_failure =
+        details.get("classification").and_then(Value::as_str) == Some("snapshot_construction");
+    if is_snapshot_failure {
+        if let Some(recovery) = details.get_mut("recovery").and_then(Value::as_object_mut) {
+            recovery.remove("command");
+        }
+    }
+    details
 }
 
 fn current_lifecycle_diagnostic(record: &AgentTaskRunRecord) -> Option<CollectedDiagnostic> {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -60,7 +60,7 @@ fn diagnose_projects_causal_pre_execution_provider_evidence() {
 }
 
 #[test]
-fn cook_snapshot_failure_projects_one_unavailable_lifecycle_recovery() {
+fn historical_cook_snapshot_failure_projects_lifecycle_admission() {
     with_temp_home(|| {
         let run_id = "run-cli-cook-snapshot-failure";
         let workspace = tempfile::tempdir().expect("workspace");
@@ -89,14 +89,13 @@ fn cook_snapshot_failure_projects_one_unavailable_lifecycle_recovery() {
         )
         .expect("record snapshot failure");
         agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
-            record.metadata["cook_id"] = serde_json::json!("cook-snapshot-failure");
+            record.metadata["cook_id"] = serde_json::json!("cook-snapshot-parent");
             record.metadata["pre_execution_failure"]["details"] = serde_json::json!({
                 "classification": "snapshot_construction",
                 "recovery": {
-                    "owner": "durable_lifecycle",
-                    "action": "project_lifecycle_recovery",
-                    "reason": "No safe in-place recovery is known until the durable lifecycle owner evaluates this failed snapshot record.",
-                    "remediation": "Correct the controller-side snapshot inputs, then start the replacement lifecycle run selected by its owner.",
+                    "owner": "homeboy_snapshot_staging",
+                    "action": "rebuild_snapshot_staging_and_replay_cook",
+                    "command": "homeboy agent-task retry <run-id> --run",
                 },
             });
         })
@@ -115,7 +114,8 @@ fn cook_snapshot_failure_projects_one_unavailable_lifecycle_recovery() {
 
         let expected = &diagnosis["lab_snapshot_failure"];
         assert_eq!(&status_value["lab_snapshot_failure"], expected);
-        assert_eq!(expected["owner"]["run_id"], run_id);
+        assert_eq!(expected["owner"]["cook_id"], "cook-snapshot-parent");
+        assert_eq!(expected["owner"]["attempt_run_id"], run_id);
         assert_eq!(expected["owner"]["lifecycle"], "cook");
         assert_eq!(expected["readiness"], "unavailable");
         assert_eq!(expected["admission"]["admitted"], false);
@@ -124,15 +124,10 @@ fn cook_snapshot_failure_projects_one_unavailable_lifecycle_recovery() {
         assert!(diagnosis["retry_replay"]["action"].is_null());
         assert!(!diagnosis
             .to_string()
-            .contains("agent-task retry run-cli-cook-snapshot-failure"));
-        let status_retry = status_value["action_eligibility"]["actions"]
-            .as_array()
-            .expect("status action eligibility")
-            .iter()
-            .find(|action| action["action"] == "retry")
-            .expect("retry action");
-        assert_eq!(status_retry["availability"], "unavailable");
-        assert_eq!(status_retry["reason"], expected["reason"]);
+            .contains("homeboy agent-task retry <run-id> --run"));
+        assert!(!status_value
+            .to_string()
+            .contains("homeboy agent-task retry <run-id> --run"));
         assert!(homeboy::agents::agent_task_service::retry(run_id, None, false, false).is_err());
         assert_eq!(
             agent_task_lifecycle::exact_record(run_id)
@@ -140,6 +135,79 @@ fn cook_snapshot_failure_projects_one_unavailable_lifecycle_recovery() {
                 .metadata["provider_executions_consumed"],
             0
         );
+    });
+}
+
+#[test]
+fn current_non_cook_snapshot_failure_keeps_admitted_lab_replay_actionable() {
+    with_temp_home(|| {
+        let run_id = "run-cli-generic-snapshot-failure";
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("workspace.txt"), "recorded")
+            .expect("write workspace");
+        let identity = homeboy::runner::generic_lab_replay_artifact_identity(workspace.path())
+            .expect("record identity");
+        let mut plan = test_plan();
+        plan.metadata["generic_lab_command_replay"] = serde_json::json!({
+            "schema": "homeboy/generic-lab-command-replay/v1",
+            "normalized_args": ["homeboy", "bench"],
+            "materialization": {
+                "canonical_root": workspace.path(),
+                "content_identity": identity,
+            },
+        });
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submit generic replay");
+        let error = Error::internal_unexpected("snapshot staging unavailable").with_retryable(true);
+        agent_task_lifecycle::record_pre_execution_failure(
+            run_id,
+            &plan,
+            "lab_workspace_stage",
+            &error,
+        )
+        .expect("record snapshot failure");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["pre_execution_failure"]["details"] = serde_json::json!({
+                "classification": "snapshot_construction",
+                "recovery": {
+                    "owner": "durable_lifecycle",
+                    "action": "project_lifecycle_recovery",
+                    "reason": "No safe in-place recovery is known until the durable lifecycle owner evaluates this failed snapshot record.",
+                    "remediation": "Correct the controller-side snapshot inputs, then start the replacement lifecycle run selected by its owner.",
+                },
+            });
+        })
+        .expect("mark current snapshot recovery");
+
+        let (status_value, _) = status(StatusArgs {
+            run_id: run_id.to_string(),
+            ..Default::default()
+        })
+        .expect("status snapshot failure");
+        let (diagnosis, _) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: true,
+        })
+        .expect("diagnose snapshot failure");
+
+        assert_eq!(
+            status_value["lab_snapshot_failure"],
+            diagnosis["lab_snapshot_failure"]
+        );
+        assert_eq!(status_value["lab_snapshot_failure"]["readiness"], "ready");
+        assert_eq!(
+            diagnosis["lab_snapshot_failure"]["action"]["id"],
+            "agent-task.retry.lab-replay.v1"
+        );
+        let command = diagnosis["retry_replay"]["action"]["args"]
+            .as_array()
+            .expect("admitted retry args");
+        assert_eq!(command[3], "retry");
+        assert_eq!(command[4], run_id);
+        assert!(diagnosis["_homeboy_actionable"]["next_actions"]
+            .as_array()
+            .expect("actionable retry")
+            .iter()
+            .any(|action| action["action"]["id"] == "agent-task.retry.lab-replay.v1"));
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -60,6 +60,90 @@ fn diagnose_projects_causal_pre_execution_provider_evidence() {
 }
 
 #[test]
+fn cook_snapshot_failure_projects_one_unavailable_lifecycle_recovery() {
+    with_temp_home(|| {
+        let run_id = "run-cli-cook-snapshot-failure";
+        let workspace = tempfile::tempdir().expect("workspace");
+        let mut plan = test_plan();
+        plan.metadata["generic_lab_command_replay"] = serde_json::json!({
+            "schema": "homeboy/generic-lab-command-replay/v1",
+            "normalized_args": ["homeboy", "bench"],
+            "materialization": {
+                "canonical_root": workspace.path(),
+                "content_identity": "snapshot:recorded",
+            },
+        });
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submit Cook attempt");
+        let error = Error::validation_invalid_argument(
+            "workspace_snapshot",
+            "Lab workspace snapshot construction failed before SSH transport",
+            None,
+            None,
+        )
+        .with_retryable(false);
+        agent_task_lifecycle::record_pre_execution_failure(
+            run_id,
+            &plan,
+            "lab_workspace_stage",
+            &error,
+        )
+        .expect("record snapshot failure");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["cook_id"] = serde_json::json!("cook-snapshot-failure");
+            record.metadata["pre_execution_failure"]["details"] = serde_json::json!({
+                "classification": "snapshot_construction",
+                "recovery": {
+                    "owner": "durable_lifecycle",
+                    "action": "project_lifecycle_recovery",
+                    "reason": "No safe in-place recovery is known until the durable lifecycle owner evaluates this failed snapshot record.",
+                    "remediation": "Correct the controller-side snapshot inputs, then start the replacement lifecycle run selected by its owner.",
+                },
+            });
+        })
+        .expect("mark Cook ownership and snapshot recovery");
+
+        let (status_value, _) = status(StatusArgs {
+            run_id: run_id.to_string(),
+            ..Default::default()
+        })
+        .expect("status snapshot failure");
+        let (diagnosis, _) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: true,
+        })
+        .expect("diagnose snapshot failure");
+
+        let expected = &diagnosis["lab_snapshot_failure"];
+        assert_eq!(&status_value["lab_snapshot_failure"], expected);
+        assert_eq!(expected["owner"]["run_id"], run_id);
+        assert_eq!(expected["owner"]["lifecycle"], "cook");
+        assert_eq!(expected["readiness"], "unavailable");
+        assert_eq!(expected["admission"]["admitted"], false);
+        assert!(expected["action"].is_null());
+        assert_eq!(diagnosis["retry_replay"]["readiness"], "unavailable");
+        assert!(diagnosis["retry_replay"]["action"].is_null());
+        assert!(!diagnosis
+            .to_string()
+            .contains("agent-task retry run-cli-cook-snapshot-failure"));
+        let status_retry = status_value["action_eligibility"]["actions"]
+            .as_array()
+            .expect("status action eligibility")
+            .iter()
+            .find(|action| action["action"] == "retry")
+            .expect("retry action");
+        assert_eq!(status_retry["availability"], "unavailable");
+        assert_eq!(status_retry["reason"], expected["reason"]);
+        assert!(homeboy::agents::agent_task_service::retry(run_id, None, false, false).is_err());
+        assert_eq!(
+            agent_task_lifecycle::exact_record(run_id)
+                .expect("durable attempt")
+                .metadata["provider_executions_consumed"],
+            0
+        );
+    });
+}
+
+#[test]
 fn status_projects_detached_staging_phase_and_failure_cause() {
     with_temp_home(|| {
         let run_id = "run-cli-detached-staging-failure";

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -2491,9 +2491,10 @@ fn snapshot_construction_failure(
         .unwrap_or(serde_json::Value::Null);
     error.details["reason"] = serde_json::json!(reason);
     error.details["recovery"] = serde_json::json!({
-        "owner": "homeboy_snapshot_staging",
-        "action": "rebuild_snapshot_staging_and_replay_cook",
-        "command": "homeboy agent-task retry <run-id> --run",
+        "owner": "durable_lifecycle",
+        "action": "project_lifecycle_recovery",
+        "reason": "No safe in-place recovery is known until the durable lifecycle owner evaluates this failed snapshot record.",
+        "remediation": "Correct the controller-side snapshot inputs, then start the replacement lifecycle run selected by its owner.",
     });
     error
 }

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -2157,6 +2157,12 @@ fn snapshot_construction_failure_does_not_start_transport_or_accept_source_drift
     )
     .expect_err("construction failure must reject transport");
     assert_eq!(error.details["classification"], "snapshot_construction");
+    assert_eq!(error.details["recovery"]["owner"], "durable_lifecycle");
+    assert_eq!(
+        error.details["recovery"]["action"],
+        "project_lifecycle_recovery"
+    );
+    assert!(error.details["recovery"]["command"].is_null());
     assert!(
         !marker.path().exists(),
         "transport must not start after staging failure"

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1745,6 +1745,7 @@ fn snapshot_install_commands_parse_under_posix_shells() {
 #[test]
 fn snapshot_staging_rejects_a_disappearing_runtime_overlay_before_ssh() {
     let source = tempfile::tempdir().expect("snapshot source");
+    let scratch = tempfile::tempdir().expect("snapshot scratch");
     let overlay = source.path().join("runtime-overlays");
     fs::create_dir_all(&overlay).expect("runtime overlay source");
     fs::write(overlay.join("runtime.js"), "runtime").expect("runtime artifact");
@@ -1754,7 +1755,7 @@ fn snapshot_staging_rejects_a_disappearing_runtime_overlay_before_ssh() {
     // preserves the declaration identity and staging now fails before transport.
     let manifest = snapshot_input_manifest(source.path(), &[]).expect("input manifest");
     fs::remove_dir_all(&overlay).expect("remove overlay after manifest creation");
-    let error = materialize_snapshot_stage(source.path(), &[], &manifest, None)
+    let error = materialize_snapshot_stage(source.path(), &[], &manifest, Some(scratch.path()))
         .expect_err("missing declared overlay must fail during local staging");
 
     assert_eq!(error.retryable, Some(false));
@@ -1772,7 +1773,16 @@ fn snapshot_staging_rejects_a_disappearing_runtime_overlay_before_ssh() {
         .is_some_and(|reason| reason.contains("tar: ./runtime-overlays: Cannot stat")));
     assert_eq!(
         error.details["recovery"]["action"],
-        "rebuild_snapshot_staging_and_replay_cook"
+        "project_lifecycle_recovery"
+    );
+    assert_eq!(error.details["recovery"]["owner"], "durable_lifecycle");
+    assert!(error.details["recovery"]["command"].is_null());
+    assert!(
+        fs::read_dir(scratch.path())
+            .expect("inspect scratch cleanup")
+            .next()
+            .is_none(),
+        "failed staging must not retain its scratch directory"
     );
 }
 


### PR DESCRIPTION
## Summary
- replace the producer-owned generic retry command with a durable lifecycle recovery marker
- project the exact record admission consistently through `status` and `diagnose`
- retain historical snapshot markers while removing obsolete retry-command hints
- preserve actionable generic Lab replay for non-Cook records

Fixes #14545

## Verification
- `cargo test -p homeboy-cli historical_cook_snapshot_failure_projects_lifecycle_admission`
- `cargo test -p homeboy-cli current_non_cook_snapshot_failure_keeps_admitted_lab_replay_actionable`
- `cargo test -p homeboy-cli cook_owned_generic_lab_replay_status_has_no_lab_action`
- `cargo test -p homeboy-cli stale_generic_lab_replay_status_has_no_executable_action`
- `cargo test -p homeboy-lab-runner snapshot_construction_failure_does_not_start_transport_or_accept_source_drift`
- `cargo fmt --check`
- `git diff --check`

## Limitation
No full workspace suite or live Lab handoff was run. Focused lifecycle and snapshot regressions passed.

## AI Assistance
OpenAI gpt-5.6-terra via direct OpenCode implementation; OpenAI gpt-6-astra via OpenCode investigation, orchestration, and review.