### PR TITLE
Validate Cook attempts against the canonical index

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -2410,6 +2410,51 @@ fn cook_index_keeps_repeated_attempts_unique_with_stable_latest_alias() {
     assert!(path.display().to_string().contains(&second_run_id));
 }
 
+/// (#14579). SQLite owns the Cook index; the file beside it is a derived
+/// projection this module writes best effort and deliberately exercises
+/// failing. Attempt validation therefore has to read the canonical projection:
+/// trusting the file skipped validation entirely whenever that write was lost,
+/// which let one run claim two different attempt numbers.
+#[test]
+fn cook_attempt_validation_survives_a_missing_derived_index_file() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    let aggregate = succeeded_aggregate(&plan);
+    let cook_id = "cook-issue-14579";
+    let run_id = cook_attempt_run_id(cook_id, 1);
+
+    let mut record = lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, &run_id, |_| Ok(json!({})))
+        .expect("attempt recorded");
+    record_aggregate_in_store(&lifecycle_store, &mut record, &plan, &aggregate)
+        .expect("attempt aggregate recorded");
+    record_cook_attempt_in_store(&lifecycle_store, cook_id, 1, &run_id).expect("attempt indexed");
+
+    // Reproduce the state the projection-write failure hook exists to create.
+    let derived = lifecycle_store.cook_index_path(cook_id);
+    assert!(derived.exists(), "the derived projection is written first");
+    std::fs::remove_file(&derived).expect("drop the derived Cook index projection");
+
+    let error = record_cook_attempt_in_store(&lifecycle_store, cook_id, 2, &run_id)
+        .expect_err("one run cannot also claim a second attempt number");
+    assert_eq!(
+        error.code,
+        homeboy_core::ErrorCode::ValidationInvalidArgument
+    );
+    assert_eq!(
+        error.details["problem"],
+        "durable Cook index maps this run to a different attempt"
+    );
+
+    // The canonical index is untouched by the rejected registration.
+    let index = cook_index_in_store(&lifecycle_store, cook_id).expect("canonical index readable");
+    assert_eq!(index.latest_run_id, run_id);
+    assert_eq!(index.attempts.len(), 1);
+    assert_eq!(index.attempts[0].attempt, 1);
+}
+
 #[test]
 fn run_record_exists_resolves_a_cook_id_to_its_latest_run() {
     // #8390: the Lab retry handoff guarded on the exact-match `run_record_exists`,

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -2157,11 +2157,13 @@ pub(super) fn validate_cook_index_attempt_in_store(
 ) -> Result<()> {
     let cook_id = sanitize_run_id(cook_id);
     let run_id = sanitize_run_id(run_id);
-    let path = store.cook_index_path(&cook_id);
-    if !path.exists() {
+    // SQLite owns the Cook index. The filesystem copy is a derived projection
+    // this module writes best effort and deliberately exercises failing, so
+    // reading it here would skip validation whenever that write was lost and
+    // reject a valid attempt whenever it went stale.
+    let Some(index) = projected_cook_index_in_store(store, &cook_id)? else {
         return Ok(());
-    }
-    let index: AgentTaskCookIndex = read_json(&path)?;
+    };
     if index.cook_id != cook_id {
         return Err(Error::validation_invalid_argument(
             "cook_id",


### PR DESCRIPTION
## Summary

`validate_cook_index_attempt_in_store` is the guard that stops one run from being registered under two different Cook attempt numbers. It read the **filesystem** Cook index and returned `Ok(())` whenever that file was absent, so the guard disappeared exactly when the file did.

Since #13697, SQLite owns the Cook index and the file is a derived compatibility projection: `read_cook_index_in_store` rewrites it best effort and discards failures, and the module ships a `FAIL_NEXT_COOK_INDEX_PROJECTION_WRITE` hook whose purpose is to exercise that write failing while the SQLite projection is already committed. The design guarantees the file can be missing or stale; the validator treated it as truth.

- read the canonical projection through `projected_cook_index_in_store`
- absence of the derived file no longer means "no index"; only an absent SQLite projection is a legitimate skip

Fixes #14579.

## Consequences this closes

1. **Fail-open.** With the file gone and SQLite holding a complete index, the guard validated nothing and a run could claim a conflicting attempt number.
2. **False rejection.** With a stale file, it rejected a registration SQLite considered valid — observed as a real test failure while fixing #13697.

## Coverage

`cook_attempt_validation_survives_a_missing_derived_index_file` indexes an attempt, deletes the derived projection to reproduce the state the failure hook exists to create, and requires the conflicting registration to be rejected and the canonical index to stay intact.

It fails on `main` — the conflicting registration is accepted — and passes here.

## Verification

- new test fails without the source change and passes with it
- `cargo test -p homeboy-agents --lib` — 2368 passing; the 17 local failures reproduce on `main` in this environment, and the 3 that differ between runs pass individually (provider readiness/scheduler timing flakes under parallel load)
- `cargo fmt --all -- --check`, `cargo check --workspace --tests`, `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Terra via OpenCode found this while fixing the #13697 regression set, filed #14579 with the authority-split evidence, and implemented this fix and its regression test under Chris Huber's direction.