### PR TITLE
chore: clear the unused imports left by the dedupe work

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/promotion_service.rs
+++ b/crates/homeboy-agents/src/agent_task_service/promotion_service.rs
@@ -21,6 +21,7 @@ use crate::agent_task_promotion::{
     AgentTaskPromotionReport, AgentTaskPromotionRequest, PromotionProgressCallback,
 };
 
+#[cfg(test)]
 use crate::agent_task_gate::VerifyGateOptions;
 
 pub const AGENT_TASK_PROMOTION_JOB_TYPE: &str = "agent-task-promotion";

--- a/crates/homeboy-cli/src/commands/runs/artifact_index_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/artifact_index_tests.rs
@@ -1,6 +1,5 @@
-use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+use homeboy::core::observation::{ObservationStore, RunStatus};
 use homeboy::test_support::with_isolated_home;
-use serde_json::Value;
 
 use super::types::RunsArtifactsArgs;
 use super::{handlers, list_runs, RunsListArgs, RunsOutput};

--- a/crates/homeboy-cli/src/commands/runs/bench/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/bench/mod.rs
@@ -553,7 +553,6 @@ fn collect_numeric_object(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy::core::observation::NewRunRecord;
     use homeboy::test_support::with_isolated_home;
 
     use crate::commands::runs::test_support::sample_run;

--- a/crates/homeboy-cli/src/commands/runs/bundle_import_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/bundle_import_tests.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use homeboy::core::observation::{
-    ArtifactRecord, FindingListFilter, NewFindingRecord, NewRunRecord, NewTraceSpanRecord,
-    ObservationStore, RecordedHomeboyFinding, RunListFilter, RunRecord, TraceSpanRecord,
+    ArtifactRecord, FindingListFilter, NewFindingRecord, NewTraceSpanRecord, ObservationStore,
+    RecordedHomeboyFinding, RunListFilter, RunRecord, TraceSpanRecord,
 };
 use homeboy::test_support::with_isolated_home;
 use serde::Deserialize;

--- a/crates/homeboy-cli/src/commands/runs/compare.rs
+++ b/crates/homeboy-cli/src/commands/runs/compare.rs
@@ -281,7 +281,7 @@ mod tests {
         homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
     }
     use super::*;
-    use homeboy::core::observation::{NewRunRecord, RunStatus};
+    use homeboy::core::observation::RunStatus;
     use homeboy::test_support::with_isolated_home;
 
     use crate::commands::runs::test_support::sample_run;

--- a/crates/homeboy-cli/src/commands/runs/distribution.rs
+++ b/crates/homeboy-cli/src/commands/runs/distribution.rs
@@ -221,7 +221,7 @@ mod tests {
     }
     use super::*;
 
-    use homeboy::core::observation::{NewRunRecord, RunStatus};
+    use homeboy::core::observation::RunStatus;
     use homeboy::test_support::with_isolated_home;
 
     use crate::commands::runs::test_support::sample_run;

--- a/crates/homeboy-cli/src/commands/runs/reconcile.rs
+++ b/crates/homeboy-cli/src/commands/runs/reconcile.rs
@@ -517,7 +517,7 @@ fn read_extension_children(run_dir_path: &Path) -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy::core::observation::{NewRunRecord, RunRecord};
+    use homeboy::core::observation::RunRecord;
     use homeboy::test_support::with_isolated_home;
 
     use crate::commands::runs::test_support::sample_run;

--- a/crates/homeboy-cli/src/commands/trace/test_support.rs
+++ b/crates/homeboy-cli/src/commands/trace/test_support.rs
@@ -1,13 +1,6 @@
 //! Shared fixtures for `homeboy trace` tests.
 
-use super::test_fixture::{write_trace_extension, write_trace_rig, TRACE_FIXTURE_EXTENSION_ID};
-use super::workload::trace_workload_scenario_id;
 use super::*;
-use crate::test_support::with_isolated_home;
-use homeboy::core::component::ScopedExtensionConfig;
-use homeboy::rig::{self, ComponentSpec, RigSpec};
-use std::{collections::HashMap, fs};
-
 pub(super) fn trace_args_for_rig(rig_id: &str, component_id: &str, scenario_id: &str) -> TraceArgs {
     TraceArgs {
         command: None,

--- a/crates/homeboy-core/src/extension/trace/canonicality.rs
+++ b/crates/homeboy-core/src/extension/trace/canonicality.rs
@@ -596,11 +596,9 @@ fn parse_ahead_behind(value: &str) -> Option<(Option<u32>, Option<u32>)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::trace::run::{run_trace_workflow, TraceRunnerInputs};
+    use crate::extension::trace::run::run_trace_workflow;
     use homeboy_core::engine::run_dir::RunDir;
-    use homeboy_engine_primitives::baseline::BaselineFlags;
     use homeboy_extension_contract::ExtensionCapability;
-    use std::path::Path;
 
     #[test]
     fn trace_canonical_policy_defaults_to_canonical() {

--- a/crates/homeboy-core/src/extension/trace/run/tests/workflow.rs
+++ b/crates/homeboy-core/src/extension/trace/run/tests/workflow.rs
@@ -5,16 +5,12 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use crate::extension::invoke::RunnerOutput;
-use crate::extension::resolve::ExtensionExecutionContext;
 use crate::extension::trace::attach::TraceAttachment;
-use crate::extension::trace::canonicality::TraceCanonicalPolicy;
 use crate::extension::trace::parsing::{TraceGitProvenance, TraceResults, TraceStatus};
 use crate::extension::trace::probes::TraceProbeConfig;
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::RunDir;
 use homeboy_core::error::{Error, ErrorCode};
-use homeboy_engine_primitives::baseline::BaselineFlags;
-use homeboy_extension_contract::ExtensionCapability;
 
 use super::super::list::run_trace_list_workflow;
 use super::super::provenance::{
@@ -24,7 +20,7 @@ use super::super::runner::{
     build_trace_runner, failure_from_output, resolve_trace_baseline_root, trace_is_unclaimed,
     trace_probes_with_fswatch_attachments,
 };
-use super::super::types::{TraceListWorkflowArgs, TraceRunWorkflowArgs, TraceRunnerInputs};
+use super::super::types::{TraceListWorkflowArgs, TraceRunnerInputs};
 use super::super::workflow::run_trace_workflow;
 #[test]
 fn test_build_trace_runner() {

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -2196,7 +2196,6 @@ mod tests {
     use crate::test_support::with_isolated_home;
     use std::collections::BTreeSet;
     use std::sync::mpsc;
-    use std::time::Duration;
 
     /// The preflight gates every publication path, so a healthy filesystem must
     /// stay silently healthy. A capacity gate that fails closed on a machine

--- a/crates/homeboy-deploy/src/effect.rs
+++ b/crates/homeboy-deploy/src/effect.rs
@@ -100,8 +100,6 @@ mod tests {
     use crate::types::DeployEffect;
     use homeboy_core::component::{Component, VersionTarget};
     use homeboy_core::project::Project;
-    use homeboy_core::server::SshClient;
-    use std::collections::HashMap;
 
     #[test]
     fn post_effect_version_read_uses_applied_remote_tree() {

--- a/crates/homeboy-deploy/src/transfer.rs
+++ b/crates/homeboy-deploy/src/transfer.rs
@@ -255,8 +255,6 @@ fn scp_file_atomic(
 mod tests {
     use super::{process_output_result, scp_file, upload_directory, upload_file};
     use crate::test_support::local_client;
-    use homeboy_core::server::SshClient;
-    use std::collections::HashMap;
     use std::fs;
     use std::process::Command;
 

--- a/crates/homeboy-deploy/src/version_overrides.rs
+++ b/crates/homeboy-deploy/src/version_overrides.rs
@@ -829,12 +829,10 @@ mod tests {
     use super::*;
     use crate::test_support::local_client;
     use homeboy_core::component::VersionTarget;
-    use homeboy_core::server::SshClient;
     use homeboy_extension_contract::manifest_toolchain_config::DeployOverride;
     use homeboy_extension_contract::{
         DeployArchiveInstallPolicy, DeployRequiredHeader, DeployVerification, ExtensionManifest,
     };
-    use std::collections::HashMap;
     use std::fs;
     use std::io::Write;
 

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -13,7 +13,6 @@ use homeboy_core::api_jobs::{Job, RunnerJobLogSnapshot};
 use std::time::Duration;
 
 use reqwest::blocking::Client;
-use serde::Deserialize;
 use serde_json::{json, Value};
 
 use homeboy_core::error::{Error, Result};

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -9,8 +9,6 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::{Runner, RunnerKind};
-
 /// These cases run inside `with_isolated_home`, so reading the environment here
 /// observes that isolated home. Naming the roots keeps the call sites explicit
 /// about which installation the evidence is being mirrored into.
@@ -26,7 +24,6 @@ use homeboy_core::error::{Error, ErrorCode};
 use homeboy_core::observation::{
     runs_service, ArtifactRecord, NewRunRecord, ObservationStore, RunRecord,
 };
-use homeboy_core::server::{RunnerPolicy, RunnerSettings};
 
 use super::detail::{
     explicit_observation_run_ids, remote_detail_artifacts, remote_detail_to_run_record,


### PR DESCRIPTION
Cleanup of warnings my own PRs introduced. Moving a fixture into a shared module leaves the imports it used behind in the file it came from, and I did that six times today.

**Workspace `unused`-family warnings: 35 → 3.**

Sources: #14512, #14519, #14522, #14523, #14525, #14526 — plus `trace/test_support.rs`, where I had copied the whole `use` block from `rig_tests.rs` when only `super::*` was needed.

## The three left
- `component_install_provider`: fields `url`, `manifest_path`, `component_id` never read — pre-existing, and removing struct fields touches construction sites
- `worktree::store_ops::cleanup_with_store` — the wrapper called only by tests, documented in #14548

## Verification
`cargo check --workspace --all-targets` clean. Full lib suites against a baseline worktree at the same commit:

| crate | baseline | this branch |
|---|---|---|
| `homeboy-core` | 3600 passed, 35 failed | **3601 passed, 34 failed** |
| `homeboy-lab-runner` | 2000 passed, 18 failed | **2001 passed, 17 failed** |
| `homeboy-deploy` | 319 passed, 11 failed | **319 passed, 11 failed** |

Each is equal or one better; the differences are the crates' existing flaky sets.

## Unrelated finding while measuring
`commands::utils::execution_provenance::tests` — seven tests — **pass but take ~197s each**, so nextest's 120s `slow-timeout` terminates them and they report as `TIMEOUT`. They are not hung and not contended: a single one run entirely alone still takes 196.94s.

That is roughly 23 minutes of the `homeboy-cli` suite spent on seven tests that are green. Worth its own investigation into what `placement_directive` does per call; I have not touched it here.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode iterated the compiler's `unused` warnings to a fixed point and compared three full crate suites against a baseline worktree. Chris Huber directed the work and remains responsible for acceptance.