### PR TITLE
test(cli): isolate execution provenance from the developer's installation

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
+++ b/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
@@ -275,7 +275,18 @@ mod tests {
     use crate::cli_surface::Cli;
     use clap::Parser;
 
+    /// Build provenance for `args` against an empty installation.
+    ///
+    /// `placement_directive` resolves the lab route contract, which walks the
+    /// component inventory and shells out to `git` once per registered
+    /// component. Against a populated developer machine that turned each of
+    /// these shape assertions into a ~197s discovery run; isolated it is ~3s
+    /// and depends on nothing outside the test.
     fn provenance(args: &[&str]) -> Value {
+        homeboy::core::test_support::with_isolated_home(|_| provenance_in_current_home(args))
+    }
+
+    fn provenance_in_current_home(args: &[&str]) -> Value {
         let argv = args
             .iter()
             .map(|arg| (*arg).to_string())
@@ -365,33 +376,35 @@ mod tests {
 
     #[test]
     fn records_resolved_lab_runner_separately_from_lab_intent() {
-        let args = ["homeboy", "--placement", "lab", "review"];
-        let argv = args
-            .iter()
-            .map(|arg| (*arg).to_string())
-            .collect::<Vec<_>>();
-        let cli = Cli::try_parse_from(&argv).expect("parse CLI");
-        let value = build(
-            &homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult::new(
-                argv.clone(),
-                crate::commands::utils::resource_policy::parsed_command_preflight_input(
-                    &cli, &argv,
+        homeboy::core::test_support::with_isolated_home(|_| {
+            let args = ["homeboy", "--placement", "lab", "review"];
+            let argv = args
+                .iter()
+                .map(|arg| (*arg).to_string())
+                .collect::<Vec<_>>();
+            let cli = Cli::try_parse_from(&argv).expect("parse CLI");
+            let value = build(
+                &homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult::new(
+                    argv.clone(),
+                    crate::commands::utils::resource_policy::parsed_command_preflight_input(
+                        &cli, &argv,
+                    ),
+                    None,
+                    None,
+                    homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::NotApplicable,
+                    homeboy::core::parsed_command_preflight::FallbackDirective::None,
+                    crate::cli_runtime::placement_directive(&cli, Some("runner-a"), false),
+                    Some("runner-a".to_string()),
                 ),
-                None,
-                None,
-                homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::NotApplicable,
-                homeboy::core::parsed_command_preflight::FallbackDirective::None,
-                crate::cli_runtime::placement_directive(&cli, Some("runner-a"), false),
-                Some("runner-a".to_string()),
-            ),
-        );
+            );
 
-        assert_eq!(value["operator_intent"]["placement"], "lab");
-        assert_eq!(value["operator_intent"]["runner_id"], Value::Null);
-        assert_eq!(value["resolved_execution"]["location"], "lab");
-        assert_eq!(value["resolved_execution"]["runner_id"], "runner-a");
-        assert!(value["resource_policy"].get("policy_runner_id").is_none());
-        assert_eq!(value["resource_policy"]["decision_origin"], "explicit");
+            assert_eq!(value["operator_intent"]["placement"], "lab");
+            assert_eq!(value["operator_intent"]["runner_id"], Value::Null);
+            assert_eq!(value["resolved_execution"]["location"], "lab");
+            assert_eq!(value["resolved_execution"]["runner_id"], "runner-a");
+            assert!(value["resource_policy"].get("policy_runner_id").is_none());
+            assert_eq!(value["resource_policy"]["decision_origin"], "explicit");
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The eleven `commands::utils::execution_provenance::tests` assert the *shape* of a provenance record, but they reached into the developer's real Homeboy installation to do it. On a populated machine each one took **~197s**; nextest's 120s `slow-timeout` then terminated them, so they surfaced as `TIMEOUT` failures despite being green.

They now run against an isolated home. **11 passed in 6.0s.**

## What they were actually doing
Profiled with `sample` against the test binary. The chain is entirely inside one call:

```
provenance()
  cli_runtime::placement_directive
    generic_route_policy_snapshot
      infra::route::lab_offload_command
        contract_lab_routing::lab_route_contract
          lab_required_extensions_for -> review_lab_extension_ids
            engine::execution_context::resolve
              component::resolution::detect_from_cwd -> inventory_at -> inventory
                listing::registered_core -> resolve_attachment
                  component::portable::try_discover_from_portable
                    git::release_download::detect_remote_url_within
                      command::wait_with_bounded_output_until_cancelled
                        std::thread::sleep
```

Computing a placement directive walks the whole component inventory and spawns `git` once per registered component to detect its remote URL, polling each with sleeps. 630 of 1675 samples were in `thread::sleep`.

So runtime scaled with how many components the developer happened to have registered. Proof: the same test binary, same test, only `HOME` changed — **196.94s against my installation, 3.19s against an empty one**.

## Verification
Same isolated home on both sides:

| | result |
|---|---|
| baseline | 11 passed, 7.397s |
| this branch | 11 passed, 6.811s |

Equal where the environment is controlled, which is the point: the branch no longer depends on the environment at all.

## Measurement caveat, and a warning
I could not produce a trustworthy full-crate comparison. Mid-measurement the `homeboy-cli` suite collapsed from ~2868 passing to 781 passing / 2145 failed — on **unmodified `main`**. The cause was a live `homeboy runner exec homeboy-lab` job holding `~/.config/homeboy/config.lock` while the suite ran.

That is worth knowing independently of this PR: **running the `homeboy-cli` suite locally contends with real Homeboy work on the same machine**, because the tests use the ambient installation. This change removes eleven tests from that category; it does not fix the rest.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode profiled the hang with `sample`, traced it to inventory discovery inside `placement_directive`, isolated the tests, and verified both sides under a controlled home. Chris Huber directed the work and remains responsible for acceptance.