### PR TITLE
fix(agents): prevent daemon terminal-recovery recursion

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -1146,6 +1146,21 @@ pub fn terminal_transport_recovery_required(run_id: &str) -> bool {
 /// completed child run back into execution during controller reconciliation.
 pub fn terminal_run_result(run_id: &str) -> Result<Option<AgentTaskRunResult<AgentTaskAggregate>>> {
     let record = agent_task_lifecycle::reconcile_status(run_id)?;
+    terminal_run_result_for_record(record)
+}
+
+/// Read terminal evidence without consulting runner authority. Daemon job
+/// reconciliation calls this while runner status itself is being resolved.
+pub(crate) fn persisted_terminal_run_result(
+    run_id: &str,
+) -> Result<Option<AgentTaskRunResult<AgentTaskAggregate>>> {
+    let record = agent_task_lifecycle::exact_record(run_id)?;
+    terminal_run_result_for_record(record)
+}
+
+fn terminal_run_result_for_record(
+    record: agent_task_lifecycle::AgentTaskRunRecord,
+) -> Result<Option<AgentTaskRunResult<AgentTaskAggregate>>> {
     if !matches!(
         record.state,
         agent_task_lifecycle::AgentTaskRunState::Succeeded

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -1146,7 +1146,7 @@ pub fn terminal_transport_recovery_required(run_id: &str) -> bool {
 /// completed child run back into execution during controller reconciliation.
 pub fn terminal_run_result(run_id: &str) -> Result<Option<AgentTaskRunResult<AgentTaskAggregate>>> {
     let record = agent_task_lifecycle::reconcile_status(run_id)?;
-    terminal_run_result_for_record(record)
+    terminal_run_result_for_record(record, true)
 }
 
 /// Read terminal evidence without consulting runner authority. Daemon job
@@ -1154,12 +1154,15 @@ pub fn terminal_run_result(run_id: &str) -> Result<Option<AgentTaskRunResult<Age
 pub(crate) fn persisted_terminal_run_result(
     run_id: &str,
 ) -> Result<Option<AgentTaskRunResult<AgentTaskAggregate>>> {
-    let record = agent_task_lifecycle::exact_record(run_id)?;
-    terminal_run_result_for_record(record)
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    let record = lifecycle_store.read_record_bounded(run_id)?;
+    terminal_run_result_for_record(record, false)
 }
 
 fn terminal_run_result_for_record(
     record: agent_task_lifecycle::AgentTaskRunRecord,
+    recover_missing_aggregate: bool,
 ) -> Result<Option<AgentTaskRunResult<AgentTaskAggregate>>> {
     if !matches!(
         record.state,
@@ -1175,7 +1178,7 @@ fn terminal_run_result_for_record(
 
     let aggregate = match agent_task_lifecycle::read_aggregate(&record.run_id) {
         Ok(aggregate) => aggregate,
-        Err(_) => {
+        Err(_) if recover_missing_aggregate => {
             // A terminal Lab result may have been persisted before its typed
             // aggregate projection. Reconcile only that recorded terminal
             // evidence; never resume or rerun the provider for this path.
@@ -1195,6 +1198,7 @@ fn terminal_run_result_for_record(
         )
             })?
         }
+        Err(error) => return Err(error),
     };
     Ok(Some(AgentTaskRunResult {
         exit_code: aggregate_exit_code(&aggregate),

--- a/crates/homeboy-agents/src/api_jobs_terminal_recovery.rs
+++ b/crates/homeboy-agents/src/api_jobs_terminal_recovery.rs
@@ -65,7 +65,10 @@ impl AgentTaskTerminalRecoveryProvider for AgentTaskTerminalRecoveryProviderImpl
     }
 
     fn linked_durable_run_state(&self, run_id: &str) -> Option<DaemonLinkedDurableRunState> {
-        let record = crate::agent_task_lifecycle::exact_record(run_id).ok()?;
+        let lifecycle_store =
+            crate::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+                .ok()?;
+        let record = lifecycle_store.read_record_bounded(run_id).ok()?;
         if record.state.is_terminal() {
             Some(DaemonLinkedDurableRunState::Terminal)
         } else {

--- a/crates/homeboy-agents/src/api_jobs_terminal_recovery.rs
+++ b/crates/homeboy-agents/src/api_jobs_terminal_recovery.rs
@@ -20,7 +20,7 @@ struct AgentTaskTerminalRecoveryProviderImpl;
 
 impl AgentTaskTerminalRecoveryProvider for AgentTaskTerminalRecoveryProviderImpl {
     fn recovered_terminal_agent_task_job(&self, run_id: &str) -> Option<RecoveredTerminalJob> {
-        let result = agent_task_service::terminal_run_result(run_id).ok()??;
+        let result = agent_task_service::persisted_terminal_run_result(run_id).ok()??;
         let status = match result.value.status {
             AgentTaskAggregateStatus::Succeeded
             | AgentTaskAggregateStatus::CandidateRecoverable => JobStatus::Succeeded,
@@ -65,7 +65,7 @@ impl AgentTaskTerminalRecoveryProvider for AgentTaskTerminalRecoveryProviderImpl
     }
 
     fn linked_durable_run_state(&self, run_id: &str) -> Option<DaemonLinkedDurableRunState> {
-        let record = crate::agent_task_lifecycle::reconcile_status(run_id).ok()?;
+        let record = crate::agent_task_lifecycle::exact_record(run_id).ok()?;
         if record.state.is_terminal() {
             Some(DaemonLinkedDurableRunState::Terminal)
         } else {
@@ -79,4 +79,150 @@ impl AgentTaskTerminalRecoveryProvider for AgentTaskTerminalRecoveryProviderImpl
 /// agent-task subsystem.
 pub fn register() {
     register_agent_task_terminal_recovery_provider(Box::new(AgentTaskTerminalRecoveryProviderImpl));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use homeboy_core::api_jobs::{Job, RunnerJobLogSnapshot};
+    use homeboy_core::run_lifecycle_record::{RunExecutionState, RunLifecycleRecord};
+    use serde_json::json;
+
+    use super::*;
+    use crate::agent_task_lifecycle::{
+        AgentTaskLabHandoff, AgentTaskLabHandoffAuthority, AgentTaskLabHandoffState,
+        AgentTaskLifecycleStore, AgentTaskRunRecord, AgentTaskRunState, RunnerContinuationProvider,
+        RunnerContinuationSubmission, RunnerContinuationTestGuard,
+    };
+    use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskAggregateTotals};
+
+    struct CountingRunnerProvider(Arc<AtomicUsize>);
+
+    impl RunnerContinuationProvider for CountingRunnerProvider {
+        fn runner_job_log_snapshot(
+            &self,
+            _runner_id: &str,
+            _job_id: &str,
+        ) -> homeboy_core::Result<RunnerJobLogSnapshot> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Err(homeboy_core::Error::internal_unexpected(
+                "runner status must not be queried during terminal recovery",
+            ))
+        }
+
+        fn is_runner_connected(&self, _runner_id: &str) -> bool {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            true
+        }
+
+        fn run_continuation_exec(
+            &self,
+            _runner_id: &str,
+            _cwd: &str,
+            _command: &[String],
+            _run_id: &str,
+        ) -> homeboy_core::Result<i32> {
+            Err(homeboy_core::Error::internal_unexpected("not used"))
+        }
+
+        fn submit_runner_api_request(
+            &self,
+            _runner_id: &str,
+            _submission: RunnerContinuationSubmission,
+        ) -> homeboy_core::Result<Job> {
+            Err(homeboy_core::Error::internal_unexpected("not used"))
+        }
+    }
+
+    #[test]
+    fn terminal_recovery_uses_persisted_records_without_reentering_runner_status() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let store = AgentTaskLifecycleStore::from_current_environment().expect("store");
+            let run_id = "runner-linked-terminal-recovery";
+            let record = AgentTaskRunRecord {
+                schema: crate::agent_task_lifecycle::schemas::RUN.to_string(),
+                run_id: run_id.to_string(),
+                plan_id: "plan".to_string(),
+                state: AgentTaskRunState::Running,
+                submitted_at: "2026-09-12T00:00:00Z".to_string(),
+                updated_at: None,
+                plan_path: store.controller_plan_path(run_id).display().to_string(),
+                aggregate_path: None,
+                totals: None,
+                tasks: Vec::new(),
+                artifact_refs: Vec::new(),
+                provider_handles: Vec::new(),
+                latest_executor_evidence: None,
+                lifecycle: RunLifecycleRecord::with_execution_state(RunExecutionState::Running),
+                lab_handoff: Some(AgentTaskLabHandoff {
+                    state: AgentTaskLabHandoffState::Accepted,
+                    authority: AgentTaskLabHandoffAuthority::RunnerDaemon,
+                    runner_id: "homeboy-lab".to_string(),
+                    submission_key: None,
+                    payload_fingerprint: None,
+                    runner_job_id: Some("runner-job".to_string()),
+                    submitted_at: None,
+                    acceptance_deadline_at: None,
+                    accepted_at: Some("2026-09-12T00:00:01Z".to_string()),
+                    expired_at: None,
+                    workspace_identity: None,
+                    workspace_lifecycle_revision: 0,
+                    workspace_owner_lease: None,
+                    workspace_claim: None,
+                }),
+                candidate_adoption: None,
+                adoption_run_id: None,
+                acceptance: None,
+                workspace_identity: None,
+                workspace_lifecycle_revision: 0,
+                workspace_owner_lease: None,
+                workspace_claim: None,
+                metadata: json!({}),
+            };
+            store.write_record(&record).expect("write linked record");
+
+            let calls = Arc::new(AtomicUsize::new(0));
+            let _guard = RunnerContinuationTestGuard::install(Box::new(CountingRunnerProvider(
+                Arc::clone(&calls),
+            )));
+            assert_eq!(
+                AgentTaskTerminalRecoveryProviderImpl.linked_durable_run_state(run_id),
+                Some(DaemonLinkedDurableRunState::Active)
+            );
+            assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+            let mut terminal_record = record;
+            terminal_record.state = AgentTaskRunState::Succeeded;
+            terminal_record.lifecycle =
+                RunLifecycleRecord::with_execution_state(RunExecutionState::Succeeded);
+            store
+                .write_aggregate(
+                    run_id,
+                    &AgentTaskAggregate {
+                        schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+                        plan_id: "plan".to_string(),
+                        status: AgentTaskAggregateStatus::Succeeded,
+                        totals: AgentTaskAggregateTotals::default(),
+                        outcomes: Vec::new(),
+                        events: Vec::new(),
+                        artifact_lineage: Vec::new(),
+                        child_runs: Vec::new(),
+                        artifact_bindings: Vec::new(),
+                        queue: Default::default(),
+                    },
+                )
+                .expect("write terminal aggregate");
+            store
+                .write_record(&terminal_record)
+                .expect("write terminal record");
+            assert!(AgentTaskTerminalRecoveryProviderImpl
+                .recovered_terminal_agent_task_job(run_id)
+                .is_some());
+            assert_eq!(calls.load(Ordering::SeqCst), 0);
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #14602.

- Read terminal recovery inputs directly from the persisted lifecycle record instead of re-entering runner status while daemon status is resolving.
- Keep the persisted recovery path read-only when an aggregate projection is missing, preventing it from restarting reconciliation.

## Root Cause

Refresh run 551f4544-d11a-4069-90b6-b0ddb9a164f9 reached generation rotation and exhausted four health probes. Retained candidate termination evidence then showed SIGABRT from a Rust stack overflow. The candidate was not merely slow: terminal job recovery called lifecycle reconciliation while daemon runner status was already being resolved, recursively re-entering that status path.

## Verification

- cargo test -p homeboy-agents api_jobs_terminal_recovery::tests::terminal_recovery_uses_persisted_records_without_reentering_runner_status
- cargo build --bin homeboy
- cargo test --test daemon_ensure_running_cli ensure_running_observes_the_isolated_daemon_startup_lease
- cargo fmt --check
- git diff --check origin/main...HEAD

Lab workload admission remains intentionally blocked because the live old generation has protected state; the branch was validated in an isolated checkout without rotating, cancelling, or altering that generation.

## AI Assistance

OpenAI gpt-5.6-terra via OpenCode inspected the retained refresh artifact and read-only runner process and termination evidence, traced the failure to recursive terminal recovery, carried the focused owning-layer repair onto this branch, and ran the listed verification. Chris Huber directed and owns the work.