### PR TITLE
Keep lifecycle routing existence checks read-only

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -6017,13 +6017,14 @@ pub fn run_record_exists_readonly_in_store(
     lifecycle_store.record_exists_readonly(&sanitize_run_id(run_id))
 }
 
-/// `run_record_exists_resolved` against explicitly injected durable lifecycle
-/// roots.
+/// Non-initializing resolved existence check against explicitly injected
+/// durable lifecycle roots. Routing must not run startup migration while
+/// deciding which machine owns a read-only command.
 pub fn run_record_exists_resolved_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<bool> {
-    lifecycle_store.record_exists(&resolve_run_id_in_store(lifecycle_store, run_id)?)
+    lifecycle_store.record_exists_readonly(&resolve_run_id_in_store(lifecycle_store, run_id)?)
 }
 
 // The ambient `mark_resuming()` shim that used to sit here is gone. The resume

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -1232,6 +1232,37 @@ fn controller_local_record_owns_lifecycle_reads_and_cook_retries_before_lab_sele
 }
 
 #[test]
+fn lifecycle_routing_does_not_initialize_unrelated_historical_cook_indexes() {
+    crate::test_support::with_isolated_home(|_| {
+        let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+            "readonly-owner-routing",
+            vec![serde_json::from_value(serde_json::json!({
+                "task_id": "readonly-owner-task",
+                "executor": { "backend": "fixture" },
+                "instructions": "resolve lifecycle ownership without startup migration"
+            }))
+            .expect("task")],
+        );
+        let run_id = "readonly-owner-run";
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("controller-local record");
+
+        let store = agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+            .expect("lifecycle store");
+        let unrelated_index = store.cook_index_path("unrelated-corrupt-cook");
+        std::fs::create_dir_all(unrelated_index.parent().expect("Cook index parent"))
+            .expect("create unrelated Cook directory");
+        std::fs::write(&unrelated_index, "{").expect("write corrupt historical Cook index");
+
+        let cli = Cli::try_parse_from(["homeboy", "agent-task", "status", run_id, "--exact"])
+            .expect("status command parses");
+        assert!(
+            controller_owns_agent_task_lifecycle_command(&cli).expect("owner resolves read-only"),
+            "an unrelated historical projection must not break exact lifecycle routing"
+        );
+    });
+}
+
+#[test]
 fn every_generated_next_action_command_round_trips_to_the_record_owner() {
     // A generated next action that walks the operator back into the failure it
     // was printed to resolve is worse than no guidance at all (#11599). Each of


### PR DESCRIPTION
## Summary
- keep controller ownership routing on the bounded read-only observation path
- avoid initializing or migrating unrelated historical Cook indexes while routing lifecycle reads
- cover routing with an unrelated corrupt historical index

## Root cause
`controller_owns_agent_task_lifecycle_command` used the resolved existence helper, which resolved the requested identity read-only but then called the initializing `record_exists`. On a retained runner generation, that startup migration traversed unrelated historical Cook indexes during `agent-task status` and exhausted the stack before command dispatch.

The live retained-run reproduction now reaches the status handler and returns a normal typed result instead of stack-overflowing. This is a follow-up to #14594 and #14595.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-cli lifecycle_routing_does_not_initialize_unrelated_historical_cook_indexes -- --test-threads=1`
- `cargo test -p homeboy-cli controller_local_record_owns_lifecycle_reads_and_cook_retries_before_lab_selection -- --test-threads=1`
- `cargo check --workspace`
- exact retained-run `agent-task status` using an isolated candidate build: command reached normal typed status handling with no stack overflow

## AI assistance
OpenAI gpt-5.6-sol was used through OpenCode to trace the live call boundary, implement the minimal read-only fix, and add/run the regression and verification.