### PR TITLE
refactor(contracts): give each wire identifier one definition

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/types.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/types.rs
@@ -6,7 +6,9 @@ use homeboy_extension_contract::agent_task_executor_declaration::{
     DEFAULT_PROVIDER_READINESS_INVOCATION_TIMEOUT_MS,
 };
 
-pub const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA: &str = "homeboy/agent-task-executor-provider/v1";
+/// Re-exported from the owning contract so the wire identifier has one
+/// definition rather than two that can drift apart at a version bump.
+pub use homeboy_extension_contract::agent_task_executor_declaration::AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA;
 pub const AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA: &str =
     "homeboy/agent-task-provider-capability-contract/v1";
 /// Provider accepts `executor.config.workspace_permission_root` as the exact

--- a/crates/homeboy-core/src/artifact_manifest.rs
+++ b/crates/homeboy-core/src/artifact_manifest.rs
@@ -9,8 +9,12 @@ use serde_json::Value;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
-pub const ARTIFACT_MANIFEST_FILE: &str = "homeboy-artifact-manifest.json";
-pub const ARTIFACT_MANIFEST_SCHEMA: &str = "homeboy/artifact-manifest/v1";
+/// Re-exported from the owning contract so the wire identifier has one
+/// definition rather than two that can drift apart at a version bump.
+pub use homeboy_lab_contract::lab::handoff::ARTIFACT_MANIFEST_FILE;
+/// Re-exported from the owning contract so the wire identifier has one
+/// definition rather than two that can drift apart at a version bump.
+pub use homeboy_lab_contract::lab::handoff::ARTIFACT_MANIFEST_SCHEMA;
 pub const RUNTIME_AGENT_ARTIFACT_PATHS_SCHEMA: &str = "homeboy/runtime-agent-artifact-paths/v1";
 
 // Drift guard: the lab-contract type layer (`command_contract::lab::handoff`)

--- a/crates/homeboy-core/src/runner_job_execution_context.rs
+++ b/crates/homeboy-core/src/runner_job_execution_context.rs
@@ -17,7 +17,9 @@ use crate::api_jobs::Job;
 use crate::error::{Error, ErrorCode, Result};
 use crate::runner_execution_envelope::RunnerExecutionEnvelope;
 
-pub const RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA: &str = "homeboy/runner-job-execution-context/v1";
+/// Re-exported from the owning contract so the wire identifier has one
+/// definition rather than two that can drift apart at a version bump.
+pub use homeboy_runner_contract::RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA;
 pub const RUNNER_JOB_EXECUTION_CONTEXT_EVIDENCE_SCHEMA: &str =
     "homeboy/runner-job-execution-context-evidence/v1";
 pub const RUNNER_JOB_ID_ENV: &str = "HOMEBOY_RUNNER_JOB_ID";

--- a/crates/homeboy-lab-runner/src/lab/agent_task_bridge.rs
+++ b/crates/homeboy-lab-runner/src/lab/agent_task_bridge.rs
@@ -273,7 +273,9 @@ pub(super) fn parse_offloaded_agent_task_handoff(
     Ok(None)
 }
 
-const AGENT_TASK_LAB_HANDOFF_SCHEMA: &str = "homeboy/agent-task-lab-handoff/v1";
+/// Re-exported from the owning contract so the wire identifier has one
+/// definition rather than two that can drift apart at a version bump.
+use homeboy_agents::agent_task_lifecycle::agent_task_handoff_event::AGENT_TASK_LAB_HANDOFF_SCHEMA;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(super) struct AgentTaskLabHandoff {


### PR DESCRIPTION
Five wire identifiers were declared twice — once in the contract crate that owns them, once again in the consumer:

| identifier | owner | duplicate |
|---|---|---|
| `AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA` | `homeboy-extension-contract` | `homeboy-agents` |
| `ARTIFACT_MANIFEST_SCHEMA` | `homeboy-lab-contract` | `homeboy-core` |
| `ARTIFACT_MANIFEST_FILE` | `homeboy-lab-contract` | `homeboy-core` |
| `RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA` | `homeboy-runner-contract` | `homeboy-core` |
| `AGENT_TASK_LAB_HANDOFF_SCHEMA` | `homeboy-agents` | `homeboy-lab-runner` |

Every consumer already depends on the owning crate, so each duplicate is now a re-export.

## Why this one matters more than its size
These are not internal helpers, they are the strings that identify a serialized shape on disk and across the wire — `homeboy/artifact-manifest/v1`, `homeboy/agent-task-lab-handoff/v1`. Two declarations of one schema identifier means a `v1` to `v2` bump can be applied to one and missed on the other, and the two halves then disagree about what they are reading while both still compile.

That is the same failure mode as #13347's two promotion shapes, which is what motivated looking for it.

## Verification
`cargo check --workspace --all-targets` clean. Under a controlled home:

| suite | baseline | this branch |
|---|---|---|
| `homeboy-agents` (provider/handoff/manifest) | 371 passed, 3 failed | **372 passed, 2 failed** |
| `homeboy-lab-runner` | — | **95 passed, 0 failed** |
| `homeboy-core` | — | **20 passed, 0 failed** |

One better than baseline; that crate has an existing flaky set.

## Remaining
Eight more duplicated string constants exist, but they are filenames, sentinels and env-var names rather than schema identifiers, and several sit in crates with no dependency edge between them. Left alone.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode found these by comparing named string constants across the tree, checked each consumer already depended on the owning contract, and verified against a baseline worktree. Chris Huber directed the work and remains responsible for acceptance.