### PR TITLE
Fix implicit runtime account credential selection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_service.rs
@@ -888,12 +888,9 @@ mod tests {
                 "backend": "claude-code",
                 "capabilities": ["cli_runtime", "provider_owned_auth"],
                 "invocation": { "argv": ["claude-code"] },
-                "provider_defaults": {
-                    "claude-code": {
-                        "secret_env": [required.clone()],
-                        "required_secret_env": [required.clone()]
-                    }
-                }
+                "secret_env_requirements": [{
+                    "env": [required.clone()]
+                }]
             }))
             .expect("provider fixture")],
             ..Default::default()

--- a/crates/homeboy-agents/src/agent_task_provider/credential_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/credential_readiness.rs
@@ -24,10 +24,10 @@
 //! - `runner_readiness[].secret_env`
 //! - `secret_requirements[]` that are not explicitly `required: false`
 //! - `secret_env_requirements[]` with no `when` condition
-//! - the `required_secret_env` of a *sole* `provider_defaults` entry — when a
-//!   provider declares exactly one provider default, that default is what
-//!   dispatch uses unless the request overrides it, so its explicitly-required
-//!   credentials are unconditionally required.
+//!
+//! Account-scoped `provider_defaults` stay request-scoped. Catalog status does
+//! not treat a sole unused alternative as unconditionally required. Native
+//! provider-owned auth is not a Homeboy-invented credential list.
 //!
 //! Request-conditional requirements (`secret_env_requirements[].when`, and the
 //! `secret_env` of a provider default named by the request) stay owned by the
@@ -209,52 +209,7 @@ fn declared_credentials(provider: &AgentTaskExecutorProvider) -> Vec<DeclaredCre
         }
     }
 
-    for env in sole_provider_default_required_secret_env(provider) {
-        push_declared_credential(
-            &mut declared,
-            &env,
-            "provider_defaults.required_secret_env",
-            None,
-            None,
-        );
-    }
-
     declared
-}
-
-/// `required_secret_env` of the provider's sole declared provider default.
-///
-/// When a provider declares exactly one provider default, dispatch uses it
-/// unless the request names another, so anything that default marks explicitly
-/// required is unconditionally required. With two or more declared defaults the
-/// choice is request-dependent and this returns nothing rather than guessing.
-///
-/// Only `required_secret_env` is read — never the broader `secret_env` list,
-/// which routinely carries derivable or optional companions (access tokens,
-/// expiry stamps) that must not make a provider look undispatchable.
-fn sole_provider_default_required_secret_env(provider: &AgentTaskExecutorProvider) -> Vec<String> {
-    if provider.provider_defaults.len() != 1 {
-        return Vec::new();
-    }
-    let Some(provider_default) = provider.provider_defaults.values().next() else {
-        return Vec::new();
-    };
-    let Some(provider_default) = provider_default.as_object() else {
-        return Vec::new();
-    };
-    for key in ["required_secret_env", "requiredSecretEnv"] {
-        match provider_default.get(key) {
-            Some(Value::String(name)) => return vec![name.clone()],
-            Some(Value::Array(items)) => {
-                return items
-                    .iter()
-                    .filter_map(|item| item.as_str().map(str::to_string))
-                    .collect()
-            }
-            _ => {}
-        }
-    }
-    Vec::new()
 }
 
 /// Resolve a provider's declared credentials against the observed scope.
@@ -400,52 +355,54 @@ mod tests {
         serde_json::from_value(value).expect("valid provider fixture")
     }
 
-    /// The exact shape the claude-code runtime publishes: one provider default
-    /// that names its own required credential (#11479).
-    fn claude_code_shaped_provider(
-        auth_path: Option<&std::path::Path>,
-    ) -> AgentTaskExecutorProvider {
-        let required = format!("HOMEBOY_TEST_CREDENTIAL_{}", uuid::Uuid::new_v4());
-        let secret_env_sources = auth_path.map_or_else(
-            || serde_json::json!({}),
-            |path| {
-                serde_json::json!({
-                    required.clone(): { "source": "json-file", "path": path, "field": "token" }
-                })
-            },
-        );
+    fn unused_account_default_provider() -> AgentTaskExecutorProvider {
         provider(serde_json::json!({
-            "id": "claude-code.agent-task-executor",
-            "backend": "claude-code",
+            "id": "sample-runtime.agent-task-executor",
+            "backend": "sample-runtime",
             "capabilities": ["cli_runtime", "provider_owned_auth"],
             "secret_env_requirements": [{
                 "source": "provider_default",
-                "env": [required.clone()],
-                "when": { "any": [{ "path": "executor.config.provider", "equals": "claude-code" }] }
+                "env": ["UNUSED_ACCOUNT_TOKEN"],
+                "when": { "any": [{ "path": "executor.config.provider", "equals": "unused-account" }] }
             }],
             "provider_defaults": {
-                "claude-code": {
+                "unused-account": {
                     "secret_env": [
-                        required.clone(),
-                        format!("{required}_ACCESS_TOKEN"),
-                        format!("{required}_EXPIRES_AT")
+                        "UNUSED_ACCOUNT_TOKEN",
+                        "UNUSED_ACCOUNT_ACCESS_TOKEN",
+                        "UNUSED_ACCOUNT_EXPIRES_AT"
                     ],
-                    "required_secret_env": [required.clone()],
+                    "required_secret_env": ["UNUSED_ACCOUNT_TOKEN"],
                     "optional_secret_env": [
-                        format!("{required}_ACCESS_TOKEN"),
-                        format!("{required}_EXPIRES_AT")
-                    ],
-                    "secret_env_sources": secret_env_sources
+                        "UNUSED_ACCOUNT_ACCESS_TOKEN",
+                        "UNUSED_ACCOUNT_EXPIRES_AT"
+                    ]
                 }
             }
         }))
     }
 
-    fn required_credential(provider: &AgentTaskExecutorProvider) -> String {
-        sole_provider_default_required_secret_env(provider)
-            .into_iter()
-            .next()
-            .expect("required credential")
+    fn unconditional_credential_provider(
+        env: &str,
+        auth_path: Option<&std::path::Path>,
+    ) -> AgentTaskExecutorProvider {
+        let secret_env_sources = auth_path.map_or_else(
+            || serde_json::json!({}),
+            |path| {
+                serde_json::json!({
+                    env: { "source": "json-file", "path": path, "field": "token" }
+                })
+            },
+        );
+        provider(serde_json::json!({
+            "id": "sample-runtime.agent-task-executor",
+            "backend": "sample-runtime",
+            "secret_env_requirements": [{
+                "source": "provider_default",
+                "env": [env],
+                "secret_env_sources": secret_env_sources
+            }]
+        }))
     }
 
     #[test]
@@ -464,48 +421,32 @@ mod tests {
     }
 
     #[test]
-    fn a_sole_provider_default_required_credential_makes_an_unconfigured_provider_undispatchable() {
-        let provider = claude_code_shaped_provider(None);
-        let required = required_credential(&provider);
-        let readiness = provider_credential_readiness(&provider);
+    fn an_unselected_account_default_is_not_a_catalog_credential() {
+        let readiness = provider_credential_readiness(&unused_account_default_provider());
 
         assert!(
-            !readiness.dispatchable,
-            "a backend whose required credential is absent is declared, not dispatchable"
+            readiness.dispatchable,
+            "an unused account alternative is request-scoped, not catalog-required"
         );
-        assert_eq!(
-            readiness.missing,
-            vec![required.clone()],
-            "the reason must name the exact credential"
-        );
-        assert_eq!(
-            readiness.reason(),
-            Some(format!("missing credential {required}"))
-        );
-    }
-
-    #[test]
-    fn optional_companions_of_a_required_credential_are_not_treated_as_required() {
-        let readiness = provider_credential_readiness(&claude_code_shaped_provider(None));
-
-        // `secret_env` also lists the access token and expiry stamp. Those
-        // are derivable/optional; reporting them would make every provider
-        // that caches a token look broken.
+        assert!(readiness.missing.is_empty());
+        assert!(readiness.requirements.is_empty());
+        assert!(readiness.reason().is_none());
         assert!(
             !readiness
                 .missing
                 .iter()
                 .any(|env| env.contains("ACCESS_TOKEN") || env.contains("EXPIRES_AT")),
-            "only explicitly required credentials block dispatch: {:?}",
+            "account-default companions must not block catalog dispatch: {:?}",
             readiness.missing
         );
     }
 
     #[test]
-    fn a_configured_credential_makes_the_provider_dispatchable() {
+    fn a_configured_unconditional_credential_makes_the_provider_dispatchable() {
+        let required = format!("HOMEBOY_TEST_CREDENTIAL_{}", uuid::Uuid::new_v4());
         let auth = tempfile::NamedTempFile::new().expect("auth file");
         std::fs::write(auth.path(), r#"{"token":"refresh-token-value"}"#).expect("write auth");
-        let provider = claude_code_shaped_provider(Some(auth.path()));
+        let provider = unconditional_credential_provider(&required, Some(auth.path()));
         let readiness = provider_credential_readiness(&provider);
 
         assert!(
@@ -521,12 +462,12 @@ mod tests {
         // Only a `when`-gated declaration: the plan-level preflight owns it
         // once a request exists, so catalog status must not pre-judge it.
         let readiness = provider_credential_readiness(&provider(serde_json::json!({
-            "id": "codex.agent-task-executor",
-            "backend": "codex",
+            "id": "sample-runtime.agent-task-executor",
+            "backend": "sample-runtime",
             "secret_env_requirements": [{
                 "source": "provider_default",
-                "env": ["AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN"],
-                "when": { "any": [{ "path": "executor.config.provider", "equals": "codex" }] }
+                "env": ["SELECTED_ACCOUNT_TOKEN"],
+                "when": { "any": [{ "path": "executor.config.provider", "equals": "selected-account" }] }
             }]
         })));
 
@@ -538,8 +479,8 @@ mod tests {
     fn an_unconditional_secret_env_requirement_blocks_dispatch() {
         let required = format!("HOMEBOY_TEST_CREDENTIAL_{}", uuid::Uuid::new_v4());
         let readiness = provider_credential_readiness(&provider(serde_json::json!({
-            "id": "example.agent-task-executor",
-            "backend": "example",
+            "id": "sample-runtime.agent-task-executor",
+            "backend": "sample-runtime",
             "secret_env_requirements": [{
                 "source": "provider_default",
                 "env": [required.clone()]
@@ -553,10 +494,10 @@ mod tests {
     #[test]
     fn an_explicitly_optional_secret_requirement_does_not_block_dispatch() {
         let readiness = provider_credential_readiness(&provider(serde_json::json!({
-            "id": "example.agent-task-executor",
-            "backend": "example",
+            "id": "sample-runtime.agent-task-executor",
+            "backend": "sample-runtime",
             "secret_requirements": [{
-                "name": "EXAMPLE_OPTIONAL_KEY",
+                "name": "SAMPLE_OPTIONAL_KEY",
                 "required": false
             }]
         })));
@@ -570,11 +511,11 @@ mod tests {
         // Which default runs is a request decision when more than one is
         // declared, so nothing here is unconditionally required.
         let readiness = provider_credential_readiness(&provider(serde_json::json!({
-            "id": "wordpress.codebox-agent-task-executor",
-            "backend": "wp-codebox",
+            "id": "sample-runtime.agent-task-executor",
+            "backend": "sample-runtime",
             "provider_defaults": {
-                "openai": { "required_secret_env": ["OPENAI_API_KEY"] },
-                "claude-code": { "required_secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"] }
+                "first-account": { "required_secret_env": ["FIRST_ACCOUNT_TOKEN"] },
+                "second-account": { "required_secret_env": ["SECOND_ACCOUNT_TOKEN"] }
             }
         })));
 
@@ -584,8 +525,8 @@ mod tests {
 
     #[test]
     fn the_preflight_error_is_a_configuration_failure_naming_the_credential() {
-        let provider = claude_code_shaped_provider(None);
-        let required = required_credential(&provider);
+        let required = format!("HOMEBOY_TEST_CREDENTIAL_{}", uuid::Uuid::new_v4());
+        let provider = unconditional_credential_provider(&required, None);
         let error = preflight_provider_credentials(&provider)
             .expect_err("a missing required credential must fail fast");
 
@@ -603,14 +544,15 @@ mod tests {
 
     #[test]
     fn backend_preflight_ignores_backends_that_do_not_resolve() {
-        let providers = vec![claude_code_shaped_provider(None)];
+        let required = format!("HOMEBOY_TEST_CREDENTIAL_{}", uuid::Uuid::new_v4());
+        let providers = vec![unconditional_credential_provider(&required, None)];
 
         // Resolution failures belong to the runner-readiness validator; this
         // preflight must not shadow them with a credential error.
         preflight_provider_credentials_for_backend(&providers, "no-such-backend", None)
             .expect("unresolvable backends are not this preflight's error");
 
-        preflight_provider_credentials_for_backend(&providers, "claude-code", None)
+        preflight_provider_credentials_for_backend(&providers, "sample-runtime", None)
             .expect_err("a resolvable backend with a missing credential fails");
     }
 }

--- a/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
@@ -1509,18 +1509,16 @@ mod tests {
             "id": "revocable.agent-task-executor",
             "backend": "revocable",
             "capabilities": ["cli_runtime", "provider_owned_auth"],
-            "provider_defaults": {
-                "revocable": {
-                    "required_secret_env": ["HOMEBOY_TEST_REVOCABLE_REFRESH_TOKEN"],
-                    "secret_env_sources": {
-                        "HOMEBOY_TEST_REVOCABLE_REFRESH_TOKEN": {
-                            "source": "json-file",
-                            "path": auth_path,
-                            "field": "token"
-                        }
+            "secret_env_requirements": [{
+                "env": ["HOMEBOY_TEST_REVOCABLE_REFRESH_TOKEN"],
+                "secret_env_sources": {
+                    "HOMEBOY_TEST_REVOCABLE_REFRESH_TOKEN": {
+                        "source": "json-file",
+                        "path": auth_path,
+                        "field": "token"
                     }
                 }
-            }
+            }]
         }))
         .expect("provider fixture")
     }
@@ -1870,11 +1868,9 @@ mod tests {
             serde_json::from_value(json!({
                 "id": "credential.provider",
                 "backend": "credential",
-                "provider_defaults": {
-                    "credential": {
-                        "required_secret_env": ["HOMEBOY_TEST_DISPATCHABILITY_MISSING_CREDENTIAL"]
-                    }
-                }
+                "secret_env_requirements": [{
+                    "env": ["HOMEBOY_TEST_DISPATCHABILITY_MISSING_CREDENTIAL"]
+                }]
             }))
             .expect("credential provider");
         let model_provider: super::super::AgentTaskExecutorProvider =

--- a/crates/homeboy-agents/src/agent_task_provider/secrets.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/secrets.rs
@@ -180,11 +180,11 @@ pub(super) fn provider_secret_sources(
     sources
 }
 
-/// Every secret source a provider declares for itself, independent of any
-/// dispatch request: its unconditional `secret_env_requirements` sources plus
-/// a sole provider default, which is the same implicit-default rule scheduling
-/// uses. Multiple account defaults remain request-scoped; merging them here
-/// would let map iteration choose an arbitrary source for a shared env name.
+/// Every secret source a provider declares independently of any dispatch
+/// request: unconditional `secret_env_requirements` sources only.
+/// Account-scoped `provider_defaults` stay request-scoped through
+/// `provider_secret_sources(provider, Some(request))`. Overlaying a sole unused
+/// account here would let an unselected source replace an unconditional one.
 ///
 /// This is the single source-resolution path behind `agent-task auth status`,
 /// `agent-task providers --secret-env`, and provider credential readiness
@@ -198,13 +198,7 @@ pub(super) fn provider_secret_sources(
 pub(super) fn provider_declared_secret_sources(
     provider: &AgentTaskExecutorProvider,
 ) -> HashMap<String, defaults::AgentTaskSecretSource> {
-    let mut sources = provider_secret_sources(provider, None);
-    if provider.provider_defaults.len() == 1 {
-        if let Some(provider_default) = provider.provider_defaults.values().next() {
-            sources.extend(provider_config_secret_sources(provider_default));
-        }
-    }
-    sources
+    provider_secret_sources(provider, None)
 }
 
 fn secret_source_map_from_extra(
@@ -292,21 +286,17 @@ fn effective_provider_default<'a>(
     {
         return provider.provider_defaults.get(name);
     }
-    // A concrete provider/model route is more specific than a provider's sole
-    // fallback account. Do not require credentials for an unrelated fallback
-    // merely because this executor happens to declare only one default.
-    if let Some(model_provider) = request
+    // Provider defaults are route-scoped. Only a request that names the default
+    // via executor.config.provider or a provider/model route may inherit that
+    // default's credentials. An unused alternative must not become mandatory
+    // merely because the executor declares exactly one account.
+    request
         .executor
         .model
         .as_deref()
         .and_then(|model| model.split_once('/').map(|(provider, _)| provider))
         .filter(|provider| !provider.trim().is_empty())
-    {
-        return provider.provider_defaults.get(model_provider);
-    }
-    (provider.provider_defaults.len() == 1)
-        .then(|| provider.provider_defaults.values().next())
-        .flatten()
+        .and_then(|model_provider| provider.provider_defaults.get(model_provider))
 }
 
 fn requirement_matches_request(when: Option<&Value>, request: Option<&AgentTaskRequest>) -> bool {
@@ -392,7 +382,46 @@ mod tests {
     }
 
     #[test]
-    fn sole_default_required_secret_is_effective_without_an_explicit_provider() {
+    fn unused_account_source_does_not_override_unconditional_source() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "test.provider",
+            "backend": "test",
+            "secret_env_requirements": [{
+                "env": ["SHARED_TOKEN"],
+                "secret_env_sources": {
+                    "SHARED_TOKEN": {"source": "env", "env_var": "UNCONDITIONAL_SOURCE"}
+                }
+            }],
+            "provider_defaults": {
+                "unused-account": {
+                    "required_secret_env": ["SHARED_TOKEN"],
+                    "secret_env_sources": {
+                        "SHARED_TOKEN": {"source": "env", "env_var": "UNUSED_ACCOUNT_SOURCE"}
+                    }
+                }
+            }
+        }))
+        .expect("provider");
+
+        assert_eq!(
+            provider_declared_secret_sources(&provider)["SHARED_TOKEN"]
+                .env_var
+                .as_deref(),
+            Some("UNCONDITIONAL_SOURCE")
+        );
+        assert_eq!(
+            provider_secret_sources(
+                &provider,
+                Some(&request(serde_json::json!({"provider": "unused-account"})))
+            )["SHARED_TOKEN"]
+                .env_var
+                .as_deref(),
+            Some("UNUSED_ACCOUNT_SOURCE")
+        );
+    }
+
+    #[test]
+    fn unselected_sole_default_is_not_required() {
         let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
             "id": "test.provider",
             "backend": "test",
@@ -402,9 +431,77 @@ mod tests {
         }))
         .expect("provider");
 
+        assert!(provider_secret_env(&provider, Some(&request(Value::Null))).is_empty());
+        assert!(provider_secret_sources(&provider, Some(&request(Value::Null))).is_empty());
+    }
+
+    #[test]
+    fn dispatch_secret_plan_omits_unrelated_sole_default_credentials() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "test.provider",
+            "backend": "test",
+            "capabilities": ["provider_owned_auth"],
+            "provider_defaults": {
+                "unused-account": { "required_secret_env": ["UNUSED_ACCOUNT_TOKEN"] }
+            }
+        }))
+        .expect("provider");
+        let mut task = request(Value::Null);
+        task.executor.selector = Some("test.provider".to_string());
+        let plan = AgentTaskPlan::new("secret-selection", vec![task]);
+
+        assert!(
+            provider_runner_secret_env_for_plan_with_providers(&plan, &[provider.clone()])
+                .is_empty()
+        );
+        assert!(provider_secret_env_plan(&provider, &plan.tasks[0])
+            .secret_env_names()
+            .is_empty());
+    }
+
+    #[test]
+    fn dispatch_secret_plan_enforces_selected_declared_credentials() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "test.provider",
+            "backend": "test",
+            "provider_defaults": {
+                "used-account": { "required_secret_env": ["USED_ACCOUNT_TOKEN"] },
+                "unused-account": { "required_secret_env": ["UNUSED_ACCOUNT_TOKEN"] }
+            }
+        }))
+        .expect("provider");
+        let mut task = request(serde_json::json!({"provider": "used-account"}));
+        task.executor.selector = Some("test.provider".to_string());
+        let plan = AgentTaskPlan::new("secret-selection-selected", vec![task]);
+
         assert_eq!(
-            provider_secret_env(&provider, Some(&request(Value::Null))),
-            vec!["ONLY_ACCOUNT_TOKEN"]
+            provider_runner_secret_env_for_plan_with_providers(&plan, &[provider.clone()]),
+            vec!["USED_ACCOUNT_TOKEN".to_string()]
+        );
+        assert_eq!(
+            provider_secret_env_plan(&provider, &plan.tasks[0]).secret_env_names(),
+            vec!["USED_ACCOUNT_TOKEN".to_string()]
+        );
+    }
+
+    #[test]
+    fn dispatch_secret_plan_enforces_unconditional_secret_requirements() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "test.provider",
+            "backend": "test",
+            "secret_requirements": [{ "name": "REQUIRED_TOKEN" }],
+            "provider_defaults": {
+                "unused-account": { "required_secret_env": ["UNUSED_ACCOUNT_TOKEN"] }
+            }
+        }))
+        .expect("provider");
+        let mut task = request(Value::Null);
+        task.executor.selector = Some("test.provider".to_string());
+        let plan = AgentTaskPlan::new("secret-selection-required", vec![task]);
+
+        assert_eq!(
+            provider_runner_secret_env_for_plan_with_providers(&plan, &[provider]),
+            vec!["REQUIRED_TOKEN".to_string()]
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_provider/tests/workspace_secrets_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/workspace_secrets_tests.rs
@@ -70,21 +70,19 @@ fn provider_default_secret_sources_resolve_required_env_without_duplicate_mappin
 }
 
 #[test]
-fn provider_secret_sources_for_providers_include_default_json_sources() {
+fn provider_secret_sources_for_providers_include_unconditional_json_sources() {
     let (_request, mut provider) = request("task-a", "node provider-a.js".to_string());
-    provider.provider_defaults.insert(
-        "example-oauth".to_string(),
-        json!({
-            "secret_env": ["EXAMPLE_PROVIDER_ACCESS_TOKEN"],
-            "secret_env_sources": {
-                "EXAMPLE_PROVIDER_ACCESS_TOKEN": {
-                    "source": "json-file",
-                    "path": "~/.example-provider/auth.json",
-                    "field": "tokens.access_token"
-                }
+    provider.secret_env_requirements = serde_json::from_value(json!([{
+        "env": ["EXAMPLE_PROVIDER_ACCESS_TOKEN"],
+        "secret_env_sources": {
+            "EXAMPLE_PROVIDER_ACCESS_TOKEN": {
+                "source": "json-file",
+                "path": "~/.example-provider/auth.json",
+                "field": "tokens.access_token"
             }
-        }),
-    );
+        }
+    }]))
+    .expect("unconditional secret sources");
 
     let sources = provider_secret_sources_for_providers(&[provider]);
 
@@ -153,7 +151,7 @@ fn provider_default_secret_sources_accept_nested_json_sources() {
 }
 
 #[test]
-fn provider_default_secret_sources_feed_secret_readiness_status() {
+fn unconditional_secret_sources_feed_secret_readiness_status() {
     let temp = tempfile::tempdir().expect("tempdir");
     let auth_path = temp.path().join("provider-auth.json");
     fs::write(
@@ -168,18 +166,17 @@ fn provider_default_secret_sources_feed_secret_readiness_status() {
     .expect("write auth");
     let access = format!("HOMEBOY_TEST_ACCESS_{}", uuid::Uuid::new_v4());
     let (_request, mut provider) = request("task-a", "node provider-a.js".to_string());
-    provider.provider_defaults.insert(
-        "example-oauth".to_string(),
-        json!({
-            "secret_env_sources": {
-                access.clone(): {
-                    "source": "json-file",
-                    "path": auth_path,
-                    "field": "tokens.access_token"
-                }
+    provider.secret_env_requirements = serde_json::from_value(json!([{
+        "env": [access.clone()],
+        "secret_env_sources": {
+            access.clone(): {
+                "source": "json-file",
+                "path": auth_path,
+                "field": "tokens.access_token"
             }
-        }),
-    );
+        }
+    }]))
+    .expect("unconditional secret sources");
     let fallback_sources = provider_secret_sources_for_providers(&[provider]);
 
     let status =

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4894,7 +4894,7 @@ fn compile_cook_with_injected_catalog_rejects_each_unavailable_dimension_before_
                     providers: vec![serde_json::from_value(serde_json::json!({
                         "id": "credential.provider",
                         "backend": "credential",
-                        "provider_defaults": { "credential": { "required_secret_env": [missing_credential] } }
+                        "secret_env_requirements": [{ "env": [missing_credential] }]
                     })).expect("credential provider")],
                     ..Default::default()
                 },

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -3364,12 +3364,9 @@ mod tests {
             "id": "claude-code.agent-task-executor",
             "backend": "claude-code",
             "capabilities": ["cli_runtime", "provider_owned_auth"],
-            "provider_defaults": {
-                "claude-code": {
-                    "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
-                    "required_secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
-                }
-            }
+            "secret_env_requirements": [{
+                "env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
+            }]
         }))
         .expect("provider fixture")
     }
@@ -4008,18 +4005,15 @@ mod tests {
                 "id": "claude-code.agent-task-executor",
                 "backend": "claude-code",
                 "capabilities": ["cli_runtime", "provider_owned_auth"],
-                "provider_defaults": {
-                    "claude-code": {
-                        "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
-                        "required_secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
-                        "secret_env_sources": {
-                            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN": {
-                                "source": "env",
-                                "env_var": "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"
-                            }
+                "secret_env_requirements": [{
+                    "env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
+                    "secret_env_sources": {
+                        "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN": {
+                            "source": "env",
+                            "env_var": "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"
                         }
                     }
-                }
+                }]
             }))
             .expect("provider fixture");
             let mut args = providers_args();
@@ -4067,12 +4061,9 @@ mod tests {
             let requiring: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
                 "id": "claude-code.agent-task-executor",
                 "backend": "claude-code",
-                "provider_defaults": {
-                    "claude-code": {
-                        "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
-                        "required_secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
-                    }
-                }
+                "secret_env_requirements": [{
+                    "env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
+                }]
             }))
             .expect("requiring provider");
             let sourced: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
@@ -4206,10 +4197,10 @@ mod tests {
             unavailable.backend = "unavailable".to_string();
             let credential = format!("HOMEBOY_ROTATED_FALLBACK_{}", uuid::Uuid::new_v4());
             let mut fallback = provider("fallback.provider", "fallback");
-            fallback.provider_defaults.insert(
-                "fallback".to_string(),
-                serde_json::json!({ "required_secret_env": [credential.clone()] }),
-            );
+            fallback.secret_env_requirements = serde_json::from_value(serde_json::json!([{
+                "env": [credential.clone()]
+            }]))
+            .expect("secret env requirements");
             let catalog = provider_catalog(vec![unavailable, fallback]);
             let route =
                 agent_task_dispatch_service::resolve_cook_initial_provider_route_with_catalog(
@@ -4297,18 +4288,16 @@ mod tests {
             "id": "owned-auth.provider",
             "backend": "owned-auth",
             "capabilities": ["cli_runtime", "provider_owned_auth"],
-            "provider_defaults": {
-                "owned-auth": {
-                    "required_secret_env": ["HOMEBOY_TEST_OWNED_AUTH_TOKEN"],
-                    "secret_env_sources": {
-                        "HOMEBOY_TEST_OWNED_AUTH_TOKEN": {
-                            "source": "json-file",
-                            "path": auth.path(),
-                            "field": "token"
-                        }
+            "secret_env_requirements": [{
+                "env": ["HOMEBOY_TEST_OWNED_AUTH_TOKEN"],
+                "secret_env_sources": {
+                    "HOMEBOY_TEST_OWNED_AUTH_TOKEN": {
+                        "source": "json-file",
+                        "path": auth.path(),
+                        "field": "token"
                     }
                 }
-            }
+            }]
         }))
         .expect("provider fixture");
         let catalog = provider_catalog(vec![provider.clone()]);

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -1265,12 +1265,9 @@ mod preview_tests {
                     "id": "declared.agent-task-executor",
                     "backend": "declared",
                     "invocation": { "argv": ["true"] },
-                    "provider_defaults": {
-                        "declared": {
-                            "secret_env": [required.clone()],
-                            "required_secret_env": [required],
-                        },
-                    },
+                    "secret_env_requirements": [{
+                        "env": [required]
+                    }],
                 }))
                 .expect("declared provider"),
             ],
@@ -1281,32 +1278,15 @@ mod preview_tests {
     }
 
     #[test]
-    fn backend_preview_readiness_injects_sole_default_fallback_credentials() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let credential = root.path().join("credential.json");
-        let readiness = root.path().join("readiness.js");
-        std::fs::write(&credential, r#"{"token":"fallback-token"}"#).expect("credential");
-        std::fs::write(
-            &readiness,
-            "const fs=require('fs');JSON.parse(fs.readFileSync(0,'utf8'));const token=process.env.PREVIEW_FALLBACK_TOKEN||'';process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:token==='fallback-token',classification:token==='fallback-token'?'ready':'auth_failure',retryable:false,remediation:'',reason:'',cache_key:'preview',identity:{}}));",
-        )
-        .expect("readiness script");
+    fn backend_preview_does_not_select_unrelated_account_default_credentials() {
         let catalog = provider::AgentTaskProviderCatalog {
             providers: vec![serde_json::from_value(serde_json::json!({
-                "id": "fallback.agent-task-executor",
-                "backend": "fallback",
+                "id": "sample-runtime.agent-task-executor",
+                "backend": "sample-runtime",
                 "invocation": { "argv": ["true"] },
-                "readiness_invocation": { "argv": ["node", readiness] },
                 "provider_defaults": {
-                    "only": {
-                        "required_secret_env": ["PREVIEW_FALLBACK_TOKEN"],
-                        "secret_env_sources": {
-                            "PREVIEW_FALLBACK_TOKEN": {
-                                "source": "json-file",
-                                "path": credential,
-                                "field": "token"
-                            }
-                        }
+                    "unused-account": {
+                        "required_secret_env": ["UNUSED_ACCOUNT_TOKEN"]
                     }
                 }
             }))
@@ -1314,7 +1294,42 @@ mod preview_tests {
             ..Default::default()
         };
 
-        assert_eq!(ready_cook_backends(&catalog), vec!["fallback"]);
+        assert_eq!(ready_cook_backends(&catalog), vec!["sample-runtime"]);
+    }
+
+    #[test]
+    fn backend_preview_readiness_injects_unconditional_declared_credentials() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let credential = root.path().join("credential.json");
+        let readiness = root.path().join("readiness.js");
+        std::fs::write(&credential, r#"{"token":"required-token"}"#).expect("credential");
+        std::fs::write(
+            &readiness,
+            "const fs=require('fs');JSON.parse(fs.readFileSync(0,'utf8'));const token=process.env.PREVIEW_REQUIRED_TOKEN||'';process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:token==='required-token',classification:token==='required-token'?'ready':'auth_failure',retryable:false,remediation:'',reason:'',cache_key:'preview',identity:{}}));",
+        )
+        .expect("readiness script");
+        let catalog = provider::AgentTaskProviderCatalog {
+            providers: vec![serde_json::from_value(serde_json::json!({
+                "id": "sample-runtime.agent-task-executor",
+                "backend": "sample-runtime",
+                "invocation": { "argv": ["true"] },
+                "readiness_invocation": { "argv": ["node", readiness] },
+                "secret_env_requirements": [{
+                    "env": ["PREVIEW_REQUIRED_TOKEN"],
+                    "secret_env_sources": {
+                        "PREVIEW_REQUIRED_TOKEN": {
+                            "source": "json-file",
+                            "path": credential,
+                            "field": "token"
+                        }
+                    }
+                }]
+            }))
+            .expect("provider")],
+            ..Default::default()
+        };
+
+        assert_eq!(ready_cook_backends(&catalog), vec!["sample-runtime"]);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/secrets/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/lab/secrets/tests/part_b.rs
@@ -308,8 +308,109 @@ fn lab_dispatch_model_route_does_not_require_an_unrelated_sole_provider_default(
 }
 
 #[test]
-fn declared_agent_task_providers_still_include_provider_default_sources() {
+fn lab_dispatch_without_selected_route_does_not_require_unrelated_sole_provider_default() {
     let provider = fixture_provider_with_example_defaults();
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--backend".to_string(),
+        "sample-runtime".to_string(),
+    ];
+
+    let names = declared_agent_task_controller_secret_env_with_providers(
+        &args,
+        std::slice::from_ref(&provider),
+    )
+    .expect("unselected route secret discovery");
+    let sources = declared_agent_task_controller_secret_sources_with_providers(
+        &args,
+        1,
+        std::slice::from_ref(&provider),
+    )
+    .expect("unselected route source discovery");
+
+    assert!(names.is_empty());
+    assert!(sources.is_empty());
+
+    let mut env = HashMap::new();
+    let metadata = hydrate_agent_task_secret_env_with_providers(
+        &args,
+        &mut env,
+        std::slice::from_ref(&provider),
+    )
+    .expect("unselected route hydrates without invented credentials");
+    assert!(env.is_empty());
+    assert_eq!(
+        metadata["runner_deferred_secret_env"],
+        serde_json::json!([])
+    );
+}
+
+#[test]
+fn lab_dispatch_selected_route_keeps_declared_credentials_runner_owned() {
+    let provider = fixture_provider_with_example_defaults();
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--backend".to_string(),
+        "sample-runtime".to_string(),
+        "--model".to_string(),
+        "example-oauth/default".to_string(),
+    ];
+
+    let names = declared_agent_task_controller_secret_env_with_providers(
+        &args,
+        std::slice::from_ref(&provider),
+    )
+    .expect("selected route secret discovery");
+    let sources = declared_agent_task_controller_secret_sources_with_providers(
+        &args,
+        1,
+        std::slice::from_ref(&provider),
+    )
+    .expect("selected route source discovery");
+
+    assert_eq!(names, vec!["EXAMPLE_PROVIDER_ACCESS_TOKEN".to_string()]);
+    assert_eq!(
+        sources
+            .get("EXAMPLE_PROVIDER_ACCESS_TOKEN")
+            .and_then(|source| source.path.as_deref()),
+        Some("~/.example-provider/auth.json")
+    );
+
+    let mut env = HashMap::new();
+    let metadata = hydrate_agent_task_secret_env_with_providers(
+        &args,
+        &mut env,
+        std::slice::from_ref(&provider),
+    )
+    .expect("selected route defers declared credentials to the runner");
+    assert!(env.is_empty());
+    assert_eq!(
+        metadata["runner_deferred_secret_env"],
+        serde_json::json!([{
+            "name": "EXAMPLE_PROVIDER_ACCESS_TOKEN",
+            "source": "runner"
+        }])
+    );
+}
+
+#[test]
+fn declared_agent_task_providers_include_unconditional_sources() {
+    let mut provider = fixture_provider_with_example_defaults();
+    provider.secret_env_requirements = serde_json::from_value(serde_json::json!([{
+        "env": ["EXAMPLE_PROVIDER_ACCESS_TOKEN"],
+        "secret_env_sources": {
+            "EXAMPLE_PROVIDER_ACCESS_TOKEN": {
+                "source": "json-file",
+                "path": "~/.example-provider/auth.json",
+                "field": "tokens.access_token"
+            }
+        }
+    }]))
+    .expect("unconditional secret sources");
     let args = vec![
         "homeboy".to_string(),
         "agent-task".to_string(),


### PR DESCRIPTION
## Summary

Remove implicit selection of a runtime's sole account default from task secret planning, catalog credential readiness, and request-independent credential source lookup.

An OpenCode task with no provider/model override inherited five Codex credential requirements because its runtime declared Codex as its only account alternative. Lab correctly rejected the resulting mandatory secret plan, but Homeboy had invented the account selection upstream. The fix consumes explicit runtime declarations without adding provider names, model IDs, or credential-name special cases to production code.

- Account-scoped defaults apply only to the selected request route.
- Unconditional credential requirements remain enforced.
- An unused account cannot override an unconditional credential source with the same environment name.
- Selected account credentials retain their runner ownership.
- Replace tests preserving implicit defaults with explicit unconditional declarations and request-selection regressions.

## Verification

The following focused suites passed locally (60 tests total):

```sh
cargo test -p homeboy-agents --lib agent_task_provider::secrets::tests -- --test-threads=1
cargo test -p homeboy-agents --lib credential_readiness -- --test-threads=1
cargo test -p homeboy-agents --lib workspace_secrets -- --test-threads=1
cargo test -p homeboy-lab-runner --lib lab::secrets::tests::part_b:: -- --test-threads=1
cargo test -p homeboy-cli --lib backend_preview_ -- --test-threads=1
cargo fmt --check
git diff --check
```

These cover request selection, missing mandatory credentials, actual readiness subprocess credential injection, source collisions, and Lab secret handoff. Live runner validation remains pending installation of the repaired binary. The full suite is not claimed green: the existing `aggregate_precedence_keeps_each_failed_dimension_unavailable` test has expectations inconsistent with existing unresolved/static readiness behavior; this change leaves those expectations untouched.

## AI Assistance

xAI Grok 4.6 (`xai/grok-4.6`) through direct `opencode run` traced and implemented the repair. OpenAI gpt-6-astra through OpenCode reviewed the patch, requested completion across readiness and source lookup, reran the focused tests, and handled GitHub orchestration. Chris directed the architecture, authorized bypassing the failing coding control plane for this repair, and requested landing it.
