### PR TITLE
Execute direct staged jobs through the daemon lifecycle

### DIFF
--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -11,7 +11,7 @@ use super::persistence::{
     apply_event_retention, job_not_found, lookup_tombstone, timestamp_ms, validate_transition,
     ReplayTombstoneKind,
 };
-use super::store::{JobStore, RemoteRunnerSubmission, StoredJob};
+use super::store::{JobStore, LocalRunnerJob, RemoteRunnerSubmission, StoredJob};
 use super::types::{Job, JobEvent, JobEventKind, JobStatus};
 use crate::engine::command::CommandCaptureMetadata;
 use crate::env_materialization_plan::EnvMaterializationPlan;
@@ -717,6 +717,10 @@ pub(super) struct StoredRemoteRunnerJob {
     /// provider boundary after the worker has materialized its inputs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) execution_receipt: Option<RemoteRunnerExecutionReceipt>,
+    /// Durable direction fence set before runner-side staged-source work starts.
+    /// A selected job remains queued and retryable until direct adoption.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(super) direct_execution_selected: bool,
 }
 
 #[derive(Deserialize)]
@@ -733,6 +737,8 @@ struct StoredRemoteRunnerJobCompat {
     execution_context_id: Option<String>,
     #[serde(default)]
     execution_receipt: Option<RemoteRunnerExecutionReceipt>,
+    #[serde(default)]
+    direct_execution_selected: bool,
 }
 
 impl<'de> Deserialize<'de> for StoredRemoteRunnerJob {
@@ -782,6 +788,7 @@ impl<'de> Deserialize<'de> for StoredRemoteRunnerJob {
             workspace_owner_lease: stored.workspace_owner_lease.or(legacy_owner_lease),
             execution_context_id: stored.execution_context_id,
             execution_receipt: stored.execution_receipt,
+            direct_execution_selected: stored.direct_execution_selected,
         })
     }
 }
@@ -966,7 +973,371 @@ fn execution_context_id_from_evidence(stored: &StoredJob) -> Result<Option<Strin
     }
 }
 
+/// Only the sealed staging pipeline may convert a reverse submission into a
+/// direct daemon child. Ordinary remote runner jobs remain reverse-only.
+fn is_runner_staged_execution(stored: &StoredJob) -> bool {
+    stored.job.operation == "runner_staged_execution"
+        && stored.remote_runner.as_ref().is_some_and(|remote| {
+            remote
+                .envelope
+                .metadata
+                .get("staged_source_artifact")
+                .is_some()
+                && remote
+                    .envelope
+                    .metadata
+                    .get("staged_workspace_materialization")
+                    .is_some()
+        })
+}
+
 impl JobStore {
+    /// Return the immutable, redacted envelope of one still-queued reverse job.
+    /// This is intentionally unavailable after direct adoption or terminalization
+    /// so callers cannot treat historical reverse input as new admission work.
+    pub fn queued_staged_execution(
+        &self,
+        job_id: Uuid,
+        runner_id: &str,
+    ) -> Result<Option<RunnerExecutionEnvelope>> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        if stored.job.target_runner_id.as_deref() != Some(runner_id) {
+            return Err(Error::validation_invalid_argument(
+                "runner_id",
+                "staged execution belongs to a different runner",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        Ok(
+            (stored.job.status == JobStatus::Queued && is_runner_staged_execution(stored))
+                .then(|| {
+                    stored
+                        .remote_runner
+                        .as_ref()
+                        .map(|remote| remote.envelope.clone())
+                })
+                .flatten(),
+        )
+    }
+
+    /// Read the sealed staged envelope for either its queued reverse record or
+    /// a previously adopted direct record. Adoption retains this provenance so
+    /// a replacement daemon can replay the exact UUID.
+    pub fn staged_direct_execution_envelope(
+        &self,
+        job_id: Uuid,
+        runner_id: &str,
+    ) -> Result<Option<RunnerExecutionEnvelope>> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        if stored.job.target_runner_id.as_deref() != Some(runner_id) {
+            return Err(Error::validation_invalid_argument(
+                "runner_id",
+                "staged execution belongs to a different runner",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        if is_runner_staged_execution(stored) {
+            return Ok(stored
+                .remote_runner
+                .as_ref()
+                .map(|remote| remote.envelope.clone()));
+        }
+        Ok(stored.events.iter().rev().find_map(|event| {
+            let data = event.data.as_ref()?;
+            (data.get("phase").and_then(Value::as_str) == Some("staged_execution_adopted"))
+                .then(|| data.get("staged_execution_envelope"))?
+                .cloned()
+                .and_then(|envelope| serde_json::from_value(envelope).ok())
+        }))
+    }
+
+    /// Select direct execution before any runner-side source preparation. This
+    /// durable direction fence and reverse claiming share the same transaction,
+    /// so exactly one execution path can win for a staged job.
+    pub fn select_staged_direct_execution(
+        &self,
+        job_id: Uuid,
+        runner_id: &str,
+    ) -> Result<Option<RunnerExecutionEnvelope>> {
+        let deliveries = self
+            .credential_deliveries
+            .lock()
+            .expect("credential delivery mutex poisoned");
+        if deliveries.contains_key(&job_id) {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                "staged execution has reverse credential authority and cannot be selected directly",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        let selection = self.durable_transaction(|inner| {
+            let stored = inner.jobs.get_mut(&job_id).ok_or_else(|| job_not_found(job_id))?;
+            if stored.job.target_runner_id.as_deref() != Some(runner_id) {
+                return Err(Error::validation_invalid_argument(
+                    "runner_id",
+                    "staged execution belongs to a different runner",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if stored.local_runner.is_some() || stored.job.status.is_terminal() {
+                return Ok(None);
+            }
+            if stored.job.status != JobStatus::Queued || stored.job.claim_id.is_some() {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "staged execution is already claimed or is not queued",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if !is_runner_staged_execution(stored) {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not a runner-staged execution",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            let (envelope, selected_now) = {
+                let remote = stored
+                    .remote_runner
+                    .as_mut()
+                    .expect("staged job has remote record");
+                if remote.execution_context_id.is_some()
+                    || remote.execution_receipt.is_some()
+                    || remote.workspace_claim_binding().is_some()
+                    || remote.workspace_owner_lease().is_some()
+                {
+                    return Err(Error::validation_invalid_argument(
+                        "job_id",
+                        "staged execution requires reverse-runner authority and cannot be selected directly",
+                        Some(job_id.to_string()),
+                        None,
+                    ));
+                }
+                let selected_now = !remote.direct_execution_selected;
+                remote.direct_execution_selected = true;
+                (remote.envelope.clone(), selected_now)
+            };
+            if selected_now {
+                stored.job.updated_at_ms = timestamp_ms();
+                Self::append_event_already_locked(
+                    self,
+                    inner,
+                    job_id,
+                    JobEventKind::Progress,
+                    Some("staged direct execution selected".to_string()),
+                    Some(serde_json::json!({ "phase": "staged_direct_execution_selected" })),
+                )?;
+            }
+            Ok(Some(envelope))
+        });
+        drop(deliveries);
+        selection
+    }
+
+    /// Atomically turn one exact queued reverse submission into the existing
+    /// daemon-local execution lifecycle. The submission index and event history
+    /// remain attached to the same UUID; clearing `remote_runner` prevents any
+    /// reverse worker from subsequently claiming it.
+    pub(crate) fn adopt_queued_staged_execution_for_local_runner(
+        &self,
+        job_id: Uuid,
+        expected_envelope: &RunnerExecutionEnvelope,
+        local_runner: LocalRunnerJob,
+        source_snapshot: Option<SourceSnapshot>,
+        metadata: Value,
+        path_materialization_plan: Option<PathMaterializationPlan>,
+    ) -> Result<(Job, bool)> {
+        // Reverse claiming holds this mutex before taking the durable store
+        // lock. Keep this guard through the durable conversion so credential
+        // delivery cannot appear between the rejection check and commit.
+        let deliveries = self
+            .credential_deliveries
+            .lock()
+            .expect("credential delivery mutex poisoned");
+        if deliveries.contains_key(&job_id) {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                "staged execution has an unconsumed reverse credential delivery",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        let adoption = self.durable_transaction(|inner| {
+            let stored = inner.jobs.get_mut(&job_id).ok_or_else(|| job_not_found(job_id))?;
+            if stored.local_runner.is_some() {
+                return Ok((stored.job.clone(), false));
+            }
+            if stored.job.status.is_terminal() {
+                return Ok((stored.job.clone(), false));
+            }
+            if stored.job.status != JobStatus::Queued || stored.job.claim_id.is_some() {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "staged execution is already claimed or is not queued",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if stored.job.target_runner_id.as_deref() != Some(local_runner.runner_id.as_str()) {
+                return Err(Error::validation_invalid_argument(
+                    "runner_id",
+                    "staged execution belongs to a different runner",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            let remote = stored.remote_runner.as_ref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not a queued staged reverse execution",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })?;
+            if !is_runner_staged_execution(stored) {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not a runner-staged execution",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if !remote.direct_execution_selected {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "staged execution was not selected for direct execution",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if &remote.envelope != expected_envelope {
+                return Err(Error::validation_invalid_argument(
+                    "expected_envelope",
+                    "staged execution envelope does not match the durable submission",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if remote.execution_context_id.is_some()
+                || remote.execution_receipt.is_some()
+                || remote.workspace_claim_binding().is_some()
+                || remote.workspace_owner_lease().is_some()
+            {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "staged execution requires reverse-runner authority and cannot be directly adopted",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            stored.local_runner = Some(local_runner);
+            stored.remote_runner = None;
+            stored.job.operation = "runner.exec".to_string();
+            // This daemon generation owns the pre-worker handoff. A later
+            // generation may recover only if no child reservation was recorded.
+            stored.job.daemon_lease_id = self.daemon_lease_id.clone();
+            stored.job.source_snapshot = source_snapshot;
+            stored.job.path_materialization_plan = path_materialization_plan;
+            stored.job.updated_at_ms = timestamp_ms();
+            Self::append_event_already_locked(
+                self,
+                inner,
+                job_id,
+                JobEventKind::Progress,
+                Some("queued staged execution adopted for direct daemon execution".to_string()),
+                Some(serde_json::json!({
+                    "phase": "staged_execution_adopted",
+                    "staged_execution_envelope": expected_envelope,
+                    "local_execution": metadata,
+                })),
+            )?;
+            Ok((
+                inner.jobs.get(&job_id).expect("adopted job exists").job.clone(),
+                true,
+            ))
+        });
+        drop(deliveries);
+        adoption
+    }
+
+    /// Take over a queued adopted job only after the daemon lifecycle has
+    /// proved the exact previous lease dead. A merely different lease is not
+    /// ownership evidence: its worker may still be waiting for capacity.
+    pub(crate) fn recover_proven_dead_adopted_staged_direct_execution(
+        &self,
+        job_id: Uuid,
+        runner_id: &str,
+        proven_dead_lease_id: &str,
+    ) -> Result<Option<Job>> {
+        let Some(current_lease_id) = self.daemon_lease_id.as_deref() else {
+            return Ok(None);
+        };
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            let Some(local) = stored.local_runner.as_ref() else {
+                return Ok(None);
+            };
+            if local.runner_id != runner_id {
+                return Err(Error::validation_invalid_argument(
+                    "runner_id",
+                    "adopted staged execution belongs to a different runner",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if stored.job.status != JobStatus::Queued || stored.local_child.is_some() {
+                return Ok(None);
+            }
+            let Some(previous_lease_id) = stored.job.daemon_lease_id.clone() else {
+                return Ok(None);
+            };
+            if previous_lease_id == current_lease_id {
+                return Ok(None);
+            }
+            if previous_lease_id != proven_dead_lease_id {
+                return Err(Error::validation_invalid_argument(
+                    "proven_dead_lease_id",
+                    "adopted staged execution is not owned by the proven-dead daemon lease",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            stored.job.daemon_lease_id = Some(current_lease_id.to_string());
+            stored.job.updated_at_ms = timestamp_ms();
+            let job = stored.job.clone();
+            Self::append_event_already_locked(
+                self,
+                inner,
+                job_id,
+                JobEventKind::Progress,
+                Some("abandoned staged direct pre-worker handoff recovered".to_string()),
+                Some(serde_json::json!({
+                    "phase": "staged_direct_execution_recovered",
+                    "proven_dead_lease_id": previous_lease_id,
+                    "daemon_lease_id": current_lease_id,
+                })),
+            )?;
+            Ok(Some(job))
+        })
+    }
+
     pub fn remote_runner_workspace_claim_binding(
         &self,
         job_id: Uuid,
@@ -1153,6 +1524,7 @@ impl JobStore {
                     workspace_owner_lease,
                     execution_context_id: None,
                     execution_receipt: None,
+                    direct_execution_selected: false,
                 },
             },
             now,
@@ -1334,6 +1706,7 @@ impl JobStore {
                 workspace_owner_lease: public_request.workspace_owner_lease,
                 execution_context_id: None,
                 execution_receipt: None,
+                direct_execution_selected: false,
             },
         };
         self.admit_remote_runner_job(admission, now)
@@ -1623,6 +1996,11 @@ impl JobStore {
                 .values()
                 .filter(|stored| {
                     stored.remote_runner.is_some()
+                        && !stored
+                            .remote_runner
+                            .as_ref()
+                            .expect("filtered remote runner job has request")
+                            .direct_execution_selected
                         && stored.job.status == JobStatus::Queued
                         && stored.job.target_runner_id.as_deref() == Some(runner_id)
                         && project_matches(stored.job.target_project_id.as_deref(), project_id)
@@ -2094,7 +2472,10 @@ impl JobStore {
                 .jobs
                 .get(&job_id)
                 .ok_or_else(|| job_not_found(job_id))?;
-            if stored.remote_runner.is_none() {
+            let adopted_direct = stored.local_runner.as_ref().is_some_and(|local| {
+                stored.job.target_runner_id.as_deref() == Some(local.runner_id.as_str())
+            });
+            if stored.remote_runner.is_none() && !adopted_direct {
                 return Err(Error::validation_invalid_argument(
                     "job_id",
                     "job is not a remote runner job",

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -2208,24 +2208,27 @@ impl JobStore {
         )
     }
 
-    /// Fallible variant used by the daemon request boundary so a failed durable
-    /// queue commit can roll back a just-registered workspace owner.
-    pub(crate) fn try_run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner<
-        T,
-        F,
-    >(
+    /// Start the standard direct-child worker for either a newly admitted local
+    /// job or a remote job atomically adopted by the caller. The adoption
+    /// transaction supplies `created`; replayed adoptions therefore retain the
+    /// original UUID without spawning another worker.
+    pub(crate) fn try_run_capacity_queued_local_child_background_with_existing_job<T, F>(
         &self,
         request: LocalRunnerJobRequest,
         capacity: usize,
+        existing_job: Option<(Job, bool)>,
         run: F,
     ) -> Result<(JobRunner, bool)>
     where
         T: Serialize + Send + 'static,
         F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
     {
-        let (job, created) = self.durable_transaction(|inner| {
-            self.create_or_reuse_active_local_runner_job_inner(inner, request.clone())
-        })?;
+        let (job, created) = match existing_job {
+            Some(job) => job,
+            None => self.durable_transaction(|inner| {
+                self.create_or_reuse_active_local_runner_job_inner(inner, request.clone())
+            })?,
+        };
         let job_id = job.id;
         // An idempotent resubmission reused an already-enqueued job that already
         // has its own worker. Do not spawn a second worker for it — return a
@@ -2575,10 +2578,20 @@ impl JobStore {
         let reservation_id = Uuid::new_v4().to_string();
         let reservation_expires_at_ms = now.saturating_add(LOCAL_CHILD_RESERVATION_LEASE_MS);
         self.durable_transaction(|inner| {
-            inner
+            let job = inner
                 .jobs
                 .get(&job_id)
                 .ok_or_else(|| job_not_found(job_id))?;
+            if let Some(current_lease_id) = self.daemon_lease_id.as_deref() {
+                if job.job.daemon_lease_id.as_deref() != Some(current_lease_id) {
+                    return Err(Error::validation_invalid_argument(
+                        "daemon_lease_id",
+                        "local child reservation belongs to a different daemon generation",
+                        Some(job_id.to_string()),
+                        None,
+                    ));
+                }
+            }
             if let Some((runner_id, capacity)) = runner_capacity {
                 let active = inner.jobs.values().filter(|candidate| {
                     candidate.job.id != job_id

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::fs;
+use std::sync::{Arc, Barrier};
 
 use serde_json::json;
 
@@ -23,6 +24,298 @@ fn controller_owned_secret_plan(name: &str) -> SecretEnvPlan {
         },
     );
     plan
+}
+
+fn direct_local_runner(runner_id: &str) -> LocalRunnerJob {
+    LocalRunnerJob {
+        runner_id: runner_id.to_string(),
+        command: vec!["homeboy".to_string(), "test".to_string()],
+        cwd: Some("/srv/extrachill".to_string()),
+        lifecycle: None,
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
+    }
+}
+
+fn staged_runner_request(runner_id: &str) -> RemoteRunnerJobRequest {
+    let mut request = remote_runner_request(runner_id, None);
+    request.operation = "runner_staged_execution".to_string();
+    request.metadata = Some(json!({
+        "staged_source_artifact": { "id": "sealed:test" },
+        "staged_workspace_materialization": { "workspace": "test" },
+    }));
+    request
+}
+
+#[test]
+fn exact_staged_adoption_retains_uuid_and_excludes_reverse_claims() {
+    let store = JobStore::default();
+    let original = store
+        .submit_runner_api_fixture(staged_runner_request("homeboy-lab"))
+        .expect("queue original staged job");
+    let expected = store
+        .queued_staged_execution(original.id, "homeboy-lab")
+        .expect("read authoritative staged envelope")
+        .expect("queued staged envelope");
+    assert_eq!(
+        store
+            .select_staged_direct_execution(original.id, "homeboy-lab")
+            .expect("select direct execution"),
+        Some(expected.clone())
+    );
+    let competing = store
+        .submit_runner_api_fixture(staged_runner_request("homeboy-lab"))
+        .expect("queue competing staged job");
+
+    let (adopted, created) = store
+        .adopt_queued_staged_execution_for_local_runner(
+            original.id,
+            &expected,
+            direct_local_runner("homeboy-lab"),
+            None,
+            json!({ "runner_id": "homeboy-lab" }),
+            None,
+        )
+        .expect("adopt exact staged job");
+    assert!(created);
+    assert_eq!(adopted.id, original.id);
+    assert!(store
+        .queued_staged_execution(original.id, "homeboy-lab")
+        .expect("inspect adopted job")
+        .is_none());
+
+    let replay = store
+        .adopt_queued_staged_execution_for_local_runner(
+            original.id,
+            &expected,
+            direct_local_runner("homeboy-lab"),
+            None,
+            json!({ "runner_id": "homeboy-lab" }),
+            None,
+        )
+        .expect("replay adoption");
+    assert_eq!(replay.0.id, original.id);
+    assert!(!replay.1);
+
+    let claimed = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("claim remaining reverse job")
+        .expect("competing job remains eligible");
+    assert_eq!(claimed.job.id, competing.id);
+}
+
+#[test]
+fn concurrent_exact_staged_adoption_creates_one_local_executor() {
+    let store = JobStore::default();
+    let job = store
+        .submit_runner_api_fixture(staged_runner_request("homeboy-lab"))
+        .expect("queue staged job");
+    let expected = store
+        .queued_staged_execution(job.id, "homeboy-lab")
+        .expect("read authoritative staged envelope")
+        .expect("queued staged envelope");
+    store
+        .select_staged_direct_execution(job.id, "homeboy-lab")
+        .expect("select direct execution");
+    let barrier = Arc::new(Barrier::new(2));
+    let first_store = store.clone();
+    let first_expected = expected.clone();
+    let first_barrier = Arc::clone(&barrier);
+    let first = std::thread::spawn(move || {
+        first_barrier.wait();
+        first_store
+            .adopt_queued_staged_execution_for_local_runner(
+                job.id,
+                &first_expected,
+                direct_local_runner("homeboy-lab"),
+                None,
+                json!({}),
+                None,
+            )
+            .expect("first adoption")
+            .1
+    });
+    barrier.wait();
+    let second = store
+        .adopt_queued_staged_execution_for_local_runner(
+            job.id,
+            &expected,
+            direct_local_runner("homeboy-lab"),
+            None,
+            json!({}),
+            None,
+        )
+        .expect("second adoption")
+        .1;
+    assert_ne!(first.join().expect("join adoption"), second);
+}
+
+#[test]
+fn exact_staged_adoption_rejects_reverse_claimed_job() {
+    let store = JobStore::default();
+    let expected = remote_runner_request("homeboy-lab", None).execution_envelope();
+    let job = store
+        .submit_runner_api_fixture(staged_runner_request("homeboy-lab"))
+        .expect("queue staged job");
+    let claimed = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("claim staged job")
+        .expect("claimed job");
+    assert_eq!(claimed.job.id, job.id);
+    assert!(store
+        .adopt_queued_staged_execution_for_local_runner(
+            job.id,
+            &expected,
+            direct_local_runner("homeboy-lab"),
+            None,
+            json!({}),
+            None,
+        )
+        .is_err());
+}
+
+#[test]
+fn staged_direct_selection_and_reverse_claim_are_mutually_exclusive() {
+    let store = JobStore::default();
+    let job = store
+        .submit_runner_api_fixture(staged_runner_request("homeboy-lab"))
+        .expect("queue staged job");
+    let barrier = Arc::new(Barrier::new(2));
+    let selecting_store = store.clone();
+    let selecting_barrier = Arc::clone(&barrier);
+    let select = std::thread::spawn(move || {
+        selecting_barrier.wait();
+        selecting_store
+            .select_staged_direct_execution(job.id, "homeboy-lab")
+            .ok()
+            .flatten()
+            .is_some()
+    });
+    barrier.wait();
+    let claimed = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("claim result")
+        .is_some();
+    assert_ne!(select.join().expect("join selection"), claimed);
+}
+
+#[test]
+fn selected_staged_execution_survives_restart_and_remains_reverse_ineligible() {
+    let directory = tempfile::tempdir().expect("temporary durable store");
+    let path = directory.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let job = store
+        .submit_runner_api_fixture(staged_runner_request("homeboy-lab"))
+        .expect("queue staged job");
+    let selected = store
+        .select_staged_direct_execution(job.id, "homeboy-lab")
+        .expect("select direct execution")
+        .expect("selected envelope");
+    drop(store);
+
+    let restarted = JobStore::open_without_reconciliation(&path).expect("restart store");
+    assert_eq!(
+        restarted
+            .select_staged_direct_execution(job.id, "homeboy-lab")
+            .expect("replay selection"),
+        Some(selected)
+    );
+    assert!(restarted
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("selected job cannot be reverse claimed")
+        .is_none());
+}
+
+#[test]
+fn new_daemon_lease_recovers_adopted_pre_worker_job_once() {
+    let directory = tempfile::tempdir().expect("temporary durable store");
+    let path = directory.path().join("jobs.json");
+    let old = JobStore::open_without_reconciliation(&path)
+        .expect("durable store")
+        .with_daemon_lease("old-daemon".to_string());
+    let job = old
+        .submit_runner_api_fixture(staged_runner_request("homeboy-lab"))
+        .expect("queue staged job");
+    let expected = old
+        .select_staged_direct_execution(job.id, "homeboy-lab")
+        .expect("select staged job")
+        .expect("selected envelope");
+    old.adopt_queued_staged_execution_for_local_runner(
+        job.id,
+        &expected,
+        direct_local_runner("homeboy-lab"),
+        Some(crate::source_snapshot::existing_remote(
+            "homeboy-lab",
+            "/prepared/workspace",
+            Some("/prepared"),
+        )),
+        json!({}),
+        None,
+    )
+    .expect("durably adopt without spawning worker");
+    let old_worker_store = old.clone();
+    drop(old);
+
+    let recovered_store = JobStore::open_without_reconciliation(&path)
+        .expect("reopen store")
+        .with_daemon_lease("new-daemon".to_string());
+    assert_eq!(
+        recovered_store
+            .staged_direct_execution_envelope(job.id, "homeboy-lab")
+            .expect("read retained sealed envelope"),
+        Some(expected.clone())
+    );
+    let recovered = recovered_store
+        .recover_proven_dead_adopted_staged_direct_execution(job.id, "homeboy-lab", "old-daemon")
+        .expect("recover abandoned handoff")
+        .expect("new generation owns recovery");
+    assert_eq!(recovered.id, job.id);
+    assert_eq!(
+        recovered
+            .source_snapshot
+            .as_ref()
+            .expect("prepared snapshot")
+            .remote_path,
+        Some("/prepared/workspace".to_string())
+    );
+    assert!(recovered_store
+        .recover_proven_dead_adopted_staged_direct_execution(job.id, "homeboy-lab", "old-daemon",)
+        .expect("same generation observes recovery")
+        .is_none());
+    assert!(old_worker_store
+        .reserve_local_child_with_runner_capacity(job.id, "homeboy-lab", 1)
+        .is_err());
+
+    let request = LocalRunnerJobRequest {
+        operation: "runner.exec".to_string(),
+        source_snapshot: recovered.source_snapshot.clone(),
+        metadata: None,
+        path_materialization_plan: None,
+        local_runner: Some(direct_local_runner("homeboy-lab")),
+        admission_idempotency_key: None,
+    };
+    let runner = recovered_store
+        .try_run_capacity_queued_local_child_background_with_existing_job(
+            request,
+            1,
+            Some((recovered, true)),
+            |handle| {
+                handle.start_with_reserved_child_identity(
+                    std::process::id(),
+                    None,
+                    LocalChildStartDiscriminator::Unsupported {
+                        evidence: "state-level recovery fixture".to_string(),
+                    },
+                )?;
+                Ok(json!({ "recovered": true }))
+            },
+        )
+        .expect("run recovered job");
+    runner.0.handle.join().expect("join recovered worker");
+    assert_eq!(
+        recovered_store.get(job.id).expect("recovered job").status,
+        JobStatus::Succeeded
+    );
 }
 
 #[test]

--- a/crates/homeboy-core/src/daemon/generation_store.rs
+++ b/crates/homeboy-core/src/daemon/generation_store.rs
@@ -233,6 +233,90 @@ pub(super) fn record_job(job_id: &str, lease_id: &str) -> Result<()> {
     })
 }
 
+/// Move a queued job away from the exact daemon lease proven dead during
+/// startup recovery. Ordinary admission retries intentionally retain their
+/// original owner; only the owner-locked death proof may use this transfer.
+pub(super) fn transfer_proven_dead_job(
+    job_id: &str,
+    proven_dead_lease_id: &str,
+    replacement: &DaemonState,
+) -> Result<()> {
+    mutate_registry(|registry| {
+        let registry = registry.as_mut().ok_or_else(|| {
+            Error::internal_unexpected("local daemon recovery has no generation registry")
+        })?;
+        if registry
+            .generations
+            .generations
+            .get(proven_dead_lease_id)
+            .is_none_or(|generation| generation.endpoint.lease_id != proven_dead_lease_id)
+        {
+            return Err(Error::validation_invalid_argument(
+                "proven_dead_lease_id",
+                "proven-dead daemon lease is not an exact generation endpoint",
+                Some(proven_dead_lease_id.to_string()),
+                None,
+            ));
+        }
+        let owner = registry
+            .generations
+            .job_owner(job_id)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job_id",
+                    "recovered job has no durable daemon generation owner",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })?
+            .to_string();
+        let replacement_lease_id = &replacement.lease_id;
+        if owner != proven_dead_lease_id && owner != *replacement_lease_id {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                "recovered job is owned by a different daemon generation",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+
+        if !registry
+            .generations
+            .generations
+            .contains_key(replacement_lease_id)
+        {
+            registry.generations.begin(
+                replacement_lease_id.clone(),
+                LocalDaemonEndpoint::from_state(replacement),
+            );
+        }
+        if owner == *replacement_lease_id {
+            return Ok(());
+        }
+
+        let completed = registry.completed_jobs.contains(job_id);
+        registry
+            .generations
+            .job_owners
+            .insert(job_id.to_string(), replacement_lease_id.clone());
+        if !completed {
+            let old = registry
+                .generations
+                .generations
+                .get_mut(proven_dead_lease_id)
+                .expect("proven-dead generation was validated");
+            old.active_jobs = old.active_jobs.saturating_sub(1);
+            let replacement = registry
+                .generations
+                .generations
+                .get_mut(replacement_lease_id)
+                .expect("replacement generation was inserted or found");
+            replacement.active_jobs += 1;
+        }
+        Ok(())
+    })
+}
+
 pub(super) fn activate(state: &DaemonState) -> Result<()> {
     mutate_registry(|registry| {
         let registry = registry.as_mut().ok_or_else(|| {
@@ -501,6 +585,49 @@ mod tests {
                     .expect("owner")
                     .lease_id,
                 "A"
+            );
+        });
+    }
+
+    #[test]
+    fn proven_dead_transfer_moves_only_recovered_jobs_once() {
+        with_isolated_home(|_| {
+            let a = state("A", "127.0.0.1:1001");
+            let b = state("B", "127.0.0.1:1002");
+            seed(&a).expect("seed A");
+            record_job("recovered", "A").expect("record recovered job");
+            record_job("terminal", "A").expect("record terminal job");
+            record_job("other", "A").expect("record other job");
+            mark_job_terminal("terminal").expect("mark terminal job");
+
+            transfer_proven_dead_job("recovered", "A", &b).expect("transfer recovered job");
+            transfer_proven_dead_job("terminal", "A", &b).expect("transfer terminal job");
+            // The same recovery can be retried without moving active counts again.
+            transfer_proven_dead_job("recovered", "A", &b).expect("repeat transfer");
+
+            assert_eq!(
+                endpoint_for_job("recovered")
+                    .expect("route recovered")
+                    .expect("replacement endpoint")
+                    .lease_id,
+                "B"
+            );
+            assert_eq!(
+                endpoint_for_job("other")
+                    .expect("route unrelated")
+                    .expect("original endpoint")
+                    .lease_id,
+                "A"
+            );
+            let registry = read_registry().expect("read registry").expect("registry");
+            assert_eq!(registry.generations.generations["A"].active_jobs, 1);
+            assert_eq!(registry.generations.generations["B"].active_jobs, 1);
+
+            let before = registry.clone();
+            assert!(transfer_proven_dead_job("other", "wrong", &b).is_err());
+            assert_eq!(
+                read_registry().expect("read unchanged registry"),
+                Some(before)
             );
         });
     }

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1138,6 +1138,11 @@ struct ExecRequest {
     workspace_owner_request: Option<WorkspaceOwnerRegisterRequest>,
 }
 
+enum StagedDirectExecution {
+    Adoption(Uuid, RunnerExecutionEnvelope),
+    Recovered(Uuid, RunnerExecutionEnvelope, String),
+}
+
 /// Direct-daemon transport adapter for the canonical runner submission.
 ///
 /// The inline descriptor and `raw_exec` remain local to the direct runner
@@ -1570,6 +1575,21 @@ where
     let local_addr = listener.local_addr().map_err(|e| {
         Error::internal_io(e.to_string(), Some("read daemon local address".to_string()))
     })?;
+    // The exclusive daemon-owner lock is already held. Keep exact prior-owner
+    // death evidence before write_state replaces the lease; version skew alone
+    // never authorizes replay of an adopted job.
+    let prior = validate_lease_file(&paths::daemon_state_file()?)?;
+    let proven_dead = if prior.stale_reason_code == Some(DaemonStaleReasonCode::PidDead) {
+        let candidates = control::daemon_process_candidates(&paths::daemon_jobs_file()?)?
+            .into_iter()
+            .filter(|candidate| candidate.pid != std::process::id())
+            .collect::<Vec<_>>();
+        (!has_conflicting_process_candidates(&candidates))
+            .then_some(prior.state)
+            .flatten()
+    } else {
+        None
+    };
     let state = write_state(local_addr)?;
     generation_store::seed(&state)?;
     let job_store = JobStore::open_without_reconciliation(paths::daemon_jobs_file()?)
@@ -1582,6 +1602,9 @@ where
     // Expire only reservations that never recorded a child identity.
     job_store.reconcile_expired_local_child_reservations()?;
     job_store.reconcile_expired_admissions()?;
+    if let Some(prior) = proven_dead {
+        recover_staged_direct_jobs_after_owner_death(&job_store, &prior.lease_id, &state)?;
+    }
     reconcile_pending_workspace_owner_releases();
     reconcile_terminal_workspace_owner_leases(&job_store);
     recover_controller_jobs(&job_store);
@@ -2340,7 +2363,9 @@ where
         | ("POST", "/runner/workspace-owners/release") => {
             remote_runner::route(method, path, body, job_store, &broker_auth)
         }
-        ("POST", "/runner/staging") | ("POST", "/runner/staging/capabilities") => {
+        ("POST", "/runner/staging")
+        | ("POST", "/runner/staging/direct")
+        | ("POST", "/runner/staging/capabilities") => {
             remote_runner::route(method, path, body, job_store, &broker_auth)
         }
         ("POST", "/runner/jobs") | ("POST", "/runner/jobs/claim") => {
@@ -3550,6 +3575,192 @@ fn enqueue_exec_job(
     job_store: &JobStore,
 ) -> Result<serde_json::Value> {
     let request = decode_exec_request(body)?;
+    enqueue_exec_request(request, job_store, None)
+}
+
+fn recover_staged_direct_jobs_after_owner_death(
+    job_store: &JobStore,
+    proven_dead_lease: &str,
+    replacement: &DaemonState,
+) -> Result<()> {
+    for job in job_store.list().into_iter().filter(|job| {
+        job.status == JobStatus::Queued
+            && job.operation == "runner.exec"
+            && job.daemon_lease_id.as_deref() == Some(proven_dead_lease)
+    }) {
+        let Some(runner_id) = job.target_runner_id.as_deref() else {
+            continue;
+        };
+        let Some(envelope) = job_store.staged_direct_execution_envelope(job.id, runner_id)? else {
+            continue;
+        };
+        let request = ExecRequest {
+            submission_key: None,
+            legacy_submission_key_is_run_id: false,
+            envelope: envelope.clone(),
+            runner: None,
+            raw_exec: false,
+            workspace_claim_binding: None,
+            workspace_owner_request: None,
+        };
+        // Rebind before preparation, so a terminal preparation failure and any
+        // later result both route through the replacement generation.
+        generation_store::transfer_proven_dead_job(
+            &job.id.to_string(),
+            proven_dead_lease,
+            replacement,
+        )?;
+        if let Err(error) = enqueue_exec_request(
+            request,
+            job_store,
+            Some(StagedDirectExecution::Recovered(
+                job.id,
+                envelope,
+                proven_dead_lease.to_string(),
+            )),
+        ) {
+            // No child existed at the proven-dead boundary. A preparation
+            // failure is terminal evidence for the normal retry lifecycle,
+            // rather than another apparently accepted, unconsumed queue entry.
+            job_store.fail_with_data(
+                job.id,
+                error.to_string(),
+                Some(json!({
+                    "phase": "staged_direct_recovery_preparation_failed",
+                    "proven_dead_lease_id": proven_dead_lease,
+                    "error_code": error.code.as_str(),
+                    "error_details": error.details,
+                })),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Execute one already-admitted staged runner submission through the daemon's
+/// normal local-child lifecycle. The stored envelope is the admission authority;
+/// staged source materialization occurs only in the runner exec driver after
+/// this durable boundary.
+pub fn enqueue_staged_direct_exec(
+    job_store: &JobStore,
+    job_id: Uuid,
+    expected_envelope: RunnerExecutionEnvelope,
+    materialized_envelope: RunnerExecutionEnvelope,
+    runner: Option<serde_json::Value>,
+) -> Result<serde_json::Value> {
+    let runner_id = materialized_envelope
+        .dispatch
+        .as_ref()
+        .map(|dispatch| dispatch.runner_id.as_str())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "materialized_envelope.dispatch",
+                "staged direct execution requires dispatch",
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+    validate_staged_materialization(&expected_envelope, &materialized_envelope, job_id)?;
+    let selected = job_store.select_staged_direct_execution(job_id, runner_id)?;
+    let authoritative = selected
+        .map(|_| job_store.queued_staged_execution(job_id, runner_id))
+        .transpose()?
+        .flatten();
+    match authoritative {
+        Some(authoritative) if authoritative == expected_envelope => {}
+        Some(_) => {
+            return Err(Error::validation_invalid_argument(
+                "expected_envelope",
+                "staged direct execution does not match the queued durable submission",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        None => {
+            let job = job_store.get(job_id)?;
+            if job.status == JobStatus::Running && job.claim_id.is_some() {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "staged execution is claimed by a reverse runner",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            return Ok(serde_json::json!({
+                "command": "api.runner.exec.enqueue",
+                "job": job,
+                "poll": {
+                    "job": format!("/jobs/{job_id}"),
+                    "events": format!("/jobs/{job_id}/events"),
+                },
+                "idempotent_resubmission": true,
+            }));
+        }
+    }
+    enqueue_exec_request(
+        ExecRequest {
+            submission_key: None,
+            legacy_submission_key_is_run_id: false,
+            envelope: materialized_envelope,
+            runner,
+            raw_exec: false,
+            workspace_claim_binding: None,
+            workspace_owner_request: None,
+        },
+        job_store,
+        Some(StagedDirectExecution::Adoption(job_id, expected_envelope)),
+    )
+}
+
+/// Staging may resolve the runner-owned workspace location, but must not turn a
+/// sealed submission into a different command or policy. The runner integration
+/// performs its source guard before this boundary and supplies those permitted
+/// location changes as `materialized_envelope`.
+fn validate_staged_materialization(
+    expected: &RunnerExecutionEnvelope,
+    materialized: &RunnerExecutionEnvelope,
+    job_id: Uuid,
+) -> Result<()> {
+    expected.dispatch.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "expected_envelope.dispatch",
+            "staged direct execution requires a sealed dispatch",
+            Some(job_id.to_string()),
+            None,
+        )
+    })?;
+    let materialized_dispatch = materialized.dispatch.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "materialized_envelope.dispatch",
+            "staged direct execution requires a materialized dispatch",
+            Some(job_id.to_string()),
+            None,
+        )
+    })?;
+    let mut permitted = expected.clone();
+    let permitted_dispatch = permitted
+        .dispatch
+        .as_mut()
+        .expect("expected dispatch was checked");
+    // Source staging owns only the runner-local working location and snapshot.
+    permitted_dispatch.cwd = materialized_dispatch.cwd.clone();
+    permitted_dispatch.source_snapshot = materialized_dispatch.source_snapshot.clone();
+    if permitted != *materialized {
+        return Err(Error::validation_invalid_argument(
+            "materialized_envelope",
+            "staged materialization may change only runner-owned workspace locations",
+            Some(job_id.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn enqueue_exec_request(
+    request: ExecRequest,
+    job_store: &JobStore,
+    staged_adoption: Option<StagedDirectExecution>,
+) -> Result<serde_json::Value> {
     let dispatch = request.envelope.dispatch.as_ref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "envelope.dispatch",
@@ -3620,7 +3831,7 @@ fn enqueue_exec_job(
         )
     })?;
     let submission_key = request.submission_key.clone();
-    let plan = runner_exec_driver::prepare_exec(runner_exec_driver::RunnerExecPrepareRequest {
+    let prepare_request = runner_exec_driver::RunnerExecPrepareRequest {
         runner_id: dispatch.runner_id.clone(),
         runner: request.runner.clone(),
         cwd: dispatch.cwd.clone(),
@@ -3643,7 +3854,16 @@ fn enqueue_exec_job(
             .and_then(|lifecycle| lifecycle.durable_run_id.clone())
             .or_else(|| submission_key.clone()),
         validate_require_paths_on_host: true,
-    })?;
+    };
+    let plan = match staged_adoption.as_ref() {
+        Some(StagedDirectExecution::Adoption(job_id, expected_envelope)) => {
+            runner_exec_driver::prepare_staged_exec(prepare_request, *job_id, expected_envelope)?
+        }
+        Some(StagedDirectExecution::Recovered(job_id, expected_envelope, _)) => {
+            runner_exec_driver::prepare_staged_exec(prepare_request, *job_id, expected_envelope)?
+        }
+        None => runner_exec_driver::prepare_exec(prepare_request)?,
+    };
     let source_snapshot = Some(plan.source_snapshot.clone());
 
     let mut lifecycle = request.envelope.lifecycle.clone();
@@ -3669,21 +3889,23 @@ fn enqueue_exec_job(
     // A dropped response can hide successful admission. Return the active
     // execution for the caller-owned submission key, but never confuse its
     // preceding capacity reservation for the execution itself.
-    if let Some(submission_key) = submission_key.as_deref() {
-        if let Some(existing) =
-            job_store.active_execution_job_for_admission_idempotency_key(submission_key)
-        {
-            let existing_job_id = existing.id;
-            return Ok(json!({
-                "command": "api.runner.exec.enqueue",
-                "job": existing,
-                "poll": {
-                    "job": format!("/jobs/{existing_job_id}"),
-                    "events": format!("/jobs/{existing_job_id}/events"),
-                },
-                "request": summary,
-                "idempotent_resubmission": true,
-            }));
+    if staged_adoption.is_none() {
+        if let Some(submission_key) = submission_key.as_deref() {
+            if let Some(existing) =
+                job_store.active_execution_job_for_admission_idempotency_key(submission_key)
+            {
+                let existing_job_id = existing.id;
+                return Ok(json!({
+                    "command": "api.runner.exec.enqueue",
+                    "job": existing,
+                    "poll": {
+                        "job": format!("/jobs/{existing_job_id}"),
+                        "events": format!("/jobs/{existing_job_id}/events"),
+                    },
+                    "request": summary,
+                    "idempotent_resubmission": true,
+                }));
+            }
         }
     }
 
@@ -3760,17 +3982,57 @@ fn enqueue_exec_job(
     let capacity = plan.concurrency_limit.unwrap_or(usize::MAX).max(1);
     let stall_watchdog_store = job_store.clone();
     let workspace_owner_renewal_store = (*job_store).clone();
+    let local_request = LocalRunnerJobRequest {
+        operation,
+        source_snapshot: source_snapshot.clone(),
+        metadata: Some(run_ref_metadata.clone()),
+        path_materialization_plan: path_materialization_plan.clone(),
+        local_runner: Some(local_runner),
+        admission_idempotency_key: submission_key.clone(),
+    };
+    let existing_job = match staged_adoption {
+        Some(StagedDirectExecution::Adoption(job_id, expected_envelope)) => Some(
+            job_store.adopt_queued_staged_execution_for_local_runner(
+                job_id,
+                &expected_envelope,
+                local_request
+                    .local_runner
+                    .clone()
+                    .expect("direct local request has runner authority"),
+                local_request.source_snapshot.clone(),
+                run_ref_metadata.clone(),
+                path_materialization_plan.clone(),
+            )?,
+        ),
+        Some(StagedDirectExecution::Recovered(job_id, _, proven_dead_lease_id)) => Some((
+            job_store
+                .recover_proven_dead_adopted_staged_direct_execution(
+                    job_id,
+                    local_request
+                        .local_runner
+                        .as_ref()
+                        .expect("direct local request has runner authority")
+                        .runner_id
+                        .as_str(),
+                    &proven_dead_lease_id,
+                )?
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "job_id",
+                        "staged direct recovery lost its proven-dead pre-worker claim",
+                        Some(job_id.to_string()),
+                        None,
+                    )
+                })?,
+            true,
+        )),
+        None => None,
+    };
     let (runner, created) = match job_store
-        .try_run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
-            LocalRunnerJobRequest {
-                operation,
-                source_snapshot: source_snapshot.clone(),
-                metadata: Some(run_ref_metadata),
-                path_materialization_plan: path_materialization_plan.clone(),
-                local_runner: Some(local_runner),
-                admission_idempotency_key: submission_key.clone(),
-            },
+        .try_run_capacity_queued_local_child_background_with_existing_job(
+            local_request,
             capacity,
+            existing_job,
             move |job| {
                 let mut plan = plan;
                 if let (Some(lease), Some(claim_store)) = (
@@ -4576,6 +4838,94 @@ mod tests {
         self, DaemonExecOutput, PreparedDaemonExec, PreparedDaemonExecRequest, RunnerExecDriver,
         RunnerExecPrepareRequest,
     };
+
+    #[test]
+    fn staged_startup_recovery_records_preparation_failure_on_the_original_job_route() {
+        crate::test_support::with_isolated_home(|_| {
+            register_enqueue_test_driver(); // This driver intentionally has no staged-source support.
+            let directory = tempfile::tempdir().unwrap();
+            let path = directory.path().join("jobs.json");
+            let old_state = write_state("127.0.0.1:31001".parse().unwrap()).unwrap();
+            generation_store::seed(&old_state).unwrap();
+            let old = JobStore::open_without_reconciliation(&path)
+                .unwrap()
+                .with_daemon_lease(old_state.lease_id.clone());
+            let mut envelope = RunnerExecutionEnvelope::planned("staged-recovery", "test");
+            envelope.dispatch = Some(homeboy_runner_contract::RunnerExecutionDispatch {
+                runner_id: "lab".to_string(),
+                project_id: None,
+                operation: "runner_staged_execution".to_string(),
+                command: vec!["true".to_string()],
+                cwd: Some("/tmp".to_string()),
+                env: Default::default(),
+                source_snapshot: None,
+                require_paths: Vec::new(),
+                extension_env_providers: Vec::new(),
+            });
+            envelope.metadata =
+                json!({"staged_source_artifact": null, "staged_workspace_materialization": null});
+            let job = old
+                .submit_runner_api_request(homeboy_runner_contract::RunnerApiSubmitRequest {
+                    schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+                    api_version: homeboy_runner_contract::RUNNER_API_V1,
+                    submission_key: "staged-recovery".to_string(),
+                    envelope: envelope.clone(),
+                    workspace_claim_binding: None,
+                    workspace_owner_lease: None,
+                    credential_delivery: None,
+                })
+                .unwrap();
+            old.select_staged_direct_execution(job.id, "lab").unwrap();
+            old.adopt_queued_staged_execution_for_local_runner(
+                job.id,
+                &envelope,
+                LocalRunnerJob {
+                    runner_id: "lab".to_string(),
+                    command: vec!["true".to_string()],
+                    cwd: Some("/tmp".to_string()),
+                    lifecycle: None,
+                    workspace_claim_binding: None,
+                    workspace_owner_lease: None,
+                },
+                None,
+                json!({}),
+                None,
+            )
+            .unwrap();
+            generation_store::record_job(&job.id.to_string(), &old_state.lease_id).unwrap();
+            drop(old);
+            let replacement = write_state("127.0.0.1:31002".parse().unwrap()).unwrap();
+            let reopened = JobStore::open_without_reconciliation(&path)
+                .unwrap()
+                .with_daemon_lease(replacement.lease_id.clone());
+            recover_staged_direct_jobs_after_owner_death(
+                &reopened,
+                "different-lease",
+                &replacement,
+            )
+            .unwrap();
+            assert_eq!(reopened.get(job.id).unwrap().status, JobStatus::Queued);
+            recover_staged_direct_jobs_after_owner_death(
+                &reopened,
+                &old_state.lease_id,
+                &replacement,
+            )
+            .unwrap();
+            assert_eq!(reopened.get(job.id).unwrap().status, JobStatus::Failed);
+            assert!(reopened.events(job.id).unwrap().iter().any(|event| {
+                event.data.as_ref().is_some_and(|data| {
+                    data["phase"] == "staged_direct_recovery_preparation_failed"
+                })
+            }));
+            assert_eq!(
+                generation_store::endpoint_for_job(&job.id.to_string())
+                    .unwrap()
+                    .unwrap()
+                    .lease_id,
+                replacement.lease_id
+            );
+        });
+    }
 
     #[test]
     fn network_control_plane_submission_binds_actor_to_submit_credential() {

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -172,7 +172,13 @@ pub(in crate::daemon) fn route(
             Err(err) => auth_or_bad_request(err),
         },
         ("POST", "/runner/staging") => {
-            match super::with_daemon_job_admission(|| stage(body, job_store, auth)) {
+            match super::with_daemon_job_admission(|| stage(body, job_store, auth, false)) {
+                Ok(body) => daemon_endpoint_response("runner.staging.submit", body),
+                Err(err) => auth_or_bad_request(err),
+            }
+        }
+        ("POST", "/runner/staging/direct") => {
+            match super::with_daemon_job_admission(|| stage(body, job_store, auth, true)) {
                 Ok(body) => daemon_endpoint_response("runner.staging.submit", body),
                 Err(err) => auth_or_bad_request(err),
             }
@@ -296,11 +302,20 @@ fn staging_capabilities(body: Option<Value>, auth: &BrokerAuthContext) -> Result
     }))
 }
 
-fn stage(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
+fn stage(
+    body: Option<Value>,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+    direct: bool,
+) -> Result<Value> {
     let runner_id = staging_runner_id(&body)?;
     auth.authorize(BrokerScope::Submit, Some(&runner_id))?;
     crate::daemon::runner_staging::with_provider(|provider| {
-        provider.stage(body.unwrap_or(Value::Null), job_store)
+        if direct {
+            provider.stage_direct(body.unwrap_or(Value::Null), job_store)
+        } else {
+            provider.stage(body.unwrap_or(Value::Null), job_store)
+        }
     })
 }
 

--- a/crates/homeboy-core/src/daemon/runner_exec_driver.rs
+++ b/crates/homeboy-core/src/daemon/runner_exec_driver.rs
@@ -24,6 +24,8 @@ use crate::error::{Error, Result};
 use crate::runner_job_execution_context::RunnerJobExecutionContext;
 use crate::server::HeartbeatOnlyStallPolicy;
 use crate::source_snapshot::SourceSnapshot;
+use homeboy_runner_contract::RunnerExecutionEnvelope;
+use uuid::Uuid;
 
 /// Everything the driver needs to build a runner process plan. Mirrors the
 /// daemon's `ExecRequest`, but carries the runner descriptor as raw JSON so no
@@ -155,6 +157,20 @@ pub trait RunnerExecDriver: Send + Sync {
     /// Prepare a runner process plan from the exec request.
     fn prepare(&self, request: RunnerExecPrepareRequest) -> Result<PreparedDaemonExec>;
 
+    /// Prepare a sealed staged submission. Drivers that own staged source
+    /// materialization override this so the daemon never accepts a caller-owned
+    /// workspace path as execution authority.
+    fn prepare_staged(
+        &self,
+        _request: RunnerExecPrepareRequest,
+        _job_id: Uuid,
+        _envelope: &RunnerExecutionEnvelope,
+    ) -> Result<PreparedDaemonExec> {
+        Err(Error::internal_unexpected(
+            "runner exec driver does not support staged direct execution",
+        ))
+    }
+
     /// Execute a prepared runner child, driving it with the daemon's
     /// cancellation, progress, and child-identity callbacks.
     ///
@@ -209,6 +225,15 @@ homeboy_engine_primitives::provider_registry_arc! {
 /// Prepare a runner process via the registered driver (or the no-op driver).
 pub(crate) fn prepare_exec(request: RunnerExecPrepareRequest) -> Result<PreparedDaemonExec> {
     active_driver().prepare(request)
+}
+
+/// Prepare a sealed staged runner process via the registered driver.
+pub(crate) fn prepare_staged_exec(
+    request: RunnerExecPrepareRequest,
+    job_id: Uuid,
+    envelope: &RunnerExecutionEnvelope,
+) -> Result<PreparedDaemonExec> {
+    active_driver().prepare_staged(request, job_id, envelope)
 }
 
 /// Execute a prepared runner child via the registered driver. The registry lock

--- a/crates/homeboy-core/src/daemon/runner_staging.rs
+++ b/crates/homeboy-core/src/daemon/runner_staging.rs
@@ -10,6 +10,14 @@ pub trait RunnerStagingProvider: Send + Sync {
     /// The daemon-owned queue is passed through this narrow boundary so staging
     /// admits the real execution job instead of inventing a second executor.
     fn stage(&self, request: Value, jobs: &JobStore) -> Result<Value>;
+    fn stage_direct(&self, _request: Value, _jobs: &JobStore) -> Result<Value> {
+        Err(crate::Error::validation_invalid_argument(
+            "runner_capabilities",
+            "runner does not support direct staged execution",
+            None,
+            None,
+        ))
+    }
 }
 
 struct NoopProvider;

--- a/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
+++ b/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
@@ -16,6 +16,8 @@ use homeboy_core::daemon::runner_exec_driver::{
 use homeboy_core::error::Result;
 use homeboy_core::runner_job_execution_context::RunnerJobExecutionContext;
 use homeboy_core::secret_env_plan::SecretEnvPlan;
+use homeboy_runner_contract::RunnerExecutionEnvelope;
+use uuid::Uuid;
 
 use super::execution::{
     execute_runner_process_until_cancelled_with_progress, prepare_daemon_local_process,
@@ -27,6 +29,12 @@ struct DaemonPreparedPlan {
     plan: PreparedRunnerProcess,
     extension_env_providers: Vec<String>,
     authoritative_run_id: Option<String>,
+    staged: Option<DaemonStagedPlan>,
+}
+
+struct DaemonStagedPlan {
+    envelope: RunnerExecutionEnvelope,
+    workspace: Option<super::worker::StagedWorkspaceDirectory>,
 }
 
 /// The runner layer's `RunnerExecDriver`. Registered with core at startup.
@@ -34,80 +42,42 @@ pub struct RunnerDaemonExecDriver;
 
 impl RunnerExecDriver for RunnerDaemonExecDriver {
     fn prepare(&self, request: RunnerExecPrepareRequest) -> Result<PreparedDaemonExec> {
-        let runner: Option<Runner> = match request.runner {
-            Some(value) => Some(serde_json::from_value(value).map_err(|err| {
-                homeboy_core::error::Error::validation_invalid_argument(
-                    "runner",
-                    format!("invalid runner descriptor in exec request: {err}"),
-                    None,
-                    None,
-                )
-            })?),
-            None => None,
-        };
-        let secret_env_plan: Option<SecretEnvPlan> = match request.secret_env_plan {
-            Some(Value::Null) | None => None,
-            Some(value) => Some(serde_json::from_value(value).map_err(|err| {
-                homeboy_core::error::Error::validation_invalid_argument(
-                    "secret_env_plan",
-                    format!("invalid secret env plan in exec request: {err}"),
-                    None,
-                    None,
-                )
-            })?),
-        };
+        prepare_daemon_exec(request, None)
+    }
 
-        let provider_secret_names = request
-            .extension_env_providers
-            .iter()
-            .map(|id| homeboy_core::extension::invoke::declared_secret_names(id))
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        let secret_env_plan = super::execution::runner_exec_secret_env_plan(
-            &request.command,
-            None,
-            &provider_secret_names,
-            &request.env,
-            secret_env_plan,
-        );
-        let authoritative_run_id = request.authoritative_run_id;
-        let plan = prepare_daemon_local_process(RunnerProcessRequest {
-            runner_id: request.runner_id,
-            runner,
-            cwd: request.cwd,
-            project_id: request.project_id,
-            command: request.command,
-            env: request.env,
-            secret_env_names: request.secret_env_names,
-            secret_env_plan: Some(secret_env_plan),
-            capture_patch: request.capture_patch,
-            raw_exec: request.raw_exec,
-            source_snapshot: request.source_snapshot,
-            require_paths: request.require_paths,
-            validate_require_paths_on_host: request.validate_require_paths_on_host,
+    fn prepare_staged(
+        &self,
+        mut request: RunnerExecPrepareRequest,
+        job_id: Uuid,
+        envelope: &RunnerExecutionEnvelope,
+    ) -> Result<PreparedDaemonExec> {
+        // The sealed submission is the source authority. Only the runner driver
+        // may derive its workspace location after extracting and verifying it.
+        let mut materialized_envelope = envelope.clone();
+        let workspace = super::worker::materialize_staged_source_artifact(
+            &request.runner_id,
+            &job_id.to_string(),
+            &mut materialized_envelope,
+        )?;
+        super::worker::verify_staged_workspace_before_execution(
+            &request.runner_id,
+            &materialized_envelope,
+            workspace.as_ref(),
+        )?;
+        let dispatch = materialized_envelope.dispatch.as_ref().ok_or_else(|| {
+            homeboy_core::error::Error::internal_unexpected(
+                "staged runner job has no execution dispatch",
+            )
         })?;
-        Ok(PreparedDaemonExec::new(PreparedDaemonExecRequest {
-            runner_id: plan.runner.id.clone(),
-            cwd: plan.cwd.clone(),
-            command: plan.command.clone(),
-            env: plan.env.clone(),
-            secret_env_names: plan.secret_env_names.clone(),
-            source_snapshot: plan.source_snapshot.clone(),
-            require_paths: plan.require_paths.clone(),
-            concurrency_limit: plan.runner.settings.concurrency_limit,
-            heartbeat_only_stall: plan.runner.settings.heartbeat_only_stall.clone(),
-            // This is a durable declaration, not provider output. The provider
-            // itself is resolved only after the authenticated context arrives
-            // at `execute`.
-            extension_env_provenance: serde_json::json!({ "providers": request.extension_env_providers.clone() }),
-            plan_token: Arc::new(DaemonPreparedPlan {
-                plan,
-                extension_env_providers: request.extension_env_providers,
-                authoritative_run_id,
+        request.cwd = dispatch.cwd.clone();
+        request.source_snapshot = dispatch.source_snapshot.clone();
+        prepare_daemon_exec(
+            request,
+            Some(DaemonStagedPlan {
+                envelope: materialized_envelope,
+                workspace,
             }),
-        }))
+        )
     }
 
     fn execute(
@@ -119,94 +89,206 @@ impl RunnerExecDriver for RunnerDaemonExecDriver {
         require_child_identity_acknowledgement: bool,
         child_started: Option<ExecChildStarted>,
     ) -> Result<DaemonExecOutput> {
-        let base = prepared
-            .plan_token()
-            .downcast_ref::<DaemonPreparedPlan>()
-            .ok_or_else(|| {
-                homeboy_core::error::Error::internal_unexpected(
-                    "runner exec driver received a plan it did not prepare",
-                )
-            })?;
-
-        // The daemon may have mutated `prepared.env` (e.g. injecting the child
-        // reservation id) between prepare and execute, so run with that env.
-        if execution_context.verify_integrity().is_err()
-            || execution_context.runner_id() != prepared.runner_id
-            || execution_context.runtime_id()
-                != prepared
-                    .command
-                    .first()
-                    .map(String::as_str)
-                    .unwrap_or_default()
-        {
-            return Err(homeboy_core::error::Error::validation_invalid_argument(
-                "execution_context",
-                "daemon execution context does not match the accepted runner job",
-                Some(prepared.runner_id.clone()),
-                Some(vec![
-                    "Claim a fresh runner job through the controller before retrying.".to_string(),
-                ]),
-            ));
-        }
-        let mut plan = base.plan.clone();
-        plan.env = prepared.env.clone();
-        // Provider adapters execute only after the daemon supplied the verified
-        // typed context. No environment value participates in this decision.
-        let contributions = super::execution::resolve_provider_env_with_execution_context(
+        execute_daemon_exec(
+            prepared,
             execution_context,
-            &base.extension_env_providers,
-            std::path::Path::new(&plan.cwd),
-            &plan.env,
-            base.authoritative_run_id.as_deref(),
-        )?;
-        for contribution in &contributions {
-            for (key, value) in &contribution.public_env {
-                plan.env.insert(key.clone(), value.clone());
-            }
-        }
-        let diagnostic_hints = super::execution::apply_explicit_runner_exec_run_id_env(
-            &mut plan.env,
-            base.authoritative_run_id.as_deref(),
-        )
-        .into_iter()
-        .collect();
-        let extension_env_provenance = serde_json::to_value(&contributions).map_err(|err| {
-            homeboy_core::error::Error::internal_json(
-                err.to_string(),
-                Some("serialize extension env provenance".to_string()),
-            )
-        })?;
-
-        let output = execute_runner_process_until_cancelled_with_progress(
-            &plan,
             is_cancelled,
             progress_sink,
             require_child_identity_acknowledgement,
             child_started,
-            #[cfg(unix)]
-            None,
-        )?;
-        let (stdout, stderr) = super::execution::redaction::redact_runner_exec_streams(
-            output.stdout,
-            output.stderr,
-            &plan.env,
-            &plan.secret_env_names,
-        );
-
-        Ok(DaemonExecOutput {
-            stdout,
-            stderr,
-            exit_code: output.exit_code,
-            metrics: output
-                .metrics
-                .and_then(|metrics| serde_json::to_value(metrics).ok()),
-            capture: output
-                .capture
-                .and_then(|capture| serde_json::to_value(capture).ok()),
-            extension_env_provenance,
-            diagnostic_hints,
-        })
+        )
     }
+}
+
+fn prepare_daemon_exec(
+    request: RunnerExecPrepareRequest,
+    staged: Option<DaemonStagedPlan>,
+) -> Result<PreparedDaemonExec> {
+    let runner: Option<Runner> = match request.runner {
+        Some(value) => Some(serde_json::from_value(value).map_err(|err| {
+            homeboy_core::error::Error::validation_invalid_argument(
+                "runner",
+                format!("invalid runner descriptor in exec request: {err}"),
+                None,
+                None,
+            )
+        })?),
+        None => None,
+    };
+    let secret_env_plan: Option<SecretEnvPlan> = match request.secret_env_plan {
+        Some(Value::Null) | None => None,
+        Some(value) => Some(serde_json::from_value(value).map_err(|err| {
+            homeboy_core::error::Error::validation_invalid_argument(
+                "secret_env_plan",
+                format!("invalid secret env plan in exec request: {err}"),
+                None,
+                None,
+            )
+        })?),
+    };
+
+    let provider_secret_names = request
+        .extension_env_providers
+        .iter()
+        .map(|id| homeboy_core::extension::invoke::declared_secret_names(id))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let secret_env_plan = super::execution::runner_exec_secret_env_plan(
+        &request.command,
+        None,
+        &provider_secret_names,
+        &request.env,
+        secret_env_plan,
+    );
+    let authoritative_run_id = request.authoritative_run_id;
+    let plan = prepare_daemon_local_process(RunnerProcessRequest {
+        runner_id: request.runner_id,
+        runner,
+        cwd: request.cwd,
+        project_id: request.project_id,
+        command: request.command,
+        env: request.env,
+        secret_env_names: request.secret_env_names,
+        secret_env_plan: Some(secret_env_plan),
+        capture_patch: request.capture_patch,
+        raw_exec: request.raw_exec,
+        source_snapshot: request.source_snapshot,
+        require_paths: request.require_paths,
+        validate_require_paths_on_host: request.validate_require_paths_on_host,
+    })?;
+    Ok(PreparedDaemonExec::new(PreparedDaemonExecRequest {
+        runner_id: plan.runner.id.clone(),
+        cwd: plan.cwd.clone(),
+        command: plan.command.clone(),
+        env: plan.env.clone(),
+        secret_env_names: plan.secret_env_names.clone(),
+        source_snapshot: plan.source_snapshot.clone(),
+        require_paths: plan.require_paths.clone(),
+        concurrency_limit: plan.runner.settings.concurrency_limit,
+        heartbeat_only_stall: plan.runner.settings.heartbeat_only_stall.clone(),
+        // This is a durable declaration, not provider output. The provider
+        // itself is resolved only after the authenticated context arrives
+        // at `execute`.
+        extension_env_provenance: serde_json::json!({ "providers": request.extension_env_providers.clone() }),
+        plan_token: Arc::new(DaemonPreparedPlan {
+            plan,
+            extension_env_providers: request.extension_env_providers,
+            authoritative_run_id,
+            staged,
+        }),
+    }))
+}
+
+fn execute_daemon_exec(
+    prepared: &PreparedDaemonExec,
+    execution_context: &RunnerJobExecutionContext,
+    is_cancelled: ExecCancellationProbe,
+    progress_sink: Option<ExecProgressSink>,
+    require_child_identity_acknowledgement: bool,
+    child_started: Option<ExecChildStarted>,
+) -> Result<DaemonExecOutput> {
+    let base = prepared
+        .plan_token()
+        .downcast_ref::<DaemonPreparedPlan>()
+        .ok_or_else(|| {
+            homeboy_core::error::Error::internal_unexpected(
+                "runner exec driver received a plan it did not prepare",
+            )
+        })?;
+
+    // The daemon may have mutated `prepared.env` (e.g. injecting the child
+    // reservation id) between prepare and execute, so run with that env.
+    if execution_context.verify_integrity().is_err()
+        || execution_context.runner_id() != prepared.runner_id
+        || execution_context.runtime_id()
+            != prepared
+                .command
+                .first()
+                .map(String::as_str)
+                .unwrap_or_default()
+    {
+        return Err(homeboy_core::error::Error::validation_invalid_argument(
+            "execution_context",
+            "daemon execution context does not match the accepted runner job",
+            Some(prepared.runner_id.clone()),
+            Some(vec![
+                "Claim a fresh runner job through the controller before retrying.".to_string(),
+            ]),
+        ));
+    }
+    let mut plan = base.plan.clone();
+    plan.env = prepared.env.clone();
+    if let Some(staged) = &base.staged {
+        // Revalidate immediately before providers can inspect the workspace or
+        // a child can be spawned. The retained descriptor remains authoritative
+        // while capacity admission waits.
+        super::worker::verify_staged_workspace_before_execution(
+            &prepared.runner_id,
+            &staged.envelope,
+            staged.workspace.as_ref(),
+        )?;
+    }
+    // Provider adapters execute only after the daemon supplied the verified
+    // typed context. No environment value participates in this decision.
+    let contributions = super::execution::resolve_provider_env_with_execution_context(
+        execution_context,
+        &base.extension_env_providers,
+        std::path::Path::new(&plan.cwd),
+        &plan.env,
+        base.authoritative_run_id.as_deref(),
+    )?;
+    for contribution in &contributions {
+        for (key, value) in &contribution.public_env {
+            plan.env.insert(key.clone(), value.clone());
+        }
+    }
+    let diagnostic_hints = super::execution::apply_explicit_runner_exec_run_id_env(
+        &mut plan.env,
+        base.authoritative_run_id.as_deref(),
+    )
+    .into_iter()
+    .collect();
+    let extension_env_provenance = serde_json::to_value(&contributions).map_err(|err| {
+        homeboy_core::error::Error::internal_json(
+            err.to_string(),
+            Some("serialize extension env provenance".to_string()),
+        )
+    })?;
+
+    let output = execute_runner_process_until_cancelled_with_progress(
+        &plan,
+        is_cancelled,
+        progress_sink,
+        require_child_identity_acknowledgement,
+        child_started,
+        #[cfg(unix)]
+        base.staged
+            .as_ref()
+            .and_then(|staged| staged.workspace.as_ref())
+            .map(super::worker::StagedWorkspaceDirectory::fd),
+    )?;
+    let (stdout, stderr) = super::execution::redaction::redact_runner_exec_streams(
+        output.stdout,
+        output.stderr,
+        &plan.env,
+        &plan.secret_env_names,
+    );
+
+    Ok(DaemonExecOutput {
+        stdout,
+        stderr,
+        exit_code: output.exit_code,
+        metrics: output
+            .metrics
+            .and_then(|metrics| serde_json::to_value(metrics).ok()),
+        capture: output
+            .capture
+            .and_then(|capture| serde_json::to_value(capture).ok()),
+        extension_env_provenance,
+        diagnostic_hints,
+    })
 }
 
 /// Register the runner daemon-exec driver with core. Called once at startup.

--- a/crates/homeboy-lab-runner/src/execution/tests/daemon_exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/daemon_exec.rs
@@ -18,6 +18,9 @@ use homeboy_runner_contract::{
     RunnerApiSubmitRequest, RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_V1,
 };
 
+use crate::runner_staging_operation::SourceArtifactTransfer;
+use crate::runner_staging_store::RemoteRunnerStagingRequest;
+
 /// Register the runner-side exec driver the daemon `/exec` route drives.
 /// Production wires this at CLI startup; the registration is an idempotent
 /// process-global slot, so registering per test is safe.
@@ -61,6 +64,59 @@ fn wait_for_job(store: &JobStore, job_id: &str) -> Job {
     store.get(id).expect("job")
 }
 
+fn staged_envelope(
+    source: &std::path::Path,
+    command: Vec<String>,
+    run_id: &str,
+) -> crate::runner_staging_operation::RemoteRunnerStagingEnvelope {
+    let mut envelope = crate::runner_staging_operation::tests_support::envelope();
+    envelope.handoff.run_id = run_id.to_string();
+    envelope.handoff.idempotency_key = run_id.to_string();
+    envelope.handoff.runner_id = "lab-local".to_string();
+    envelope.handoff.recipe.run_id = run_id.to_string();
+    envelope.handoff.recipe.runner_id = "lab-local".to_string();
+    envelope.handoff.recipe.placement_decision =
+        homeboy_core::lab_routing::compatibility_placement_decision(
+            homeboy_lab_runner_contract::Placement::Lab,
+            Some("lab-local"),
+            false,
+        );
+    envelope.handoff.recipe.normalized_args = command;
+    envelope.materialization.authority_id = format!("authority-{run_id}");
+    envelope.materialization.workspace_key = run_id.to_string();
+    envelope.materialization.source_artifact = Some(
+        SourceArtifactTransfer::from_directory(format!("source-{run_id}"), source)
+            .expect("bounded source package"),
+    );
+    envelope.validate().expect("staged envelope");
+    envelope
+}
+
+fn stage_request(
+    store: &JobStore,
+    path: &str,
+    envelope: &crate::runner_staging_operation::RemoteRunnerStagingEnvelope,
+) -> serde_json::Value {
+    let response = route_with_body(
+        "POST",
+        path,
+        Some(
+            serde_json::to_value(RemoteRunnerStagingRequest::new(envelope.clone()))
+                .expect("serialize staging request"),
+        ),
+        store,
+    );
+    assert_eq!(response.status_code, 200, "{}", response.body);
+    response.body["body"].clone()
+}
+
+fn staged_job_id(response: &serde_json::Value) -> String {
+    response["receipt"]["handoff"]["runner_job_id"]
+        .as_str()
+        .expect("staged runner job id")
+        .to_string()
+}
+
 fn direct_submission(command: Vec<&str>, submission_key: &str) -> serde_json::Value {
     let request = RemoteRunnerJobRequest {
         runner_id: "lab-local".to_string(),
@@ -98,6 +154,64 @@ fn direct_submission(command: Vec<&str>, submission_key: &str) -> serde_json::Va
         workspace_owner_request: None,
     })
     .expect("serialize direct submission")
+}
+
+#[test]
+fn direct_staging_recovers_the_original_queue_entry_and_replays_one_execution() {
+    register_driver();
+    crate::runner_staging_store::register_runner_staging_provider();
+    let _home = create_lab_local_runner();
+    write_runner_config(
+        "runner-1",
+        &serde_json::json!({"id":"runner-1","kind":"local"}),
+    );
+    let marker = tempfile::tempdir().expect("marker root");
+    let marker_path = marker.path().join("executions");
+    let store = JobStore::default();
+    let mut envelope = crate::runner_staging_operation::tests_support::envelope();
+    envelope.handoff.recipe.normalized_args = vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        format!("cat source.bin; printf x >> '{}'", marker_path.display()),
+    ];
+    let payload = serde_json::to_value(
+        crate::runner_staging_store::RemoteRunnerStagingRequest::new(envelope),
+    )
+    .expect("staging request");
+    let queued = route_with_body("POST", "/runner/staging", Some(payload.clone()), &store);
+    assert_eq!(queued.status_code, 200, "{}", queued.body);
+    let receipt = queued.body["body"]["receipt"].clone();
+    let id = receipt["handoff"]["runner_job_id"]
+        .as_str()
+        .expect("job ID");
+    let job_id = uuid::Uuid::parse_str(id).unwrap();
+    assert_eq!(store.get(job_id).unwrap().status, JobStatus::Queued);
+    assert!(!marker_path.exists());
+
+    let accepted = route_with_body(
+        "POST",
+        "/runner/staging/direct",
+        Some(payload.clone()),
+        &store,
+    );
+    assert_eq!(accepted.status_code, 200, "{}", accepted.body);
+    assert_eq!(accepted.body["body"]["receipt"], receipt);
+    let terminal = wait_for_job(&store, id);
+    let events = store.events(job_id).unwrap();
+    assert_eq!(terminal.status, JobStatus::Succeeded, "{events:?}");
+    assert!(events.iter().any(|event| event.kind == JobEventKind::Result
+        && event
+            .data
+            .as_ref()
+            .is_some_and(|result| result["stdout"] == "source package")));
+    assert_eq!(std::fs::read_to_string(&marker_path).unwrap(), "x");
+
+    let replay = route_with_body("POST", "/runner/staging/direct", Some(payload), &store);
+    assert_eq!(replay.status_code, 200, "{}", replay.body);
+    assert_eq!(replay.body["body"]["receipt"], receipt);
+    assert_eq!(store.get(job_id).unwrap().status, JobStatus::Succeeded);
+    assert_eq!(std::fs::read_to_string(marker_path).unwrap(), "x");
+    assert_eq!(store.events(job_id).unwrap().len(), events.len());
 }
 
 #[test]
@@ -140,7 +254,6 @@ fn typed_daemon_exec_rejects_submitted_authority_before_owner_registration() {
     let _home = create_lab_local_runner();
     let store = JobStore::default();
     let mut payload = direct_submission(vec!["sh", "-c", "printf no"], "typed-authority");
-    payload["submission"]["workspace_claim_binding"] = serde_json::json!({"workspace": "x"});
     payload["workspace_owner_request"] = serde_json::json!({
         "workspace": {
             "schema": homeboy_core::workspace_claim::WORKSPACE_IDENTITY_SCHEMA,
@@ -149,6 +262,12 @@ fn typed_daemon_exec_rejects_submitted_authority_before_owner_registration() {
         },
         "owner_id": "owner",
         "ttl_ms": 1000,
+    });
+    // Keep the submitted authority well-formed so this reaches the admission
+    // policy rather than failing earlier during JSON deserialization.
+    payload["submission"]["workspace_claim_binding"] = serde_json::json!({
+        "workspace": payload["workspace_owner_request"]["workspace"].clone(),
+        "lifecycle_revision": 1,
     });
 
     let response = route_with_body("POST", "/exec", Some(payload), &store);
@@ -185,6 +304,179 @@ fn typed_daemon_exec_rejects_inline_secret_before_execution() {
         .contains("cannot accept inline secret env values"));
     assert!(response.body["body"]["job"].is_null());
     assert!(!marker.exists());
+}
+
+#[test]
+fn direct_staging_concurrent_replays_preserve_source_mutations_and_environment() {
+    register_driver();
+    crate::register_runner_staging_provider();
+    let _home = create_lab_local_runner();
+    let source = tempfile::tempdir().expect("source");
+    let marker_root = tempfile::tempdir().expect("marker");
+    let marker = marker_root.path().join("executed");
+    std::fs::write(source.path().join("input.txt"), "sealed input\n").expect("source input");
+    let run_id = format!("direct-staged-{}", uuid::Uuid::new_v4());
+    let mut envelope = staged_envelope(
+        source.path(),
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!(
+                "set -e; test \"$STAGED_PUBLIC\" = preserved; test \"$(cat input.txt)\" = 'sealed input'; printf 'sealed stdout'; printf changed > input.txt; sleep 0.1; test \"$(cat input.txt)\" = changed; printf x >> '{}'",
+                marker.display()
+            ),
+        ],
+        &run_id,
+    );
+    envelope
+        .handoff
+        .recipe
+        .job_override_env
+        .insert("STAGED_PUBLIC".to_string(), "preserved".to_string());
+    let store = JobStore::default();
+
+    let queued = stage_request(&store, "/runner/staging", &envelope);
+    let job_id = staged_job_id(&queued);
+    assert_eq!(
+        store
+            .get(uuid::Uuid::parse_str(&job_id).expect("uuid"))
+            .expect("job")
+            .status,
+        JobStatus::Queued
+    );
+    assert!(!marker.exists(), "reverse staging must remain queue-only");
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let submissions = (0..2)
+        .map(|_| {
+            let store = store.clone();
+            let envelope = envelope.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                stage_request(&store, "/runner/staging/direct", &envelope)
+            })
+        })
+        .collect::<Vec<_>>();
+    let responses = submissions
+        .into_iter()
+        .map(|thread| thread.join().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(responses[0]["receipt"], responses[1]["receipt"]);
+    let direct = &responses[0];
+    assert_eq!(
+        staged_job_id(&direct),
+        job_id,
+        "direct adoption retains the staged UUID"
+    );
+    let terminal = wait_for_job(&store, &job_id);
+    assert_eq!(terminal.status, JobStatus::Succeeded);
+    let result = store
+        .events(terminal.id)
+        .expect("events")
+        .into_iter()
+        .find(|event| event.kind == JobEventKind::Result)
+        .and_then(|event| event.data)
+        .expect("execution result");
+    assert_eq!(result["stdout"], "sealed stdout");
+    assert_eq!(std::fs::read_to_string(&marker).expect("marker"), "x");
+
+    let replay = stage_request(&store, "/runner/staging/direct", &envelope);
+    assert_eq!(replay["receipt"], direct["receipt"]);
+    assert_eq!(staged_job_id(&replay), job_id);
+    assert_eq!(wait_for_job(&store, &job_id).status, JobStatus::Succeeded);
+    assert_eq!(std::fs::read_to_string(&marker).expect("marker"), "x");
+}
+
+#[test]
+fn direct_staging_preserves_nonzero_child_failure() {
+    register_driver();
+    crate::register_runner_staging_provider();
+    let _home = create_lab_local_runner();
+    let source = tempfile::tempdir().expect("source");
+    std::fs::write(source.path().join("input.txt"), "failure input\n").expect("source input");
+    let run_id = format!("direct-staged-failure-{}", uuid::Uuid::new_v4());
+    let envelope = staged_envelope(
+        source.path(),
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "test \"$(cat input.txt)\" = 'failure input' && printf staged-out; printf staged-err >&2; exit 23".to_string(),
+        ],
+        &run_id,
+    );
+    let store = JobStore::default();
+    let response = stage_request(&store, "/runner/staging/direct", &envelope);
+    let job_id = staged_job_id(&response);
+    let terminal = wait_for_job(&store, &job_id);
+    assert_eq!(terminal.status, JobStatus::Failed);
+    let result = store
+        .events(terminal.id)
+        .expect("events")
+        .into_iter()
+        .find(|event| event.kind == JobEventKind::Result)
+        .and_then(|event| event.data)
+        .expect("execution result");
+    assert_eq!(result["exit_code"], 23);
+    assert_eq!(result["stdout"], "staged-out");
+    assert_eq!(result["stderr"], "staged-err");
+}
+
+#[test]
+#[cfg(unix)]
+fn direct_staging_retains_the_original_cancel_endpoint_and_reaps_the_child() {
+    register_driver();
+    crate::register_runner_staging_provider();
+    let _home = create_lab_local_runner();
+    let source = tempfile::tempdir().expect("source");
+    std::fs::write(source.path().join("input"), "sealed").unwrap();
+    let evidence = tempfile::tempdir().expect("child evidence");
+    let pid_path = evidence.path().join("pid");
+    let late_path = evidence.path().join("late");
+    let envelope = staged_envelope(
+        source.path(),
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!(
+                "printf '%s' $$ > '{}'; sleep 30; printf late > '{}'",
+                pid_path.display(),
+                late_path.display()
+            ),
+        ],
+        "direct-cancel",
+    );
+    let store = JobStore::default();
+    let accepted = stage_request(&store, "/runner/staging/direct", &envelope);
+    let id = staged_job_id(&accepted);
+    for _ in 0..100 {
+        if pid_path.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    let pid = std::fs::read_to_string(&pid_path)
+        .expect("child started")
+        .parse::<i32>()
+        .unwrap();
+    let cancelled = route_with_body("POST", &format!("/runner/jobs/{id}/cancel"), None, &store);
+    assert_eq!(cancelled.status_code, 200, "{}", cancelled.body);
+    assert_eq!(wait_for_job(&store, &id).status, JobStatus::Cancelled);
+    for _ in 0..100 {
+        if unsafe { libc::kill(pid, 0) } != 0 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert_ne!(
+        unsafe { libc::kill(pid, 0) },
+        0,
+        "cancelled child still exists"
+    );
+    assert!(!late_path.exists());
+    let replay = stage_request(&store, "/runner/staging/direct", &envelope);
+    assert_eq!(replay["receipt"], accepted["receipt"]);
+    assert_eq!(wait_for_job(&store, &id).status, JobStatus::Cancelled);
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -27,6 +27,7 @@ pub const REMOTE_RUNNER_STAGING_SCHEMA: &str = "homeboy/remote-runner-staging/v2
 pub const REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA: &str = "homeboy/remote-runner-staging-receipt/v1";
 pub const REMOTE_RUNNER_STAGING_CAPABILITY_V1: &str = "remote-runner-staging/v1";
 pub const REMOTE_RUNNER_STAGING_CAPABILITY: &str = "remote-runner-staging/v2";
+pub const DIRECT_RUNNER_STAGED_EXECUTION_CAPABILITY: &str = "direct-runner-staged-execution/v1";
 pub const REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY: &str =
     "remote-runner-source-materialization/v2";
 pub const REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY: &str = "remote-runner-source-artifact/v1";

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -776,7 +776,8 @@ impl RemoteRunnerStagingTransport for ProductionRunnerStagingTransport {
     }
 
     fn supports_capability(&self, capability: &str) -> bool {
-        self.session.mode == RunnerTunnelMode::Reverse
+        (self.session.mode == RunnerTunnelMode::Reverse
+            || self.capabilities.iter().any(|candidate| candidate == crate::runner_staging_operation::DIRECT_RUNNER_STAGED_EXECUTION_CAPABILITY))
             && self
                 .capabilities
                 .iter()
@@ -806,7 +807,7 @@ impl RemoteRunnerStagingTransport for ProductionRunnerStagingTransport {
             RunnerTunnelMode::DirectSsh => {
                 let data = crate::execution::daemon_api_post_json_for_session_with_broker_token(
                     &self.session,
-                    "/runner/staging",
+                    "/runner/staging/direct",
                     &body,
                     self.broker_token.as_deref(),
                 )?;
@@ -967,8 +968,56 @@ impl RunnerStagingMaterializer for SealedPayloadMaterializer {
 struct ProductionStagingProvider;
 
 impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionStagingProvider {
+    fn stage_direct(
+        &self,
+        request: serde_json::Value,
+        jobs: &homeboy_core::api_jobs::JobStore,
+    ) -> Result<serde_json::Value> {
+        let response = self.stage(request, jobs)?;
+        let receipt: RemoteRunnerStagingReceipt =
+            serde_json::from_value(response["receipt"].clone()).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("decode durable staging receipt".to_string()),
+                )
+            })?;
+        let job_id = uuid::Uuid::parse_str(&receipt.handoff.runner_job_id).map_err(|error| {
+            Error::internal_unexpected(format!("invalid staged job identity: {error}"))
+        })?;
+        let root = homeboy_core::paths::runner_session_file(&receipt.handoff.runner_id)?
+            .with_file_name(format!("{}-staging", receipt.handoff.runner_id));
+        let store = RunnerStagingStore::open(
+            root.join("store.json"),
+            receipt.handoff.runner_id.clone(),
+            SealedPayloadMaterializer { root },
+        )?;
+        // Serialize replay preparation before any source writes. The durable
+        // direct selection separately excludes competing reverse-worker claims.
+        let _preparation = store.admission_lock()?;
+        if let Some(envelope) =
+            jobs.staged_direct_execution_envelope(job_id, &receipt.handoff.runner_id)?
+        {
+            homeboy_core::daemon::enqueue_staged_direct_exec(
+                jobs,
+                job_id,
+                envelope.clone(),
+                envelope,
+                None,
+            )?;
+        } else if jobs.get(job_id)?.claim_id.is_some() {
+            return Err(Error::validation_invalid_argument(
+                "runner_staging",
+                "staged job is already claimed by a reverse worker",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        Ok(response)
+    }
+
     fn capabilities(&self, _runner_id: &str) -> Result<Vec<String>> {
         let mut capabilities = vec![
+            crate::runner_staging_operation::DIRECT_RUNNER_STAGED_EXECUTION_CAPABILITY.to_string(),
             REMOTE_RUNNER_STAGING_CAPABILITY_V1.to_string(),
             REMOTE_RUNNER_STAGING_CAPABILITY.to_string(),
             REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY.to_string(),
@@ -1044,7 +1093,7 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
                     cwd: workspace
                         .as_ref()
                         .map(|workspace| workspace.remote_cwd.clone()),
-                    env: Default::default(),
+                    env: envelope.handoff.recipe.job_override_env.clone(),
                     source_snapshot: None,
                     require_paths: Vec::new(),
                     extension_env_providers: Vec::new(),
@@ -1055,6 +1104,17 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
                     "staged_workspace_materialization": workspace,
                 });
                 execution.mutation_policy.capture_patch = envelope.handoff.recipe.capture_patch;
+                execution.secret_env = Some(
+                    homeboy_core::secret_env_plan::SecretEnvPlan::from_secret_env_names(
+                        envelope.handoff.recipe.secret_env_names.clone(),
+                    ),
+                );
+                execution.lifecycle = Some(homeboy_runner_contract::RunnerJobLifecycleMetadata {
+                    source: Some("sealed-staging".to_string()),
+                    kind: Some("runner_staged_execution".to_string()),
+                    durable_run_id: Some(envelope.handoff.run_id.clone()),
+                    ..Default::default()
+                });
                 let job = jobs.submit_runner_api_request(
                     homeboy_runner_contract::RunnerApiSubmitRequest {
                         schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA
@@ -1371,7 +1431,7 @@ mod tests {
     }
 
     #[test]
-    fn production_staging_refuses_direct_and_submits_reverse_with_paired_bearer_tokens() {
+    fn production_staging_requires_direct_execution_capability_and_preserves_reverse_transport() {
         let request = envelope();
         let receipt = RemoteRunnerStagingReceipt {
             schema: REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA.to_string(),
@@ -1388,7 +1448,7 @@ mod tests {
             },
         };
         let seen = Arc::new(Mutex::new(Vec::new()));
-        let endpoint = staging_endpoint(receipt.clone(), seen.clone(), 3);
+        let endpoint = staging_endpoint(receipt.clone(), seen.clone(), 4);
         let broker_token = "paired-staging-token".to_string();
         let direct_session = production_session(RunnerTunnelMode::DirectSsh, &endpoint);
         assert!(
@@ -1409,6 +1469,14 @@ mod tests {
         let error = submit_remote_runner_staging(&mut direct, &request)
             .expect_err("direct staging has no staged-source consumer");
         assert_eq!(error.code, homeboy_core::ErrorCode::RunnerCapabilityMissing);
+
+        direct.capabilities.push(
+            crate::runner_staging_operation::DIRECT_RUNNER_STAGED_EXECUTION_CAPABILITY.to_string(),
+        );
+        assert_eq!(
+            submit_remote_runner_staging(&mut direct, &request).expect("capable direct staging"),
+            receipt
+        );
 
         let reverse_session = production_session(RunnerTunnelMode::Reverse, &endpoint);
         assert!(
@@ -1438,6 +1506,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             [
                 "/runner/staging/capabilities",
+                "/runner/staging/direct",
                 "/runner/staging/capabilities",
                 "/runner/staging",
             ]
@@ -1445,6 +1514,61 @@ mod tests {
         assert!(paths.iter().all(|(_, canonical, authorization)| {
             canonical == &broker_token && authorization == &format!("Bearer {broker_token}")
         }));
+    }
+
+    #[test]
+    fn production_direct_transport_requires_the_direct_execution_capability_and_uses_direct_route()
+    {
+        let request = envelope();
+        let receipt = RemoteRunnerStagingReceipt {
+            schema: REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA.to_string(),
+            handoff: DirectLabHandoffReceipt::accepted(&request.handoff, "runner-stage-direct"),
+            artifacts: RunnerStagingArtifacts {
+                lifecycle_id: "lifecycle-direct".to_string(),
+                source_artifact_id: "source-direct".to_string(),
+                workspace_artifact_id: "workspace-direct".to_string(),
+                source_artifact: request
+                    .materialization
+                    .source_artifact
+                    .as_ref()
+                    .map(crate::runner_staging_operation::SourceArtifactTransfer::descriptor),
+            },
+        };
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let endpoint = staging_endpoint(receipt.clone(), seen.clone(), 1);
+        let mut direct = ProductionRunnerStagingTransport {
+            runner_id: "runner-1".to_string(),
+            session: production_session(RunnerTunnelMode::DirectSsh, &endpoint),
+            capabilities: vec![
+                REMOTE_RUNNER_STAGING_CAPABILITY.to_string(),
+                REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY.to_string(),
+                REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY.to_string(),
+                crate::runner_staging_operation::DIRECT_RUNNER_STAGED_EXECUTION_CAPABILITY
+                    .to_string(),
+            ],
+            broker_token: Some("direct-token".to_string()),
+        };
+
+        assert_eq!(
+            submit_remote_runner_staging(&mut direct, &request).expect("direct stage"),
+            receipt
+        );
+        assert_eq!(seen.lock().expect("paths")[0].0, "/runner/staging/direct");
+
+        let unsupported = ProductionRunnerStagingTransport {
+            runner_id: "runner-1".to_string(),
+            session: production_session(RunnerTunnelMode::DirectSsh, "http://127.0.0.1:9"),
+            capabilities: vec![
+                REMOTE_RUNNER_STAGING_CAPABILITY.to_string(),
+                REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY.to_string(),
+                REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY.to_string(),
+            ],
+            broker_token: None,
+        };
+        assert!(
+            !unsupported.supports_capability(REMOTE_RUNNER_STAGING_CAPABILITY),
+            "an old direct daemon must fail capability negotiation before staging"
+        );
     }
 
     fn production_session(mode: RunnerTunnelMode, endpoint: &str) -> RunnerSession {

--- a/crates/homeboy-lab-runner/src/worker/mod.rs
+++ b/crates/homeboy-lab-runner/src/worker/mod.rs
@@ -7,4 +7,8 @@ mod types;
 mod tests;
 
 pub use run::run_reverse_worker;
+pub(crate) use run::{
+    materialize_staged_source_artifact, verify_staged_workspace_before_execution,
+    StagedWorkspaceDirectory,
+};
 pub use types::{ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -1050,7 +1050,7 @@ fn reverse_worker_lab_offload(raw: &str) -> Result<serde_json::Value> {
 
 /// A staged job's source is runner-owned durable storage, not a controller path.
 /// Verify and extract it before the normal queue executor consumes the command.
-fn materialize_staged_source_artifact(
+pub(crate) fn materialize_staged_source_artifact(
     runner_id: &str,
     job_id: &str,
     envelope: &mut RunnerExecutionEnvelope,
@@ -1113,22 +1113,22 @@ fn materialize_staged_source_artifact(
         .as_mut()
         .ok_or_else(|| Error::internal_unexpected("staged runner job has no execution dispatch"))?;
     dispatch.cwd = Some(workspace.display().to_string());
-    Ok(None)
+    Ok(Some(open_staged_workspace_directory(&workspace)?))
 }
 
-struct StagedWorkspaceDirectory {
+pub(crate) struct StagedWorkspaceDirectory {
     #[cfg(unix)]
     directory: File,
 }
 
 impl StagedWorkspaceDirectory {
     #[cfg(unix)]
-    fn fd(&self) -> std::os::fd::RawFd {
+    pub(crate) fn fd(&self) -> std::os::fd::RawFd {
         self.directory.as_raw_fd()
     }
 }
 
-fn verify_staged_workspace_before_execution(
+pub(crate) fn verify_staged_workspace_before_execution(
     runner_id: &str,
     envelope: &RunnerExecutionEnvelope,
     authority: Option<&StagedWorkspaceDirectory>,
@@ -1138,6 +1138,26 @@ fn verify_staged_workspace_before_execution(
         .get("staged_workspace_materialization")
         .filter(|workspace| !workspace.is_null())
     else {
+        if envelope
+            .metadata
+            .get("staged_source_artifact")
+            .filter(|source| !source.is_null())
+            .is_some()
+        {
+            let authority = authority.ok_or_else(|| {
+                Error::internal_unexpected(
+                    "staged source workspace authority was not retained until execution",
+                )
+            })?;
+            let cwd = envelope
+                .dispatch
+                .as_ref()
+                .and_then(|dispatch| dispatch.cwd.as_deref())
+                .ok_or_else(|| {
+                    Error::internal_unexpected("staged runner job has no execution cwd")
+                })?;
+            verify_staged_workspace_path(authority, cwd)?;
+        }
         return Ok(());
     };
     let workspace = serde_json::from_value(raw.clone()).map_err(|error| {
@@ -1153,6 +1173,68 @@ fn verify_staged_workspace_before_execution(
     })?;
     verify_controller_workspace(runner_id, &workspace, Some(authority))?;
     Ok(())
+}
+
+#[cfg(unix)]
+fn open_staged_workspace_directory(path: &std::path::Path) -> Result<StagedWorkspaceDirectory> {
+    use std::fs::OpenOptions;
+
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_DIRECTORY);
+    let directory = options.open(path).map_err(|error| {
+        Error::validation_invalid_argument(
+            "staged_source_artifact",
+            format!("open extracted runner workspace without following links: {error}"),
+            Some(path.display().to_string()),
+            None,
+        )
+    })?;
+    Ok(StagedWorkspaceDirectory { directory })
+}
+
+#[cfg(not(unix))]
+fn open_staged_workspace_directory(_path: &std::path::Path) -> Result<StagedWorkspaceDirectory> {
+    Err(Error::validation_invalid_argument(
+        "staged_source_artifact",
+        "staged source workspaces require Unix no-follow verification",
+        None,
+        None,
+    ))
+}
+
+#[cfg(unix)]
+fn verify_staged_workspace_path(authority: &StagedWorkspaceDirectory, path: &str) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let current = open_staged_workspace_directory(std::path::Path::new(path))?;
+    let retained = authority.directory.metadata().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("stat retained staged workspace".to_string()),
+        )
+    })?;
+    let current = current.directory.metadata().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("stat staged workspace path".to_string()),
+        )
+    })?;
+    if retained.dev() != current.dev() || retained.ino() != current.ino() {
+        return Err(Error::validation_invalid_argument(
+            "staged_source_artifact",
+            "staged source workspace path was replaced after materialization",
+            Some(path.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn verify_staged_workspace_path(_authority: &StagedWorkspaceDirectory, _path: &str) -> Result<()> {
+    unreachable!("non-Unix staged workspaces cannot be materialized")
 }
 
 #[cfg(unix)]
@@ -1552,7 +1634,9 @@ fn non_empty_run_id(run_id: Option<&str>) -> Option<String> {
 
 #[cfg(test)]
 mod provenance_tests {
-    use super::reverse_worker_lab_offload;
+    use super::{
+        open_staged_workspace_directory, reverse_worker_lab_offload, verify_staged_workspace_path,
+    };
     use sha2::{Digest, Sha256};
 
     #[test]
@@ -1572,5 +1656,23 @@ mod provenance_tests {
             reverse_worker_lab_offload(&reference).expect("referenced Lab metadata")["sync_mode"],
             "snapshot"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_staged_workspace_authority_refuses_path_replacement_before_spawn() {
+        let root = tempfile::tempdir().expect("workspace root");
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        std::fs::write(workspace.join("source.bin"), b"sealed source").expect("write source");
+        let authority = open_staged_workspace_directory(&workspace).expect("retain workspace");
+
+        std::fs::rename(&workspace, root.path().join("replaced")).expect("move workspace");
+        std::fs::create_dir(&workspace).expect("replace workspace path");
+        std::fs::write(workspace.join("source.bin"), b"replacement").expect("write replacement");
+
+        let error = verify_staged_workspace_path(&authority, &workspace.display().to_string())
+            .expect_err("replacement must be refused before spawn");
+        assert!(error.message.contains("was replaced after materialization"));
     }
 }

--- a/docs/direct-staged-execution.md
+++ b/docs/direct-staged-execution.md
@@ -1,0 +1,93 @@
+# Direct Staged Execution
+
+Tracker: [#14588](https://github.com/Extra-Chill/homeboy/issues/14588).
+This follows the preventive capability refusal in
+[#14589](https://github.com/Extra-Chill/homeboy/pull/14589).
+
+## Contract
+
+Direct sessions negotiate `direct-runner-staged-execution/v1` before submitting
+the unchanged sealed staging request to `POST /runner/staging/direct`. A daemon
+without that capability remains refused. Reverse transport continues to use
+`POST /runner/staging` and its existing worker-claim lifecycle.
+
+The direct handler persists or replays the original staging receipt, then selects
+that exact queued job for direct execution. The selection is durable and excludes
+reverse claims before source preparation. Direct replay preparation is serialized
+under the existing staging lock. Atomic adoption preserves the job UUID,
+submission-key index, event history, and source provenance while transferring
+execution into the normal daemon-local capacity and child lifecycle.
+
+The runner driver shares the reverse worker's source verification. It retains a
+directory descriptor during preparation and capacity waiting, rechecks ownership
+before execution, and uses that descriptor as the child working directory. Public
+environment overrides, declared secret names, and the durable run identity are
+carried into the execution envelope; secret values remain runner-resolved.
+
+Terminal and concurrent receipt replays do not launch a second command or restore
+source files over a running command's mutations. The original runner-job cancel
+endpoint remains valid after adoption and uses the local child's cancellation
+and reap path. Nonzero exit status, stdout, and stderr remain result evidence on
+the original job.
+
+## Interrupted Adoption
+
+A new daemon lease alone does not authorize takeover. Startup captures the exact
+previous `PidDead` lease verdict under the daemon-owner lock, excludes conflicting
+foreground owners, and limits recovery to adopted queued jobs without a child
+reservation. The shared driver prepares the retained sealed source, and recovery
+transfers the exact original job to the new worker under the proven-dead lease.
+Old workers are fenced at child reservation. The generation registry transfers
+the original job route and counts without moving unrelated jobs or double-counting
+replays. Preparation failure becomes terminal diagnostic evidence for the normal
+retry lifecycle instead of another apparently accepted queue entry.
+
+This is same-store recovery and receipt replay. It does not forcibly replace a
+live draining daemon, migrate arbitrary stores between generations, cancel live
+jobs, or authorize a runtime rollout.
+
+## Verification
+
+The managed Lab run `homeboy-14588-final-gates-v2` passed workspace compilation,
+format checks, and all nine selected test groups (121 test executions):
+
+```sh
+cargo fmt --all --check
+cargo check --workspace
+cargo test -p homeboy-core --lib staged -- --test-threads=1
+cargo test -p homeboy-core --lib new_daemon_lease_recovers_adopted_pre_worker_job_once -- --test-threads=1
+cargo test -p homeboy-core --lib daemon::generation_store::tests -- --test-threads=1
+cargo test -p homeboy-core --lib remote_runner -- --test-threads=1
+cargo test -p homeboy-lab-runner --lib execution::tests::daemon_exec:: -- --test-threads=1
+cargo test -p homeboy-lab-runner --lib runner_staging_store::tests:: -- --test-threads=1
+cargo test -p homeboy-lab-runner --lib runner_staging_operation:: -- --test-threads=1
+cargo test -p homeboy-lab-runner --lib reverse_worker_executes_a_verified_staged_source_package -- --test-threads=1
+cargo test -p homeboy-lab-runner --lib retained_staged_workspace_authority_refuses_path_replacement_before_spawn -- --test-threads=1
+```
+
+The daemon-execution tests call the production routes and real runner driver to
+execute sealed-file reads, preserve public environment, observe one side effect
+under concurrent replay, retain a nonzero child result, and cancel/reap a child.
+Core tests cover direct-versus-reverse selection, durable recovery state,
+generation routing, and explicit preparation failure. These are focused gates,
+not a claim that the entire repository test suite passed.
+
+The existing submitted-authority test failed on immutable base
+`68d9f780d039bcdc59bf5bf556a7aec4c173d482` because its malformed binding failed
+deserialization before reaching the intended policy. Its fixture is now a
+well-formed but unauthorized binding; the policy refusal and no-owner-registration
+assertions remain intact. Baseline run: `homeboy-14588-baseline-authority-guard`.
+
+Operator-retained final evidence:
+
+- Runner job: `82f21707-9c2d-4229-9fe0-457b1d0810e8`
+- Artifact: `runner-exec-fd16faee5d370b15fe6c5e14ded9e356aa1b2f6100062bbb4ca87d5a48af78ed`
+- File: `homeboy-14588-verification.log`
+- SHA-256: `3aa1d911b9d6d0b52fba1edc3b8ad77a3a1c5cecf7408935906853d6f53117f7`
+- Candidate base: `68d9f780d039bcdc59bf5bf556a7aec4c173d482`, plus this change
+
+These IDs resolve in the operator's Homeboy store, not a public artifact host.
+The commands above are the repository-native reproduction path. The original
+MDI consumer parity workload has not yet completed through an installed version
+of this repair; live runtime convergence and retained-generation recovery remain
+separate operational steps.

--- a/docs/validation-dependency-recovery.md
+++ b/docs/validation-dependency-recovery.md
@@ -25,10 +25,14 @@ Cleanup still refuses unpushed work, and promotion's existing authorized dirty
 candidate path is preserved. This does not change historical records' base refs
 or correct inflated cleanup counts caused by stale local base branches.
 
-The controller also refuses sealed staging for direct-SSH sessions, whose
+At the #14589 boundary, the controller refused sealed staging for direct-SSH sessions, whose
 daemon currently has no consumer for that queue. Reverse-worker staging is
 unchanged. This is a preventive capability correction only: it does not execute
 or recover previously queued direct jobs. The v1 request wire shape is unchanged.
+
+The subsequent [direct staged-execution repair](direct-staged-execution.md)
+adds capability-negotiated execution and same-store recovery. The evidence below
+remains the historical #14589 verification and live replay boundary.
 
 ## Repository-Native Verification
 


### PR DESCRIPTION
## Summary

Follow-up to #14589 for #14588. Replace the preventive direct-staging refusal with a capability-negotiated execution path that uses the existing daemon-local child lifecycle.

- Negotiate direct-runner-staged-execution/v1 and submit the unchanged sealed request through authenticated POST /runner/staging/direct. Older direct daemons remain refused; reverse transport retains its worker-claim route.
- Durably select the exact original job before source preparation, excluding competing reverse claims. Serialize direct replay preparation and atomically adopt the original UUID into the normal capacity/child lifecycle.
- Share source verification with the reverse worker, retain directory authority through capacity waiting and spawn, and preserve declared environment, secret names, run identity, result evidence, and the original cancellation endpoint.
- Recover childless adopted work only after startup proves the exact prior daemon owner dead. Fence old reservations, transfer the original generation route, and record preparation failures instead of silently stranding the queue.
- Document the contract and reproduction in docs/direct-staged-execution.md.

Most driver diff churn is extraction of the existing prepare/execute bodies so staged and ordinary direct execution share them. No alternate executor or sidecar is introduced.

## Verification

Managed Lab run homeboy-14588-final-gates-v2 passed all nine selected groups: 121 test executions, cargo check --workspace, and cargo fmt --all --check. git diff --check also passes.

Real production-route/driver tests execute sealed-file reads, preserve public environment, produce exactly one side effect under concurrent replay, retain nonzero exits, and cancel/reap a child through the original job endpoint. Core tests cover selection races, durable recovery state, generation routing, and startup preparation failure. Reverse source execution and replacement-path refusal remain covered.

An existing submitted-authority test failed on unchanged base 68d9f780d because its malformed binding stopped at deserialization. Its fixture now supplies a well-formed unauthorized binding and retains the policy-refusal/no-registration assertions. Baseline run: homeboy-14588-baseline-authority-guard.

Evidence:

- Candidate commit: 80107e6af
- Tested base: 68d9f780d039bcdc59bf5bf556a7aec4c173d482
- Runner job: 82f21707-9c2d-4229-9fe0-457b1d0810e8
- Log: homeboy-14588-verification.log
- Log SHA-256: 3aa1d911b9d6d0b52fba1edc3b8ad77a3a1c5cecf7408935906853d6f53117f7

These IDs identify operator-retained artifacts, not publicly hosted files. The evidence document includes repository-native reproduction commands. This is a focused gate suite, not a full-repository test claim.

## Rollout Boundary

The original MDI parity workload has not completed through an installed version of this repair. Its historical job is retained in an older daemon generation. Same-store replay/recovery does not authorize forcibly replacing a live draining daemon or migrating arbitrary job stores.

No release, live daemon replacement, job cancellation, or production migration is included. Runtime convergence and the original consumer replay remain operational follow-up work.

## AI Assistance

OpenAI GPT-6 Astra (openai/gpt-6-astra) via OpenCode inspected the retained queue failure, coordinated parallel implementation and review agents, corrected race and recovery findings, ran managed Lab verification, and prepared this PR under Chris Huber’s direction.