### PR TITLE
Let a terminal Cook release its stranded attempts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -807,11 +807,24 @@ pub(crate) fn controller_upgrade_admission_for_records(
             }
         }
     }
+    // A Cook whose own durable state is terminal is authoritative over the
+    // attempts it owns: an attempt cannot still be executing once its parent
+    // recorded a terminal outcome. Runner-generation reconciliation only
+    // retires daemon generations, and the durable reconciler deliberately
+    // leaves a runner-owned record alone, so an attempt stranded in `running`
+    // by a daemon restart is reachable by neither plane and would otherwise
+    // block every controller replacement permanently (#14571).
+    let terminal_run_ids = records
+        .iter()
+        .filter(|record| record.state.is_terminal())
+        .map(|record| record.run_id.as_str())
+        .collect::<BTreeSet<_>>();
     let mut blockers = records
         .iter()
         // Durable terminal state is authoritative even when stale ownership
         // metadata remains from the process that produced it.
         .filter(|record| !record.state.is_terminal())
+        .filter(|record| !owns_terminal_cook_parent(record, &terminal_run_ids))
         // A Cook that has not materialized any task and is blocked only by a
         // stale runner needs this controller replacement to converge runtime.
         // It owns no executable work, so it cannot safely block that upgrade.
@@ -1244,6 +1257,23 @@ fn discovery_run(
             reconcile: format!("{command_prefix} reconcile {run_id} --dry-run"),
         },
     }
+}
+
+/// Whether this record is an attempt owned by a Cook that already reached a
+/// durable terminal state, which disproves the attempt's own live projection.
+///
+/// Only a parent that is present in the same durable record set counts: an
+/// absent parent proves nothing, so ownership stays fail-closed and the
+/// attempt continues to block replacement.
+fn owns_terminal_cook_parent(
+    record: &AgentTaskRunRecord,
+    terminal_run_ids: &BTreeSet<&str>,
+) -> bool {
+    record
+        .metadata
+        .get("cook_id")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|cook_id| cook_id != record.run_id && terminal_run_ids.contains(cook_id))
 }
 
 /// Explain every stale read projection, including a pure discovery read that

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -3132,6 +3132,71 @@ fn upgrade_admission_ignores_terminal_records_with_stale_owner_metadata() {
 }
 
 #[test]
+fn upgrade_admission_ignores_a_runner_owned_attempt_of_a_terminal_cook() {
+    with_isolated_home(|_| {
+        for run_id in ["terminal-cook", "terminal-cook-attempt-1"] {
+            agent_task_lifecycle::submit_plan(&discovery_plan(), Some(run_id)).expect("submitted");
+        }
+        agent_task_lifecycle::rewrite_record_for_test("terminal-cook", |record| {
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Succeeded);
+        })
+        .expect("terminal cook stored");
+        // The attempt is stranded in `running` on a runner whose daemon
+        // restarted: runner reconcile retires generations without touching it
+        // and the durable reconciler leaves runner-owned records alone.
+        agent_task_lifecycle::rewrite_record_for_test("terminal-cook-attempt-1", |record| {
+            record.submitted_at = "2000-01-01T00:00:00+00:00".to_string();
+            record.updated_at = None;
+            record.metadata["cook_id"] = serde_json::json!("terminal-cook");
+            record.metadata["runner_id"] = serde_json::json!("lab");
+            record.metadata["runner_job_id"] = serde_json::json!("old-job");
+        })
+        .expect("stranded attempt stored");
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admission =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+
+        assert!(
+            admission.allows_controller_replacement(),
+            "a terminal Cook is authoritative over its own attempts: {:?}",
+            admission.blockers
+        );
+        assert!(admission.blockers.is_empty());
+    });
+}
+
+#[test]
+fn upgrade_admission_still_blocks_an_attempt_whose_cook_is_not_terminal() {
+    with_isolated_home(|_| {
+        for run_id in ["live-cook", "live-cook-attempt-1"] {
+            agent_task_lifecycle::submit_plan(&discovery_plan(), Some(run_id)).expect("submitted");
+        }
+        agent_task_lifecycle::rewrite_record_for_test("live-cook-attempt-1", |record| {
+            record.submitted_at = "2000-01-01T00:00:00+00:00".to_string();
+            record.updated_at = None;
+            record.metadata["cook_id"] = serde_json::json!("live-cook");
+            record.metadata["runner_id"] = serde_json::json!("lab");
+            record.metadata["runner_job_id"] = serde_json::json!("old-job");
+        })
+        .expect("attempt stored");
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admission =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+
+        assert!(
+            admission
+                .blockers
+                .iter()
+                .any(|blocker| blocker.run_id == "live-cook-attempt-1"),
+            "a non-terminal Cook proves nothing about its attempt: {:?}",
+            admission.blockers
+        );
+    });
+}
+
+#[test]
 fn controller_upgrade_admission_uses_liveness_and_bounded_record_health() {
     with_isolated_home(|_| {
         for run_id in ["stale-local", "live-owner", "unverified-runner"] {


### PR DESCRIPTION
Fixes #14571

## Root cause

Controller upgrade admission was permanently blocked by a Cook attempt stranded in `running`.

The parent Cook run reached `succeeded`, but its attempt record stayed `running` and runner-owned after the runner daemon restarted:

```
parent  agent-task-<id>                    authoritative_state=succeeded  source=local
attempt agent-task-<id>-attempt-1-<hash>   authoritative_state=running    source=runner:homeboy-lab
```

Neither reconciliation plane could retire that projection:

- `homeboy runner reconcile <runner>` (the prescribed recovery) succeeds and reports `unresolved_retained_projection_count: 0`. It retires daemon generations and does not mutate the durable record.
- `homeboy agent-task reconcile <run-id>` returns `action: no-op`, because an accepted remote handoff stays runner-owned unless its provider authoritatively confirms the runner was removed.
- `homeboy agent-task reconcile-records` only considers records with `conflicting_projections` and never selects this one.

The blocker therefore prescribed a recovery command that could not satisfy its own postcondition, and `homeboy upgrade` could never install a new controller.

## What changed

- Admission treats a Cook whose durable state is terminal as authoritative over the attempts it owns. An attempt cannot still be executing once its parent recorded a terminal outcome.
- Ownership stays fail-closed: only a parent present in the same durable record set counts, so an absent parent proves nothing and a non-terminal Cook still blocks replacement.

## Compatibility

No schema, CLI, or config change. This narrows one admission filter using durable parent authority that is already stored. Genuinely live owners, unverified runner ownership, and attempts of non-terminal Cooks continue to block controller replacement exactly as before.

## Verification

| Command | Result |
|---|---|
| `cargo test -p homeboy-agents --lib -j2 upgrade_admission_` | 15 passed, 0 failed |
| `cargo fmt --check` | clean |
| `git diff --check` | clean |

New coverage:
- `upgrade_admission_ignores_a_runner_owned_attempt_of_a_terminal_cook` reproduces the stranded runner-owned attempt and asserts replacement is admitted.
- `upgrade_admission_still_blocks_an_attempt_whose_cook_is_not_terminal` asserts the safety boundary is preserved.

The full `cargo test -p homeboy-agents --lib` run reports 2345 passed / 20 failed. Those failures reproduce identically on unmodified `origin/main` in the same worktree (verified by stashing this change and re-running `runtime_readiness`), and none are in the admission or discovery paths touched here.

## Not addressed

The secondary defect in #14571 is still open: admission describes a version-advancing upgrade as a `same-version controller repair`, and blocker-to-recovery-command ownership routing for runner-backed records is unchanged. This PR fixes the deadlock only.

## AI assistance

OpenAI gpt-6-astra via OpenCode reproduced the deadlock against the live durable records, identified the root cause, implemented this change, and ran the tests above at Chris Huber direction.