### PR TITLE
fix(release): report an incomplete release and undo its tag

### DIFF
--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -521,6 +521,10 @@ fn bounded_release_projection(payload: &Value, exit_code: i32, output_file: Opti
         "warnings": warnings,
         "evidence_refs": evidence_refs,
         "failure": failure,
+        // An incomplete release already knows how to finish itself. Dropping
+        // this is what reported a recovered-but-unpublished release as an
+        // unexplained failure while holding the exact command (#14577).
+        "continuation_command": result.get("continuation_command").and_then(Value::as_str).map(bounded_release_text),
         "full_command": format!("homeboy release {} --full", bounded_release_text(result.get("component_id").and_then(Value::as_str).unwrap_or("<component>"))),
         "output": output_file.map(bounded_release_text),
     });

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -1356,6 +1356,47 @@ fn cook_batch_child_failure_digest(
     })
 }
 
+/// Report a release that stopped short of publication without failing a step.
+///
+/// The operator needs the state it reached and the command that finishes it,
+/// both of which the release already computed.
+fn incomplete_release_digest(data: &Value) -> Option<CommandFailureDigest> {
+    let status = data
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("incomplete");
+    let continuation = data.get("continuation_command").and_then(Value::as_str);
+    let tag = data.get("tag").and_then(Value::as_str);
+    let summary = match (tag, continuation) {
+        (Some(tag), Some(command)) => format!(
+            "Release is incomplete ({status}) at tag {tag}; publication has not run. Continue with: {}",
+            bounded_text(command, 400)
+        ),
+        (None, Some(command)) => format!(
+            "Release is incomplete ({status}); publication has not run. Continue with: {}",
+            bounded_text(command, 400)
+        ),
+        (Some(tag), None) => {
+            format!("Release is incomplete ({status}) at tag {tag}; publication has not run.")
+        }
+        (None, None) => format!("Release is incomplete ({status}); publication has not run."),
+    };
+    Some(CommandFailureDigest {
+        summary,
+        stdout_tail: None,
+        stderr_tail: None,
+        artifact_refs: Vec::new(),
+        next_actions: continuation
+            .map(|command| {
+                CommandNextAction::new("finish the release", command)
+                    .with_kind(CommandNextActionKind::Repair)
+            })
+            .into_iter()
+            .collect(),
+        retryable: None,
+    })
+}
+
 /// Lift the first failed release step into the bounded command envelope. The
 /// complete plan and step payload remain available under `data` for inspection.
 fn release_failure_digest(data: &Value) -> Option<CommandFailureDigest> {
@@ -1364,7 +1405,15 @@ fn release_failure_digest(data: &Value) -> Option<CommandFailureDigest> {
     }
 
     if data.get("schema").and_then(Value::as_str) == Some("homeboy/release-operator-summary/v1") {
-        let failure = data.get("failure")?;
+        // A release can end incomplete without any step failing: `--recover`
+        // finishes git state, then reports that publication still has to run.
+        // `failure` is null there, and treating that as a failed step rendered
+        // "release step unknown (unknown) failed: release step failed without a
+        // reported error" over a release that knew its own next command (#14577).
+        let failure = match data.get("failure").filter(|failure| !failure.is_null()) {
+            Some(failure) => failure,
+            None => return incomplete_release_digest(data),
+        };
         let step = failure
             .get("step")
             .and_then(Value::as_str)
@@ -3015,6 +3064,94 @@ mod tests {
                 "{step} must not recommend a plan-only dry run"
             );
         }
+    }
+
+    /// `--recover` finishes git state and then reports, by design, that
+    /// publication still has to run. No step failed, so `failure` is null. This
+    /// is the payload that used to render "release step unknown (unknown)
+    /// failed: release step failed without a reported error" while the release
+    /// was holding the one command that finishes it.
+    fn recovered_incomplete_payload() -> Value {
+        json!({
+            "schema": "homeboy/release-operator-summary/v1",
+            "command": "release",
+            "exit_code": 4,
+            "component": "demo",
+            "status": "git_recovered",
+            "phase": "recover",
+            "tag": "v1.2.3",
+            "failure": Value::Null,
+            "continuation_command": "homeboy release demo --head --apply",
+        })
+    }
+
+    #[test]
+    fn incomplete_release_reports_its_continuation_command() {
+        let digest = release_failure_digest(&recovered_incomplete_payload()).expect("digest");
+
+        assert!(
+            !digest.summary.contains("without a reported error"),
+            "a release that stopped short of publication is not an unexplained step failure: {}",
+            digest.summary
+        );
+        assert!(
+            !digest.summary.contains("unknown"),
+            "the release knows its state; it must not be reported as unknown: {}",
+            digest.summary
+        );
+        assert!(
+            digest.summary.contains("git_recovered") && digest.summary.contains("v1.2.3"),
+            "the operator needs the state and tag actually reached: {}",
+            digest.summary
+        );
+
+        let action = digest
+            .next_actions
+            .first()
+            .expect("an incomplete release must hand back the command that finishes it");
+        assert_eq!(action.command, "homeboy release demo --head --apply");
+    }
+
+    /// The continuation command is the whole point of the digest, so it has to
+    /// survive the projection that builds the envelope, not just the type.
+    #[test]
+    fn incomplete_release_without_continuation_still_explains_itself() {
+        let mut payload = recovered_incomplete_payload();
+        payload["continuation_command"] = Value::Null;
+
+        let digest = release_failure_digest(&payload).expect("digest");
+
+        assert!(
+            digest.summary.contains("git_recovered"),
+            "state must still be reported: {}",
+            digest.summary
+        );
+        assert!(!digest.summary.contains("without a reported error"));
+    }
+
+    /// A real failed step must keep its own diagnosis; the incomplete path is
+    /// only for releases that stopped without failing anything.
+    #[test]
+    fn failed_step_still_reports_the_step_failure() {
+        let mut payload = recovered_incomplete_payload();
+        payload["status"] = json!("partial");
+        payload["failure"] = json!({
+            "step": "git.push",
+            "type": "git.push",
+            "cause": "push declined due to repository rule violations",
+            "reproduction_commands": ["homeboy release demo --dry-run"],
+        });
+
+        let digest = release_failure_digest(&payload).expect("digest");
+
+        assert!(digest.summary.contains("git.push"), "{}", digest.summary);
+        assert!(
+            digest
+                .summary
+                .contains("push declined due to repository rule violations"),
+            "{}",
+            digest.summary
+        );
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/checkout_guard.rs
+++ b/crates/homeboy-release/src/release/checkout_guard.rs
@@ -57,6 +57,12 @@ impl ReleaseCheckoutGuard {
         }))
     }
 
+    /// The checkout this guard restores, so rollback can undo non-checkout
+    /// state (a created tag) against the same repository.
+    pub(super) fn path(&self) -> &str {
+        &self.path
+    }
+
     pub(super) fn restore_after_failure(&self) -> Result<CheckoutRestoreEvidence> {
         self.restore_after_failure_with_hook(|| {})
     }

--- a/crates/homeboy-release/src/release/executor/tagging.rs
+++ b/crates/homeboy-release/src/release/executor/tagging.rs
@@ -138,6 +138,10 @@ pub(crate) fn run_git_tag(
     // Bind the tag operation to the exact release commit for durable operator
     // summaries and recovery evidence; GitOutput itself only records streams.
     data["head"] = serde_json::json!(head_commit);
+    // Name the tag this step created. Rollback has to undo exactly the tag this
+    // run made, and without the name it could only record that some tag was
+    // created while leaving it behind (#14577).
+    data["tag"] = serde_json::json!(tag_name);
 
     if !output.success {
         let mut hints = Vec::new();

--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -236,12 +236,26 @@ fn restore_checkout_after_failed_run(
         let restored = evidence.restored;
         let recovery_action =
             (!restored).then(|| format!("homeboy release {} --apply", run.component_id));
-        let tag_state = if run.result.steps.iter().any(|step| {
-            step.step_type == "git.tag" && matches!(step.status, ReleaseStepStatus::Success)
-        }) {
-            "local_tag_created"
-        } else {
-            "not_created"
+        // Restoring HEAD discards the release commit, which leaves any tag this
+        // run created pointing at an object no longer reachable from the branch.
+        // Reporting that as `local_tag_created` and stopping is what made the
+        // next release refuse to run at all: it saw a tag ahead of the source
+        // version and unreachable from HEAD, and declined to reconcile an
+        // orphaned release identity. Rollback owns undoing what the run did, so
+        // delete the tag here rather than leaving an operator to find it (#14577).
+        let tag_state = match created_local_tag(run) {
+            Some(tag) => match homeboy_core::git::delete_local_tag(checkout_guard.path(), &tag) {
+                Ok(output) if output.success => "deleted",
+                // A tag that survives is the operator's problem to see, not to
+                // discover later through an unrelated failure.
+                _ => {
+                    run.result.warnings.push(format!(
+                        "Release rollback could not delete local tag {tag}; delete it before the next release: git tag -d {tag}"
+                    ));
+                    "local_tag_retained"
+                }
+            },
+            None => "not_created",
         };
         run.result.rollback = Some(ReleaseRollbackEvidence {
             status: if restored { "restored" } else { "interrupted" }.to_string(),
@@ -274,6 +288,24 @@ fn restore_checkout_after_failed_run(
     Ok(())
 }
 
+/// The tag this run created, if it created one.
+///
+/// A tag step that skipped because the tag already existed and pointed at HEAD
+/// did not create anything, so rollback must leave that tag alone.
+fn created_local_tag(run: &ReleaseRun) -> Option<String> {
+    run.result
+        .steps
+        .iter()
+        .filter(|step| {
+            step.step_type == "git.tag" && matches!(step.status, ReleaseStepStatus::Success)
+        })
+        .filter_map(|step| step.data.as_ref())
+        .find(|data| data.get("skipped").and_then(serde_json::Value::as_bool) != Some(true))
+        .and_then(|data| data.get("tag"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
 fn release_was_pushed(steps: &[ReleaseStepResult]) -> bool {
     steps.iter().any(|step| {
         step.step_type == "git.push" && matches!(step.status, ReleaseStepStatus::Success)
@@ -282,8 +314,136 @@ fn release_was_pushed(steps: &[ReleaseStepResult]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::release_was_pushed;
-    use crate::release::types::{ReleaseStepResult, ReleaseStepStatus};
+    use super::{release_was_pushed, restore_checkout_after_failed_run};
+    use crate::release::checkout_guard::ReleaseCheckoutGuard;
+    use crate::release::types::{
+        ReleaseRun, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
+    };
+    use homeboy_core::component::Component;
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git");
+        assert!(
+            status.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&status.stderr)
+        );
+    }
+
+    fn git_stdout(dir: &std::path::Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_repo() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_git(dir, &["init", "-q", "--initial-branch", "main"]);
+        run_git(dir, &["config", "user.email", "homeboy@example.com"]);
+        run_git(dir, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(dir.join("file.txt"), "main\n").expect("write");
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "Initial commit"]);
+        temp
+    }
+
+    fn tag_step(data: serde_json::Value) -> ReleaseStepResult {
+        ReleaseStepResult {
+            id: "git.tag".to_string(),
+            step_type: "git.tag".to_string(),
+            status: ReleaseStepStatus::Success,
+            data: Some(data),
+            ..Default::default()
+        }
+    }
+
+    fn failed_run(steps: Vec<ReleaseStepResult>) -> ReleaseRun {
+        ReleaseRun {
+            component_id: "fixture".to_string(),
+            enabled: true,
+            result: ReleaseRunResult {
+                steps,
+                status: ReleaseStepStatus::Failed,
+                warnings: Vec::new(),
+                summary: None,
+                phase_timings: None,
+                rollback: None,
+            },
+        }
+    }
+
+    /// Rolling back discards the release commit, so a tag this run created is
+    /// left pointing at an unreachable object. Leaving it behind made the next
+    /// release refuse to start at all, seeing a tag ahead of the source version
+    /// and unreachable from HEAD.
+    #[test]
+    fn rollback_deletes_the_tag_the_failed_run_created() {
+        let temp = init_repo();
+        let dir = temp.path();
+        let original_head = git_stdout(dir, &["rev-parse", "HEAD"]);
+        let guard = ReleaseCheckoutGuard::capture(&Component {
+            id: "fixture".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        })
+        .expect("capture")
+        .expect("git repo");
+
+        // Stand in for the release: a version commit, then its tag.
+        std::fs::write(dir.join("file.txt"), "released\n").expect("write");
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "release: v1.2.3"]);
+        run_git(dir, &["tag", "-a", "v1.2.3", "-m", "Release v1.2.3"]);
+        assert_eq!(git_stdout(dir, &["tag", "-l", "v1.2.3"]), "v1.2.3");
+
+        let mut run = failed_run(vec![tag_step(serde_json::json!({"tag": "v1.2.3"}))]);
+        restore_checkout_after_failed_run(Some(&guard), &mut run).expect("rollback");
+
+        assert_eq!(git_stdout(dir, &["rev-parse", "HEAD"]), original_head);
+        assert_eq!(
+            git_stdout(dir, &["tag", "-l", "v1.2.3"]),
+            "",
+            "a rolled-back release must not leave its tag behind to block the next one"
+        );
+        let rollback = run.result.rollback.expect("rollback evidence");
+        assert_eq!(rollback.tag_state, "deleted");
+    }
+
+    /// A tag the run found already pointing at HEAD is not the run's to remove.
+    #[test]
+    fn rollback_keeps_a_tag_the_run_did_not_create() {
+        let temp = init_repo();
+        let dir = temp.path();
+        run_git(dir, &["tag", "-a", "v1.2.3", "-m", "Pre-existing"]);
+        let guard = ReleaseCheckoutGuard::capture(&Component {
+            id: "fixture".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        })
+        .expect("capture")
+        .expect("git repo");
+
+        let mut run = failed_run(vec![tag_step(
+            serde_json::json!({"tag": "v1.2.3", "skipped": true}),
+        )]);
+        restore_checkout_after_failed_run(Some(&guard), &mut run).expect("rollback");
+
+        assert_eq!(
+            git_stdout(dir, &["tag", "-l", "v1.2.3"]),
+            "v1.2.3",
+            "rollback must not delete a tag that existed before the release ran"
+        );
+        let rollback = run.result.rollback.expect("rollback evidence");
+        assert_eq!(rollback.tag_state, "not_created");
+    }
 
     #[test]
     fn published_push_prevents_checkout_rollback_after_deploy_failure() {


### PR DESCRIPTION
## What happened

Releasing `a8c-intelligence v0.8.12` today, `homeboy release --recover --apply` printed:

```
Release step unknown (unknown) failed: release step failed without a reported error
```

The release had not failed. It had recovered git state, pushed the tag, and returned `git_recovered` / exit `4` — the documented `RECOVERY_INCOMPLETE_EXIT_CODE`, meaning *publication still has to run*. It had already computed the command that finishes it:

```
homeboy release a8c-intelligence --head --apply
```

Running that one command published the release immediately: `status: released`, exit 0, 9/9 gates.

I spent the intervening time investigating disk space and hand-assembling a release branch, because the tool was printing a placeholder instead of the answer it was holding.

## Root cause

Two independent defects that compound.

**1. The envelope discards the release's own diagnosis.**

`--recover` sets `continuation_command` and `release_summary` on `ReleaseCommandResult` (`workflow_recover.rs:417-455`). The `homeboy/release-operator-summary/v1` projection carries neither — there is no `continuation_command` key in the output.

Because no *step* failed, `failure` is `null`. `release_failure_digest()` did `data.get("failure")?`, which does not short-circuit on `Value::Null`, so every field fell through to its placeholder and a successful partial recovery was rendered as an unexplained step failure.

This is the same defect the step-failure path already fixed, documented in this very function (`response.rs:1149-1153`):

> *"The step already classified itself (`reason: "gh-upload-failed"`) and already computed the repair command. Dropping both here is what left CI printing `Release failed: Unknown error` while holding the exact fix (#10441)."*

The `--recover` path was missed.

**2. Rollback leaks the tag it created.**

`restore_checkout_after_failed_run()` restores HEAD — discarding the release commit — then records `tag_state: "local_tag_created"` and leaves the tag on disk, now pointing at an unreachable object. The *next* release refuses to start:

```
Latest release tag v0.8.12 is ahead of source version 0.8.11 but is not
reachable from HEAD. Refusing to reconcile an orphaned release identity.
```

Recovering from one failed release required a manual `git tag -d` that nothing told me to run. I hit this twice in one session.

## Change

- Carry `continuation_command` in the operator-summary projection.
- Report a release that stopped short of publication as **incomplete**, naming the status and tag it reached, with the continuation command as its next action. A genuinely failed step keeps its existing diagnosis.
- Rollback **deletes** the tag the failed run created and reports `deleted`. A tag that was skipped because it already existed is not the run's to remove and is left alone. A tag that cannot be deleted becomes a warning naming the exact command, rather than an unrelated refusal later.
- `git.tag` records the tag name it created, so rollback can undo exactly that tag.

## Verification

Every new test was confirmed to **fail against the previous implementation** before passing against this one.

Reverting the digest guard reproduces the production string verbatim:

```
state must still be reported: Release step unknown (unknown) failed:
release step failed without a reported error
```

Reverting the rollback change observes the surviving tag:

```
a rolled-back release must not leave its tag behind to block the next one
  left: "v1.2.3"
 right: ""
```

`homeboy-release` lib suite: **583 passed, 0 failed.** `response::` + `json_output`: **70 passed, 0 failed.** `cargo fmt --check` clean; the one clippy hit in the touched file is pre-existing (`orchestrator.rs:188`).

Eight `agent_task` lifecycle/promotion failures exist on this base with these changes stashed, so they are pre-existing and unrelated. A full `homeboy-cli --lib` run also aborts with a stack overflow in an unrelated bench test on clean `main`.

## Not addressed

`homeboy release` pushes the release commit **directly to the target branch**. On a repo whose branch requires pull requests, `git.push` is rejected outright — that is what triggered this whole sequence. Deciding between a release-PR mode and a documented direct-push requirement is a larger design question and is left out of this fix.

AI assistance: GPT-6 Astra via OpenCode, under Chris Huber's direction, traced the root cause from a live release failure, wrote the fix and its coverage, and confirmed each test fails against the prior implementation. Chris Huber remains responsible for review.
