### PR TITLE
Fix unscoped Cook component selection

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -3766,6 +3766,14 @@ fn cook_provision_repository(args: &AgentTaskCookArgs) -> Option<String> {
         .or_else(|| {
             args.repository_identity
                 .as_ref()
+                .and_then(|identity| identity.get("component_id"))
+                .and_then(Value::as_str)
+                .filter(|component| !component.trim().is_empty())
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            args.repository_identity
+                .as_ref()
                 .and_then(|identity| identity.get("repository_name"))
                 .and_then(Value::as_str)
                 .filter(|repository| !repository.trim().is_empty())
@@ -3892,7 +3900,11 @@ pub(crate) fn resolve_cook_destination(
         Some(head) => head,
         None => derived_cook_branch(&task_url)?,
     };
-    args.to_worktree = Some(format!("{repo}@{}", slugify_cook_branch(&head)));
+    let handle_repository = cook_component_id(&args).unwrap_or(repo);
+    args.to_worktree = Some(format!(
+        "{handle_repository}@{}",
+        slugify_cook_branch(&head)
+    ));
     if args.head.is_none() {
         args.head = Some(head);
     }
@@ -4518,33 +4530,22 @@ fn cook_component_id(args: &AgentTaskCookArgs) -> Option<&str> {
 fn cook_components_for_repository_name(
     repository_name: &str,
 ) -> homeboy::core::Result<Vec<homeboy::core::component::Component>> {
-    if let Some(component) =
-        homeboy::core::component::inventory::registered_primary_by_id(repository_name)?
-    {
-        return Ok(vec![component]);
+    let repository_name = normalize_repository_name(repository_name);
+    let primary_matches = cook_components_matching_repository_name(
+        homeboy::core::component::inventory::registered_primary()?,
+        &repository_name,
+    );
+    if !primary_matches.is_empty() {
+        if primary_matches.len() > 1 {
+            return Err(repository_component_identity_ambiguity_error(
+                repository_name,
+                &primary_matches,
+            ));
+        }
+        return Ok(primary_matches);
     }
     let components = homeboy::core::component::inventory::registered_base()?;
-    if let Some(component) = components
-        .iter()
-        .find(|component| component.id == repository_name)
-        .cloned()
-    {
-        return Ok(vec![component]);
-    }
-    let repository_name = normalize_repository_name(repository_name);
-    let matches = components
-        .into_iter()
-        .filter(|component| {
-            component
-                .aliases
-                .iter()
-                .any(|alias| normalize_repository_name(alias) == repository_name)
-                || component
-                    .remote_url
-                    .as_deref()
-                    .is_some_and(|remote| normalize_repository_name(remote) == repository_name)
-        })
-        .collect::<Vec<_>>();
+    let matches = cook_components_matching_repository_name(components, &repository_name);
     if matches.len() > 1 {
         return Err(repository_component_identity_ambiguity_error(
             repository_name,
@@ -4554,13 +4555,35 @@ fn cook_components_for_repository_name(
     Ok(matches)
 }
 
+fn cook_components_matching_repository_name(
+    components: Vec<homeboy::core::component::Component>,
+    repository_name: &str,
+) -> Vec<homeboy::core::component::Component> {
+    components
+        .into_iter()
+        .filter(|component| {
+            normalize_repository_name(&component.id) == repository_name
+                || component
+                    .aliases
+                    .iter()
+                    .any(|alias| normalize_repository_name(alias) == repository_name)
+                || component
+                    .remote_url
+                    .as_deref()
+                    .is_some_and(|remote| normalize_repository_name(remote) == repository_name)
+        })
+        .collect()
+}
+
 fn cook_registered_component_by_id(
     component_id: &str,
 ) -> homeboy::core::Result<Option<homeboy::core::component::Component>> {
-    Ok(
+    if let Some(component) =
         homeboy::core::component::inventory::registered_primary_by_id(component_id)?
-            .or(homeboy::core::component::registered_by_id(component_id)?),
-    )
+    {
+        return Ok(Some(component));
+    }
+    homeboy::core::component::registered_by_id(component_id)
 }
 
 fn select_cook_repository_identity(

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -3908,7 +3908,7 @@ fn resolve_cook_base(args: &mut AgentTaskCookArgs) -> homeboy::core::Result<()> 
         .or(args.dispatch.cwd.as_deref())
         .map(Path::new);
     let component = cook_component_id(args)
-        .map(homeboy::core::component::registered_by_id)
+        .map(cook_registered_component_by_id)
         .transpose()?
         .flatten()
         .map(|component| PathBuf::from(component.local_path));
@@ -3948,7 +3948,7 @@ fn validate_cook_base_before_provisioning(args: &AgentTaskCookArgs) -> homeboy::
         })
         .or_else(|| {
             cook_component_id(args).and_then(|repo| {
-                homeboy::core::component::registered_by_id(repo)
+                cook_registered_component_by_id(repo)
                     .ok()
                     .flatten()
                     .map(|component| PathBuf::from(component.local_path))
@@ -4247,15 +4247,14 @@ fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::
     args.dispatch.repo = Some(selected.repository_name.clone());
     let component_id = match args.component.as_deref() {
         Some(component_id) => {
-            let component =
-                homeboy::core::component::registered_by_id(component_id)?.ok_or_else(|| {
-                    homeboy::core::Error::validation_invalid_argument(
-                        "component",
-                        format!("--component `{component_id}` is not a registered component"),
-                        Some(component_id.to_string()),
-                        None,
-                    )
-                })?;
+            let component = cook_registered_component_by_id(component_id)?.ok_or_else(|| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "component",
+                    format!("--component `{component_id}` is not a registered component"),
+                    Some(component_id.to_string()),
+                    None,
+                )
+            })?;
             let component_remote = component
                 .remote_url
                 .as_deref()
@@ -4284,7 +4283,7 @@ fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::
     };
     args.component = component_id.clone();
     let component_cwd = match component_id.as_deref() {
-        Some(component_id) => homeboy::core::component::registered_by_id(component_id)?
+        Some(component_id) => cook_registered_component_by_id(component_id)?
             .map(|component| durable_component_cwd(&component, &selected.repository_name))
             .transpose()?,
         None => None,
@@ -4314,8 +4313,7 @@ fn bind_cook_repository_identity_from_config(
     let (repository_name, component_id, identity) =
         cook_repository_identity_for_selection(&repo, args.component.as_deref())?;
     args.dispatch.repo = Some(repository_name);
-    args.component =
-        homeboy::core::component::registered_by_id(&component_id)?.map(|component| component.id);
+    args.component = cook_registered_component_by_id(&component_id)?.map(|component| component.id);
     let repository_path = (args.component.is_none() && Path::new(&repo).is_dir()).then_some(repo);
     let mut identity = identity;
     if let Some(repository_path) = repository_path {
@@ -4520,6 +4518,11 @@ fn cook_component_id(args: &AgentTaskCookArgs) -> Option<&str> {
 fn cook_components_for_repository_name(
     repository_name: &str,
 ) -> homeboy::core::Result<Vec<homeboy::core::component::Component>> {
+    if let Some(component) =
+        homeboy::core::component::inventory::registered_primary_by_id(repository_name)?
+    {
+        return Ok(vec![component]);
+    }
     let components = homeboy::core::component::inventory::registered_base()?;
     if let Some(component) = components
         .iter()
@@ -4549,6 +4552,15 @@ fn cook_components_for_repository_name(
         ));
     }
     Ok(matches)
+}
+
+fn cook_registered_component_by_id(
+    component_id: &str,
+) -> homeboy::core::Result<Option<homeboy::core::component::Component>> {
+    Ok(
+        homeboy::core::component::inventory::registered_primary_by_id(component_id)?
+            .or(homeboy::core::component::registered_by_id(component_id)?),
+    )
 }
 
 fn select_cook_repository_identity(
@@ -5438,7 +5450,7 @@ fn cook_component_workspace(
 }
 
 fn component_workspace(component_id: &str, workspace: &Path) -> homeboy::core::Result<PathBuf> {
-    let Some(component) = homeboy::core::component::registered_by_id(component_id)? else {
+    let Some(component) = cook_registered_component_by_id(component_id)? else {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "component workspace",
             format!("configured component `{component_id}` is no longer registered"),

--- a/crates/homeboy-core/src/component/inventory/listing.rs
+++ b/crates/homeboy-core/src/component/inventory/listing.rs
@@ -262,6 +262,17 @@ pub fn registered_by_id(id: &str) -> Result<Option<Component>> {
     registered_by_id_core(None, id)
 }
 
+/// Resolve the standalone registration for an unscoped component operation.
+///
+/// Project attachments intentionally take precedence in [`registered_by_id`],
+/// because they carry project-owned deployment configuration. Callers that
+/// select a repository outside a project scope instead need the component's
+/// durable primary registration.
+pub fn registered_primary_by_id(id: &str) -> Result<Option<Component>> {
+    crate::engine::identifier::validate_component_id(id)?;
+    load_standalone_component_core(None, id)
+}
+
 /// [`registered_by_id`] against an already-resolved config root (#7505).
 pub fn registered_by_id_in_root(config_root: &Path, id: &str) -> Result<Option<Component>> {
     registered_by_id_core(Some(config_root), id)

--- a/crates/homeboy-core/src/component/inventory/listing.rs
+++ b/crates/homeboy-core/src/component/inventory/listing.rs
@@ -273,6 +273,14 @@ pub fn registered_primary_by_id(id: &str) -> Result<Option<Component>> {
     load_standalone_component_core(None, id)
 }
 
+/// List standalone component registrations without project attachments.
+///
+/// This preserves the durable component identity for unscoped operations while
+/// [`registered`] and [`registered_by_id`] retain project attachment precedence.
+pub fn registered_primary() -> Result<Vec<Component>> {
+    load_standalone_components_core(None)
+}
+
 /// [`registered_by_id`] against an already-resolved config root (#7505).
 pub fn registered_by_id_in_root(config_root: &Path, id: &str) -> Result<Option<Component>> {
     registered_by_id_core(Some(config_root), id)

--- a/tests/cli_binary/cook_preview_lifecycle.rs
+++ b/tests/cli_binary/cook_preview_lifecycle.rs
@@ -166,6 +166,152 @@ fn stdin_prompt_preview_declares_replay_requirement() {
     );
 }
 
+#[test]
+fn unscoped_preview_uses_the_primary_component_despite_missing_project_shadows() {
+    for projects in [
+        ["shadow-first", "shadow-second"],
+        ["shadow-second", "shadow-first"],
+    ] {
+        let home = tempfile::tempdir().expect("home");
+        let repository = tempfile::tempdir().expect("repository");
+        let primary = repository.path().join("primary");
+        initialize_git_repository(&primary);
+
+        run_homeboy(
+            home.path(),
+            [
+                "component",
+                "create",
+                "--local-path",
+                primary.to_str().expect("primary path"),
+            ],
+        );
+        for project in projects {
+            let shadow = repository.path().join(project);
+            std::fs::create_dir_all(&shadow).expect("create project shadow");
+            std::fs::write(shadow.join("homeboy.json"), r#"{"id":"primary"}"#)
+                .expect("write project shadow component");
+            run_homeboy(home.path(), ["project", "create", project]);
+            run_homeboy(
+                home.path(),
+                [
+                    "project",
+                    "components",
+                    "set",
+                    project,
+                    "--json",
+                    &format!(
+                        r#"[{{"id":"primary","local_path":"{}"}}]"#,
+                        shadow.display()
+                    ),
+                ],
+            );
+            std::fs::remove_file(shadow.join("homeboy.json"))
+                .expect("remove project shadow component");
+            std::fs::remove_dir(shadow).expect("remove project shadow");
+        }
+
+        let output = Command::new(homeboy_bin())
+            .args([
+                "agent-task",
+                "cook",
+                "--repo",
+                "primary",
+                "--task-url",
+                "https://example.test/issues/14591",
+                "--head",
+                "fix/14591-primary-selection",
+                "--base",
+                "main",
+                "--backend",
+                "fixture",
+                "--prompt",
+                "Preserve the primary component selection.",
+                "--preview",
+                "--no-finalize",
+            ])
+            .env("HOME", home.path())
+            .env("XDG_CONFIG_HOME", home.path().join(".config"))
+            .env("XDG_DATA_HOME", home.path().join(".local/share"))
+            .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+            .output()
+            .expect("run Cook preview");
+
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "stdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let preview: Value = serde_json::from_slice(&output.stdout).expect("preview JSON");
+        assert_eq!(
+            preview["data"]["resolved"]["repository_identity"]["component_cwd"],
+            "."
+        );
+        assert_eq!(
+            preview["data"]["resolved"]["repository_identity"]["component_id"],
+            "primary"
+        );
+    }
+}
+
+fn run_homeboy<I, S>(home: &std::path::Path, args: I)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let output = Command::new(homeboy_bin())
+        .args(args)
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("XDG_DATA_HOME", home.join(".local/share"))
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run Homeboy setup command");
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn initialize_git_repository(path: &std::path::Path) {
+    std::fs::create_dir_all(path).expect("create primary repository");
+    for args in [
+        vec!["init", "--quiet"],
+        vec!["config", "user.email", "fixture@example.test"],
+        vec!["config", "user.name", "Fixture"],
+    ] {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git setup");
+        assert!(output.status.success(), "git setup failed");
+    }
+    std::fs::write(path.join("README.md"), "fixture\n").expect("write fixture");
+    let output = Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(path)
+        .output()
+        .expect("stage fixture");
+    assert!(output.status.success(), "stage fixture failed");
+    let output = Command::new("git")
+        .args(["commit", "--quiet", "-m", "fixture"])
+        .current_dir(path)
+        .output()
+        .expect("commit fixture");
+    assert!(output.status.success(), "commit fixture failed");
+    let output = Command::new("git")
+        .args(["branch", "-M", "main"])
+        .current_dir(path)
+        .output()
+        .expect("name fixture branch");
+    assert!(output.status.success(), "name fixture branch failed");
+}
+
 fn replay_flag_value<'a>(argv: &'a [Value], flag: &str) -> &'a str {
     let matches = argv
         .windows(2)

--- a/tests/cli_binary/cook_preview_lifecycle.rs
+++ b/tests/cli_binary/cook_preview_lifecycle.rs
@@ -186,6 +186,16 @@ fn unscoped_preview_uses_the_primary_component_despite_missing_project_shadows()
                 primary.to_str().expect("primary path"),
             ],
         );
+        run_homeboy(
+            home.path(),
+            [
+                "component",
+                "set",
+                "primary",
+                "--json",
+                r#"{"aliases":["primary-alias"],"remote_url":"https://github.com/example/primary-repository.git"}"#,
+            ],
+        );
         for project in projects {
             let shadow = repository.path().join(project);
             std::fs::create_dir_all(&shadow).expect("create project shadow");
@@ -211,48 +221,50 @@ fn unscoped_preview_uses_the_primary_component_despite_missing_project_shadows()
             std::fs::remove_dir(shadow).expect("remove project shadow");
         }
 
-        let output = Command::new(homeboy_bin())
-            .args([
-                "agent-task",
-                "cook",
-                "--repo",
-                "primary",
-                "--task-url",
-                "https://example.test/issues/14591",
-                "--head",
-                "fix/14591-primary-selection",
-                "--base",
-                "main",
-                "--backend",
-                "fixture",
-                "--prompt",
-                "Preserve the primary component selection.",
-                "--preview",
-                "--no-finalize",
-            ])
-            .env("HOME", home.path())
-            .env("XDG_CONFIG_HOME", home.path().join(".config"))
-            .env("XDG_DATA_HOME", home.path().join(".local/share"))
-            .env("HOMEBOY_NO_UPDATE_CHECK", "1")
-            .output()
-            .expect("run Cook preview");
+        for repo in ["primary", "primary-alias", "primary-repository"] {
+            let output = Command::new(homeboy_bin())
+                .args([
+                    "agent-task",
+                    "cook",
+                    "--repo",
+                    repo,
+                    "--task-url",
+                    "https://example.test/issues/14591",
+                    "--head",
+                    "fix/14591-primary-selection",
+                    "--base",
+                    "main",
+                    "--backend",
+                    "fixture",
+                    "--prompt",
+                    "Preserve the primary component selection.",
+                    "--preview",
+                    "--no-finalize",
+                ])
+                .env("HOME", home.path())
+                .env("XDG_CONFIG_HOME", home.path().join(".config"))
+                .env("XDG_DATA_HOME", home.path().join(".local/share"))
+                .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+                .output()
+                .expect("run Cook preview");
 
-        assert_eq!(
-            output.status.code(),
-            Some(0),
-            "stdout: {}\nstderr: {}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let preview: Value = serde_json::from_slice(&output.stdout).expect("preview JSON");
-        assert_eq!(
-            preview["data"]["resolved"]["repository_identity"]["component_cwd"],
-            "."
-        );
-        assert_eq!(
-            preview["data"]["resolved"]["repository_identity"]["component_id"],
-            "primary"
-        );
+            assert_eq!(
+                output.status.code(),
+                Some(0),
+                "repo {repo}; stdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let preview: Value = serde_json::from_slice(&output.stdout).expect("preview JSON");
+            assert_eq!(
+                preview["data"]["resolved"]["repository_identity"]["component_cwd"],
+                "."
+            );
+            assert_eq!(
+                preview["data"]["resolved"]["repository_identity"]["component_id"],
+                "primary"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #14591.

- Resolve unscoped Cook component IDs, aliases, and remote repository names through durable standalone registrations before project attachments.
- Keep project-attached lookup precedence for project-scoped registry operations.
- Derive deferred worktree handles and provider lookup from the selected primary component identity.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `homeboy runner exec homeboy-lab --sync-workspace . -- cargo test --test cli_binary unscoped_preview_uses_the_primary_component_despite_missing_project_shadows`
- `homeboy runner exec homeboy-lab --sync-workspace . --artifact target/debug/homeboy -- cargo build --bin homeboy`

The CLI preview regression passed for component ID, alias, and remote repository name with missing project shadows in both attachment orders. Homeboy retained the built binary as an artifact.

## AI Assistance

OpenAI GPT-5.6 Terra (`openai/gpt-5.6-terra`) via OpenCode investigated the resolution path, implemented the repair, and ran focused Lab verification under Chris Huber's direction.