### PR TITLE
Fix Cook deferred worktree preflight and Lab source authority

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -2129,6 +2129,58 @@ mod preview_tests {
     }
 
     #[test]
+    fn preview_and_execution_reject_missing_task_url_for_absent_provider_worktree() {
+        crate::test_support::with_isolated_home(|_| {
+            let repository = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .canonicalize()
+                .expect("workspace repository")
+                .display()
+                .to_string();
+            let handle = "homeboy@feature-missing-task-url";
+            let args = cook(&[
+                "homeboy",
+                "agent-task",
+                "cook",
+                "--backend",
+                "fixture",
+                "--prompt",
+                "implement the issue",
+                "--repo",
+                "homeboy",
+                "--workspace",
+                &repository,
+                "--base",
+                "main",
+                "--head",
+                "feature/missing-task-url",
+                "--to-worktree",
+                &handle,
+                "--no-finalize",
+            ]);
+
+            let preview = resolve_cook_preview_destination(args.clone())
+                .expect_err("preview rejects the missing creation requirement");
+            let execution = provision_cook_destination(&args)
+                .expect_err("execution rejects before durable Cook admission");
+
+            assert_eq!(preview.code, execution.code, "preview: {preview:?}");
+            assert_eq!(preview.message, execution.message);
+            let missing = preview.details["args"]
+                .as_array()
+                .expect("missing-argument details");
+            assert!(missing.iter().any(|value| {
+                value
+                    .as_str()
+                    .is_some_and(|value| value.contains("--task-url") && value.contains(handle))
+            }));
+            assert!(agent_task_lifecycle::list_records()
+                .expect("read lifecycle records")
+                .is_empty());
+        });
+    }
+
+    #[test]
     fn preview_rejects_an_existing_unsafe_path_without_changing_it() {
         crate::test_support::with_isolated_home(|_| {
             let path = tempfile::tempdir().expect("unsafe path");
@@ -3625,6 +3677,7 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
     // Preserve the native provisioning intent until Cook has durably admitted
     // its recipe and exact lifecycle owner. Ensure is forbidden before that
     // point.
+    preflight_missing_cook_provider_workspace(args, to_worktree)?;
     Ok(serde_json::json!({
         "action": "lookup_pending",
         "kind": "native",
@@ -3640,6 +3693,48 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
             "cleanup_policy": "remove_on_success",
         },
     }))
+}
+
+/// Resolve the native provider identity without creating a worktree. Preview
+/// and execution both use this check, so a field required only for creation is
+/// rejected before either reports a viable deferred destination.
+fn preflight_missing_cook_provider_workspace(
+    args: &AgentTaskCookArgs,
+    handle: &str,
+) -> homeboy::core::Result<homeboy::core::worktree_provider::WorktreeProvisionPlan> {
+    let intent = cook_provider_provision_intent(args, handle)?;
+    if intent.task_url.is_none() {
+        return Err(homeboy::core::Error::validation_missing_argument(vec![
+            format!("--task-url is required to create missing provider worktree `{handle}`"),
+        ]));
+    }
+    homeboy::core::worktree_provider::plan_worktree_provision(&intent)
+}
+
+fn cook_provider_provision_intent(
+    args: &AgentTaskCookArgs,
+    handle: &str,
+) -> homeboy::core::Result<homeboy::core::worktree_provider::WorktreeProvisionIntent> {
+    Ok(homeboy::core::worktree_provider::WorktreeProvisionIntent {
+        handle: handle.to_string(),
+        repo: cook_provision_repository(args).ok_or_else(|| {
+            homeboy::core::Error::validation_missing_argument(vec![
+                "--repo <repo> is required to create a missing --to-worktree destination"
+                    .to_string(),
+            ])
+        })?,
+        base: args
+            .base
+            .clone()
+            .expect("Cook base is resolved before provider preflight"),
+        head: args.head.clone().ok_or_else(|| {
+            homeboy::core::Error::validation_missing_argument(vec![
+                "--head <branch> is required to create a missing --to-worktree destination"
+                    .to_string(),
+            ])
+        })?,
+        task_url: args.dispatch.task_url.clone(),
+    })
 }
 
 /// The exact declaration used both by preview planning and live provider
@@ -3923,27 +4018,8 @@ pub(super) fn resolve_cook_preview_destination(
         validate_cook_destination_identity(&args, &path)?;
         path
     } else {
-        let intent = homeboy::core::worktree_provider::WorktreeProvisionIntent {
-            handle: handle.clone(),
-            repo: cook_provision_repository(&args).ok_or_else(|| {
-                homeboy::core::Error::validation_missing_argument(vec![
-                    "--repo <repo> is required to create a missing --to-worktree destination"
-                        .to_string(),
-                ])
-            })?,
-            base: args
-                .base
-                .clone()
-                .expect("Cook base is resolved before preview"),
-            head: args.head.clone().ok_or_else(|| {
-                homeboy::core::Error::validation_missing_argument(vec![
-                    "--head <branch> is required to create a missing --to-worktree destination"
-                        .to_string(),
-                ])
-            })?,
-            task_url: args.dispatch.task_url.clone(),
-        };
-        let plan = homeboy::core::worktree_provider::plan_worktree_provision(&intent)?;
+        let intent = cook_provider_provision_intent(&args, &handle)?;
+        let plan = preflight_missing_cook_provider_workspace(&args, &handle)?;
         let destination = match plan {
             homeboy::core::worktree_provider::WorktreeProvisionPlan::Admitted(destination)
             | homeboy::core::worktree_provider::WorktreeProvisionPlan::Planned(destination) => {

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -2598,16 +2598,25 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
         // Preserve the controller's canonical decision across ordinary retry,
         // continuation, and fanout replay. A derived baseline is the declared
         // pre-staging transition where a changed candidate may replace it.
-        let source_path = derived_cook_baseline
-            .map(|capability| capability.canonical_path())
+        let source_path = plan
+            .tasks
+            .first()
+            .and_then(|task| {
+                task.metadata
+                    .pointer("/cook_continuation_workspace/candidate_source_root")
+                    .and_then(serde_json::Value::as_str)
+            })
+            .map(PathBuf::from)
+            .or_else(|| {
+                derived_cook_baseline.map(|capability| capability.canonical_path().to_path_buf())
+            })
             .or_else(|| {
                 plan.tasks
                     .first()
                     .and_then(|task| task.workspace.root.as_deref())
-                    .map(Path::new)
+                    .map(PathBuf::from)
             })
-            .or(self.source_path.as_deref())
-            .map(PathBuf::from);
+            .or_else(|| self.source_path.clone());
         let task = plan
             .tasks
             .first()

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1889,7 +1889,7 @@ fn detached_agent_task_handoffs_do_not_use_trace_dispatch_timeout() {
 }
 
 #[test]
-fn cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace() {
+fn cook_lab_source_uses_the_recorded_execution_worktree_not_controller_context() {
     crate::test_support::with_isolated_home(|_| {
         let baseline = tempfile::tempdir().expect("derived baseline");
         let ordinary_workspace = tempfile::tempdir().expect("materialized workspace");
@@ -1901,7 +1901,8 @@ fn cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace() 
             "task",
             Some(serde_json::json!({"workspace_snapshot_identity": "snapshot:parent"})),
         );
-        let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+        let execution_workspace = tempfile::tempdir().expect("managed execution workspace");
+        let mut plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
             "cook-derived-baseline",
             vec![serde_json::from_value(serde_json::json!({
                 "task_id": "task",
@@ -1911,6 +1912,9 @@ fn cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace() 
             }))
             .expect("materialized ordinary workspace")],
         );
+        plan.tasks[0].metadata["cook_continuation_workspace"] = serde_json::json!({
+            "candidate_source_root": execution_workspace.path(),
+        });
         let dispatcher = LabCookAttemptDispatcher {
             runner_id: "missing-homeboy-lab".to_string(),
             placement_decision: fixture_preflight_decision(
@@ -1941,8 +1945,8 @@ fn cook_retry_lab_source_is_the_derived_baseline_not_the_controller_workspace() 
 
         assert_eq!(
             record.metadata["execution_placement_decision"]["identity"]["workspace"],
-            capability.canonical_path().display().to_string(),
-            "derived baseline takes priority over the materialized plan and controller sources"
+            execution_workspace.path().display().to_string(),
+            "the resolved Cook execution worktree takes priority over baseline and controller context"
         );
     });
 }


### PR DESCRIPTION
## Summary
- reject a missing `--task-url` during both preview and execution when a deferred provider worktree must be created
- preserve existing provider worktrees without a task URL
- stage the recorded Cook execution worktree ahead of derived baseline or controller context for Lab handoff

Closes #14544
Closes #13902

## Verification
- `cargo test -p homeboy-cli preview_and_execution_reject_missing_task_url_for_absent_provider_worktree`
- `cargo test -p homeboy-cli cook_lab_source_uses_the_recorded_execution_worktree_not_controller_context`
- `cargo fmt --check`
- `git diff --check`

## Limitation
No live Lab handoff was run. This draft is limited to focused regression coverage.

## AI Assistance
OpenAI gpt-5.6-terra via direct OpenCode implementation; OpenAI gpt-6-astra via OpenCode investigation, orchestration, and review.