### PR TITLE
Honor dependency overrides and admit reusable task worktrees

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -46,6 +46,10 @@ pub struct RunnerWorkspaceSyncOptions {
     pub git_fetch_refs: Vec<String>,
     pub snapshot_includes: Vec<String>,
     pub allow_dirty_lab_workspace: bool,
+    /// Explicit validation-dependency selection from the command settings.
+    /// `None` preserves manifest discovery; `Some`, including an empty list,
+    /// replaces it for this invocation.
+    pub validation_dependency_ids: Option<Vec<String>>,
     /// Opaque job-owned token folded into the deterministic remote workspace
     /// path so two distinct executions at the same source HEAD never share a
     /// mutable remote checkout.

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -3132,6 +3132,35 @@ fn annotate_cook_controller_preparation_error(mut error: Error, runner_id: &str)
     )
 }
 
+fn inject_effective_validation_dependency_setting(
+    settings: &crate::commands::utils::args::SettingArgs,
+    profile_values: &[(String, serde_json::Value)],
+    mut args: Vec<String>,
+) -> homeboy::core::Result<Vec<String>> {
+    let Some(value) = settings.effective_json_override("validation_dependencies", profile_values)
+    else {
+        return Ok(args);
+    };
+    let metadata = serde_json::to_string(&value).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize effective validation dependency setting".to_string()),
+        )
+    })?;
+    let insertion = args
+        .iter()
+        .position(|arg| arg == "--")
+        .unwrap_or(args.len());
+    args.splice(
+        insertion..insertion,
+        [
+            "--homeboy-validation-dependencies-json".to_string(),
+            metadata,
+        ],
+    );
+    Ok(args)
+}
+
 fn inline_portable_settings_profiles(
     cli: &Cli,
     args: &[String],
@@ -3150,7 +3179,7 @@ fn inline_portable_settings_profiles(
         _ => return Ok(args.to_vec()),
     };
     if settings.settings_json_file.is_empty() {
-        return Ok(args.to_vec());
+        return inject_effective_validation_dependency_setting(settings, &[], args.to_vec());
     }
 
     let profile_values = settings.settings_profile_json_overrides()?;
@@ -3195,7 +3224,7 @@ fn inline_portable_settings_profiles(
             Error::internal_unexpected("settings profile normalization lost the portable command")
         })?;
     let mut portable_profile_args = Vec::with_capacity(profile_values.len() * 2);
-    for (key, value) in profile_values {
+    for (key, value) in &profile_values {
         let value = serde_json::to_string(&value).map_err(|error| {
             Error::internal_json(
                 error.to_string(),
@@ -3206,7 +3235,7 @@ fn inline_portable_settings_profiles(
         portable_profile_args.push(format!("{key}={value}"));
     }
     rewritten.splice(insertion..insertion, portable_profile_args);
-    Ok(rewritten)
+    inject_effective_validation_dependency_setting(settings, &profile_values, rewritten)
 }
 
 fn credential_shaped_setting_key(key: &str, value: &serde_json::Value) -> Option<String> {

--- a/crates/homeboy-cli/src/commands/runner/workspace/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/workspace/mod.rs
@@ -293,6 +293,7 @@ fn sync(
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace,
+            validation_dependency_ids: None,
             run_isolation_token: None,
         },
     )

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -1865,6 +1865,35 @@ pub struct SettingArgs {
 }
 
 impl SettingArgs {
+    pub fn effective_json_override(
+        &self,
+        key: &str,
+        profile_values: &[(String, serde_json::Value)],
+    ) -> Option<serde_json::Value> {
+        let mut value = profile_values
+            .iter()
+            .filter(|(candidate, _)| candidate == key)
+            .map(|(_, value)| value.clone())
+            .last();
+        if let Some((_, string)) = self
+            .setting
+            .iter()
+            .filter(|(candidate, _)| candidate == key)
+            .last()
+        {
+            value = Some(serde_json::Value::String(string.clone()));
+        }
+        if let Some((_, json)) = self
+            .setting_json
+            .iter()
+            .filter(|(candidate, _)| candidate == key)
+            .last()
+        {
+            value = Some(json.clone());
+        }
+        value
+    }
+
     pub fn settings_overrides(&self) -> homeboy::core::Result<Vec<(String, String)>> {
         Ok(self.setting.clone())
     }
@@ -1965,6 +1994,40 @@ mod tests {
             args.settings_json_overrides()
                 .expect("explicit json settings"),
             vec![("mode".to_string(), serde_json::json!("cli-json"))]
+        );
+    }
+
+    #[test]
+    fn effective_json_override_applies_profile_string_and_json_precedence() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"validation_dependencies":["profile-dependency"]}"#,
+        )
+        .expect("write profile");
+        let args = SettingArgs {
+            settings_json_file: vec![path],
+            setting: vec![(
+                "validation_dependencies".to_string(),
+                "string-dependency".to_string(),
+            )],
+            setting_json: vec![(
+                "validation_dependencies".to_string(),
+                serde_json::json!(["selected-dependency"]),
+            )],
+        };
+
+        let profile_values = args
+            .settings_profile_json_overrides()
+            .expect("profile values");
+        assert_eq!(
+            args.effective_json_override("validation_dependencies", &profile_values),
+            Some(serde_json::json!(["selected-dependency"]))
+        );
+        assert_eq!(
+            args.effective_json_override("missing", &profile_values),
+            None
         );
     }
 

--- a/crates/homeboy-core/src/hygiene.rs
+++ b/crates/homeboy-core/src/hygiene.rs
@@ -116,8 +116,7 @@ pub fn require_dependency_hygiene_for_source_with_settings(
     settings: &[(String, serde_json::Value)],
     options: DependencyHygieneOptions,
 ) -> Result<Vec<CheckoutHygieneSnapshot>> {
-    let mut checkouts = dependency_checkouts_for_source(source_path)?;
-    checkouts.extend(dependency_checkouts_for_settings(source_path, settings)?);
+    let mut checkouts = dependency_checkouts_for_settings(source_path, settings)?;
     if let Some(extension_path) = extension_path {
         checkouts.push(DependencyCheckout {
             id: "extension".to_string(),
@@ -227,33 +226,11 @@ pub struct DependencyCheckout {
     pub path: PathBuf,
 }
 
-fn dependency_checkouts_for_source(source_path: &Path) -> Result<Vec<DependencyCheckout>> {
-    let ids = validation_dependency_ids(source_path)?;
-    if ids.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    ids.into_iter()
-        .map(|id| {
-            let path = resolve_validation_dependency_path(source_path, &id)?;
-            Ok(DependencyCheckout {
-                id,
-                role: "validation_dependency".to_string(),
-                path,
-            })
-        })
-        .collect()
-}
-
 fn dependency_checkouts_for_settings(
     source_path: &Path,
     settings: &[(String, serde_json::Value)],
 ) -> Result<Vec<DependencyCheckout>> {
-    let ids = settings
-        .iter()
-        .filter(|(key, _)| key == "validation_dependencies")
-        .flat_map(|(_, value)| validation_dependency_ids_from_value(value))
-        .collect::<Vec<_>>();
+    let ids = effective_validation_dependency_ids(source_path, settings)?;
 
     ids.into_iter()
         .map(|id| {
@@ -267,17 +244,42 @@ fn dependency_checkouts_for_settings(
         .collect()
 }
 
-fn validation_dependency_ids_from_value(value: &serde_json::Value) -> Vec<String> {
-    let Some(dependencies) = value.as_array() else {
-        return Vec::new();
+/// Select validation dependencies for one invocation. An explicit setting
+/// replaces the manifest declaration, including an explicit empty array.
+pub fn effective_validation_dependency_ids(
+    source_path: &Path,
+    settings: &[(String, serde_json::Value)],
+) -> Result<Vec<String>> {
+    if let Some((_, value)) = settings
+        .iter()
+        .rev()
+        .find(|(key, _)| key == "validation_dependencies")
+    {
+        return validation_dependency_ids_from_value(value);
+    }
+    validation_dependency_ids(source_path)
+}
+
+fn validation_dependency_ids_from_value(value: &serde_json::Value) -> Result<Vec<String>> {
+    let invalid = || {
+        Error::validation_invalid_argument(
+            "validation_dependencies",
+            "expected an array of nonempty dependency strings; use [] for no dependencies",
+            None,
+            None,
+        )
     };
+    let dependencies = value.as_array().ok_or_else(invalid)?;
 
     dependencies
         .iter()
-        .filter_map(|item| item.as_str())
-        .map(str::trim)
-        .filter(|item| !item.is_empty())
-        .map(str::to_string)
+        .map(|item| {
+            item.as_str()
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(str::to_string)
+                .ok_or_else(invalid)
+        })
         .collect()
 }
 
@@ -346,7 +348,7 @@ fn collect_validation_dependency_ids(value: &serde_json::Value, ids: &mut Vec<St
     );
 }
 
-fn resolve_validation_dependency_path(source_path: &Path, dependency: &str) -> Result<PathBuf> {
+pub fn resolve_validation_dependency_path(source_path: &Path, dependency: &str) -> Result<PathBuf> {
     let expanded = shellexpand::tilde(dependency).to_string();
     let explicit = Path::new(&expanded);
     if explicit.is_dir() {
@@ -1340,6 +1342,107 @@ mod tests {
 
         assert_eq!(err.code, ErrorCode::ValidationMultipleErrors);
         assert_eq!(err.details["checkouts"][0]["dirty"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn explicit_validation_dependency_settings_replace_manifest_declarations() {
+        let source = tempfile::tempdir().unwrap();
+        fs::write(
+            source.path().join(PORTABLE_CONFIG_FILE),
+            r#"{"validation_dependencies":["dirty-manifest"]}"#,
+        )
+        .unwrap();
+
+        let selected = effective_validation_dependency_ids(
+            source.path(),
+            &[(
+                "validation_dependencies".to_string(),
+                serde_json::json!(["clean-selected"]),
+            )],
+        )
+        .expect("explicit selection");
+        assert_eq!(selected, ["clean-selected"]);
+
+        let empty = effective_validation_dependency_ids(
+            source.path(),
+            &[("validation_dependencies".to_string(), serde_json::json!([]))],
+        )
+        .expect("empty explicit selection");
+        assert!(empty.is_empty());
+
+        let manifest =
+            effective_validation_dependency_ids(source.path(), &[]).expect("manifest fallback");
+        assert_eq!(manifest, ["dirty-manifest"]);
+
+        for invalid in [
+            serde_json::json!("typo"),
+            serde_json::json!([" "]),
+            serde_json::json!([1]),
+        ] {
+            let error = effective_validation_dependency_ids(
+                source.path(),
+                &[("validation_dependencies".to_string(), invalid)],
+            )
+            .expect_err("invalid explicit selection must fail closed");
+            assert_eq!(error.details["field"], "validation_dependencies");
+        }
+    }
+
+    #[test]
+    fn hygiene_uses_the_clean_explicit_dependency_instead_of_a_dirty_manifest_dependency() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let manifest_dependency = root.path().join("manifest-dependency");
+        let selected_dependency = root.path().join("selected-dependency");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&manifest_dependency).unwrap();
+        fs::create_dir_all(&selected_dependency).unwrap();
+        init_repo(&manifest_dependency);
+        fs::write(manifest_dependency.join("dirty.txt"), "dirty\n").unwrap();
+        let _remote = init_repo_with_upstream(&selected_dependency);
+        fs::write(
+            source.join(PORTABLE_CONFIG_FILE),
+            serde_json::json!({
+                "validation_dependencies": [manifest_dependency.display().to_string()]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let settings = vec![(
+            "validation_dependencies".to_string(),
+            serde_json::json!([selected_dependency.display().to_string()]),
+        )];
+        let snapshots = require_checkout_hygiene_without_lifecycle(
+            dependency_checkouts_for_settings(&source, &settings).unwrap(),
+            DependencyHygieneOptions { allow_stale: false },
+        )
+        .expect("clean explicit dependency should replace dirty manifest dependency");
+
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(
+            snapshots[0].path,
+            selected_dependency
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string()
+        );
+
+        fs::write(selected_dependency.join("dirty.txt"), "dirty\n").unwrap();
+        let error = require_checkout_hygiene_without_lifecycle(
+            dependency_checkouts_for_settings(&source, &settings).unwrap(),
+            DependencyHygieneOptions { allow_stale: false },
+        )
+        .expect_err("dirty explicitly selected dependency must be rejected");
+        assert_eq!(
+            error.details["checkouts"][0]["path"],
+            selected_dependency
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string()
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -763,6 +763,10 @@ pub(crate) fn safety_report_for_provider(
     safety_report(record)
 }
 
+pub(crate) fn resolve_active_task_for_provider_admission(id: &str) -> Result<TaskWorktreeRecord> {
+    resolve_active_task_for_provider_admission_with_store(id, &metadata_dir()?)
+}
+
 #[cfg(test)]
 pub(crate) fn remove_record_for_test(id: &str) {
     let store = metadata_dir().expect("task worktree store");

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -910,6 +910,71 @@ fn verify_linked_worktree_identity(source: &Path, worktree: &Path, branch: &str)
     Ok(())
 }
 
+pub(super) fn resolve_active_task_for_provider_admission_with_store(
+    id: &str,
+    store_dir: &Path,
+) -> Result<TaskWorktreeRecord> {
+    with_task_worktree_registry_read_lock(|| {
+        let record = read_record(store_dir, id)?;
+        if record.state != TaskWorktreeState::Active {
+            return Err(Error::validation_invalid_argument(
+                "to_worktree",
+                format!("native worktree `{id}` is no longer active"),
+                Some(id.to_string()),
+                None,
+            ));
+        }
+
+        let source = resolved_source_checkout(&record)?;
+        let raw_worktree = Path::new(&record.worktree_path);
+        let worktree = match raw_worktree.canonicalize() {
+            Ok(path) => path,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                normalize_missing_path(raw_worktree)
+            }
+            Err(error) => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some(record.worktree_path.clone()),
+                ));
+            }
+        };
+        let worktree_missing = !raw_worktree.exists();
+        let parent = source.parent().ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "source checkout has no parent: {}",
+                source.display()
+            ))
+        })?;
+        let primary_checkout = source == worktree;
+        let path_contained = worktree.starts_with(parent) && worktree != source;
+        let mut reasons = Vec::new();
+        if worktree_missing {
+            reasons.push("worktree directory is missing".to_string());
+        }
+        if !worktree_missing && is_dirty_until(&worktree, None)? {
+            reasons.push("dirty worktree".to_string());
+        }
+        if primary_checkout {
+            reasons.push("refuses to use primary checkout as a task worktree".to_string());
+        }
+        if !path_contained {
+            reasons.push("worktree path is outside the component checkout parent".to_string());
+        }
+        if !reasons.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "to_worktree",
+                format!("native worktree `{id}` is not safe for reuse"),
+                Some(id.to_string()),
+                Some(reasons),
+            ));
+        }
+
+        verify_linked_worktree_identity(&source, &worktree, &record.branch)?;
+        Ok(record)
+    })
+}
+
 fn resolve_gitdir_pointer(base: &Path, pointer: &str) -> Option<PathBuf> {
     let pointer = resolve_gitdir_pointer_path(base, pointer);
     pointer.canonicalize().ok()

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -1410,6 +1410,69 @@ fn safety_report_allows_missing_contained_worktree() {
 }
 
 #[test]
+fn provider_admission_rejects_dirty_missing_primary_outside_and_branch_mismatch_worktrees() {
+    let source = git_repo();
+    let store = tempfile::tempdir().unwrap();
+    let worktree = sibling_worktree_path(source.path(), "provider-admission");
+    run_git(
+        source.path(),
+        &["worktree", "add", "-b", "task", &worktree.to_string_lossy()],
+    );
+
+    let rejected = |record: TaskWorktreeRecord| {
+        write_record(store.path(), &record).unwrap();
+        resolve_active_task_for_provider_admission_with_store(&record.id, store.path())
+            .expect_err("unsafe worktree must not be admitted")
+    };
+
+    fs::write(worktree.join("dirty.txt"), "dirty\n").unwrap();
+    assert!(rejected(fixture_record(source.path(), &worktree))
+        .message
+        .contains("not safe for reuse"));
+    fs::remove_file(worktree.join("dirty.txt")).unwrap();
+
+    assert!(rejected(fixture_record(
+        source.path(),
+        &sibling_worktree_path(source.path(), "provider-missing"),
+    ))
+    .message
+    .contains("not safe for reuse"));
+
+    assert!(rejected(fixture_record(source.path(), source.path()))
+        .message
+        .contains("not safe for reuse"));
+
+    let outside = tempfile::tempdir_in(
+        source
+            .path()
+            .parent()
+            .and_then(Path::parent)
+            .expect("source checkout has a grandparent"),
+    )
+    .unwrap();
+    let outside_worktree = outside.path().join("worktree");
+    run_git(
+        source.path(),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "outside-task",
+            &outside_worktree.to_string_lossy(),
+        ],
+    );
+    let mut outside_record = fixture_record(source.path(), &outside_worktree);
+    outside_record.branch = "outside-task".to_string();
+    assert!(rejected(outside_record)
+        .message
+        .contains("not safe for reuse"));
+
+    let mut mismatch = fixture_record(source.path(), &worktree);
+    mismatch.branch = "other-task".to_string();
+    assert!(rejected(mismatch).message.contains("git rev-parse branch"));
+}
+
+#[test]
 fn cleanup_marks_missing_worktree_record_removed() {
     let dir = tempfile::tempdir().unwrap();
     let source = git_repo();

--- a/crates/homeboy-core/src/worktree_provider.rs
+++ b/crates/homeboy-core/src/worktree_provider.rs
@@ -180,19 +180,7 @@ impl NativeWorktreeProvider {
                         None,
                     ));
                 }
-                let safety = worktree::safety_report_for_provider(record)?;
-                if safety.worktree_missing || !safety.safe {
-                    let mut reasons = safety.reasons;
-                    if safety.worktree_missing {
-                        reasons.push("worktree directory is missing".to_string());
-                    }
-                    return Err(Error::validation_invalid_argument(
-                        "to_worktree",
-                        format!("native worktree `{handle}` is not safe for use"),
-                        Some(handle.to_string()),
-                        Some(reasons),
-                    ));
-                }
+                let record = worktree::resolve_active_task_for_provider_admission(handle)?;
                 (
                     WorktreeWorkspaceKind::TaskWorktree,
                     Some(record.branch.clone()),
@@ -782,6 +770,83 @@ mod tests {
                 .resolve("fixture@a?b")
                 .expect_err("colliding handle must not resolve another manifest");
             assert!(error.message.contains("does not match requested handle"));
+        });
+    }
+
+    #[test]
+    fn native_provider_admits_clean_committed_worktree_while_cleanup_retains_it() {
+        crate::test_support::with_isolated_home(|home| {
+            let source = home.path().join("Developer/fixture");
+            std::fs::create_dir_all(&source).expect("source checkout");
+            for args in [
+                vec!["init", "-q", "-b", "main"],
+                vec!["config", "user.email", "homeboy@example.test"],
+                vec!["config", "user.name", "Homeboy Test"],
+            ] {
+                assert!(std::process::Command::new("git")
+                    .args(args)
+                    .current_dir(&source)
+                    .status()
+                    .expect("initialize source")
+                    .success());
+            }
+            std::fs::write(source.join("README"), "fixture\n").expect("fixture file");
+            assert!(std::process::Command::new("git")
+                .args(["add", "README"])
+                .current_dir(&source)
+                .status()
+                .expect("stage fixture")
+                .success());
+            assert!(std::process::Command::new("git")
+                .args(["commit", "-q", "-m", "fixture"])
+                .current_dir(&source)
+                .status()
+                .expect("commit fixture")
+                .success());
+            crate::test_support::write_component_registration(home.path(), "fixture", &source);
+            let created = worktree::create(worktree::WorktreeCreateOptions {
+                component_id: "fixture".to_string(),
+                branch: "fix/admission".to_string(),
+                from: Some("main".to_string()),
+                task_url: None,
+                run_id: None,
+                cleanup_policy: None,
+                require_handoff_freshness: false,
+            })
+            .expect("create task worktree");
+            let path = PathBuf::from(&created.record.worktree_path);
+            std::fs::write(path.join("change"), "committed\n").expect("candidate change");
+            assert!(NativeWorktreeProvider
+                .resolve(&created.record.id)
+                .is_err_and(|error| error.message.contains("not safe for reuse")));
+            assert!(resolve_native_worktree_mutation_target(&created.record.id)
+                .expect("resolve dirty task mutation target")
+                .is_some());
+            assert!(std::process::Command::new("git")
+                .args(["add", "change"])
+                .current_dir(&path)
+                .status()
+                .expect("stage candidate")
+                .success());
+            assert!(std::process::Command::new("git")
+                .args(["commit", "-q", "-m", "candidate"])
+                .current_dir(&path)
+                .status()
+                .expect("commit candidate")
+                .success());
+
+            assert!(NativeWorktreeProvider
+                .resolve(&created.record.id)
+                .expect("committed task worktree is reusable")
+                .is_some());
+            let error = worktree::remove(worktree::WorktreeRemoveOptions {
+                id: created.record.id,
+                force: false,
+                cleanup_branch: false,
+                allow_unmerged_branch: false,
+            })
+            .expect_err("cleanup must retain unpushed committed worktree");
+            assert!(error.message.contains("not safe to remove"));
         });
     }
 }

--- a/crates/homeboy-lab-runner/src/dev_run.rs
+++ b/crates/homeboy-lab-runner/src/dev_run.rs
@@ -186,6 +186,7 @@ pub(crate) fn run_extension_dev_run_with(
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: false,
+            validation_dependency_ids: None,
             run_isolation_token: None,
         },
     )?;

--- a/crates/homeboy-lab-runner/src/execution/request.rs
+++ b/crates/homeboy-lab-runner/src/execution/request.rs
@@ -225,6 +225,7 @@ fn workspace_context(
         git_fetch_refs: Vec::new(),
         snapshot_includes: Vec::new(),
         allow_dirty_lab_workspace: false,
+        validation_dependency_ids: None,
         run_isolation_token: None,
     };
     let (synced, _) = crate::sync_workspace_before(

--- a/crates/homeboy-lab-runner/src/lab/offload/path_materialization.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/path_materialization.rs
@@ -9,6 +9,7 @@ use super::*;
 pub(crate) struct PathMaterializationPlanner {
     pub(crate) args: Vec<String>,
     pub(crate) extra_workspaces: Vec<ExtraLabWorkspace>,
+    pub(crate) validation_dependency_ids: Option<Vec<String>>,
 }
 
 impl PathMaterializationPlanner {
@@ -18,8 +19,19 @@ impl PathMaterializationPlanner {
         source_path: &Path,
         allow_dirty_lab_workspace: bool,
     ) -> Result<Self> {
-        let (args, workspace_ref_resolutions) = resolve_path_setting_workspace_refs_in_args(args)?;
-        let mut extra_workspaces = lab_extra_workspaces(source_path)?;
+        let (args, validation_dependency_settings) =
+            crate::lab_workspaces_deps::take_validation_dependency_settings(args)?;
+        let (args, workspace_ref_resolutions) = resolve_path_setting_workspace_refs_in_args(&args)?;
+        let validation_dependency_ids = validation_dependency_settings
+            .as_ref()
+            .map(|settings| {
+                homeboy_core::hygiene::effective_validation_dependency_ids(source_path, settings)
+            })
+            .transpose()?;
+        let mut extra_workspaces = lab_extra_workspaces(
+            source_path,
+            validation_dependency_settings.as_deref().unwrap_or(&[]),
+        )?;
         extra_workspaces.extend(provider_config_extra_workspaces(&args, source_path)?);
         extra_workspaces.extend(agent_task_plan_extra_workspaces(&args, source_path)?);
         extra_workspaces.extend(agent_task_fanout_extra_workspaces(&args, source_path)?);
@@ -56,6 +68,7 @@ impl PathMaterializationPlanner {
         Ok(Self {
             args,
             extra_workspaces,
+            validation_dependency_ids,
         })
     }
 }
@@ -114,6 +127,43 @@ fn load_primary_rig_spec(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn planner_stages_and_strips_the_controller_selected_dependency() {
+        let root = tempfile::tempdir().expect("workspace root");
+        let source = root.path().join("source");
+        let selected = root.path().join("selected");
+        std::fs::create_dir_all(&source).expect("source");
+        std::fs::create_dir_all(&selected).expect("selected");
+        std::fs::write(
+            source.join("homeboy.json"),
+            r#"{"validation_dependencies":["missing-manifest-dependency"]}"#,
+        )
+        .expect("manifest");
+        let args = vec![
+            "homeboy".to_string(),
+            "review".to_string(),
+            "test".to_string(),
+            "--homeboy-validation-dependencies-json".to_string(),
+            serde_json::json!([selected.clone()]).to_string(),
+        ];
+
+        let plan = PathMaterializationPlanner::plan(&args, None, &source, false)
+            .expect("plan selected dependency");
+
+        assert_eq!(
+            plan.validation_dependency_ids.as_deref(),
+            Some(&[selected.display().to_string()][..])
+        );
+        assert!(plan
+            .args
+            .iter()
+            .all(|arg| arg != "--homeboy-validation-dependencies-json"));
+        assert!(plan
+            .extra_workspaces
+            .iter()
+            .any(|workspace| workspace.path == selected.canonicalize().unwrap()));
+    }
 
     #[test]
     fn planner_combines_provider_settings_and_rig_passthrough_inputs_before_staging() {

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -243,6 +243,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         request.allow_dirty_lab_workspace,
     )?;
     let mut offload_args = materialization_planner.args;
+    let validation_dependency_ids = materialization_planner.validation_dependency_ids;
     verify_cook_workspace_attestations_in_args(&offload_args, source_path)?;
     let extra_workspaces = materialization_planner.extra_workspaces;
     // Isolate the primary workspace per cook/dispatch run. Without a per-run
@@ -274,6 +275,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         git_fetch_refs: git_fetch_refs.clone(),
         snapshot_includes: Vec::new(),
         allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+        validation_dependency_ids,
         run_isolation_token: run_isolation_token.clone(),
     };
     // Compatible snapshots are mutable runner workspaces, not shared immutable

--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -189,6 +189,7 @@ pub(super) fn sync_extra_lab_workspaces(
                 git_fetch_refs: extra.git_fetch_refs.clone(),
                 snapshot_includes: extra.snapshot_includes.clone(),
                 allow_dirty_lab_workspace: extra.allow_dirty_lab_workspace,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )?
@@ -385,9 +386,15 @@ pub(super) fn lab_workspace_mapping_metadata(
     })
 }
 
-pub(super) fn lab_extra_workspaces(source_path: &Path) -> Result<Vec<ExtraLabWorkspace>> {
+pub(super) fn lab_extra_workspaces(
+    source_path: &Path,
+    settings: &[(String, serde_json::Value)],
+) -> Result<Vec<ExtraLabWorkspace>> {
     let mut workspaces = accepted_extra_lab_workspaces()?;
-    workspaces.extend(discovered_validation_dependency_workspaces(source_path)?);
+    workspaces.extend(discovered_validation_dependency_workspaces(
+        source_path,
+        settings,
+    )?);
     Ok(workspaces)
 }
 
@@ -541,6 +548,7 @@ pub(super) fn sync_lab_runtime_overlays(
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: overlay.workspace.snapshot_includes.clone(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )

--- a/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
@@ -436,6 +436,7 @@ fn agent_task_plan_config_linked_worktree_remains_git_backed_for_provider_start(
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )

--- a/crates/homeboy-lab-runner/src/lab_workspaces_deps.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces_deps.rs
@@ -10,7 +10,6 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use homeboy_core::component::{self, TargetSpec};
 use homeboy_core::{Error, Result};
 
 use super::lab_workspaces::{
@@ -307,67 +306,68 @@ pub(super) fn accepted_extra_lab_workspaces() -> Result<Vec<ExtraLabWorkspace>> 
 
 pub(super) fn discovered_validation_dependency_workspaces(
     source_path: &Path,
+    settings: &[(String, serde_json::Value)],
 ) -> Result<Vec<ExtraLabWorkspace>> {
-    let source_path_string = source_path.display().to_string();
-    let Ok(target) = component::resolve_target(TargetSpec {
-        component_id: None,
-        path_override: Some(&source_path_string),
-        project: None,
-        capability: None,
-        allow_synthetic: true,
-        accept_bare_directory: true,
-        ..TargetSpec::default()
-    }) else {
-        return Ok(Vec::new());
-    };
-    let Some(extensions) = target.component.extensions.as_ref() else {
-        return Ok(Vec::new());
-    };
-
     let mut workspaces = Vec::new();
-    for config in extensions.values() {
-        let Some(dependencies) = config.settings.get("validation_dependencies") else {
-            continue;
-        };
-        let Some(dependencies) = dependencies.as_array() else {
-            continue;
-        };
-        for dependency in dependencies.iter().filter_map(|value| value.as_str()) {
-            let path = resolve_dependency_workspace_path(dependency)?;
-            workspaces.push(ExtraLabWorkspace {
-                role: "dependency".to_string(),
-                path,
-                snapshot_includes: Vec::new(),
-                git_fetch_refs: Vec::new(),
-                allow_dirty_lab_workspace: false,
-                source_provenance: None,
-            });
-        }
+    for dependency in
+        homeboy_core::hygiene::effective_validation_dependency_ids(source_path, settings)?
+    {
+        let path = resolve_dependency_workspace_path(source_path, &dependency)?;
+        workspaces.push(ExtraLabWorkspace {
+            role: "dependency".to_string(),
+            path,
+            snapshot_includes: Vec::new(),
+            git_fetch_refs: Vec::new(),
+            allow_dirty_lab_workspace: false,
+            source_provenance: None,
+        });
     }
 
     Ok(workspaces)
 }
 
-pub(super) fn resolve_dependency_workspace_path(dependency: &str) -> Result<PathBuf> {
-    let expanded = shellexpand::tilde(dependency).to_string();
-    if Path::new(&expanded).is_dir() {
-        return canonical_existing_dir(&expanded, "validation_dependencies");
+pub(crate) fn take_validation_dependency_settings(
+    args: &[String],
+) -> Result<(Vec<String>, Option<Vec<(String, serde_json::Value)>>)> {
+    let mut retained = Vec::with_capacity(args.len());
+    let mut selected = None;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            retained.push(arg.clone());
+            retained.extend(iter.cloned());
+            break;
+        }
+        if arg != "--homeboy-validation-dependencies-json" {
+            retained.push(arg.clone());
+            continue;
+        }
+        let raw = iter.next().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "homeboy-validation-dependencies-json",
+                "missing effective validation dependency setting value",
+                None,
+                None,
+            )
+        })?;
+        let value = serde_json::from_str(raw).map_err(|error| {
+            Error::validation_invalid_argument(
+                "validation_dependencies",
+                format!("invalid effective validation dependency setting: {error}"),
+                Some(raw.clone()),
+                None,
+            )
+        })?;
+        selected = Some(vec![("validation_dependencies".to_string(), value)]);
     }
+    Ok((retained, selected))
+}
 
-    let component = component::resolve_effective(Some(dependency), None, None).map_err(|err| {
-        Error::validation_invalid_argument(
-            "validation_dependencies",
-            format!(
-                "Runner workspace sync cannot resolve validation dependency `{dependency}` to a local checkout: {}",
-                err.message
-            ),
-            Some(dependency.to_string()),
-            Some(vec![
-                format!("Register the dependency component locally, or pass an explicit checkout path via {LAB_EXTRA_WORKSPACES_JSON_ENV}."),
-            ]),
-        )
-    })?;
-    canonical_existing_dir(&component.local_path, "validation_dependencies")
+pub(super) fn resolve_dependency_workspace_path(
+    source_path: &Path,
+    dependency: &str,
+) -> Result<PathBuf> {
+    homeboy_core::hygiene::resolve_validation_dependency_path(source_path, dependency)
 }
 
 pub(super) fn canonical_existing_dir(path: &str, field: &str) -> Result<PathBuf> {
@@ -432,4 +432,42 @@ pub(super) fn preflight_runtime_overlay_install_argv(
         local_path,
         remote_workdir,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_validation_dependency_setting_selects_the_staged_workspace() {
+        let root = tempfile::tempdir().expect("workspace root");
+        let source = root.path().join("source");
+        let selected = root.path().join("selected");
+        std::fs::create_dir_all(&source).expect("source");
+        std::fs::create_dir_all(&selected).expect("selected dependency");
+        std::fs::write(
+            source.join("homeboy.json"),
+            r#"{"validation_dependencies":["dirty-manifest"]}"#,
+        )
+        .expect("manifest");
+        let args = vec![
+            "homeboy".to_string(),
+            "review".to_string(),
+            "test".to_string(),
+            "--homeboy-validation-dependencies-json".to_string(),
+            serde_json::json!([selected]).to_string(),
+        ];
+
+        let workspaces = discovered_validation_dependency_workspaces(
+            &source,
+            &take_validation_dependency_settings(&args)
+                .expect("settings")
+                .1
+                .unwrap_or_default(),
+        )
+        .expect("discover selected dependency");
+
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].path, selected.canonicalize().unwrap());
+    }
 }

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -308,6 +308,7 @@ pub(super) fn sync_lab_offload_rigs(
                         git_fetch_refs: Vec::new(),
                         snapshot_includes: Vec::new(),
                         allow_dirty_lab_workspace: false,
+                        validation_dependency_ids: None,
                         run_isolation_token: None,
                     },
                 )?

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -776,9 +776,11 @@ impl RemoteRunnerStagingTransport for ProductionRunnerStagingTransport {
     }
 
     fn supports_capability(&self, capability: &str) -> bool {
-        self.capabilities
-            .iter()
-            .any(|candidate| candidate == capability)
+        self.session.mode == RunnerTunnelMode::Reverse
+            && self
+                .capabilities
+                .iter()
+                .any(|candidate| candidate == capability)
     }
 
     fn stage_durable(
@@ -1369,7 +1371,7 @@ mod tests {
     }
 
     #[test]
-    fn production_staging_requests_propagate_paired_bearer_tokens_across_transports() {
+    fn production_staging_refuses_direct_and_submits_reverse_with_paired_bearer_tokens() {
         let request = envelope();
         let receipt = RemoteRunnerStagingReceipt {
             schema: REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA.to_string(),
@@ -1386,7 +1388,7 @@ mod tests {
             },
         };
         let seen = Arc::new(Mutex::new(Vec::new()));
-        let endpoint = staging_endpoint(receipt.clone(), seen.clone(), 4);
+        let endpoint = staging_endpoint(receipt.clone(), seen.clone(), 3);
         let broker_token = "paired-staging-token".to_string();
         let direct_session = production_session(RunnerTunnelMode::DirectSsh, &endpoint);
         assert!(
@@ -1404,10 +1406,9 @@ mod tests {
             ],
             broker_token: Some(broker_token.clone()),
         };
-        assert_eq!(
-            submit_remote_runner_staging(&mut direct, &request).expect("direct"),
-            receipt
-        );
+        let error = submit_remote_runner_staging(&mut direct, &request)
+            .expect_err("direct staging has no staged-source consumer");
+        assert_eq!(error.code, homeboy_core::ErrorCode::RunnerCapabilityMissing);
 
         let reverse_session = production_session(RunnerTunnelMode::Reverse, &endpoint);
         assert!(
@@ -1437,7 +1438,6 @@ mod tests {
                 .collect::<Vec<_>>(),
             [
                 "/runner/staging/capabilities",
-                "/runner/staging",
                 "/runner/staging/capabilities",
                 "/runner/staging",
             ]

--- a/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
@@ -181,6 +181,7 @@ pub fn materialize_runner_source_path(runner: &Runner, source_path: &Path) -> Re
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: false,
+            validation_dependency_ids: None,
             run_isolation_token: None,
         },
     )?;
@@ -205,6 +206,7 @@ pub fn materialize_explicit_runner_source_path(
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: false,
+            validation_dependency_ids: None,
             run_isolation_token: None,
         },
     )?;

--- a/crates/homeboy-lab-runner/src/validation_dependencies.rs
+++ b/crates/homeboy-lab-runner/src/validation_dependencies.rs
@@ -25,9 +25,12 @@ pub(super) fn sync_validation_dependency_workspaces(
     local_path: &Path,
     remote_path: &str,
     excludes: &[String],
+    selected_dependency_ids: Option<&[String]>,
 ) -> Result<Vec<RunnerValidationDependencySyncOutput>> {
     let mut synced = Vec::new();
-    for dependency in validation_dependency_workspaces(local_path, excludes)? {
+    for dependency in
+        validation_dependency_workspaces(local_path, excludes, selected_dependency_ids)?
+    {
         let remote_dependency_path = format!(
             "{}/{}",
             parent_remote_path(remote_path),
@@ -60,8 +63,12 @@ struct PreparedValidationDependencyWorkspace {
 fn validation_dependency_workspaces(
     local_path: &Path,
     excludes: &[String],
+    selected_dependency_ids: Option<&[String]>,
 ) -> Result<Vec<PreparedValidationDependencyWorkspace>> {
-    let dependency_ids = homeboy_core::hygiene::validation_dependency_ids(local_path)?;
+    let dependency_ids = match selected_dependency_ids {
+        Some(ids) => ids.to_vec(),
+        None => homeboy_core::hygiene::validation_dependency_ids(local_path)?,
+    };
     if dependency_ids.is_empty() {
         return Ok(Vec::new());
     }
@@ -425,6 +432,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    validation_dependency_ids: None,
                     run_isolation_token: None,
                 },
             )
@@ -521,6 +529,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    validation_dependency_ids: None,
                     run_isolation_token: None,
                 },
             )
@@ -601,6 +610,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    validation_dependency_ids: None,
                     run_isolation_token: None,
                 },
             )
@@ -674,6 +684,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    validation_dependency_ids: None,
                     run_isolation_token: None,
                 },
             )
@@ -765,6 +776,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    validation_dependency_ids: None,
                     run_isolation_token: None,
                 },
             )
@@ -823,6 +835,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    validation_dependency_ids: None,
                     run_isolation_token: None,
                 },
             )
@@ -866,8 +879,8 @@ mod tests {
             )
             .expect("source manifest");
 
-            let err =
-                validation_dependency_workspaces(&source, &[]).expect_err("missing dependency");
+            let err = validation_dependency_workspaces(&source, &[], None)
+                .expect_err("missing dependency");
 
             assert_eq!(err.details["field"], "validation_dependencies");
             assert!(err.message.contains("shared-runtime"));

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -364,6 +364,7 @@ fn sync_workspace_in_roots_with_deadline(
                 &local_path,
                 &remote_path,
                 &excludes,
+                options.validation_dependency_ids.as_deref(),
             ) {
                 Ok(dependencies) => dependencies,
                 Err(err) => {
@@ -574,6 +575,7 @@ fn sync_workspace_in_roots_with_deadline(
                 &local_path,
                 &remote_path,
                 &excludes,
+                options.validation_dependency_ids.as_deref(),
             ) {
                 Ok(dependencies) => dependencies,
                 Err(err) => {
@@ -844,6 +846,7 @@ fn materialize_git_fallback_filesystem_snapshot(
         local_path,
         &remote_path,
         excludes,
+        options.validation_dependency_ids.as_deref(),
     ) {
         Ok(dependencies) => dependencies,
         Err(error) => {
@@ -2458,9 +2461,16 @@ fn write_metadata_and_sync_validation_dependencies(
     local_path: &Path,
     remote_path: &str,
     excludes: &[String],
+    selected_dependency_ids: Option<&[String]>,
 ) -> Result<Vec<RunnerValidationDependencySyncOutput>> {
     write_workspace_metadata(runner, metadata)?;
-    sync_validation_dependency_workspaces(runner, local_path, remote_path, excludes)
+    sync_validation_dependency_workspaces(
+        runner,
+        local_path,
+        remote_path,
+        excludes,
+        selected_dependency_ids,
+    )
 }
 
 /// Remove a just-materialized run checkout after a later sync step fails.

--- a/crates/homeboy-lab-runner/src/workspace/tests/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/git.rs
@@ -149,6 +149,7 @@ fn changed_since_private_origin_without_controller_closure_falls_back_to_snapsho
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: false,
+            validation_dependency_ids: None,
             run_isolation_token: None,
         };
         let sync_result = sync_workspace("lab-local-git-bundle", sync_options.clone());
@@ -318,6 +319,7 @@ fn changed_since_promisor_base_without_controller_closure_falls_back_to_snapshot
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         );
@@ -492,6 +494,7 @@ fn git_materialization_ignores_generated_homeboy_output_but_refuses_source_dirty
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    validation_dependency_ids: None,
                     run_isolation_token: None,
                 },
             )
@@ -568,6 +571,7 @@ fn controller_routed_git_sync_materializes_bundle_for_public_remote() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -666,6 +670,7 @@ fn controller_routed_git_sync_rejects_shallow_source_checkout() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -747,6 +752,7 @@ fn git_sync_of_detached_extension_source_preserves_source_revision() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -1706,6 +1706,7 @@ fn sync_options(path: String) -> RunnerWorkspaceSyncOptions {
         git_fetch_refs: Vec::new(),
         snapshot_includes: Vec::new(),
         allow_dirty_lab_workspace: false,
+        validation_dependency_ids: None,
         run_isolation_token: None,
     }
 }

--- a/crates/homeboy-lab-runner/src/workspace/tests/reap.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/reap.rs
@@ -16,6 +16,7 @@ fn sync_options(path: String) -> RunnerWorkspaceSyncOptions {
         git_fetch_refs: Vec::new(),
         snapshot_includes: Vec::new(),
         allow_dirty_lab_workspace: false,
+        validation_dependency_ids: None,
         run_isolation_token: None,
     }
 }

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -140,6 +140,7 @@ fn snapshot_git_readback_failure_rolls_back_remote_workspace_and_registration() 
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         );
@@ -221,6 +222,7 @@ fn snapshot_git_reports_checkout_provenance_for_committed_harvest() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -362,6 +364,7 @@ fn snapshot_git_carries_a_pinned_base_absent_from_destination_history() {
                 git_fetch_refs: vec![pinned_base.clone()],
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -439,6 +442,7 @@ fn snapshot_git_materializes_linked_worktree_with_valid_git_before_handoff() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -753,6 +757,7 @@ fn runner_snapshot_includes_override_generated_output_excludes() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -799,6 +804,7 @@ fn runner_snapshot_excludes_extend_default_snapshot_policy() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -843,6 +849,7 @@ fn runner_snapshot_rejects_source_runner_workspace_metadata_collision() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -1025,6 +1032,7 @@ fn test_sync_workspace() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -1101,6 +1109,7 @@ fn snapshot_sync_uses_gitignore_excludes_as_generic_fallback() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -1222,6 +1231,7 @@ fn snapshot_sync_uses_unique_clean_workspace_for_same_snapshot() {
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: false,
+            validation_dependency_ids: None,
             run_isolation_token: None,
         };
         let (first, _) =
@@ -1267,6 +1277,7 @@ fn workspace_sync_materialization_contract_records_inputs_provenance_policy_and_
                 git_fetch_refs: vec!["refs/heads/trunk".to_string()],
                 snapshot_includes: vec!["src/**".to_string()],
                 allow_dirty_lab_workspace: true,
+                validation_dependency_ids: None,
                 run_isolation_token: Some("run-123".to_string()),
             },
         )
@@ -1347,6 +1358,7 @@ fn workspace_list_reports_recent_lab_workspaces_with_exec_commands() {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -1477,6 +1489,7 @@ fn snapshot_git_sync_falls_back_for_unpublished_commit_and_preserves_dirty_overl
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                validation_dependency_ids: None,
                 run_isolation_token: None,
             },
         )
@@ -2321,6 +2334,7 @@ fn snapshot_staging_is_stable_with_sibling_worktrees_and_ignored_outputs() {
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: false,
+            validation_dependency_ids: None,
             run_isolation_token: None,
         };
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -1074,6 +1074,7 @@ fn sync_options(path: String, run_id: Option<String>) -> RunnerWorkspaceSyncOpti
         git_fetch_refs: Vec::new(),
         snapshot_includes: Vec::new(),
         allow_dirty_lab_workspace: false,
+        validation_dependency_ids: None,
         run_isolation_token: run_id,
     }
 }

--- a/crates/homeboy-lab-runner/src/workspace/tests/update.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/update.rs
@@ -578,6 +578,7 @@ fn sync_options(path: &Path) -> RunnerWorkspaceSyncOptions {
         git_fetch_refs: Vec::new(),
         snapshot_includes: Vec::new(),
         allow_dirty_lab_workspace: false,
+        validation_dependency_ids: None,
         run_isolation_token: None,
     }
 }

--- a/docs/validation-dependency-recovery.md
+++ b/docs/validation-dependency-recovery.md
@@ -1,0 +1,81 @@
+# Validation Dependency Recovery
+
+Tracking: [#14587](https://github.com/Extra-Chill/homeboy/issues/14587).
+Related execution limitation: [#14588](https://github.com/Extra-Chill/homeboy/issues/14588).
+Evidence reviewed September 12, 2026.
+
+## Changes
+
+An explicit `validation_dependencies` setting now replaces the manifest's list
+for hygiene and Lab source selection, including an explicit empty array. Values
+must be arrays of nonempty strings; malformed overrides fail rather than
+silently disabling dependency validation. Without an override, manifest
+selection is unchanged.
+
+CLI settings-file, string-setting, and JSON-setting precedence is resolved
+before Lab materialization. The profile snapshot is shared with portable
+argument construction. The selected sources flow through workspace sync and
+controller-to-runner path remapping. Internal selection metadata is removed
+before constructing the remote command.
+
+Native worktree reuse now checks active registration, cleanliness, containment,
+and linked Git/branch identity independently from destructive cleanup safety.
+A clean committed task branch is reusable even when its commits are unpushed.
+Cleanup still refuses unpushed work, and promotion's existing authorized dirty
+candidate path is preserved. This does not change historical records' base refs
+or correct inflated cleanup counts caused by stale local base branches.
+
+The controller also refuses sealed staging for direct-SSH sessions, whose
+daemon currently has no consumer for that queue. Reverse-worker staging is
+unchanged. This is a preventive capability correction only: it does not execute
+or recover previously queued direct jobs. The v1 request wire shape is unchanged.
+
+## Repository-Native Verification
+
+Run from this candidate checkout. Tests use isolated fixture repositories;
+single-threaded execution matches the repository's test setting.
+
+```sh
+cargo fmt --all --check
+cargo check --workspace
+cargo test -p homeboy-core --lib hygiene -- --test-threads=1
+cargo test -p homeboy-core --lib worktree::tests:: -- --test-threads=1
+cargo test -p homeboy-core --lib worktree_provider::tests:: -- --test-threads=1
+cargo test -p homeboy-lab-runner --lib validation_dependency -- --test-threads=1
+cargo test -p homeboy-lab-runner --lib planner_stages_and_strips_the_controller_selected_dependency -- --test-threads=1
+cargo test -p homeboy-lab-runner --lib runner_staging_store::tests:: -- --test-threads=1
+cargo test -p homeboy-cli --lib effective_json_override_applies_profile_string_and_json_precedence -- --test-threads=1
+```
+
+The final managed Lab run passed all seven test selections: 18, 64, 7, 11, 1,
+9, and 1 tests respectively (111 total), plus workspace compilation and format
+checks. The tests exercise selected clean versus dirty Git dependencies,
+intentional empty selection, malformed input, source-relative resolution,
+staging metadata, worktree identity and cleanup protection, and direct refusal
+versus authenticated reverse staging.
+
+Operator-retained evidence:
+
+- Run: `homeboy-14587-final-gates`
+- Runner job: `22b0627d-508c-4151-88fb-9ee804966fcc`
+- Artifact: `runner-exec-d36987e21ab0b25b1dd16877a02049458644fddeb75a15aaa1e70691c8d45514`
+- Artifact filename: `homeboy-14587-verification.log`
+- Candidate base: `086a34929c8d914ce047f750d6b9d4969c59605e`, plus this change
+
+These IDs resolve in the operator's Homeboy store, not a public artifact host.
+The commands above are the reviewer-facing reproduction path.
+
+## Live Replay Boundary
+
+The original paired-consumer command was retried with the candidate controller.
+It stopped before source staging with `selected runner requires admitted
+connected readiness evidence`. Runner status identified controller version
+`0.373.1` versus configured runner job binary `0.372.3`; a protected queued job
+also prevented implicit daemon replacement. The existing installation and
+queued job were left intact.
+
+Consequently, the original WordPress consumer suite has not completed through
+this candidate. Runtime convergence and safe recovery of the queued direct job
+remain necessary before claiming end-to-end workload completion. Neither this
+change nor its unit/integration gates establish SQL parity or authorize a
+release, daemon replacement, or production migration.


### PR DESCRIPTION
## Summary

Repair two Homeboy admission defects exposed while preparing paired native/MySQL consumer verification. References #14587 and the preventive portion of #14588.

- Resolve explicit validation_dependencies once with settings precedence, then use that selection for hygiene, Lab dependency staging, and path mapping. Overrides replace the manifest list, including an intentional empty array; malformed overrides fail explicitly.
- Separate native worktree reuse from destructive cleanup safety. Clean committed task branches can be reused; cleanup still protects unpushed history, and authorized dirty-candidate promotion remains supported.
- Refuse unsupported sealed staging on direct-SSH sessions before submitting a job to an unconsumed queue. Preserve reverse staging and the existing v1 wire contract.
- Retain repository-native reproduction commands, operator evidence references, and the live replay boundary in docs/validation-dependency-recovery.md.

## Verification

The final managed Lab run passed 111 tests across hygiene, worktree lifecycle/provider admission, dependency discovery/planning, staging, and CLI settings. It also passed cargo check --workspace and cargo fmt --all --check. The candidate passed git diff --check.

- Run: homeboy-14587-final-gates
- Runner job: 22b0627d-508c-4151-88fb-9ee804966fcc
- Retained log: homeboy-14587-verification.log
- Log SHA-256: 451516ebe58152162b9fc9386fcfb70e0a5e97fe5a99dd0b6c63f2be17bd71b6

These are operator-retained artifacts, not public artifact links. The evidence document supplies commands reviewers can run from this checkout. The tested source is the candidate on base 086a34929; this PR contains one commit, 63905ff8a, including that evidence document.

## Remaining Boundary

This does not complete #14588: previously queued direct jobs still need safe recovery and a supported direct staged-execution lifecycle. Historical worktree base refs and their inflated cleanup counts are not rewritten.

The original consumer replay stopped before staging because the candidate controller was 0.373.1 while the configured runner binary remained 0.372.3. A protected queued job also prevented implicit daemon replacement. No consumer-suite completion, SQL parity, or end-to-end unblock is claimed.

No release, daemon replacement, job cancellation, or production migration is included. Existing changes and merge conflicts in the primary checkout were left untouched.

## AI Assistance

OpenAI GPT-6 Astra (openai/gpt-6-astra) via OpenCode investigated the retained failures, coordinated parallel isolated implementation and review agents, corrected review findings, ran managed Lab verification, and prepared this PR under Chris Huber’s direction.