### PR TITLE
feat(code-audit): attribute the audit detectors phase (named setup spans + unattributed-time self-check)

### DIFF
--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -103,6 +103,7 @@ pub(super) fn audit_internal(
 
     if !plan.requires_discovery() {
         let detector_started = std::time::Instant::now();
+        let detector_phase_children = timing.spans.len();
         let result = audit_root_only(
             component_id,
             source_path,
@@ -113,6 +114,7 @@ pub(super) fn audit_internal(
             &mut timing,
         );
         timing.push_ok("detectors", detector_started.elapsed());
+        timing.warn_unattributed_phase_time("detectors", detector_phase_children);
         timing.log_detector_summary();
         return Ok(AuditWithAnalysis {
             result,
@@ -244,40 +246,66 @@ pub(super) fn audit_internal(
     // Phase 4: Build findings
     let mut all_findings = findings::build_findings(&check_results);
     let detectors_started = std::time::Instant::now();
+    // Everything recorded from here until the `detectors` span closes is a
+    // child of the phase, which is what lets the attribution self-check at the
+    // phase's end measure the gap without a hand-maintained span-id list
+    // (#14566).
+    let detector_phase_children = timing.spans.len();
 
     // Phase 4c: Duplication detection (identical function bodies across files)
     //
     // `all_fingerprints` is the CONVENTION corpus: index files removed and
     // single-file groups dropped. Convention, duplication, and dead-code
     // detectors need exactly that shape.
+    let corpus_started = std::time::Instant::now();
     let all_fingerprints: Vec<&fingerprint::FileFingerprint> = discovery
         .groups
         .iter()
         .flat_map(|(_, _, fps)| fps.iter())
         .collect();
+    timing.push_ok("corpus.convention", corpus_started.elapsed());
 
     // `policy_fingerprints` is the SOURCE-POLICY corpus: every extension-claimed
     // source file, index files included, no group-size filter (#10558). Path
     // scoping is validated against it too, so a configured `include_path_contains`
     // is checked against the files policies can actually reach.
+    let corpus_started = std::time::Instant::now();
     let policy_fingerprints: Vec<&fingerprint::FileFingerprint> =
         discovery.policy_fingerprints.iter().collect();
+    timing.push_ok("corpus.policy", corpus_started.elapsed());
 
+    let validate_paths_started = std::time::Instant::now();
     source_policy::validate_configured_paths(&policy_fingerprints, &audit_config)?;
+    timing.push_ok(
+        "source_policy.validate_paths",
+        validate_paths_started.elapsed(),
+    );
 
     if plan.detector_enabled("core_boundary_leaks") {
         let rules = audit_config.core_boundary_leaks.to_source_policy_rules();
+        let validate_roots_started = std::time::Instant::now();
         source_policy::validate_source_roots(&policy_fingerprints, &rules)?;
+        timing.push_ok(
+            "source_policy.validate_roots.core_boundary_leaks",
+            validate_roots_started.elapsed(),
+        );
     }
     if plan.detector_enabled("source_policy") {
+        let validate_roots_started = std::time::Instant::now();
         source_policy::validate_source_roots(&policy_fingerprints, &audit_config.source_policies)?;
+        timing.push_ok(
+            "source_policy.validate_roots.source_policy",
+            validate_roots_started.elapsed(),
+        );
     }
 
     // Build convention method set ONCE — used by duplication, near-duplicate, and parallel detectors.
     // Convention-expected methods are excluded from duplication/parallel findings because identical
     // or similar implementations across convention-following files are correct behavior.
+    let method_set_started = std::time::Instant::now();
     let convention_methods =
         build_convention_method_set(&discovered_conventions, &all_fingerprints);
+    timing.push_ok("conventions.method_set", method_set_started.elapsed());
 
     // Phase 4b2: In scoped (--changed-since) mode, compute the touched-file scope
     // ONCE up front so per-file detectors only walk the fingerprints they could
@@ -370,6 +398,7 @@ pub(super) fn audit_internal(
     // Source policies get the same changed-scope narrowing, applied to THEIR
     // corpus. Reusing the already-computed `scope_files` set keeps the two
     // corpora scoped by one identical rule.
+    let scope_policy_started = std::time::Instant::now();
     let scoped_policy_fingerprints: Option<Vec<&fingerprint::FileFingerprint>> =
         scoped_fingerprints.as_ref().map(|(scope_files, _)| {
             policy_fingerprints
@@ -382,17 +411,32 @@ pub(super) fn audit_internal(
                 })
                 .collect()
         });
+    timing.push_ok("scope.policy_fingerprints", scope_policy_started.elapsed());
     let policy_scan_fingerprints: &[&fingerprint::FileFingerprint] = scoped_policy_fingerprints
         .as_deref()
         .unwrap_or(policy_fingerprints.as_slice());
 
+    // Setup work that used to run silently inside the phase (#14566): the
+    // dead-code reference walk fingerprints every external reference tree, and
+    // the test-quality walk classifies the whole repository's test files. Both
+    // are serial, both are potentially expensive, and neither was attributable
+    // before.
     let dead_code_references = dead_code_references.or_else(|| {
-        plan.detector_enabled("dead_code")
-            .then(|| DeadCodeReferenceAnalysis::build(root, reference_paths))
+        plan.detector_enabled("dead_code").then(|| {
+            let references_started = std::time::Instant::now();
+            let analysis = DeadCodeReferenceAnalysis::build(root, reference_paths);
+            timing.push_ok("dead_code.references", references_started.elapsed());
+            analysis
+        })
     });
     let test_quality_findings = (plan.detector_enabled("test_coverage")
         || plan.detector_enabled("test_topology"))
-    .then(|| crate::test_quality::run(root));
+    .then(|| {
+        let test_quality_started = std::time::Instant::now();
+        let findings = crate::test_quality::run(root);
+        timing.push_ok("test_quality.walk", test_quality_started.elapsed());
+        findings
+    });
     let detector_context = DetectorRunContext {
         root,
         component_id,
@@ -519,7 +563,9 @@ pub(super) fn audit_internal(
         all_findings.extend(parallel_findings);
     }
 
+    let merge_started = std::time::Instant::now();
     merge_descriptor_outcomes(&mut timing, &mut all_findings, descriptor_outcomes);
+    timing.push_ok("merge.descriptors", merge_started.elapsed());
 
     // `artifact_portability` stays hand-sequenced: it logs scan statistics (runs,
     // artifacts, metadata fields) even when it produces no findings.
@@ -545,6 +591,7 @@ pub(super) fn audit_internal(
         all_findings.extend(artifact_portability_findings);
     }
     timing.push_ok("detectors", detectors_started.elapsed());
+    timing.warn_unattributed_phase_time("detectors", detector_phase_children);
     timing.log_detector_summary();
 
     // Phase 4p: Impact-scoped filtering — when auditing changed files only,

--- a/crates/homeboy-code-audit/src/types.rs
+++ b/crates/homeboy-code-audit/src/types.rs
@@ -87,6 +87,62 @@ impl AuditTiming {
         self.extend_from_timer(timer);
     }
 
+    /// Attribution self-check for a coarse phase: compare the phase span's wall
+    /// time against the sum of the child spans recorded while the phase was
+    /// open, and surface the gap when it is significant.
+    ///
+    /// `children_start` is the `timing.spans` length captured immediately before
+    /// the phase's work began; every span at or after that index except the
+    /// phase span itself counts as attributed. Index-based windows are what make
+    /// the check survive new span ids — a future setup span is a child by
+    /// construction, no id list to forget to update, and unspanned work is
+    /// exactly the residue this check exists to expose (#14566: 99.8% of the
+    /// `detectors` phase landed in no child span and every optimization guess
+    /// about it was unfalsifiable).
+    ///
+    /// Children summing to MORE than the wall is the expected parallel shape
+    /// (concurrent detectors overlap), so the gap clamps at zero and stays
+    /// quiet. The warning is emitted twice on purpose: an `eprintln!` an
+    /// operator sees live — `eprintln!` rather than `log_status!` for the same
+    /// reason [`AuditTiming::log_detector_summary`] gives, CI is never a
+    /// terminal — and a `<phase>.unattributed` span with status `warning` that
+    /// survives into the serialized `timing.spans[]` for post-mortem diffs.
+    pub(crate) fn warn_unattributed_phase_time(&mut self, phase_id: &str, children_start: usize) {
+        let wall = self
+            .spans
+            .iter()
+            .rev()
+            .find(|span| span.id == phase_id)
+            .and_then(|span| span.duration_ms);
+        let Some(wall) = wall else {
+            return;
+        };
+        let attributed: f64 = self
+            .spans
+            .iter()
+            .skip(children_start)
+            .filter(|span| span.id != phase_id)
+            .filter_map(|span| span.duration_ms)
+            .sum();
+        let unattributed = (wall - attributed).max(0.0);
+        if unattributed < UNATTRIBUTED_WARN_FRACTION * wall
+            || unattributed < UNATTRIBUTED_WARN_FLOOR_MS
+        {
+            return;
+        }
+        eprintln!(
+            "[audit] Warning: {} of the {} phase is unattributed ({:.0}% of wall) — work ran inside the phase without a timing span",
+            format_millis(unattributed),
+            phase_id,
+            unattributed / wall * 100.0
+        );
+        self.spans.push(AuditTimingSpan {
+            id: format!("{phase_id}.unattributed"),
+            status: "warning".to_string(),
+            duration_ms: Some(unattributed),
+        });
+    }
+
     /// Drain a generic phase timer into the audit-facing span list.
     fn extend_from_timer(&mut self, timer: homeboy_engine_primitives::phase_timing::PhaseTimer) {
         self.spans.extend(
@@ -199,6 +255,26 @@ const DETECTOR_SPAN_PREFIX: &str = "detector.";
 
 /// Timing id of the aggregate span covering the whole detector phase.
 const DETECTOR_PHASE_SPAN_ID: &str = "detectors";
+
+/// Fraction of a phase's wall time that may land in no child span before
+/// [`AuditTiming::warn_unattributed_phase_time`] warns.
+///
+/// The measured failure this guards against was 99.8% unattributed; a healthy
+/// phase's residue is merge and log overhead in the low single-digit percent.
+/// 10% sits far enough above that residue to never false-positive on a
+/// well-instrumented phase while still firing at one-tenth of the failure it
+/// exists to catch — and at 10% of an expensive phase the gap is already large
+/// enough to misdirect optimization work, which is the failure mode that
+/// matters.
+const UNATTRIBUTED_WARN_FRACTION: f64 = 0.10;
+
+/// Absolute floor, in milliseconds, under which
+/// [`AuditTiming::warn_unattributed_phase_time`] stays quiet regardless of
+/// fraction. A 200ms phase with 30ms of unspanned glue is 15% unattributed and
+/// not worth a warning; the same fraction of an 800s phase is the #14566
+/// failure. The floor keeps small components from training operators to ignore
+/// the signal.
+const UNATTRIBUTED_WARN_FLOOR_MS: f64 = 1_000.0;
 
 /// How many detector spans [`AuditTiming::log_detector_summary`] names
 /// individually. The full audit records 40+ detector spans; one line each would
@@ -340,6 +416,117 @@ mod tests {
                 "elapsed_ms": 12.5,
             })
         );
+    }
+
+    fn span(id: &str, duration_ms: f64) -> super::AuditTimingSpan {
+        super::AuditTimingSpan {
+            id: id.to_string(),
+            status: "ok".to_string(),
+            duration_ms: Some(duration_ms),
+        }
+    }
+
+    /// The #14566 shape: a phase wall of 518.6s whose 42 recorded children sum
+    /// to 1.1s must produce a visible `detectors.unattributed` warning span.
+    #[test]
+    fn unattributed_check_warns_when_children_do_not_cover_wall() {
+        let mut timing = super::AuditTiming::default();
+        let children_start = timing.spans.len();
+        timing
+            .spans
+            .push(span("detector.facade_passthrough", 300.0));
+        timing.spans.push(span("detector.docs", 200.0));
+        timing.spans.push(span("detector.duplication.exact", 600.0));
+        timing.spans.push(span("detectors", 518_600.0));
+
+        timing.warn_unattributed_phase_time("detectors", children_start);
+
+        let warning = timing
+            .spans
+            .iter()
+            .find(|span| span.id == "detectors.unattributed")
+            .expect("significant unattributed time must record a warning span");
+        assert_eq!(warning.status, "warning");
+        let unattributed = warning.duration_ms.expect("warning span carries the gap");
+        // 518.6s wall - 1.1s children ≈ 517.5s unattributed.
+        assert!((unattributed - 517_500.0).abs() < 1.0);
+    }
+
+    /// Concurrent detectors legitimately record more child time than wall
+    /// time — the overlap IS the speedup. That shape is fully attributed.
+    #[test]
+    fn unattributed_check_is_quiet_when_parallel_children_exceed_wall() {
+        let mut timing = super::AuditTiming::default();
+        let children_start = timing.spans.len();
+        timing.spans.push(span("detector.dead_code", 6_000.0));
+        timing.spans.push(span("detectors", 5_000.0));
+
+        timing.warn_unattributed_phase_time("detectors", children_start);
+
+        assert!(timing
+            .spans
+            .iter()
+            .all(|span| span.id != "detectors.unattributed"));
+    }
+
+    /// Spans recorded before the phase window belong to other phases and must
+    /// not be credited against this phase's wall — otherwise a phase with zero
+    /// children of its own could hide behind an expensive earlier phase.
+    #[test]
+    fn unattributed_check_does_not_credit_other_phases_spans() {
+        let mut timing = super::AuditTiming::default();
+        timing
+            .spans
+            .push(span("discovery_fingerprinting", 50_000.0));
+        let children_start = timing.spans.len();
+        timing.spans.push(span("detectors", 5_000.0));
+
+        timing.warn_unattributed_phase_time("detectors", children_start);
+
+        let warning = timing
+            .spans
+            .iter()
+            .find(|span| span.id == "detectors.unattributed")
+            .expect("the phase has no children of its own, so the full wall is unattributed");
+        assert_eq!(
+            warning.duration_ms,
+            Some(5_000.0),
+            "the earlier phase's span must not reduce this phase's gap"
+        );
+    }
+
+    /// Below the absolute floor the check stays quiet even at a high fraction:
+    /// 400ms of unspanned glue in a half-second phase is 80% unattributed and
+    /// still not worth an operator's attention.
+    #[test]
+    fn unattributed_check_ignores_small_absolute_gaps() {
+        let mut timing = super::AuditTiming::default();
+        let children_start = timing.spans.len();
+        timing.spans.push(span("detector.docs", 100.0));
+        timing.spans.push(span("detectors", 500.0));
+
+        timing.warn_unattributed_phase_time("detectors", children_start);
+
+        assert!(timing
+            .spans
+            .iter()
+            .all(|span| span.id != "detectors.unattributed"));
+    }
+
+    /// The phase span itself is not its own child; without the exclusion the
+    /// gap would always clamp to zero and the check could never fire.
+    #[test]
+    fn unattributed_check_excludes_the_phase_span_from_children() {
+        let mut timing = super::AuditTiming::default();
+        let children_start = timing.spans.len();
+        timing.spans.push(span("detectors", 10_000.0));
+
+        timing.warn_unattributed_phase_time("detectors", children_start);
+
+        assert!(timing
+            .spans
+            .iter()
+            .any(|span| span.id == "detectors.unattributed"));
     }
 }
 


### PR DESCRIPTION
Closes #14566. Follow-up optimization issue: #14568.

## What this PR is (and deliberately is not)

**Instrumentation only.** It makes the ~99.8% unattributed fraction of the `detectors` phase attributable. It does not optimize anything — that is the mistake #14566 exists to prevent. The data this PR produces now points at one specific hot spot, tracked in #14568.

The reading of the code that this PR confirms: **no detector class was unspanned.** All 36 data-driven descriptor detectors already emit `detector.*` spans via `time_audit_detector_isolated`, as do all six duplication passes and `artifact_portability`. The 517.5s was the **serial setup work around the fan-out** — above all `DeadCodeReferenceAnalysis::build`, which `run_audit` triggers in-phase via the `dead_code_references: None` fallback and which fingerprints every external reference tree on the main thread before any detector starts.

## Before / after

**BEFORE** — real CI run, `data-machine-events` PR #826 ([run 34547781791](https://github.com/Extra-Chill/data-machine-events/actions/runs/34547781791), from #14566):

| Span | Duration |
|---|---|
| `detectors` (parent) | **518.6s** |
| `reference_baseline` | 50.6s |
| `discovery_fingerprinting` | 49.7s |
| sum of all 42 `detector.*` children | 1.1s |
| **UNACCOUNTED** | **517.5s = 99.8% of the phase** |

**AFTER** — real run of this branch (`review audit data-machine-events --placement local --changed-since origin/main`, 454 files, full profile), `timing.spans` from the persisted run artifact:

| Span | Duration | |
|---|---|---|
| `detectors` (phase wall) | **830.58s** | |
| → `dead_code.references` | **829.22s** | **the hot spot** |
| → sum of 42 `detector.*` spans | ~5.1s | largest: `detector.artifact_portability` 1.04s |
| → `scope.fingerprints` | 0.15s | |
| → `test_quality.walk` | 0.14s | |
| → `conventions.method_set` | 3.8ms | |
| → `corpus.convention` / `corpus.policy` / `source_policy.*` / `scope.policy_fingerprints` / `merge.descriptors` | < 0.1ms each | |
| **UNACCOUNTED** | **~0** | children sum (834.7s) slightly exceeds wall from parallel overlap |
| `discovery_fingerprinting` | 98.31s | |
| `reference_baseline` | 71.64s | |

Absolute numbers differ from the CI run (different machine, different diff), but the shape is identical and now fully attributed: **the 517.5s mystery is `DeadCodeReferenceAnalysis::build`** — 99.8% of the phase, once again. Two facts in the same run prove it is both real and avoidable, and #14568 tracks the optimization:

1. With references built, the `detector.dead_code` detector itself takes 189ms.
2. The base-ref audit inside `reference_baseline` reuses the shared reference analysis (projected onto the archive) and its entire detectors phase finishes in **823ms** — three orders of magnitude faster.

## Spans added, and why those boundaries

All inside the `detectors` phase (engine.rs), using the file's existing dotted convention (`scope.fingerprints`, `detector.*`):

| Span | Boundary |
|---|---|
| `corpus.convention` / `corpus.policy` | The two fingerprint-corpus collects (`all_fingerprints`, `policy_fingerprints`) — named for the code's own CONVENTION / SOURCE-POLICY corpus vocabulary. Expected trivial; spanned so that stays verifiable. |
| `source_policy.validate_paths` | `source_policy::validate_configured_paths` — config validation with corpus-iteration cost. |
| `source_policy.validate_roots.core_boundary_leaks` / `source_policy.validate_roots.source_policy` | The two `validate_source_roots` call sites, kept separate so the gated detectors stay individually attributable. |
| `conventions.method_set` | `build_convention_method_set` — O(conventions × methods) set construction shared by three detectors. |
| `scope.policy_fingerprints` | The policy-corpus changed-scope narrowing (its sibling `scope.fingerprints` was already spanned). |
| `dead_code.references` | `DeadCodeReferenceAnalysis::build` in the `or_else` fallback — the unspanned walk that turned out to be the entire hot spot. |
| `test_quality.walk` | `test_quality::run` — a whole-repository test-file classification pass feeding topology + coverage. |
| `merge.descriptors` | `merge_descriptor_outcomes` — findings + span replay; expected trivial, spanned for the same verifiability reason as the corpora. |

Both the full path and the root-only fast path get the self-check.

## The unattributed-time self-check

`AuditTiming::warn_unattributed_phase_time(phase_id, children_start)` (types.rs): the caller captures `timing.spans.len()` when the phase opens; at phase end the check sums every span recorded inside that window (excluding the phase span itself) against the phase wall, and when the gap is significant it

1. `eprintln!`s a warning an operator sees live (deliberately `eprintln!` rather than `log_status!` for the same reason `log_detector_summary` gives: CI is never a terminal), and
2. records a `detectors.unattributed` span with status `warning`, so the signal survives into the serialized `timing.spans[]` for post-mortem diffs of `review-audit.json`.

**Index-based windows, not a span-id list:** a future setup span becomes a child by construction; unspanned work is exactly the residue the check measures — no list to forget to update, which is how #14566 became a 517s blind spot in the first place.

**Threshold: warn when the gap is both > 10% of the phase wall and > 1s absolute.** Reasoning: the measured failure was 99.8% unattributed; a healthy phase's residue is merge/log overhead in the low single-digit percent, so 10% never false-positives on well-instrumented phases while still firing at one-tenth of the failure it guards against — and at 10% of an expensive phase the gap already misdirects optimization work. The 1s floor keeps sub-second phases (30ms of glue in a 200ms phase is 15% unattributed but bounded and not worth attention) from training operators to ignore the signal. Children summing to *more* than the wall is the expected parallel shape — the overlap IS the speedup — so the gap clamps at zero and stays quiet.

Both thresholds are named constants (`UNATTRIBUTED_WARN_FRACTION`, `UNATTRIBUTED_WARN_FLOOR_MS`) with the reasoning in their doc comments; trivial to tune.

On the AFTER run above the self-check correctly stayed silent: children now cover the wall. Re-running the pre-instrumentation behavior in a unit test (`unattributed_check_warns_when_children_do_not_cover_wall`) reproduces the #14566 numbers and fires exactly as intended.

## Behaviour-preserving: findings output is unchanged

- The diff touches only `engine.rs` (Instant::now() boundaries around existing calls, in existing order — no call moved, gated, or reordered) and `types.rs` (new method, constants, tests). No detector, dispatch, filter, or finding code path changed.
- The only output additions are timing spans and the self-check warning, which are post-phase metadata; `findings`, `duplicate_groups`, and the summary are built from untouched code.
- Demonstrated: the demo run above completed `verdict: pass`, `introduced_findings: 0`, `contextual_findings: 0`, exit code 0 — matching the component's baseline state. The base-ref audit inside `reference_baseline` behaved identically (823ms detectors phase, shared references), confirming the instrumentation does not perturb the comparison workflow.

## Not optimized, on purpose

This PR does not make anything faster. What the data now says should be optimized next, with evidence: **`DeadCodeReferenceAnalysis::build` — 829.22s of the 830.58s phase — with the base-ref audit's 823ms reuse path proving shared/cacheable reference analysis collapses the phase entirely.** Filed and linked: #14568. (Timeouts / coverage reductions / disabling detectors remain ruled out, same as #14566.)

## Verification

- `cargo build --locked` — clean (pre-existing warnings only, untouched crates)
- `cargo fmt --all --check` — clean
- `cargo clippy --locked --workspace --all-targets` — exit 0 (warnings are pre-existing on origin/main, including `items_after_test_module` in types.rs)
- `cargo test --locked --workspace` — all suites pass except two failures that reproduce identically on a clean stash of origin/main in this environment and are untouched by this diff (`detectors::artifact_portability::tests::homeboy_config_declares_homeboy_run_marker`, `fanout_supervisor_cli::fanout_status_reports_a_pre_child_coordinator_failure`)
- New unit tests: 5 for the self-check (warn shape, parallel-overlap quiet, pre-window exclusion, absolute floor, phase-span self-exclusion)
- End-to-end: the ~20 min real audit against `data-machine-events` shown in the AFTER table

## AI Assistance

Extra Chill Bot (Z.AI `zai-coding-plan/glm-5.3-flash` via OpenCode/kimaki) implemented this change autonomously from issue #14566 under Homeboy-managed task orchestration, including the local verification runs and the demonstration audit. Chris Huber authorized the work and remains responsible for acceptance.