### PR TITLE
Fix portable release preflight gate selection

### DIFF
--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -4,6 +4,8 @@ use std::process::{Command, Stdio};
 use std::{fs, path::Path};
 
 use homeboy::core::component;
+use homeboy::core::plan::PlanStepStatus;
+use homeboy::core::quality::{build_quality_steps, QualityPlanOptions};
 use homeboy::core::scope::{self, Scope};
 use homeboy_deploy::{self as deploy, ReleaseStateStatus};
 use homeboy_release::release::{
@@ -876,12 +878,25 @@ fn run_portable_preflight_with(
     let mut gate_results = Vec::new();
     let mut evidence_refs = Vec::new();
     let mut resolved_runner_id = None;
-    for gate in ["audit", "lint", "test"] {
-        if skip_all || skipped.iter().any(|skip| skip == gate) {
+    let quality_steps = build_quality_steps(
+        &QualityPlanOptions::release_preflight(component_id, skip_all).with_granular_skips(skipped),
+    );
+    for step in quality_steps {
+        let gate = step.id.strip_prefix("preflight.").ok_or_else(|| {
+            homeboy::core::Error::internal_unexpected(format!(
+                "release preflight quality step has invalid ID '{}'",
+                step.id
+            ))
+        })?;
+        if step.status == PlanStepStatus::Disabled {
             gate_results.push(ReleaseReadinessGateResult {
                 gate: gate.to_string(),
                 status: "skipped".to_string(),
-                reason: Some("--skip-checks".to_string()),
+                reason: step
+                    .inputs
+                    .get("reason")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
                 source_sha: Some(commit.clone()),
                 runner_id: None,
                 evidence_refs: Vec::new(),
@@ -2540,7 +2555,13 @@ jobs:
         .expect("preflight should complete")
         .expect("lab preflight is enabled");
 
-        assert_eq!(*dispatcher.calls.borrow(), vec!["audit", "test"]);
+        assert_eq!(*dispatcher.calls.borrow(), vec!["test"]);
+        assert_eq!(readiness.gate_results[0].gate, "audit");
+        assert_eq!(readiness.gate_results[0].status, "skipped");
+        assert_eq!(
+            readiness.gate_results[0].reason.as_deref(),
+            Some("no-release-audit-policy")
+        );
         assert_eq!(readiness.gate_results[1].gate, "lint");
         assert_eq!(readiness.gate_results[1].status, "skipped");
         assert!(release::readiness_is_valid(&readiness));
@@ -2564,7 +2585,7 @@ jobs:
         .expect("dispatch failure is retained as a gate result")
         .expect("lab preflight is enabled");
 
-        assert_eq!(*dispatcher.calls.borrow(), vec!["audit", "lint", "test"]);
+        assert_eq!(*dispatcher.calls.borrow(), vec!["lint", "test"]);
         let lint = readiness
             .gate_results
             .iter()
@@ -2659,7 +2680,7 @@ jobs:
         assert!(readiness
             .gate_results
             .iter()
-            .filter(|gate| ["audit", "lint", "test"].contains(&gate.gate.as_str()))
+            .filter(|gate| gate.status == "passed")
             .all(|gate| gate.provenance.as_ref() == Some(&child_provenance)));
     }
 


### PR DESCRIPTION
## Summary
- derive portable release gates from the canonical release quality plan instead of a duplicate hardcoded list
- retain disabled gate reasons such as `no-release-audit-policy` in readiness evidence
- prevent Lab release preflight from dispatching review audit when release planning disables audit

This fixes the control-plane mismatch observed while releasing WP Codebox: Lab lint and test passed, but an undeclared audit was dispatched and its optional artifact transport timeout invalidated release readiness.

Fixes #14363.

## Evidence
- Failed readiness: `release-readiness-66de1f66-c08a-4837-a9af-2e22a1bd495a`
- Failed undeclared audit run: `14a1311e-8164-421b-96b3-fdd700456ba4`

## Verification
- `cargo test -p homeboy-cli commands::release::tests --lib` (45 passed)
- `cargo check -p homeboy-cli`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance
GPT-5.6 Sol via OpenCode was used to inspect retained Homeboy readiness evidence, identify the duplicate gate-selection path, implement the canonical-plan reuse, and run verification under Chris Huber’s direction.