### PR TITLE
Fix runner recovery blocked by orphaned Cook indexes

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
@@ -374,3 +374,50 @@ fn cook_index_projection_reconciles_after_its_filesystem_write_fails() {
         "a restarted reader converges on the same durable index"
     );
 }
+
+#[test]
+fn orphaned_historical_cook_index_does_not_block_canonical_lifecycle_records() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let store = AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "canonical-run";
+    let cook_id = "canonical-cook";
+
+    let mut run = record(&store, run_id, "canonical");
+    run.metadata["cook_id"] = json!(cook_id);
+    store.write_record(&run).expect("write canonical run");
+    store
+        .write_cook_index_attempt(cook_id, 1, run_id, "canonical".to_string(), None)
+        .expect("write canonical index");
+
+    let orphan_path = store.cook_index_path("orphaned-cook");
+    std::fs::create_dir_all(orphan_path.parent().expect("orphan parent"))
+        .expect("create orphan parent");
+    homeboy_core::engine::local_files::write_json_file(
+        &orphan_path,
+        &crate::agent_task_lifecycle::AgentTaskCookIndex {
+            schema: crate::agent_task_lifecycle::records::schemas::COOK_INDEX.to_string(),
+            cook_id: "orphaned-cook".to_string(),
+            latest_run_id: "missing-run".to_string(),
+            latest_substantive_candidate: None,
+            cancellation_fence: None,
+            attempts: vec![crate::agent_task_lifecycle::AgentTaskCookIndexAttempt {
+                attempt: 1,
+                run_id: "missing-run".to_string(),
+                recorded_at: "orphaned".to_string(),
+            }],
+        },
+    )
+    .expect("write orphaned historical index");
+
+    let observation = store
+        .open_observation_initialized()
+        .expect("orphaned derived index must not block lifecycle store");
+    assert!(observation
+        .control_plane_resource_projection("agent_task_run", cook_id)
+        .expect("read canonical projection")
+        .is_some());
+    assert!(observation
+        .control_plane_resource_projection("agent_task_run", "orphaned-cook")
+        .expect("read orphan projection")
+        .is_none());
+}

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -265,14 +265,12 @@ impl AgentTaskLifecycleStore {
             {
                 continue;
             }
-            let run = observation.get_run(&index.latest_run_id)?.ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "cook_index",
-                    "Cook index latest attempt has no canonical lifecycle record",
-                    Some(index.latest_run_id.clone()),
-                    None,
-                )
-            })?;
+            let Some(run) = observation.get_run(&index.latest_run_id)? else {
+                // Historical Cook indexes are derived compatibility projections.
+                // An orphan cannot restore authority and must not block unrelated
+                // canonical lifecycle records from opening.
+                continue;
+            };
             let record = record_from_run(&run)?;
             let projection = agent_task_resource_projection(self, &record, Some(&index))?;
             observation.upsert_control_plane_resource_projection(&projection)?;


### PR DESCRIPTION
## Summary

- treat historical Cook indexes as derived compatibility projections when their referenced lifecycle run is absent
- prevent one orphaned derived file from blocking every agent-task lifecycle-store open
- retain fail-closed handling for canonical projection conflicts
- add a regression proving canonical lifecycle records remain available beside an orphaned index

## Runtime impact

This repairs the first ownership-resolution failure in #14594. During `runner reconcile`, the draining daemon invokes linked-task terminal recovery. Previously an unrelated orphaned historical index made `AgentTaskLifecycleStore::open_observation_initialized()` fail globally, so no linked run could be resolved and a queued old-generation job permanently held runner admission.

The migration does not synthesize, delete, or import the orphan. It skips a derived projection that has no canonical lifecycle authority and continues opening the store.

## Verification

- `cargo test -p homeboy-agents orphaned_historical_cook_index_does_not_block_canonical_lifecycle_records --lib`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::lifecycle_store --lib`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #14594

## AI assistance disclosure

OpenAI `gpt-5.6-sol` via OpenCode was used to trace the live runner-generation deadlock to lifecycle-store migration, implement the focused fix and regression, and run verification. The operator directed the repair and reviewed the resulting workflow evidence.