### PR TITLE
Project verified pre-provider runner cancellations

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -101,6 +101,12 @@ pub(crate) fn reconcile_runner_job_snapshot_in_store(
         *record = reconciled;
         return Ok(());
     }
+    if verified_pre_provider_cancellation(&reconciled, snapshot) {
+        project_terminal_runner_job_snapshot(&mut reconciled, snapshot);
+        lifecycle_store.write_record(&reconciled)?;
+        *record = reconciled;
+        return Ok(());
+    }
     match snapshot.job.status {
         homeboy_core::api_jobs::JobStatus::Queued | homeboy_core::api_jobs::JobStatus::Running => {
             reconciled.updated_at = Some(now_timestamp());
@@ -276,6 +282,52 @@ fn record_pending_runner_synchronization(
             "runner_job_status": snapshot.job.status,
         }),
     );
+}
+
+/// A cancelled daemon job has no inner aggregate when it was cancelled before
+/// the worker started. Require its complete queued-to-cancelled history so an
+/// incomplete terminal snapshot cannot erase provider work.
+fn verified_pre_provider_cancellation(
+    record: &AgentTaskRunRecord,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+) -> bool {
+    if snapshot.job.status != homeboy_core::api_jobs::JobStatus::Cancelled
+        || !record.has_accepted_lab_handoff()
+        || !record.provider_handles.is_empty()
+        || snapshot.job.target_runner_id.as_deref() != record.runner_id()
+        || snapshot.job.event_count != snapshot.events.len()
+        || snapshot.events.len() != 2
+    {
+        return false;
+    }
+
+    let mut queued_sequence = None;
+    let mut cancelled_sequence = None;
+    for event in &snapshot.events {
+        if event.job_id != snapshot.job.id
+            || event.kind != homeboy_core::api_jobs::JobEventKind::Status
+        {
+            return false;
+        }
+        match event
+            .data
+            .as_ref()
+            .and_then(|data| data.get("status"))
+            .and_then(Value::as_str)
+        {
+            Some("queued") => queued_sequence = Some(event.sequence),
+            Some("cancelled") => cancelled_sequence = Some(event.sequence),
+            // A running status is positive evidence that this is not the
+            // pre-provider cancellation case.
+            Some("running") => return false,
+            _ => {}
+        }
+    }
+
+    matches!(
+        (queued_sequence, cancelled_sequence),
+        (Some(queued), Some(cancelled)) if queued < cancelled
+    )
 }
 
 fn project_terminal_runner_job_snapshot(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -1563,6 +1563,183 @@ fn typed_pre_provider_runner_failure_snapshot(
     snapshot
 }
 
+fn pre_provider_cancellation_snapshot() -> homeboy_core::api_jobs::RunnerJobLogSnapshot {
+    let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+    snapshot.job.status = homeboy_core::api_jobs::JobStatus::Cancelled;
+    snapshot.job.target_runner_id = Some("homeboy-lab".to_string());
+    snapshot.events = vec![
+        homeboy_core::api_jobs::JobEvent {
+            sequence: 1,
+            job_id: snapshot.job.id,
+            kind: JobEventKind::Status,
+            timestamp_ms: 1,
+            message: Some("remote runner job queued".to_string()),
+            data: Some(json!({ "status": "queued" })),
+        },
+        homeboy_core::api_jobs::JobEvent {
+            sequence: 2,
+            job_id: snapshot.job.id,
+            kind: JobEventKind::Status,
+            timestamp_ms: 2,
+            message: Some("cancel requested via HTTP API".to_string()),
+            data: Some(json!({ "status": "cancelled" })),
+        },
+    ];
+    snapshot.job.event_count = snapshot.events.len();
+    snapshot
+}
+
+#[test]
+fn verified_pre_provider_runner_cancellation_terminalizes_and_replays_idempotently() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let run_id = "cook-14599-attempt-cancelled-before-provider";
+    let mut record = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        },
+    )
+    .expect("accepted detached handoff");
+    let snapshot = pre_provider_cancellation_snapshot();
+
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect("verified pre-provider cancellation projects");
+    let first = record.clone();
+
+    assert_eq!(record.state, AgentTaskRunState::Cancelled);
+    assert_eq!(record.tasks[0].state, AgentTaskState::Cancelled);
+    assert_eq!(record.metadata["runner_job_status"], "cancelled");
+    assert_eq!(
+        record.metadata["runner_result_synchronization"]["state"],
+        "projected"
+    );
+    assert_eq!(record.metadata["runner_handoff"]["state"], "terminal");
+    assert_eq!(record.metadata["runner_job_events"], json!(snapshot.events));
+    assert!(lifecycle_store.read_aggregate(run_id).is_err());
+
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect("terminal cancellation replay is a no-op");
+    assert_eq!(record, first);
+    assert_eq!(
+        reconcile_status_in_store(
+            &lifecycle_store,
+            run_id,
+            AgentTaskStatusOptions::default(),
+            false,
+        )
+        .expect("terminal status")
+        .record
+        .state,
+        AgentTaskRunState::Cancelled
+    );
+}
+
+#[test]
+fn pre_provider_cancellation_rejects_mismatched_job_without_mutating_record() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let mut record = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
+            run_id: "cook-14599-mismatched-job",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        },
+    )
+    .expect("accepted detached handoff");
+    let before = record.clone();
+    let mut snapshot = pre_provider_cancellation_snapshot();
+    snapshot.job.id =
+        uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000999").expect("job id");
+    for event in &mut snapshot.events {
+        event.job_id = snapshot.job.id;
+    }
+
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect_err("mismatched job is rejected");
+    assert_eq!(record, before);
+    assert!(lifecycle_store.read_aggregate(&record.run_id).is_err());
+}
+
+#[test]
+fn cancellation_after_runner_start_stays_pending_without_an_inner_aggregate() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let mut record = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
+            run_id: "cook-14599-cancelled-after-start",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        },
+    )
+    .expect("accepted detached handoff");
+    let mut snapshot = pre_provider_cancellation_snapshot();
+    snapshot.events.insert(
+        1,
+        homeboy_core::api_jobs::JobEvent {
+            sequence: 2,
+            job_id: snapshot.job.id,
+            kind: JobEventKind::Status,
+            timestamp_ms: 2,
+            message: Some("runner job started".to_string()),
+            data: Some(json!({ "status": "running" })),
+        },
+    );
+    snapshot.events[2].sequence = 3;
+    snapshot.job.event_count = snapshot.events.len();
+
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect("ambiguous terminal transport stays pending");
+    assert_eq!(record.state, AgentTaskRunState::Running);
+    assert_eq!(
+        record.metadata["runner_result_synchronization"]["state"],
+        "pending"
+    );
+    assert!(lifecycle_store.read_aggregate(&record.run_id).is_err());
+}
+
+#[test]
+fn truncated_cancellation_history_stays_pending_without_an_inner_aggregate() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let mut record = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
+            run_id: "cook-14599-truncated-cancellation-history",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        },
+    )
+    .expect("accepted detached handoff");
+    let mut snapshot = pre_provider_cancellation_snapshot();
+    snapshot.job.event_count = 3;
+
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect("truncated terminal transport stays pending");
+    assert_eq!(record.state, AgentTaskRunState::Running);
+    assert_eq!(
+        record.metadata["runner_result_synchronization"]["state"],
+        "pending"
+    );
+    assert!(lifecycle_store.read_aggregate(&record.run_id).is_err());
+}
+
 #[test]
 fn typed_pre_provider_failure_outranks_stale_runner_status_and_terminalizes_once() {
     let context = homeboy_core::test_support::HermeticTestContext::new();


### PR DESCRIPTION
## Summary

References #14599. Follow-up found during runtime convergence after #14597.

An accepted runner job cancelled before provider execution cannot produce an inner aggregate. Project that narrowly verified terminal state rather than wait indefinitely for a result that will never exist.

- Require the accepted handoff, matching runner/job identity, no provider handles, and complete queued-to-cancelled event history.
- Retain the existing terminal projection, cancellation provenance, task/run state updates, and idempotent replay.
- Preserve aggregate precedence and leave started, mismatched, or truncated histories protected.

## Verification

Executed locally with Rust while Lab convergence was blocked:

```sh
cargo test -p homeboy-agents --lib terminal_and_reconcile -- --test-threads=1
cargo fmt --all --check
git diff --check
```

The module recorded 73 passed / 1 failed. All four new tests passed: verified cancellation and replay, mismatched job refusal, started-job protection, and truncated-history protection. Existing transport-only pending and typed pre-provider failure tests also passed.

The sole failure, aggregate_source_loads_completed_run_without_path_spelunking, reproduces on unchanged base aaed0c00a6f4705e6587fb990f2bbbd697b34e31 with the same missing aggregate.json error:

```sh
cargo test -p homeboy-agents --lib aggregate_source_loads_completed_run_without_path_spelunking -- --test-threads=1
```

No failure was suppressed or reported green.

## Runtime Boundary

The original daemon job cancellation is durably confirmed, but the live agent-task record remains unresolved. A candidate CLI status invocation alone did not establish end-to-end repair; the owning runtime and retained-generation reconciliation still need verification.

The attempted Lab update subsequently failed its bounded health checks and rolled back. The refresh error does not retain enough candidate launch/health detail to identify that separate failure. This draft does not claim to fix runner rotation or complete the MDI parity workload. No release, forced daemon replacement, or unrelated job cancellation is included.

## AI Assistance

OpenAI GPT-6 Astra (openai/gpt-6-astra) via OpenCode investigated the retained cancellation, coordinated the focused implementation and tests, verified the inherited baseline failure, and prepared this draft under Chris Huber’s direction.