### PR TITLE
fix(process): restore controller-death watcher cleanup

### DIFF
--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -456,7 +456,7 @@ fn controller_death_guard_loop(
             unsafe { libc::_exit(0) };
         }
         if read < 0 {
-            if io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+            if io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
                 continue;
             }
             unsafe { libc::_exit(1) };
@@ -470,12 +470,28 @@ fn controller_death_guard_loop(
         if read == 0 {
             controller_death_cleanup(process_group);
         }
-        if read < 0 && io::Error::last_os_error().kind() != io::ErrorKind::Interrupted {
+        if read < 0 && io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
             unsafe {
                 libc::_exit(1);
             }
         }
     }
+}
+
+#[cfg(unix)]
+fn write_u32_nul(buf: &mut [u8; 12], mut value: u32) -> *const libc::c_char {
+    buf[11] = 0;
+    if value == 0 {
+        buf[10] = b'0';
+        return buf[10..].as_ptr().cast();
+    }
+    let mut i = 11;
+    while value > 0 {
+        i -= 1;
+        buf[i] = b'0' + (value % 10) as u8;
+        value /= 10;
+    }
+    buf[i..].as_ptr().cast()
 }
 
 /// The death watcher is already a single-threaded fork child. Exec a standalone
@@ -496,6 +512,7 @@ trap 'rm -f "$state" "$snapshot"' EXIT
 discover() {
   /bin/ps -axo pid=,ppid=,lstart= > "$snapshot"
   /usr/bin/awk -v root="$root" '
+    BEGIN { split("", owned) }
     FILENAME==ARGV[1] { owned[$1 FS $2 FS $3 FS $4 FS $5 FS $6]=1; next }
     { pid=$1; ppid=$2; ident=$3 FS $4 FS $5 FS $6 FS $7; row[pid]=ident; parent[pid]=ppid }
     END {
@@ -533,7 +550,9 @@ discover
 "#,
         "\0"
     );
-    let root = std::ffi::CString::new(root_pid.to_string()).expect("pid has no NUL");
+    // This fork child must not allocate before exec: another thread may have held malloc's lock.
+    let mut root_buf = [0u8; 12];
+    let root = write_u32_nul(&mut root_buf, root_pid);
     unsafe {
         libc::execl(
             c"/bin/sh".as_ptr(),
@@ -541,7 +560,7 @@ discover
             c"-c".as_ptr(),
             SCRIPT.as_ptr().cast::<libc::c_char>(),
             c"homeboy-child-guard".as_ptr(),
-            root.as_ptr(),
+            root,
             std::ptr::null::<libc::c_char>(),
         );
         libc::kill(-(root_pid as libc::pid_t), libc::SIGKILL);


### PR DESCRIPTION
## Summary

Repair a demonstrated shared controller-death cleanup failure under #12008 / #11932. Related leaked-helper evidence: #14553. This is a bounded first slice, not closure of the entire containment workstream.

The death watcher started with an empty ownership file. On GNU awk, evaluating `length(owned)` before the first array insertion treated the uninitialized value as a scalar; the subsequent array insertion failed. With `set -e`, the watcher exited before signalling the owned processes. Existing tests reproduced surviving release-mutation and gate descendants on Linux at baseline `085f3cd5333a94edbcd8f5ab5605da4276deaec4`.

- Initialize the AWK ownership array explicitly before reading the empty state file.
- Preserve root identity seeding, PID/start-time matching and TERM/KILL escalation.
- Format the root PID into a stack buffer rather than allocating after a multithreaded controller forks.
- Use the raw OS interruption code in the fork-child read loops.

No per-caller cleanup wrapper, provider-specific logic, timeout increase or test assertion relaxation is introduced.

## Linux Verification

Both existing real-subprocess regressions failed on the baseline and passed three consecutive times with the candidate:

```sh
for iteration in 1 2 3; do
  cargo test -p homeboy-engine-primitives --lib -- --exact command::tests::controller_loss_reaps_the_release_mutation_process_group || exit 1
  cargo test -p homeboy-agents --lib -- --exact agent_task_gate::baseline_tests::killing_the_gate_controller_reaps_its_background_descendant || exit 1
done
```

Additional Linux checks passed:

```sh
cargo test -p homeboy-engine-primitives --lib -- --exact command::tests::completed_parent_does_not_deadlock_on_a_background_output_holder
cargo test -p homeboy-engine-primitives --lib -- --exact command::tests::cancellation_reaps_the_entire_isolated_process_group
cargo test -p homeboy-upgrade --lib -- --exact upgrade::execution::tests::part_a::installer_timeout_kills_setsid_descendant_before_delayed_mutation
```

Local macOS `cargo check -p homeboy-engine-primitives`, `cargo fmt --check` and `git diff --check` pass. Existing behavioral tests cover the repair; no source-shape tests were added. Full nextest and Windows checks are not claimed.

## Remaining Work

Fast double-fork/session-escape containment, identity-safe adopted-child reaping, and the test that compares two live `/proc` scans remain unresolved. Experimental changes to those paths were excluded from this patch. This PR does not claim the full suite or #12008 is fixed.

Original CI evidence: https://github.com/Extra-Chill/homeboy/actions/runs/34707545383 (candidate and baseline failures in both attempts).

## AI Assistance

xAI Grok 4.6 (`xai/grok-4.6`) through direct OpenCode CLI reproduced the Linux failures and implemented the candidate. OpenAI gpt-6-astra through OpenCode reviewed ownership and cross-platform risks, narrowed the patch to the demonstrated watcher failure, verified the final diff and local checks, and prepared this PR. Chris directed the separate stabilization workstream.
