### PR TITLE
Preserve terminal control-plane repair evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4331,6 +4331,99 @@ fn provider_timeout_ms(
         .or(Some(crate::agent_task_timeout::DEFAULT_PROVIDER_TIMEOUT_MS))
 }
 
+/// The runner records this only after every observable progress channel stayed
+/// empty. It is not a wall-clock timeout: keep the distinction at Cook's
+/// operator-facing boundary rather than suggesting a larger timeout.
+fn startup_without_output_liveness_diagnostic(
+    aggregate: &crate::agent_task_schedule::AgentTaskAggregate,
+) -> Option<&crate::agent_task::AgentTaskDiagnostic> {
+    aggregate
+        .outcomes
+        .iter()
+        .flat_map(|outcome| &outcome.diagnostics)
+        .find(|diagnostic| {
+            diagnostic.class == "agent_task.provider_liveness_timeout"
+                && diagnostic.data["deadline"] == "liveness"
+                && [
+                    "stdout_bytes",
+                    "stderr_bytes",
+                    "runtime_progress_events",
+                    "workspace_progress_events",
+                ]
+                .iter()
+                .all(|field| diagnostic.data[*field].as_u64() == Some(0))
+        })
+}
+
+/// Project the bounded no-output liveness evidence into Cook's durable result.
+///
+/// The provider's terminal diagnostic remains the authority on the underlying
+/// execution. This projection makes its actionable meaning visible without
+/// reclassifying the attempt as a timeout or manufacturing a retry that could
+/// repeat an opaque startup.
+fn make_startup_without_output_actionable(
+    lifecycle_store: Option<&AgentTaskLifecycleStore>,
+    report: &mut AgentTaskRunResult<AgentTaskCookReport>,
+    aggregate: &crate::agent_task_schedule::AgentTaskAggregate,
+    run_id: &str,
+) {
+    let Some(diagnostic) = startup_without_output_liveness_diagnostic(aggregate) else {
+        return;
+    };
+    let mut diagnostic_value = homeboy_core::redaction::redact_json(&serde_json::json!({
+        "class": diagnostic.class,
+        "message": redact_diagnostic_text(&diagnostic.message),
+        "data": diagnostic.data,
+    }));
+    bound_diagnostic_value(&mut diagnostic_value, 0);
+    let status = AgentTaskCookRecoveryAction {
+        action: "status".to_string(),
+        command: lifecycle_store.map_or_else(
+            || cook_recovery_command(run_id, &["status", run_id]),
+            |store| cook_recovery_command_in_store(store, run_id, &["status", run_id]),
+        ),
+    };
+    let diagnose = AgentTaskCookRecoveryAction {
+        action: "diagnose".to_string(),
+        command: lifecycle_store.map_or_else(
+            || cook_recovery_command(run_id, &["diagnose", run_id]),
+            |store| cook_recovery_command_in_store(store, run_id, &["diagnose", run_id]),
+        ),
+    };
+
+    report.value.terminal_phase = Some("provider_startup".to_string());
+    report.value.terminal_failure_classification =
+        Some("provider_startup_without_output".to_string());
+    report.value.stop_reason = Some(
+        "provider startup produced no stdout, stderr, structured progress, or workspace activity before its bounded liveness diagnostic; this is not a provider timeout. Inspect the durable status and diagnostics before choosing a recovery path.".to_string(),
+    );
+    report.value.primary_failure = Some(AgentTaskCookPrimaryFailure {
+        schema: "homeboy/agent-task-cook-primary-failure/v1",
+        provider_id: diagnostic.data["provider"]
+            .as_str()
+            .unwrap_or("provider")
+            .to_string(),
+        operation: "startup_without_output".to_string(),
+        phase: "provider_startup".to_string(),
+        exit_code: 1,
+        stderr_excerpt: truncate_diagnostic_text(&redact_diagnostic_text(&diagnostic.message)),
+        evidence_ref: format!("homeboy://agent-task/run/{run_id}/status"),
+        next_action: status.clone(),
+        diagnostic: Some(diagnostic_value.clone()),
+    });
+    if let Some(context) = report.value.failure_context.as_mut() {
+        context.phase = "provider_startup".to_string();
+        context.reason_code = "provider_startup_without_output".to_string();
+        context.diagnostic = Some(diagnostic_value);
+        context.recovery_legal = true;
+        context.recovery_reason =
+            "read-only status and diagnostic inspection are safe; no timeout increase or retry is implied"
+                .to_string();
+        context.legal_actions = vec![status.clone(), diagnose.clone()];
+        context.next_actions = vec![status, diagnose];
+    }
+}
+
 fn make_provider_timeout_actionable(
     lifecycle_store: Option<&AgentTaskLifecycleStore>,
     report: &mut AgentTaskRunResult<AgentTaskCookReport>,
@@ -7177,6 +7270,12 @@ fn run_cook_spine(
                     &run_id,
                 )
                 .unwrap_or(true),
+            );
+            make_startup_without_output_actionable(
+                Some(lifecycle_store),
+                &mut report,
+                &aggregate,
+                &run_id,
             );
             make_provider_rotation_actionable(
                 Some(lifecycle_store),

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4332,15 +4332,17 @@ fn provider_timeout_ms(
 }
 
 /// The runner records this only after every observable progress channel stayed
-/// empty. It is not a wall-clock timeout: keep the distinction at Cook's
-/// operator-facing boundary rather than suggesting a larger timeout.
+/// empty. Classify only the current terminal completion, not prior attempts.
+/// It is not a wall-clock timeout: keep the distinction at Cook's operator-facing
+/// boundary rather than suggesting a larger timeout.
 fn startup_without_output_liveness_diagnostic(
     aggregate: &crate::agent_task_schedule::AgentTaskAggregate,
 ) -> Option<&crate::agent_task::AgentTaskDiagnostic> {
     aggregate
         .outcomes
+        .last()?
+        .diagnostics
         .iter()
-        .flat_map(|outcome| &outcome.diagnostics)
         .find(|diagnostic| {
             diagnostic.class == "agent_task.provider_liveness_timeout"
                 && diagnostic.data["deadline"] == "liveness"
@@ -7271,13 +7273,13 @@ fn run_cook_spine(
                 )
                 .unwrap_or(true),
             );
-            make_startup_without_output_actionable(
+            make_provider_rotation_actionable(
                 Some(lifecycle_store),
                 &mut report,
                 &aggregate,
                 &run_id,
             );
-            make_provider_rotation_actionable(
+            make_startup_without_output_actionable(
                 Some(lifecycle_store),
                 &mut report,
                 &aggregate,

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -8617,17 +8617,11 @@ pub fn prepare_cook_workspace_base(target: &Path, base: &str) -> Result<CookBase
     std::fs::write(&alternates, format!("{}/objects\n", common_dir.trim())).map_err(|error| {
         Error::internal_io(error.to_string(), Some(alternates.display().to_string()))
     })?;
-    let Some(resolved) =
-        crate::agent_task_promotion::capture_declared_base(graph.path(), Some(base))?
+    let Some(resolved) = tolerate_retryable_cook_base_resolution(
+        crate::agent_task_promotion::capture_declared_base(graph.path(), Some(base)),
+    )?
     else {
-        return Ok(CookBasePreparation {
-            schema: "homeboy/cook-base-preparation/v1",
-            declared_base: base.to_string(),
-            base_sha: None,
-            provenance: "base_unresolved",
-            remote_freshness: "deferred",
-            topology: None,
-        });
+        return Ok(deferred_cook_base_preparation(base));
     };
     let topology = preflight_cook_workspace_resolved_base_ancestry(
         target,
@@ -8646,6 +8640,28 @@ pub fn prepare_cook_workspace_base(target: &Path, base: &str) -> Result<CookBase
         remote_freshness: "checked",
         topology,
     })
+}
+
+fn deferred_cook_base_preparation(base: &str) -> CookBasePreparation {
+    CookBasePreparation {
+        schema: "homeboy/cook-base-preparation/v1",
+        declared_base: base.to_string(),
+        base_sha: None,
+        provenance: "base_unresolved",
+        remote_freshness: "deferred",
+        topology: None,
+    }
+}
+
+/// Preview must not present an unverified fallback as an admitted base. A
+/// retryable authoritative probe instead produces the same deferred contract as
+/// an unavailable declared base, so replay cannot silently claim parity.
+fn tolerate_retryable_cook_base_resolution<T>(result: Result<Option<T>>) -> Result<Option<T>> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) if error.retryable == Some(true) => Ok(None),
+        Err(error) => Err(error),
+    }
 }
 
 fn preflight_cook_workspace_resolved_base_ancestry(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5229,11 +5229,10 @@ fn workspace_base_ancestry_preflight_converges_clean_behind_destination_at_pinne
                 .success()
         };
         assert!(!destination_has_observed_base());
-        // Shallow and single-branch checkouts may not retain this local ref. The
-        // admission check must still resolve the authoritative origin base.
-        git(
-            &destination,
-            &["update-ref", "-d", "refs/remotes/origin/main"],
+        let stale_tracking_base = git(&destination, &["rev-parse", "origin/main"]);
+        assert_ne!(
+            stale_tracking_base, observed_base,
+            "the local origin tracking ref remains stale while the remote advances"
         );
 
         let preparation = prepare_cook_workspace_base(&destination, "main")
@@ -5365,6 +5364,18 @@ fn workspace_base_ancestry_preflight_converges_clean_behind_destination_at_pinne
             .unwrap_or_default()
             .contains("--ff-only")));
     });
+}
+
+#[test]
+fn retryable_preview_base_resolution_is_deferred_not_admitted() {
+    let error = Error::internal_unexpected("authoritative remote unavailable").with_retryable(true);
+    assert!(tolerate_retryable_cook_base_resolution::<()>(Err(error))
+        .expect("retryable remote probe is deferred")
+        .is_none());
+    let preparation = deferred_cook_base_preparation("main");
+    assert_eq!(preparation.base_sha, None);
+    assert_eq!(preparation.provenance, "base_unresolved");
+    assert_eq!(preparation.remote_freshness, "deferred");
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -950,10 +950,26 @@ fn startup_without_output_liveness_is_projected_without_becoming_a_timeout() {
         .initial_plan;
     let mut aggregate = review_form_aggregate(&plan);
     aggregate.status = crate::agent_task_scheduler::AgentTaskAggregateStatus::Failed;
-    aggregate.outcomes[0].status = crate::agent_task::AgentTaskOutcomeStatus::Failed;
+    aggregate.outcomes[0].status = crate::agent_task::AgentTaskOutcomeStatus::Timeout;
     aggregate.outcomes[0].failure_classification =
+        Some(crate::agent_task::AgentTaskFailureClassification::Timeout);
+    aggregate.outcomes[0].diagnostics = vec![
+        crate::agent_task::AgentTaskDiagnostic {
+            class: "agent_task.provider_timeout".to_string(),
+            message: "provider exceeded timeout_ms=1200000".to_string(),
+            data: serde_json::json!({ "timeout_ms": 1_200_000 }),
+        },
+        crate::agent_task::AgentTaskDiagnostic {
+            class: "agent_task.provider_rotation_exhausted".to_string(),
+            message: "an earlier provider rotation exhausted".to_string(),
+            data: serde_json::json!({}),
+        },
+    ];
+    let mut startup_outcome = aggregate.outcomes[0].clone();
+    startup_outcome.status = crate::agent_task::AgentTaskOutcomeStatus::Failed;
+    startup_outcome.failure_classification =
         Some(crate::agent_task::AgentTaskFailureClassification::Stalled);
-    aggregate.outcomes[0].diagnostics = vec![crate::agent_task::AgentTaskDiagnostic {
+    startup_outcome.diagnostics = vec![crate::agent_task::AgentTaskDiagnostic {
         class: "agent_task.provider_liveness_timeout".to_string(),
         message: "provider produced no observable progress before the liveness boundary"
             .to_string(),
@@ -968,6 +984,7 @@ fn startup_without_output_liveness_is_projected_without_becoming_a_timeout() {
             "workspace_progress_events": 0,
         }),
     }];
+    aggregate.outcomes.push(startup_outcome);
     let mut report = cook_report(CookReportInput {
         cook_id: "startup-without-output-report".to_string(),
         status: "provider_failure",
@@ -1001,6 +1018,16 @@ fn startup_without_output_liveness_is_projected_without_becoming_a_timeout() {
         next_actions: Vec::new(),
     });
 
+    make_provider_timeout_actionable(
+        None,
+        &mut report,
+        &aggregate,
+        &plan,
+        "startup-without-output-run",
+        Some(AgentTaskExecutionBudget::new(1, 1, 0)),
+        false,
+    );
+    make_provider_rotation_actionable(None, &mut report, &aggregate, "startup-without-output-run");
     make_startup_without_output_actionable(
         None,
         &mut report,
@@ -1037,6 +1064,65 @@ fn startup_without_output_liveness_is_projected_without_becoming_a_timeout() {
         .legal_actions
         .iter()
         .all(|action| !action.command.contains("--timeout-ms")));
+}
+
+#[test]
+fn earlier_startup_liveness_diagnostic_does_not_overwrite_later_terminal_failure() {
+    let plan = compile_options("later-terminal-failure")
+        .identity
+        .initial_plan;
+    let mut aggregate = review_form_aggregate(&plan);
+    aggregate.status = crate::agent_task_scheduler::AgentTaskAggregateStatus::Failed;
+    aggregate.outcomes[0].status = crate::agent_task::AgentTaskOutcomeStatus::Failed;
+    aggregate.outcomes[0].failure_classification =
+        Some(crate::agent_task::AgentTaskFailureClassification::Stalled);
+    aggregate.outcomes[0].diagnostics = vec![crate::agent_task::AgentTaskDiagnostic {
+        class: "agent_task.provider_liveness_timeout".to_string(),
+        message: "provider produced no observable progress before the liveness boundary"
+            .to_string(),
+        data: serde_json::json!({
+            "deadline": "liveness",
+            "stdout_bytes": 0,
+            "stderr_bytes": 0,
+            "runtime_progress_events": 0,
+            "workspace_progress_events": 0,
+        }),
+    }];
+    let mut later_failure = aggregate.outcomes[0].clone();
+    later_failure.status = crate::agent_task::AgentTaskOutcomeStatus::Failed;
+    later_failure.failure_classification =
+        Some(crate::agent_task::AgentTaskFailureClassification::ExecutionFailed);
+    later_failure.diagnostics.clear();
+    aggregate.outcomes.push(later_failure);
+    let mut report = cook_report(CookReportInput {
+        cook_id: "later-terminal-failure".to_string(),
+        status: "provider_failure",
+        disposition: CookDisposition::Terminal,
+        attempts: Vec::new(),
+        finalization: None,
+        stop_reason: Some("later provider execution failed".to_string()),
+        exit_code: 1,
+        invocation_latest_run_id: Some("later-terminal-failure-run"),
+    });
+    report.value.terminal_phase = Some("provider".to_string());
+    report.value.terminal_failure_classification = Some("provider_execution_failed".to_string());
+
+    make_startup_without_output_actionable(
+        None,
+        &mut report,
+        &aggregate,
+        "later-terminal-failure-run",
+    );
+
+    assert_eq!(report.value.terminal_phase.as_deref(), Some("provider"));
+    assert_eq!(
+        report.value.terminal_failure_classification.as_deref(),
+        Some("provider_execution_failed")
+    );
+    assert_eq!(
+        report.value.stop_reason.as_deref(),
+        Some("later provider execution failed")
+    );
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -944,6 +944,102 @@ fn provider_timeout_report_surfaces_budget_and_exact_recovery() {
 }
 
 #[test]
+fn startup_without_output_liveness_is_projected_without_becoming_a_timeout() {
+    let plan = compile_options("startup-without-output-report")
+        .identity
+        .initial_plan;
+    let mut aggregate = review_form_aggregate(&plan);
+    aggregate.status = crate::agent_task_scheduler::AgentTaskAggregateStatus::Failed;
+    aggregate.outcomes[0].status = crate::agent_task::AgentTaskOutcomeStatus::Failed;
+    aggregate.outcomes[0].failure_classification =
+        Some(crate::agent_task::AgentTaskFailureClassification::Stalled);
+    aggregate.outcomes[0].diagnostics = vec![crate::agent_task::AgentTaskDiagnostic {
+        class: "agent_task.provider_liveness_timeout".to_string(),
+        message: "provider produced no observable progress before the liveness boundary"
+            .to_string(),
+        data: serde_json::json!({
+            "provider": "generic-provider",
+            "deadline": "liveness",
+            "liveness_timeout_ms": 300_000,
+            "timeout_ms": 1_230_000,
+            "stdout_bytes": 0,
+            "stderr_bytes": 0,
+            "runtime_progress_events": 0,
+            "workspace_progress_events": 0,
+        }),
+    }];
+    let mut report = cook_report(CookReportInput {
+        cook_id: "startup-without-output-report".to_string(),
+        status: "provider_failure",
+        disposition: CookDisposition::Terminal,
+        attempts: Vec::new(),
+        finalization: None,
+        stop_reason: None,
+        exit_code: 1,
+        invocation_latest_run_id: Some("startup-without-output-run"),
+    });
+    report.value.failure_context = Some(AgentTaskCookFailureContext {
+        cook_id: "startup-without-output-report".to_string(),
+        latest_run_id: "startup-without-output-run".to_string(),
+        selected_run_id: None,
+        selected_task_id: None,
+        selected_artifact_id: None,
+        promotion_provenance: None,
+        durable_recipe_ref: "homeboy://agent-task/cooks/startup-without-output-report/recipe"
+            .to_string(),
+        lifecycle_state: "Failed".to_string(),
+        phase: "provider".to_string(),
+        reason_code: "failed".to_string(),
+        diagnostic: None,
+        continuation_admission: None,
+        blocking_claim: None,
+        provider_budget_consumed: true,
+        provider_executions_consumed: 1,
+        recovery_legal: false,
+        recovery_reason: "generic".to_string(),
+        legal_actions: Vec::new(),
+        next_actions: Vec::new(),
+    });
+
+    make_startup_without_output_actionable(
+        None,
+        &mut report,
+        &aggregate,
+        "startup-without-output-run",
+    );
+
+    assert_eq!(report.value.status, "provider_failure");
+    assert_eq!(
+        report.value.terminal_failure_classification.as_deref(),
+        Some("provider_startup_without_output")
+    );
+    assert_ne!(
+        report.value.terminal_failure_classification.as_deref(),
+        Some("provider_timeout")
+    );
+    let context = report
+        .value
+        .failure_context
+        .expect("startup diagnostic context");
+    assert_eq!(
+        context.diagnostic.expect("diagnostic")["data"]["timeout_ms"],
+        1_230_000
+    );
+    assert_eq!(
+        context
+            .legal_actions
+            .iter()
+            .map(|action| action.action.as_str())
+            .collect::<Vec<_>>(),
+        vec!["status", "diagnose"]
+    );
+    assert!(context
+        .legal_actions
+        .iter()
+        .all(|action| !action.command.contains("--timeout-ms")));
+}
+
+#[test]
 fn provider_rotation_terminal_projection_retains_heterogeneous_route_causes() {
     use crate::agent_task::{AgentTaskDiagnostic, AgentTaskOutcome, AgentTaskOutcomeStatus};
     use crate::agent_task_scheduler::{

--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -1659,11 +1659,15 @@ pub(crate) fn remote_path_writable(client: &SshClient, path: &str) -> bool {
 
 pub(crate) fn remote_artifact_store_available(client: &SshClient, path: &str) -> bool {
     client
-        .execute(&format!(
-            "if [ -e {0} ]; then test -w {0}; else test -w $(dirname {0}); fi",
-            common::shell_word(path)
-        ))
+        .execute(&remote_artifact_store_available_command(path))
         .success
+}
+
+pub(super) fn remote_artifact_store_available_command(path: &str) -> String {
+    let path = common::shell_word(path);
+    format!(
+        "if [ -e {path} ]; then test -d {path} && test -w {path}; else parent=$(dirname {path}); test -d \"$parent\" && test -w \"$parent\"; fi"
+    )
 }
 
 pub(crate) fn connected_daemon_exec_checks(

--- a/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
@@ -248,17 +248,13 @@ pub fn report(
         "Make the remote workspace root writable by the runner user",
     ));
 
-    let artifact_store_available = (!scoped)
-        .then(|| probes::remote_artifact_store_available(client, &artifact_root))
-        .unwrap_or(false);
-    if !scoped {
-        checks.push(checks::path_writable_check(
-            "artifact_store.available",
-            artifact_store_available,
-            Path::new(&artifact_root),
-            "Create the artifact root or configure HOMEBOY_ARTIFACT_ROOT to a writable directory",
-        ));
-    }
+    let artifact_store_available = probes::remote_artifact_store_available(client, &artifact_root);
+    checks.push(checks::path_writable_check(
+        "artifact_store.available",
+        artifact_store_available,
+        Path::new(&artifact_root),
+        "Create the artifact root or configure HOMEBOY_ARTIFACT_ROOT to a writable directory",
+    ));
 
     if options.scope == RunnerDoctorScope::LabOffload {
         checks.extend(probes::lab_homeboy_path_checks(

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
@@ -164,6 +164,35 @@ fn remote_default_artifact_root_rejects_empty_home() {
 }
 
 #[test]
+fn remote_artifact_store_availability_contract_handles_existing_missing_and_unusable_roots() {
+    let root = tempfile::tempdir().expect("artifact fixture root");
+    let existing = root.path().join("existing");
+    std::fs::create_dir(&existing).expect("existing artifact root");
+    let missing = root.path().join("missing");
+    let unusable_parent = root.path().join("not-a-directory");
+    std::fs::write(&unusable_parent, "not a directory").expect("unusable artifact parent");
+
+    assert!(artifact_store_contract_succeeds(&existing));
+    assert!(artifact_store_contract_succeeds(&missing));
+    // A non-directory cannot be an artifact root or a writable parent for one.
+    assert!(!artifact_store_contract_succeeds(&unusable_parent));
+    assert!(!artifact_store_contract_succeeds(
+        &unusable_parent.join("child")
+    ));
+}
+
+fn artifact_store_contract_succeeds(path: &std::path::Path) -> bool {
+    std::process::Command::new("sh")
+        .arg("-c")
+        .arg(probes::remote_artifact_store_available_command(
+            &path.display().to_string(),
+        ))
+        .status()
+        .expect("run artifact-store availability contract")
+        .success()
+}
+
+#[test]
 fn unreachable_transport_report_is_terminal_and_has_no_daemon_evidence() {
     let runner = Runner {
         id: "lab".to_string(),

--- a/crates/homeboy-lab-runner/src/execution/job_flow.rs
+++ b/crates/homeboy-lab-runner/src/execution/job_flow.rs
@@ -178,6 +178,7 @@ where
     }
 
     let deadline = Instant::now() + runner_exec_wait_timeout(&flow.runner.settings);
+    let mut observed_terminal_daemon_job = job.status.is_terminal();
     let mut reported_progress_sequence = 0;
     while !job.status.is_terminal() {
         if let Some(status) = flow.run_id.as_deref().and_then(|run_id| {
@@ -220,6 +221,7 @@ where
                     // Project terminal work through the normal lifecycle instead
                     // of claiming a cancelled remote command still runs.
                     job = cancelled_job.clone();
+                    observed_terminal_daemon_job = true;
                     continue;
                 }
             }
@@ -252,6 +254,7 @@ where
         }
         std::thread::sleep(Duration::from_millis(200));
         job = poll(&job)?;
+        observed_terminal_daemon_job = job.status.is_terminal();
         if let Ok(events) = events(&job) {
             let events =
                 redact_runner_job_events(&events, flow.redaction_env, flow.secret_env_names);
@@ -311,6 +314,11 @@ where
             )?;
         }
     }
+    settle_generation_job_ownership_after_terminal_snapshot(
+        &flow.runner.id,
+        &terminal_snapshot,
+        observed_terminal_daemon_job,
+    )?;
     after_events()?;
     let mirrored = if flow.mirror_evidence {
         mirror(&job, &job_events, &result).map_err(|error| {
@@ -516,10 +524,123 @@ fn control_plane_terminal_job_status(
     }
 }
 
+/// Releases generation capacity only for a terminal daemon snapshot whose event
+/// read has already completed. Controller-derived terminality is not authority
+/// to settle the daemon job's durable owner.
+fn settle_generation_job_ownership_after_terminal_snapshot(
+    runner_id: &str,
+    terminal_snapshot: &RunnerJobLogSnapshot,
+    observed_terminal_daemon_job: bool,
+) -> Result<bool> {
+    if !observed_terminal_daemon_job || !terminal_snapshot.job.status.is_terminal() {
+        return Ok(false);
+    }
+    super::super::generation_store::settle_observed_terminal_job(
+        runner_id,
+        &terminal_snapshot.job.id.to_string(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{generation_store, RunnerSession, RunnerSessionRole, RunnerTunnelMode};
     use homeboy_control_plane_contract::ControlPlaneRunState;
+
+    fn direct_session() -> RunnerSession {
+        RunnerSession {
+            runner_id: "runner-a".to_string(),
+            mode: RunnerTunnelMode::DirectSsh,
+            role: RunnerSessionRole::Controller,
+            server_id: Some("server-a".to_string()),
+            controller_id: Some("controller-a".to_string()),
+            broker_url: None,
+            remote_daemon_address: Some("daemon-a:4000".to_string()),
+            local_port: Some(4000),
+            local_url: Some("http://daemon-a:4000".to_string()),
+            tunnel_pid: None,
+            tunnel_process_start_identity: None,
+            proxy_forward: None,
+            remote_daemon_pid: Some(42),
+            remote_daemon_lease_id: Some("lease-a".to_string()),
+            homeboy_version: "test".to_string(),
+            homeboy_build_identity: Some("homeboy test+lease-a".to_string()),
+            connected_at: "2026-09-10T00:00:00Z".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+            leaseless_recovery_evidence: None,
+        }
+    }
+
+    #[test]
+    fn failed_read_only_terminal_snapshot_retains_evidence_and_releases_generation_capacity() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let session = direct_session();
+            let job_id = uuid::Uuid::new_v4();
+            generation_store::record_job("runner-a", &session, &job_id.to_string())
+                .expect("record accepted job");
+            let terminal = RunnerJobLogSnapshot {
+                job: Job {
+                    id: job_id,
+                    operation: "runner.exec --read-only-artifact".to_string(),
+                    status: JobStatus::Failed,
+                    created_at_ms: 1,
+                    updated_at_ms: 2,
+                    started_at_ms: Some(1),
+                    finished_at_ms: Some(2),
+                    event_count: 0,
+                    source_snapshot: None,
+                    path_materialization_plan: None,
+                    stale_reason: None,
+                    daemon_lease_id: Some("lease-a".to_string()),
+                    target_runner_id: Some("runner-a".to_string()),
+                    target_project_id: None,
+                    claim_id: None,
+                    claimed_by_runner_id: None,
+                    claimed_at_ms: None,
+                    claim_expires_at_ms: None,
+                    artifacts: Vec::new(),
+                    runner_job_projection: None,
+                },
+                events: Vec::new(),
+            };
+
+            assert!(
+                terminal.job.status.is_terminal(),
+                "terminal evidence is retained"
+            );
+            assert_eq!(
+                terminal.job.operation, "runner.exec --read-only-artifact",
+                "terminal snapshot retains the failed retrieval identity"
+            );
+            assert!(settle_generation_job_ownership_after_terminal_snapshot(
+                "runner-a", &terminal, true
+            )
+            .expect("settle terminal job-flow snapshot"));
+            assert!(
+                generation_store::status_job_owners("runner-a", Some(&session))
+                    .expect("read generation owners")
+                    .iter()
+                    .all(|owner| owner.job_ids.is_empty())
+            );
+            assert!(!generation_store::requires_generation_preserving_refresh(
+                "runner-a",
+                Some(&session)
+            )
+            .expect("check retained generation ownership"));
+            generation_store::with_admission_fence(
+                "runner-a",
+                Some(&session),
+                "connect",
+                |fence| {
+                    assert!(fence.is_none(), "settled job must not block capacity");
+                    Ok(())
+                },
+            )
+            .expect("check admission fence");
+        });
+    }
 
     #[test]
     fn agent_task_terminal_state_bounds_stale_runner_job_polling() {

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -2030,6 +2030,23 @@ pub(crate) fn record_job_artifacts(
     })
 }
 
+/// Settle one exact daemon job after the controller has authoritatively read
+/// its terminal snapshot and event log. Unknown or in-flight jobs never reach
+/// this boundary, so their generation ownership remains fail-closed.
+pub(crate) fn settle_observed_terminal_job(runner_id: &str, job_id: &str) -> Result<bool> {
+    with_registry_lock(runner_id, || {
+        let Some(mut generations) = read_locked(runner_id, None)? else {
+            return Ok(false);
+        };
+        if generations.job_owner(job_id).is_none() {
+            return Ok(false);
+        }
+        generations.complete_job(job_id);
+        write(runner_id, &generations)?;
+        Ok(true)
+    })
+}
+
 /// Release a durable run's generation routing claim after terminal retention
 /// removes the run record. Reconciliation remains fail-closed and only stops a
 /// drained, zero-job endpoint after its final owner is gone.

--- a/crates/homeboy-upgrade/src/upgrade/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/mod.rs
@@ -24,7 +24,8 @@ pub use helpers::{
     run_upgrade_with_method, version_is_newer,
 };
 pub use operation::{
-    load_upgrade_operation_status, UpgradeOperationStatus, UpgradePromotionWaitStatus,
+    load_upgrade_operation_status, UpgradeOperationFailure, UpgradeOperationStatus,
+    UpgradePromotionWaitStatus,
 };
 pub use planning::resolve_binary_on_path;
 pub use release_catalog::{

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -31,6 +31,9 @@ pub struct UpgradeOperationStatus {
     pub status: String,
     pub phase: String,
     pub elapsed_seconds: u64,
+    /// True when the durable terminal operation did not satisfy every required
+    /// upgrade postcondition. This is independent from the controller swap.
+    pub failed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub controller: Option<UpgradeComponentStatus>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -45,6 +48,27 @@ pub struct UpgradeOperationStatus {
     pub inspect_command: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub promotion_wait: Option<UpgradePromotionWaitStatus>,
+    /// The concrete terminal predicate and retained runner evidence, when a
+    /// post-install verification prevents convergence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<UpgradeOperationFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpgradeOperationFailure {
+    pub phase: String,
+    pub predicate: String,
+    pub elapsed_seconds: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_ms: Option<u128>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_identity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_identity: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostic_references: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runners: Vec<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -292,6 +316,13 @@ impl UpgradeOperation {
         }
         if let Some(status) = &result.runners {
             self.metadata["runners"] = json!(status);
+        }
+        // The component summaries are intentionally compact. Keep the complete
+        // result with the operation so a later status lookup can still explain
+        // a post-swap runner verification failure after the caller has exited.
+        self.metadata["result"] = json!(result);
+        if let Some(failure) = failure_from_result(result, self.started.elapsed().as_secs()) {
+            self.metadata["failure"] = json!(failure);
         }
         self.metadata["phase"] = json!("completed");
         self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
@@ -811,6 +842,7 @@ fn status_from_run(run: &RunRecord) -> Result<UpgradeOperationStatus> {
             .get("elapsed_seconds")
             .and_then(Value::as_u64)
             .unwrap_or(0),
+        failed: matches!(run.status.as_str(), "fail" | "error"),
         controller: component_from_metadata(&metadata, "controller"),
         extensions: component_from_metadata(&metadata, "extensions"),
         runners: component_from_metadata(&metadata, "runners"),
@@ -822,6 +854,96 @@ fn status_from_run(run: &RunRecord) -> Result<UpgradeOperationStatus> {
             .get("promotion_wait")
             .cloned()
             .and_then(|value| serde_json::from_value(value).ok()),
+        failure: failure_from_metadata(&metadata, &run.status),
+    })
+}
+
+fn failure_from_metadata(metadata: &Value, status: &str) -> Option<UpgradeOperationFailure> {
+    if !matches!(status, "fail" | "error") {
+        return None;
+    }
+    let phase = metadata
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or("failed")
+        .to_string();
+    let elapsed_seconds = metadata
+        .get("elapsed_seconds")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    let budget_ms = metadata
+        .pointer("/promotion_wait/wait_timeout_ms")
+        .and_then(Value::as_u64)
+        .map(u128::from);
+    if let Some(failure) = metadata
+        .get("failure")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+    {
+        return Some(failure);
+    }
+    let expected_identity = metadata
+        .get("result")
+        .and_then(|result| result.get("new_build_identity"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let predicate = metadata
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .unwrap_or("upgrade_terminal_failure")
+        .to_string();
+    Some(UpgradeOperationFailure {
+        phase,
+        predicate,
+        elapsed_seconds,
+        budget_ms,
+        expected_identity,
+        observed_identity: None,
+        diagnostic_references: Vec::new(),
+        runners: Vec::new(),
+    })
+}
+
+fn failure_from_result(
+    result: &UpgradeResult,
+    elapsed_seconds: u64,
+) -> Option<UpgradeOperationFailure> {
+    let runners = result
+        .runners_updated
+        .iter()
+        .chain(&result.runners_skipped)
+        .filter(|runner| !runner.success)
+        .map(|runner| json!(runner))
+        .collect::<Vec<_>>();
+    if runners.is_empty() {
+        return None;
+    }
+    let diagnostic_references = runners
+        .iter()
+        .flat_map(|runner| {
+            runner["recovery_commands"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+        })
+        .collect();
+    let observed_identity = runners.iter().find_map(|runner| {
+        runner["path_drift"]
+            .as_str()
+            .filter(|detail| detail.contains("observed"))
+            .map(str::to_string)
+    });
+    Some(UpgradeOperationFailure {
+        phase: "completed".to_string(),
+        predicate: "runner_post_swap_verification".to_string(),
+        elapsed_seconds,
+        budget_ms: None,
+        expected_identity: result.new_build_identity.clone(),
+        observed_identity,
+        diagnostic_references,
+        runners,
     })
 }
 
@@ -1252,6 +1374,68 @@ mod tests {
                     .as_ref()
                     .map(|component| component.status.as_str()),
                 Some("completed")
+            );
+        });
+    }
+
+    #[test]
+    fn post_swap_runner_verification_failure_survives_operation_reload() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let id = {
+                let mut operation = UpgradeOperation::start("homeboy upgrade");
+                let id = operation.id().expect("persisted operation").to_string();
+                let mut result = completed_upgrade_result();
+                result.new_build_identity = Some("0.2.0+selected".to_string());
+                result.partial = true;
+                result.runner_convergence = Some(RunnerConvergenceDisposition::Partial);
+                result.runners = Some(UpgradeComponentStatus {
+                    status: "partial".to_string(),
+                    summary: "0 converged, 1 require repair".to_string(),
+                });
+                result.runners_skipped.push(super::super::types::RunnerUpgradeEntry {
+                    runner_id: "lab".to_string(),
+                    homeboy_path: "/opt/homeboy".to_string(),
+                    success: false,
+                    upgraded: true,
+                    previous_version: Some("0.1.0".to_string()),
+                    new_version: Some("0.2.0".to_string()),
+                    bare_homeboy_version: None,
+                    path_drift: Some(
+                        "configured runner executable did not converge to initiating controller identity `0.2.0+selected`; observed `0.2.0+stale`".to_string(),
+                    ),
+                    recovery_commands: vec![
+                        "homeboy upgrade --force --upgrade-runner lab".to_string(),
+                    ],
+                    extensions_synced: Vec::new(),
+                    extensions_skipped: Vec::new(),
+                    extensions_failed: Vec::new(),
+                    stale_daemon: None,
+                    daemon_previous_version: None,
+                    daemon_new_version: None,
+                    exit_code: 1,
+                    detail: "post-swap identity verification failed".to_string(),
+                });
+                operation
+                    .finish_completed_durable(&result)
+                    .expect("persist terminal failure");
+                id
+            };
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("reload operation");
+            assert_eq!(status.status, RunStatus::Fail.as_str());
+            assert!(status.failed);
+            let failure = status.failure.expect("projected failure evidence");
+            assert_eq!(failure.phase, "completed");
+            assert_eq!(failure.predicate, "runner_post_swap_verification");
+            assert_eq!(failure.expected_identity.as_deref(), Some("0.2.0+selected"));
+            assert!(failure
+                .observed_identity
+                .as_deref()
+                .is_some_and(|observed| observed.contains("0.2.0+stale")));
+            assert_eq!(failure.runners.len(), 1);
+            assert_eq!(
+                failure.diagnostic_references,
+                vec!["homeboy upgrade --force --upgrade-runner lab"]
             );
         });
     }


### PR DESCRIPTION
## Summary
- surface terminal zero-progress provider startup diagnostics as a distinct Cook failure with read-only durable inspection actions
- defer a retryable preview base probe instead of admitting an unverified base
- validate the configured Lab artifact root for every remote doctor scope
- release a generation claim only after the daemon terminal snapshot and event log are read
- persist and reload post-swap runner convergence failure evidence from upgrade status

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-agents -p homeboy-cli -p homeboy-lab-runner -p homeboy-upgrade`
- `cargo test -p homeboy-agents startup_without_output --lib`
- `cargo test -p homeboy-agents earlier_startup_liveness_diagnostic_does_not_overwrite_later_terminal_failure --lib`
- `cargo test -p homeboy-agents retryable_preview_base_resolution_is_deferred_not_admitted --lib`
- `cargo test -p homeboy-cli remote_artifact_store_availability_contract_handles_existing_missing_and_unusable_roots --lib`
- `cargo test -p homeboy-lab-runner failed_read_only_terminal_snapshot_retains_evidence_and_releases_generation_capacity --lib`
- `cargo test -p homeboy-upgrade post_swap_runner_verification_failure_survives_operation_reload --lib`
- `git diff --check origin/main...HEAD`

## AI Assistance
OpenAI GPT-5.6 Terra (`openai/gpt-5.6-terra`) via OpenCode performed integration review and conflict-resolution oversight. OpenAI GPT-5.6 Terra (`openai/gpt-5.6-terra`) via `opencode run` implemented the Cook conflict resolutions and ran focused regressions. Chris Huber authorized the work and remains responsible for acceptance.