### PR TITLE
release: push branch and tag atomically, and name why a release lookup failed

### DIFF
--- a/crates/homeboy-agents/src/agent_tool_control_plane.rs
+++ b/crates/homeboy-agents/src/agent_tool_control_plane.rs
@@ -454,6 +454,7 @@ mod tools {
             component_id(input),
             git::PushOptions {
                 tags: bool_input(input, "tags"),
+                atomic: bool_input(input, "atomic"),
                 force_with_lease: bool_input(input, "force_with_lease"),
                 remote_url: optional_string(input, &["remote_url"]).map(str::to_string),
                 token: None,

--- a/crates/homeboy-cli/src/commands/git/mod.rs
+++ b/crates/homeboy-cli/src/commands/git/mod.rs
@@ -101,6 +101,12 @@ enum GitCommand {
         #[arg(long)]
         tags: bool,
 
+        /// Update every ref in the push or none of them (`--atomic`). Use when
+        /// a branch and its tag must land together, so a per-ref rejection
+        /// cannot strand one without the other.
+        #[arg(long)]
+        atomic: bool,
+
         /// Use `--force-with-lease` for safe force-pushes (e.g. after a
         /// rebase). Refuses to overwrite the remote if it has commits the
         /// local ref hasn't seen. Plain `--force` is intentionally not
@@ -368,6 +374,7 @@ pub fn run(args: GitArgs) -> CmdResult<GitCommandOutput> {
             json,
             component_id,
             tags,
+            atomic,
             force_with_lease,
             remote_url,
             token,
@@ -385,6 +392,7 @@ pub fn run(args: GitArgs) -> CmdResult<GitCommandOutput> {
                 component_id.as_deref(),
                 PushOptions {
                     tags,
+                    atomic,
                     force_with_lease,
                     remote_url,
                     token,

--- a/crates/homeboy-core/src/git/operations_push.rs
+++ b/crates/homeboy-core/src/git/operations_push.rs
@@ -13,6 +13,8 @@ struct PushBulkInput {
     #[serde(default)]
     tags: bool,
     #[serde(default)]
+    atomic: bool,
+    #[serde(default)]
     force_with_lease: bool,
     #[serde(default)]
     remote_url: Option<String>,
@@ -29,6 +31,13 @@ struct PushBulkInput {
 pub struct PushOptions {
     /// Push tags as well (`--follow-tags`).
     pub tags: bool,
+    /// Update every ref in the push or none of them (`--atomic`).
+    ///
+    /// Without this, git updates refs independently: a remote that rejects the
+    /// branch per-ref (branch protection, a rejected non-fast-forward) still
+    /// accepts the tag from the same push, stranding a tag on a commit that
+    /// never reached the branch.
+    pub atomic: bool,
     /// Use `--force-with-lease` for safe force-pushes (e.g. after a rebase).
     /// Deliberately the only force flavour exposed — never plain `--force`.
     pub force_with_lease: bool,
@@ -70,6 +79,9 @@ pub fn push_at(
         args.push(format!("http.https://{host}/.extraheader="));
     }
     args.push("push".to_string());
+    if options.atomic {
+        args.push("--atomic".to_string());
+    }
     if options.tags {
         args.push("--follow-tags".to_string());
     }
@@ -141,6 +153,7 @@ pub fn push_bulk(json_spec: &str) -> Result<BulkResult<GitOutput>> {
         )
     })?;
     let push_tags = input.tags;
+    let atomic = input.atomic;
     let force_with_lease = input.force_with_lease;
     let remote_url = input.remote_url;
     let token = input.token;
@@ -151,6 +164,7 @@ pub fn push_bulk(json_spec: &str) -> Result<BulkResult<GitOutput>> {
             Some(id),
             PushOptions {
                 tags: push_tags,
+                atomic,
                 force_with_lease,
                 remote_url: remote_url.clone(),
                 token: token.clone(),

--- a/crates/homeboy-release/src/release/advanced_remote.rs
+++ b/crates/homeboy-release/src/release/advanced_remote.rs
@@ -127,6 +127,13 @@ pub(crate) fn push_release_branch(
         Some(component_id),
         git::PushOptions {
             tags: true,
+            // The branch and the release tag must land together or not at all.
+            // A remote that rejects the branch per-ref -- branch protection
+            // requiring a pull request, or a non-fast-forward after the remote
+            // advanced -- otherwise still accepts the tag from this same push,
+            // stranding the tag on a commit that never reached the branch
+            // (issues #13529, #13677, #14139).
+            atomic: true,
             force_with_lease: false,
             refspec: Some(format!("HEAD:refs/heads/{branch}")),
             ..Default::default()

--- a/crates/homeboy-release/src/release/advanced_remote.rs
+++ b/crates/homeboy-release/src/release/advanced_remote.rs
@@ -322,9 +322,23 @@ fn require_unpublished_github_tag(component: &Component, tag_name: &str) -> Resu
         return Ok(());
     }
 
-    match super::executor::github_release_exists_for_tag(component, tag_name) {
-        Some(false) => Ok(()),
-        Some(true) => Err(Error::validation_invalid_argument(
+    match super::executor::github_release_lookup_for_tag(component, tag_name) {
+        // A non-GitHub remote short-circuits above, so `None` here means the
+        // remote stopped resolving mid-recovery. Refuse rather than assume.
+        Some(super::executor::GhReleaseLookup::Absent) => Ok(()),
+        None => Err(Error::validation_invalid_argument(
+            "tag",
+            format!(
+                "Refusing to move '{}': could not verify whether a GitHub Release exists because no GitHub remote resolved for this component",
+                tag_name
+            ),
+            None,
+            Some(vec![
+                "Confirm the component's GitHub remote is reachable, then retry release recovery."
+                    .to_string(),
+            ]),
+        )),
+        Some(super::executor::GhReleaseLookup::Published) => Err(Error::validation_invalid_argument(
             "tag",
             format!(
                 "Refusing to move '{}': a GitHub Release already exists for this tag",
@@ -333,16 +347,15 @@ fn require_unpublished_github_tag(component: &Component, tag_name: &str) -> Resu
             None,
             None,
         )),
-        None => Err(Error::validation_invalid_argument(
+        Some(super::executor::GhReleaseLookup::Indeterminate(blocker)) => Err(Error::validation_invalid_argument(
             "tag",
             format!(
-                "Refusing to move '{}': could not verify whether a GitHub Release exists",
-                tag_name
+                "Refusing to move '{}': could not verify whether a GitHub Release exists because {}",
+                tag_name,
+                blocker.describe()
             ),
             None,
-            Some(vec![
-                "Authenticate gh for this repository and retry release recovery.".to_string(),
-            ]),
+            Some(vec![blocker.remedy()]),
         )),
     }
 }

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -36,12 +36,14 @@ pub(crate) use git_push::run_git_push;
 pub use github_release::release_notes_path;
 pub(crate) use github_release::release_notes_path as github_release_notes_path;
 pub(crate) use github_release::run_github_release;
+pub(crate) use github_release::GhReleaseLookup;
 pub(crate) use package::{
     build_release_payload, run_extension_release_preflight, run_package, PackageRequest,
 };
 pub(crate) use publish::{publish_response_output, run_publish};
 pub(crate) use tagging::{
-    github_release_exists_for_tag, run_git_tag, run_tag_availability_preflight,
+    github_release_exists_for_tag, github_release_lookup_for_tag, run_git_tag,
+    run_tag_availability_preflight,
 };
 use version_targets::collect_version_target_mismatches;
 

--- a/crates/homeboy-release/src/release/executor/git_push.rs
+++ b/crates/homeboy-release/src/release/executor/git_push.rs
@@ -400,6 +400,80 @@ mod tests {
         );
     }
 
+    /// A remote that rejects the branch per-ref -- branch protection requiring a
+    /// pull request (issues #13529, #13677), or a rejected non-fast-forward
+    /// (issue #14139) -- must not leave the release tag behind on the remote.
+    /// Git updates refs independently unless the push is atomic, so without
+    /// `--atomic` the tag lands on a commit that never reached the branch and
+    /// every later recovery has to reason about a tag that points nowhere.
+    #[test]
+    fn run_git_push_leaves_no_tag_when_the_branch_ref_is_rejected() {
+        let local = tempfile::tempdir().expect("local tempdir");
+        let remote = tempfile::tempdir().expect("remote tempdir");
+        git(remote.path(), &["init", "--bare", "-b", "main"]);
+        git(
+            local.path(),
+            &["clone", remote.path().to_str().unwrap(), "."],
+        );
+        git(local.path(), &["config", "user.name", "Homeboy Test"]);
+        git(
+            local.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        std::fs::write(local.path().join("README.md"), "base").expect("write fixture");
+        git(local.path(), &["add", "."]);
+        git(local.path(), &["commit", "-m", "base"]);
+        git(local.path(), &["push", "origin", "main"]);
+
+        // Reject only branch updates, the way a protected default branch does.
+        // A `pre-receive` hook would reject the whole push and prove nothing;
+        // `update` runs per ref, which is the condition that strands the tag.
+        let hook = remote.path().join("hooks").join("update");
+        std::fs::write(
+            &hook,
+            "#!/bin/sh\ncase \"$1\" in refs/heads/*) echo \"remote: - Changes must be made through a pull request.\" >&2; exit 1;; esac\nexit 0\n",
+        )
+        .expect("write update hook");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod hook");
+        }
+
+        std::fs::write(local.path().join("release.txt"), "release").expect("write release");
+        git(local.path(), &["add", "."]);
+        git(local.path(), &["commit", "-m", "release: v1.0.0"]);
+        git(
+            local.path(),
+            &["tag", "-a", "v1.0.0", "-m", "Release v1.0.0"],
+        );
+
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: local.path().to_string_lossy().to_string(),
+            ..Component::default()
+        };
+
+        let result = run_git_push(&component, "fixture", Some("v1.0.0"), Some("main"))
+            .expect("push step should return result");
+
+        assert_eq!(
+            result.status,
+            ReleaseStepStatus::Failed,
+            "a rejected branch ref must fail the push step"
+        );
+        let tag_on_remote = Command::new("git")
+            .args(["show-ref", "--verify", "refs/tags/v1.0.0"])
+            .current_dir(remote.path())
+            .output()
+            .expect("git show-ref");
+        assert!(
+            !tag_on_remote.status.success(),
+            "the release tag must not reach the remote when the branch ref is rejected"
+        );
+    }
+
     #[test]
     fn test_is_non_fast_forward_rejection() {
         // The exact shape of git's stderr from issue #3611's failed push.

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -244,6 +244,126 @@ pub(crate) fn gh_release_exists(
     gh_probe_succeeds(github, config, &["release", "view", tag, "-R", repo_flag])
 }
 
+/// Outcome of asking GitHub whether a published Release exists for a tag.
+///
+/// `gh release view` exits non-zero both when the release is absent and when
+/// the query never reached GitHub, so a bare bool cannot tell "there is no
+/// release" from "nobody answered". Callers guarding a destructive tag move
+/// must not treat the second as the first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GhReleaseLookup {
+    /// GitHub answered and a published Release exists.
+    Published,
+    /// GitHub answered and no Release exists for the tag.
+    Absent,
+    /// The question could not be answered. Carries the operator-facing reason.
+    Indeterminate(GhLookupBlocker),
+}
+
+/// Why a release lookup could not be answered. Each variant maps to a different
+/// operator action, which is the whole reason they are kept apart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GhLookupBlocker {
+    /// The `gh` binary is not on PATH.
+    GhMissing,
+    /// `gh` is present but not authenticated for this host.
+    Unauthenticated { host: String },
+    /// `gh` ran and failed for some other reason -- connectivity, proxy, rate
+    /// limit, a 5xx. Carries the first line of its stderr.
+    QueryFailed { detail: String },
+}
+
+impl GhLookupBlocker {
+    /// Operator-facing description of what stopped the lookup.
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            Self::GhMissing => "the gh CLI is not installed".to_string(),
+            Self::Unauthenticated { host } => {
+                format!("gh is not authenticated for {host}")
+            }
+            Self::QueryFailed { detail } => {
+                format!("the GitHub query failed: {detail}")
+            }
+        }
+    }
+
+    /// The next action that actually addresses this blocker.
+    pub(crate) fn remedy(&self) -> String {
+        match self {
+            Self::GhMissing => {
+                "Install the gh CLI, then retry; moving a published release is destructive."
+                    .to_string()
+            }
+            Self::Unauthenticated { host } => format!(
+                "Run `gh auth login --hostname {host}`, then retry; moving a published release is destructive."
+            ),
+            Self::QueryFailed { .. } => {
+                "Restore connectivity to the GitHub host and retry; moving a published release is destructive."
+                    .to_string()
+            }
+        }
+    }
+}
+
+/// Ask GitHub whether a published Release exists for `tag`, preserving why the
+/// answer is unavailable when it is.
+pub(crate) fn gh_release_lookup(
+    github: &GitHubRepo,
+    config: &GithubConfig,
+    tag: &str,
+    repo_flag: &str,
+) -> GhReleaseLookup {
+    if !gh_is_available() {
+        return GhReleaseLookup::Indeterminate(GhLookupBlocker::GhMissing);
+    }
+    if !gh_is_authenticated(github, config) {
+        return GhReleaseLookup::Indeterminate(GhLookupBlocker::Unauthenticated {
+            host: github.host.clone(),
+        });
+    }
+
+    let output = gh_command(github, config, &["release", "view", tag, "-R", repo_flag]).output();
+
+    let output = match output {
+        Ok(output) => output,
+        Err(err) => {
+            return GhReleaseLookup::Indeterminate(GhLookupBlocker::QueryFailed {
+                detail: err.to_string(),
+            });
+        }
+    };
+    if output.status.success() {
+        return GhReleaseLookup::Published;
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if classify_release_view_stderr_as_absent(&stderr) {
+        GhReleaseLookup::Absent
+    } else {
+        GhReleaseLookup::Indeterminate(GhLookupBlocker::QueryFailed {
+            detail: first_meaningful_line(&stderr),
+        })
+    }
+}
+
+/// `gh release view` reports a missing release with a stable, specific message.
+/// Anything else on a non-zero exit is a failure to ask, not an answer.
+fn classify_release_view_stderr_as_absent(stderr: &str) -> bool {
+    let lowered = stderr.to_ascii_lowercase();
+    lowered.contains("release not found") || lowered.contains("no release found")
+}
+
+fn first_meaningful_line(stderr: &str) -> String {
+    stderr
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("no diagnostic output")
+        .chars()
+        .take(200)
+        .collect()
+}
+
 pub(crate) fn github_release_artifact_paths(state: &ReleaseState) -> Vec<String> {
     let authority_established = state
         .artifacts
@@ -1850,6 +1970,78 @@ pub(crate) fn github_cli_env(github: &GitHubRepo, config: &GithubConfig) -> Vec<
 
 #[cfg(test)]
 mod tests {
+    use super::{classify_release_view_stderr_as_absent, first_meaningful_line, GhLookupBlocker};
+
+    /// `gh release view` exits 1 both when the release is absent and when the
+    /// query never reached GitHub. Only the first is an answer; treating the
+    /// second as "no release exists" would let a destructive retag proceed
+    /// against a tag that may well have a published Release attached
+    /// (issue #14570).
+    #[test]
+    fn only_a_missing_release_counts_as_an_answer() {
+        // gh's wording when the repository resolved and the tag has no release.
+        assert!(classify_release_view_stderr_as_absent(
+            "release not found\n"
+        ));
+        assert!(classify_release_view_stderr_as_absent(
+            "HTTP 404: no release found"
+        ));
+
+        // Everything else on a non-zero exit is a failure to ask. Each of these
+        // previously collapsed to "no release exists".
+        for stderr in [
+            "error connecting to github.example.com\ncheck your internet connection",
+            "dial tcp: lookup github.example.com: no such host",
+            "HTTP 502: Bad Gateway",
+            "API rate limit exceeded",
+            "",
+        ] {
+            assert!(
+                !classify_release_view_stderr_as_absent(stderr),
+                "must not read {stderr:?} as a confirmed absent release"
+            );
+        }
+    }
+
+    /// The blocker drives operator-facing text, so each cause has to name its
+    /// own remedy. Reporting an unreachable host as an authentication problem
+    /// sends the operator to re-check credentials that were never at fault.
+    #[test]
+    fn each_blocker_names_its_own_cause_and_remedy() {
+        let missing = GhLookupBlocker::GhMissing;
+        assert!(missing.describe().contains("not installed"));
+        assert!(missing.remedy().contains("Install"));
+
+        let unauth = GhLookupBlocker::Unauthenticated {
+            host: "github.example.com".to_string(),
+        };
+        assert!(unauth.describe().contains("github.example.com"));
+        assert!(unauth.remedy().contains("gh auth login"));
+
+        let failed = GhLookupBlocker::QueryFailed {
+            detail: "error connecting to github.example.com".to_string(),
+        };
+        assert!(failed.describe().contains("error connecting"));
+        assert!(
+            failed.remedy().contains("connectivity"),
+            "a failed query must point at connectivity, not authentication"
+        );
+        assert!(
+            !failed.remedy().contains("gh auth login"),
+            "a failed query must not send the operator to re-authenticate"
+        );
+    }
+
+    #[test]
+    fn query_failure_detail_is_the_first_useful_stderr_line() {
+        assert_eq!(
+            first_meaningful_line("\n\n  error connecting to host\ncheck your connection\n"),
+            "error connecting to host"
+        );
+        assert_eq!(first_meaningful_line("   \n"), "no diagnostic output");
+        assert_eq!(first_meaningful_line(&"x".repeat(500)).len(), 200);
+    }
+
     /// #10519: resolving a just-created draft must not scan the release list.
     ///
     /// `releases/tags/{tag}` 404s for a draft by design, so the readback after

--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -29,9 +29,9 @@ pub(crate) use run::validate_declared_build_artifact;
 // non-test surface.
 pub(crate) use gh_cli::{
     download_small_release_asset, gh_failure_diagnostic, gh_is_authenticated, gh_is_available,
-    gh_release_exists, gh_release_metadata, github_release_publications,
+    gh_release_exists, gh_release_lookup, gh_release_metadata, github_release_publications,
     github_release_upload_timeout, reconcile_release_publications, run_gh_command,
-    validate_draft_adoption, verify_release_publications,
+    validate_draft_adoption, verify_release_publications, GhReleaseLookup,
 };
 
 // Re-exports consumed by the in-crate test suites — both this module's own

--- a/crates/homeboy-release/src/release/executor/tagging.rs
+++ b/crates/homeboy-release/src/release/executor/tagging.rs
@@ -242,13 +242,17 @@ fn inspect_release_tag_state(component: &Component, tag_name: &str) -> Result<Re
     })
 }
 
-/// Best-effort check for whether a published GitHub Release exists for `tag_name`.
+/// Whether a published GitHub Release exists for `tag_name`.
 ///
-/// Returns `Some(true)`/`Some(false)` when GitHub is reachable and the
-/// repository resolves, or `None` when it cannot be determined (no remote, `gh`
-/// unavailable/unauthenticated, or a non-GitHub remote). Callers that must not
-/// move a published release should treat `None` conservatively.
-pub(crate) fn github_release_exists_for_tag(component: &Component, tag_name: &str) -> Option<bool> {
+/// Returns `None` only when the component has no GitHub remote at all, which
+/// means there is no Release to protect. Every other outcome -- published,
+/// absent, or unanswerable -- is carried in the [`GhReleaseLookup`] so callers
+/// guarding a destructive tag move can tell "there is no release" from "nobody
+/// answered", and can name the actual blocker instead of guessing at one.
+pub(crate) fn github_release_lookup_for_tag(
+    component: &Component,
+    tag_name: &str,
+) -> Option<github_release::GhReleaseLookup> {
     component
         .remote_url
         .clone()
@@ -258,21 +262,24 @@ pub(crate) fn github_release_exists_for_tag(component: &Component, tag_name: &st
             ))
         })
         .and_then(|remote_url| homeboy_core::git::release_download::parse_github_url(&remote_url))
-        .and_then(|github| {
-            if !github_release::gh_is_available()
-                || !github_release::gh_is_authenticated(&github, &component.github)
-            {
-                return None;
-            }
-
+        .map(|github| {
             let repo_flag = format!("{}/{}", github.owner, github.repo);
-            Some(github_release::gh_release_exists(
-                &github,
-                &component.github,
-                tag_name,
-                &repo_flag,
-            ))
+            github_release::gh_release_lookup(&github, &component.github, tag_name, &repo_flag)
         })
+}
+
+/// Back-compatible view of [`github_release_lookup_for_tag`] for callers that
+/// only need "is it definitely published".
+///
+/// An unanswerable lookup collapses to `None` here, the same as it always has.
+/// Guards that must refuse on an unanswerable lookup call
+/// `github_release_lookup_for_tag` directly so they can report the reason.
+pub(crate) fn github_release_exists_for_tag(component: &Component, tag_name: &str) -> Option<bool> {
+    match github_release_lookup_for_tag(component, tag_name)? {
+        github_release::GhReleaseLookup::Published => Some(true),
+        github_release::GhReleaseLookup::Absent => Some(false),
+        github_release::GhReleaseLookup::Indeterminate(_) => None,
+    }
 }
 
 fn build_existing_tag_failure(

--- a/crates/homeboy-release/src/release/workflow_recover.rs
+++ b/crates/homeboy-release/src/release/workflow_recover.rs
@@ -246,7 +246,7 @@ pub(super) fn run_recover(
             current_version,
             &head_commit,
             |candidate_tag| {
-                crate::release::executor::github_release_exists_for_tag(&component, candidate_tag)
+                crate::release::executor::github_release_lookup_for_tag(&component, candidate_tag)
             },
         )? {
             return Ok((result, None, RECOVERY_INCOMPLETE_EXIT_CODE));
@@ -359,7 +359,7 @@ pub(super) fn run_recover(
 
         require_unpublished_github_release(
             &tag_name,
-            crate::release::executor::github_release_exists_for_tag(&component, &tag_name),
+            crate::release::executor::github_release_lookup_for_tag(&component, &tag_name),
         )?;
 
         if input.dry_run {
@@ -399,7 +399,7 @@ pub(super) fn run_recover(
 
         require_unpublished_github_release(
             &tag_name,
-            crate::release::executor::github_release_exists_for_tag(&component, &tag_name),
+            crate::release::executor::github_release_lookup_for_tag(&component, &tag_name),
         )?;
 
         if tag_exists_local {
@@ -658,7 +658,7 @@ fn recreate_divergent_unpublished_release<F>(
     github_release_exists: F,
 ) -> Result<Option<ReleaseCommandResult>>
 where
-    F: Fn(&str) -> Option<bool>,
+    F: Fn(&str) -> Option<crate::release::executor::GhReleaseLookup>,
 {
     // Recovery must inspect the highest release identity even when it is not
     // reachable from HEAD; that divergence is the state this path repairs.
@@ -945,24 +945,54 @@ fn require_interrupted_release_lineage(
     ))
 }
 
-fn require_unpublished_github_release(tag_name: &str, exists: Option<bool>) -> Result<()> {
-    match exists {
-        Some(false) => Ok(()),
-        Some(true) => Err(Error::validation_invalid_argument(
+/// Refuse to move a tag unless GitHub positively confirms no Release is
+/// attached to it.
+///
+/// Only a confirmed [`GhReleaseLookup::Absent`] permits the move. Everything
+/// else refuses, because moving a published release is destructive and an
+/// unanswered lookup is not evidence of absence.
+///
+/// The refusal names the blocker that actually stopped the lookup. A missing
+/// binary, an unauthenticated host, and an unreachable host each need a
+/// different action, and reporting all three as an authentication problem sends
+/// the operator to re-check credentials that were never at fault (issue #14570).
+fn require_unpublished_github_release(
+    tag_name: &str,
+    lookup: Option<crate::release::executor::GhReleaseLookup>,
+) -> Result<()> {
+    use crate::release::executor::GhReleaseLookup;
+    match lookup {
+        Some(GhReleaseLookup::Absent) => Ok(()),
+        None => Err(Error::validation_invalid_argument(
+            "retag",
+            format!(
+                "Refusing to retag '{}': could not verify whether a GitHub Release exists because no GitHub remote resolved for this component",
+                tag_name
+            ),
+            None,
+            Some(vec![
+                "Configure the component's GitHub remote, then retry; moving a published release is destructive."
+                    .to_string(),
+            ]),
+        )),
+        Some(GhReleaseLookup::Published) => Err(Error::validation_invalid_argument(
             "retag",
             format!("Refusing to retag '{}': a GitHub Release already exists", tag_name),
             None,
             None,
         )),
-        None => Err(Error::validation_invalid_argument(
-            "retag",
-            format!(
-                "Refusing to retag '{}': could not verify whether a GitHub Release exists",
-                tag_name
-            ),
-            None,
-            Some(vec!["Authenticate gh for this repository and retry; moving a published release is destructive.".to_string()]),
-        )),
+        Some(GhReleaseLookup::Indeterminate(blocker)) => {
+            Err(Error::validation_invalid_argument(
+                "retag",
+                format!(
+                    "Refusing to retag '{}': could not verify whether a GitHub Release exists because {}",
+                    tag_name,
+                    blocker.describe()
+                ),
+                None,
+                Some(vec![blocker.remedy()]),
+            ))
+        }
     }
 }
 
@@ -1486,7 +1516,7 @@ mod tests {
                 &main_before,
                 |tag| {
                     assert_eq!(tag, "v0.1.1");
-                    Some(false)
+                    Some(crate::release::executor::GhReleaseLookup::Absent)
                 },
             )
             .expect("recovery succeeds")
@@ -1623,7 +1653,7 @@ mod tests {
                 &scope,
                 "0.1.1",
                 &retry_head,
-                |_| Some(false),
+                |_| Some(crate::release::executor::GhReleaseLookup::Absent),
             )
             .expect("retry recovery succeeds")
             .expect("equal-version divergent release detected");

--- a/docs/commands/git.md
+++ b/docs/commands/git.md
@@ -76,14 +76,17 @@ Homeboy auto-detects single vs bulk commit specs by checking for a top-level `co
 ### Push
 
 ```sh
-homeboy git push [component_id] [--tags] [--force-with-lease] [--path <path>]
+homeboy git push [component_id] [--tags] [--atomic] [--force-with-lease] [--path <path>]
 ```
 
 `push --force-with-lease` is the safe post-rebase force-push path. It refuses to overwrite the remote if it has commits the local ref has not seen. Plain `--force` is intentionally not exposed.
 
+`push --atomic` updates every ref in the push or none of them. Without it git updates refs independently, so a remote that rejects one ref still accepts the others — a protected branch can reject the branch while the tag from the same push lands, leaving the tag on a commit the branch never received. Release pushes always set it.
+
 ```sh
 homeboy git push
 homeboy git push --tags
+homeboy git push --tags --atomic
 homeboy git push --force-with-lease
 ```
 
@@ -354,11 +357,12 @@ Notes:
 {
   "component_ids": ["homeboy", "sample-plugin"],
   "tags": true,
+  "atomic": false,
   "force_with_lease": false
 }
 ```
 
-`tags` and `force_with_lease` are only used by `push`.
+`tags`, `atomic`, and `force_with_lease` are only used by `push`.
 
 ## JSON Output
 


### PR DESCRIPTION
Fixes #14570. Addresses the stranded-tag condition behind #13529, #13677, and #14139.

Two bugs in the release push/recovery path. Both were found while releasing a component through a protected default branch.

## 1. The release push strands its tag when the branch is rejected

`push_release_branch` issues one `git push --follow-tags HEAD:refs/heads/<branch>`. Git updates refs independently, so a remote that rejects the branch **per ref** still accepts the tag from that same push. The release fails with its tag already published on a commit the branch never received.

Two open reports are this same condition from different triggers:

| Trigger | Report |
| --- | --- |
| Protected branch requires a pull request | #13529, #13677 |
| Remote advanced → non-fast-forward | #14139 |

`git_push.rs` already described the outcome in a comment — *"typically leaving the tag pushed but the branch behind"* — and built recovery machinery around it. `--atomic` removes the state instead of recovering from it.

Reproduced against a fixture whose `update` hook rejects only branch refs, the way branch protection does:

```
WITHOUT --atomic          WITH --atomic
 * [new tag] v1 -> v1      ! [remote rejected] HEAD -> main (hook declined)
 ! [remote rejected] HEAD  ! [remote rejected] v1 -> v1 (atomic push failure)
 -> tags stranded: 1       -> tags stranded: 0
```

A `pre-receive` hook would reject the whole push and prove nothing — it is `update`, running per ref, that produces the split. The regression test uses that fixture and fails without the flag.

`atomic` is exposed on `PushOptions` and `homeboy git push` because the property is generic to any push carrying a branch and its tag. It defaults to off, so no existing caller changes behaviour. Release pushes set it.

**This does not implement the `--via-pull-request` mode #13677 asks for.** It removes the orphaned tag that makes the manual recovery destructive; the native PR-gated release path is still open work.

## 2. The published-release guard fails open

`gh release view` exits non-zero both when a release is absent and when the query never reached GitHub:

```
absent   exit=1  stderr=release not found
netfail  exit=1  stderr=error connecting to <host>
```

`gh_release_exists` ran it through a probe that discards stderr and maps every non-zero exit to `false`. So connectivity failures, 502s, and rate limits all read as *"no release exists"* — and that answer feeds the guard protecting a destructive tag move. A tag whose published Release could not be checked was treated as unpublished, and the retag proceeded.

The filed symptom in #14570 was the misleading hint. The fail-open is the more serious half and is fixed here too.

`Option<bool>` becomes a three-state lookup. `Absent` and `Published` are answers; anything else is `Indeterminate` carrying why — `gh` missing, `gh` unauthenticated for the host, or a query that failed with its first stderr line. Absence is claimed only on gh's own `release not found` wording.

Both guards refuse on `Indeterminate` and name the blocker that actually stopped the lookup, each with the remedy that addresses it. Previously every case printed *"Authenticate gh for this repository and retry"*, which sends the operator to re-check credentials that were never at fault when the host was simply unreachable.

A component with no GitHub remote still refuses, unchanged — relaxing that would add a permissive path to a destructive guard, which this change does not need to do. The non-destructive planning path in `workflow.rs` keeps the bool view and now declines to propose publishing a release it could not confirm was missing.

## Verification

- `cargo test -p homeboy-release` — **581 passed, 0 failed**
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets` warning count unchanged (475 before, 475 after)
- Both new behaviours have tests that fail without their fix. Verified by reverting each and re-running:
  - `run_git_push_leaves_no_tag_when_the_branch_ref_is_rejected` → *"the release tag must not reach the remote when the branch ref is rejected"*
  - `only_a_missing_release_counts_as_an_answer`, `each_blocker_names_its_own_cause_and_remedy`

The full `--workspace` suite is nondeterministic under parallelism on this machine — 51 failures on clean `origin/main`, 106 on the branch, with the difference concentrated in daemon, temp-retention, and provider-scheduler tests that have no path to `PushOptions`. Sampled "new" failures pass in isolation on the branch, and per-crate totals are at or better than baseline:

| Crate | Baseline | With changes |
| --- | --- | --- |
| `homeboy-core` | 3606 / 39 failed | 3608 / **37** failed |
| `homeboy-agents` | 2331 / 40 failed | 2352 / **19** failed |
| `homeboy-release` | — | 581 / **0** failed |

AI assistance: GPT-6 Astra via OpenCode, under Chris Huber's direction, reproduced both failures against git fixtures and the `gh` CLI, traced them to `push_release_branch` and `gh_probe_succeeds`, implemented the fixes and regression coverage, and confirmed each test fails without its fix. Chris Huber remains responsible for review.
