### PR TITLE
refactor(process): isolate descendant ownership per execution

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1902,27 +1902,27 @@ fn run_gate_argv(
         )
     })?;
     let target_started = Instant::now();
-    let mut child = process.spawn().map_err(|error| {
+    let child = process.spawn().map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some(format!("run deterministic gate {command}")),
         )
     })?;
-    if let Err(error) = containment.attach(&child) {
-        let _ = containment.terminate_live(&mut child);
+    if let Err(error) = containment.attach(child) {
         return Err(Error::internal_io(
             error.to_string(),
             Some(format!("guard deterministic gate {command}")),
         ));
     }
+    let process_group = containment.leader_pid().expect("attached gate owner");
     let timeout = declared_plan
         .map(|plan| plan.suite_timeout())
         .or(execution.timeout);
     let (mut output, termination) = if let Some(timeout) = timeout {
         let supervision = execution.supervision;
         if let Some(supervision) = supervision {
-            if let Err(error) = (supervision.on_spawn)(child.id(), command) {
-                if let Err(cleanup_error) = containment.terminate_live(&mut child) {
+            if let Err(error) = (supervision.on_spawn)(process_group, command) {
+                if let Err(cleanup_error) = containment.terminate_live() {
                     return Err(Error::internal_io(
                         format!(
                             "durable gate registration failed ({error}); failed to terminate and reap its child: {cleanup_error}"
@@ -1934,14 +1934,15 @@ fn run_gate_argv(
             }
         }
         let supervised =
-            homeboy_core::engine::command::wait_with_bounded_output_supervised_with_progress(
-                &mut child,
+            homeboy_core::engine::command::wait_with_bounded_output_supervised_with_progress_owned(
+                containment.owner_mut().expect("attached gate owner"),
                 65_536,
                 timeout,
                 supervision.map(|supervision| supervision.no_progress_timeout),
                 supervision
                     .map(|supervision| supervision.heartbeat_interval)
                     .unwrap_or(Duration::from_secs(5)),
+                None,
                 || supervision.is_some_and(|supervision| (supervision.is_cancelled)()),
                 |heartbeat| {
                     let Some(supervision) = supervision else {
@@ -1977,8 +1978,8 @@ fn run_gate_argv(
             })?;
         (supervised.output, supervised.termination)
     } else {
-        let output = homeboy_core::engine::command::wait_with_bounded_output_until_cancelled(
-            &mut child,
+        let output = homeboy_core::engine::command::wait_with_bounded_output_until_cancelled_owned(
+            containment.owner_mut().expect("attached gate owner"),
             65_536,
             || false,
         )

--- a/crates/homeboy-agents/src/agent_task_gate_executor.rs
+++ b/crates/homeboy-agents/src/agent_task_gate_executor.rs
@@ -237,14 +237,13 @@ fn run_execution(
             )),
         )
     })?;
-    let mut child = command.spawn().map_err(|error| {
+    let child = command.spawn().map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some(format!("run repo-local gate {}", execution.argv.join(" "))),
         )
     })?;
-    if let Err(error) = containment.attach(&child) {
-        let _ = containment.terminate_live(&mut child);
+    if let Err(error) = containment.attach(child) {
         return Err(Error::internal_io(
             error.to_string(),
             Some(format!(
@@ -253,7 +252,12 @@ fn run_execution(
             )),
         ));
     }
-    let output = child.wait_with_output().map_err(|error| {
+    let output = homeboy_core::engine::command::wait_with_bounded_output_until_cancelled_owned(
+        containment.owner_mut().expect("attached gate owner"),
+        65_536,
+        || false,
+    )
+    .map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some(format!("run repo-local gate {}", execution.argv.join(" "))),

--- a/crates/homeboy-agents/src/agent_task_process_containment.rs
+++ b/crates/homeboy-agents/src/agent_task_process_containment.rs
@@ -36,8 +36,7 @@ use std::ops::{Deref, DerefMut};
 use std::process::{Child, Command};
 
 use homeboy_core::engine::command::{
-    terminate_remaining_process_group, ExecutionCleanup, ExecutionIdentity, ExecutionOwner,
-    ExecutionOwnerPrep,
+    ExecutionCleanup, ExecutionIdentity, ExecutionOwner, ExecutionOwnerPrep,
 };
 
 /// Owns the process group of one spawned agent-task child.
@@ -118,22 +117,10 @@ impl AgentTaskProcessContainment {
                     )
                 })
             }
-            Err(primary_error) => {
-                let group_error = self
-                    .identity
-                    .map(|identity| identity.recovery_process_group())
-                    .and_then(|pid| terminate_remaining_process_group(pid).err());
-                self.reaped = group_error.is_none();
-                let mut details = vec![primary_error.to_string()];
-                if let Some(error) = group_error {
-                    details.push(format!("fallback group cleanup failed: {error}"));
-                }
-                Err(format!(
-                    "could not terminate the contained provider process group{}: {}",
-                    self.leader_suffix(),
-                    details.join("; ")
-                ))
-            }
+            Err(primary_error) => Err(format!(
+                "could not terminate the contained provider process group{}: {primary_error}",
+                self.leader_suffix()
+            )),
         }
     }
 

--- a/crates/homeboy-agents/src/agent_task_process_containment.rs
+++ b/crates/homeboy-agents/src/agent_task_process_containment.rs
@@ -36,7 +36,8 @@ use std::ops::{Deref, DerefMut};
 use std::process::{Child, Command};
 
 use homeboy_core::engine::command::{
-    terminate_process_tree_and_reap, terminate_remaining_process_group, ControllerChildGuard,
+    terminate_remaining_process_group, ExecutionCleanup, ExecutionIdentity, ExecutionOwner,
+    ExecutionOwnerPrep,
 };
 
 /// Owns the process group of one spawned agent-task child.
@@ -45,11 +46,9 @@ use homeboy_core::engine::command::{
 /// (the process-group isolation is installed on the [`Command`]) and call
 /// [`AgentTaskProcessContainment::attach`] immediately after spawning.
 pub(crate) struct AgentTaskProcessContainment {
-    /// Also held for its `Drop`, which closes the liveness pipe the forked
-    /// death guard watches — that closure is what makes controller death kill
-    /// the tree.
-    guard: ControllerChildGuard,
-    leader_pid: Option<u32>,
+    prep: Option<ExecutionOwnerPrep>,
+    owner: Option<ExecutionOwner>,
+    identity: Option<ExecutionIdentity>,
     reaped: bool,
 }
 
@@ -58,35 +57,45 @@ impl AgentTaskProcessContainment {
     /// `command`. Must be called before `command.spawn()`.
     pub(crate) fn prepare(command: &mut Command) -> std::io::Result<Self> {
         Ok(Self {
-            guard: ControllerChildGuard::prepare(command)?,
-            leader_pid: None,
+            prep: Some(ExecutionOwner::prepare(command)?),
+            owner: None,
+            identity: None,
             reaped: false,
         })
     }
 
     /// Start the death guard for `child`. Called after spawn so the guard
     /// cannot inherit the standard library's private spawn error pipe.
-    pub(crate) fn attach(&mut self, child: &Child) -> std::io::Result<()> {
-        self.leader_pid = Some(child.id());
-        self.guard.attach(child)
+    pub(crate) fn attach(&mut self, child: Child) -> std::io::Result<&mut ExecutionOwner> {
+        let prep = self
+            .prep
+            .take()
+            .ok_or_else(|| std::io::Error::other("process containment already attached"))?;
+        let owner = prep.attach(child)?;
+        self.identity = Some(owner.identity());
+        self.owner = Some(owner);
+        Ok(self.owner.as_mut().expect("attached owner"))
     }
 
     /// Transfer the spawned child into an unwind-safe supervisor and attach the
     /// controller death guard. An attach failure still drops the supervisor,
     /// which terminates the group and waits the child before returning.
-    pub(crate) fn supervise(self, child: Child) -> std::io::Result<AgentTaskProcessSupervisor> {
-        let mut supervisor = AgentTaskProcessSupervisor {
+    pub(crate) fn supervise(mut self, child: Child) -> std::io::Result<AgentTaskProcessSupervisor> {
+        self.attach(child)?;
+        Ok(AgentTaskProcessSupervisor {
             containment: self,
-            child,
             cleanup_complete: false,
-        };
-        supervisor.containment.attach(&supervisor.child)?;
-        Ok(supervisor)
+        })
     }
 
-    /// The pid of the contained group leader, once attached.
+    /// The pid of the contained workload group leader, once attached.
     pub(crate) fn leader_pid(&self) -> Option<u32> {
-        self.leader_pid
+        self.identity
+            .map(|identity| identity.recovery_process_group())
+    }
+
+    pub(crate) fn owner_mut(&mut self) -> Option<&mut ExecutionOwner> {
+        self.owner.as_mut()
     }
 
     /// Terminate the contained tree while its leader is still running, then
@@ -95,38 +104,29 @@ impl AgentTaskProcessContainment {
     ///
     /// This replaces `Child::kill`, which signals only the direct child and
     /// leaves its build/test descendants running.
-    pub(crate) fn terminate_live(&mut self, child: &mut Child) -> Result<(), String> {
-        match terminate_process_tree_and_reap(child) {
-            Ok(_) => {
-                self.reaped = true;
-                Ok(())
+    pub(crate) fn terminate_live(&mut self) -> Result<(), String> {
+        let Some(owner) = self.owner.as_mut() else {
+            return Err("process containment was not attached to a child".to_string());
+        };
+        match owner.drain_and_reap() {
+            Ok(outcome) => {
+                self.reaped = outcome.cleanup == ExecutionCleanup::Complete;
+                outcome.into_root_status().map(|_| ()).map_err(|error| {
+                    format!(
+                        "could not terminate the contained provider process group{}: {error}",
+                        self.leader_suffix()
+                    )
+                })
             }
             Err(primary_error) => {
-                // A supervision error must not become an early return that
-                // leaves the direct child unreaped. Retry group cleanup, then
-                // independently kill and wait for the child as a final fallback.
                 let group_error = self
-                    .leader_pid
+                    .identity
+                    .map(|identity| identity.recovery_process_group())
                     .and_then(|pid| terminate_remaining_process_group(pid).err());
-                let kill_error = child
-                    .kill()
-                    .err()
-                    .filter(|error| error.kind() != std::io::ErrorKind::InvalidInput);
-                let wait_error = child.wait().err();
-                // Reaping the direct child does not prove descendants in its
-                // process group are gone. Leave the containment live when
-                // group cleanup failed so Drop retries the group.
-                self.reaped = group_error.is_none() && wait_error.is_none();
-
+                self.reaped = group_error.is_none();
                 let mut details = vec![primary_error.to_string()];
                 if let Some(error) = group_error {
                     details.push(format!("fallback group cleanup failed: {error}"));
-                }
-                if let Some(error) = kill_error {
-                    details.push(format!("fallback child kill failed: {error}"));
-                }
-                if let Some(error) = wait_error {
-                    details.push(format!("fallback child reap failed: {error}"));
                 }
                 Err(format!(
                     "could not terminate the contained provider process group{}: {}",
@@ -147,31 +147,30 @@ impl AgentTaskProcessContainment {
         if self.reaped {
             return Ok(());
         }
-        let Some(leader_pid) = self.leader_pid else {
+        let Some(owner) = self.owner.as_mut() else {
             self.reaped = true;
             return Ok(());
         };
-        match terminate_remaining_process_group(leader_pid) {
-            Ok(()) => {
-                self.reaped = true;
-                Ok(())
+        match owner.try_wait_outcome() {
+            Ok(Some(outcome)) => {
+                self.reaped = outcome.cleanup == ExecutionCleanup::Complete;
+                outcome.into_root_status().map(|_| ()).map_err(|error| {
+                    format!(
+                        "contained provider process group{} outlived its leader and did not exit: {error}",
+                        self.leader_suffix()
+                    )
+                })
             }
-            Err(primary_error) => {
-                let retry_error = terminate_remaining_process_group(leader_pid).err();
-                self.reaped = retry_error.is_none();
-                Err(format!(
-                    "contained provider process group{} outlived its leader and did not exit: {primary_error}{}",
-                    self.leader_suffix(),
-                    retry_error
-                        .map(|error| format!("; cleanup retry failed: {error}"))
-                        .unwrap_or_default()
-                ))
-            }
+            Ok(None) => self.terminate_live(),
+            Err(error) => Err(format!(
+                "contained provider process group{} outlived its leader and did not exit: {error}",
+                self.leader_suffix()
+            )),
         }
     }
 
     fn leader_suffix(&self) -> String {
-        self.leader_pid
+        self.leader_pid()
             .map(|pid| format!(" (leader pid {pid})"))
             .unwrap_or_default()
     }
@@ -193,7 +192,6 @@ impl Drop for AgentTaskProcessContainment {
 /// waits the direct child, without attempting to drain descendant-held pipes.
 pub(crate) struct AgentTaskProcessSupervisor {
     containment: AgentTaskProcessContainment,
-    child: Child,
     cleanup_complete: bool,
 }
 
@@ -202,8 +200,12 @@ impl AgentTaskProcessSupervisor {
         self.containment.leader_pid()
     }
 
+    pub(crate) fn identity(&self) -> Option<ExecutionIdentity> {
+        self.containment.identity
+    }
+
     pub(crate) fn terminate_live(&mut self) -> Result<(), String> {
-        let result = self.containment.terminate_live(&mut self.child);
+        let result = self.containment.terminate_live();
         if result.is_ok() {
             self.cleanup_complete = true;
         }
@@ -211,36 +213,30 @@ impl AgentTaskProcessSupervisor {
     }
 
     pub(crate) fn reap_after_exit(&mut self) -> Result<(), String> {
-        let group_result = self.containment.reap_after_exit();
-        let wait_result = self.child.wait().map(|_| ()).map_err(|error| {
-            format!(
-                "could not reap contained provider child{}: {error}",
-                self.containment.leader_suffix()
-            )
-        });
-        self.cleanup_complete = group_result.is_ok() && wait_result.is_ok();
-        group_result.and(wait_result)
+        let result = self.containment.reap_after_exit();
+        self.cleanup_complete = result.is_ok();
+        result
     }
 }
 
 impl Deref for AgentTaskProcessSupervisor {
-    type Target = Child;
+    type Target = ExecutionOwner;
 
     fn deref(&self) -> &Self::Target {
-        &self.child
+        self.containment.owner.as_ref().expect("supervised owner")
     }
 }
 
 impl DerefMut for AgentTaskProcessSupervisor {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.child
+        self.containment.owner.as_mut().expect("supervised owner")
     }
 }
 
 impl Drop for AgentTaskProcessSupervisor {
     fn drop(&mut self) {
         if !self.cleanup_complete {
-            let _ = self.containment.terminate_live(&mut self.child);
+            let _ = self.containment.terminate_live();
         }
     }
 }
@@ -283,7 +279,7 @@ mod tests {
 
     /// Spawn a contained shell that leaves one background descendant behind and
     /// exits immediately, returning `(child, descendant_pid)`.
-    fn spawn_leaking_child(script: &str) -> (AgentTaskProcessContainment, Child, u32) {
+    fn spawn_leaking_child(script: &str) -> (AgentTaskProcessContainment, u32) {
         let mut command = Command::new("sh");
         command
             .args(["-c", script])
@@ -292,29 +288,36 @@ mod tests {
             .stderr(Stdio::null());
         let mut containment =
             AgentTaskProcessContainment::prepare(&mut command).expect("prepare containment");
-        let mut child = command.spawn().expect("spawn contained child");
-        containment.attach(&child).expect("attach death guard");
+        let child = command.spawn().expect("spawn contained child");
+        let owner = containment.attach(child).expect("attach death guard");
 
         // Read one line rather than to EOF: the background descendant holds the
         // inherited stdout pipe open, which is precisely the hang this
         // containment exists to prevent.
-        let stdout = child.stdout.take().expect("piped stdout");
+        let stdout = owner.take_stdout().expect("piped stdout");
         let mut reader = BufReader::new(stdout);
         let mut line = String::new();
         reader.read_line(&mut line).expect("read descendant pid");
         let descendant_pid: u32 = line.trim().parse().expect("descendant pid");
 
-        (containment, child, descendant_pid)
+        (containment, descendant_pid)
     }
 
     /// The #11477 regression: the provider exits cleanly and its build/test
     /// descendant keeps running. A clean leader exit must still reap the group.
     #[test]
     fn reaping_after_leader_exit_kills_a_surviving_descendant() {
-        let (mut containment, mut child, descendant_pid) =
-            spawn_leaking_child("sleep 30 & echo $!; exit 0");
+        let (mut containment, descendant_pid) = spawn_leaking_child("sleep 30 & echo $!; exit 0");
 
-        child.wait().expect("leader exits on its own");
+        let owner = containment.owner_mut().expect("attached owner");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if owner.try_wait().expect("leader wait").is_some() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "leader did not exit on its own");
+            std::thread::sleep(Duration::from_millis(25));
+        }
         #[cfg(target_os = "linux")]
         assert!(
             !homeboy_core::process::pid_is_running(descendant_pid),
@@ -339,12 +342,12 @@ mod tests {
     /// whole tree, not just the direct child.
     #[test]
     fn terminating_a_live_leader_kills_its_descendants() {
-        let (mut containment, mut child, descendant_pid) =
-            spawn_leaking_child("sleep 30 & echo $!; sleep 30");
-        let leader_pid = child.id();
+        let (mut containment, descendant_pid) =
+            spawn_leaking_child("trap '' TERM; sleep 30 & echo $!; wait");
+        let leader_pid = containment.leader_pid().expect("leader");
 
         containment
-            .terminate_live(&mut child)
+            .terminate_live()
             .expect("contained tree terminates");
 
         assert!(
@@ -372,14 +375,15 @@ mod tests {
                 .stderr(Stdio::null());
             let containment =
                 AgentTaskProcessContainment::prepare(&mut command).expect("prepare containment");
-            let mut child = command.spawn().expect("spawn contained child");
-            let stdout = child.stdout.take().expect("piped stdout");
+            let child = command.spawn().expect("spawn contained child");
+            let mut supervisor = containment.supervise(child).expect("supervise child");
+            let stdout = supervisor.take_stdout().expect("piped stdout");
             let mut reader = BufReader::new(stdout);
             let mut line = String::new();
             reader.read_line(&mut line).expect("read descendant pid");
-            leader_pid = child.id();
+            leader_pid = supervisor.identity().expect("identity").wait_pid;
             descendant_pid = line.trim().parse().expect("descendant pid");
-            let _supervisor = containment.supervise(child).expect("supervise child");
+            let _supervisor = supervisor;
             panic!("force post-spawn unwind");
         }));
 

--- a/crates/homeboy-agents/src/agent_task_process_containment.rs
+++ b/crates/homeboy-agents/src/agent_task_process_containment.rs
@@ -315,11 +315,16 @@ mod tests {
             spawn_leaking_child("sleep 30 & echo $!; exit 0");
 
         child.wait().expect("leader exits on its own");
+        #[cfg(target_os = "linux")]
+        assert!(
+            !homeboy_core::process::pid_is_running(descendant_pid),
+            "the execution supervisor must drain descendants before exiting"
+        );
+        #[cfg(not(target_os = "linux"))]
         assert!(
             homeboy_core::process::pid_is_running(descendant_pid),
             "descendant must outlive its leader for this to test anything"
         );
-
         containment
             .reap_after_exit()
             .expect("surviving group members are reaped");

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -1113,14 +1113,14 @@ fn run_materialized_provider_command_once_contained(
                 run_id,
                 &request.request.task_id,
                 attempt,
-                child.id(),
+                child.identity().expect("supervised identity").root_pid,
             );
         } else {
             let _ = crate::agent_task_lifecycle::record_provider_execution_process(
                 run_id,
                 &request.request.task_id,
                 attempt,
-                child.id(),
+                child.identity().expect("supervised identity").root_pid,
             );
         }
     }
@@ -1169,7 +1169,7 @@ fn run_materialized_provider_command_once_contained(
             )),
         );
     }
-    let stdout_reader = child.stdout.take().map(|stdout| {
+    let stdout_reader = child.take_stdout().map(|stdout| {
         spawn_provider_output_reader(
             stdout,
             Arc::clone(&stdout_capture),
@@ -1178,7 +1178,7 @@ fn run_materialized_provider_command_once_contained(
             stdout_runtime_capture.map(|capture| capture.file),
         )
     });
-    let stderr_reader = child.stderr.take().map(|stderr| {
+    let stderr_reader = child.take_stderr().map(|stderr| {
         spawn_provider_output_reader(
             stderr,
             Arc::clone(&stderr_capture),
@@ -1188,7 +1188,7 @@ fn run_materialized_provider_command_once_contained(
         )
     });
 
-    if let Some(mut stdin) = child.stdin.take() {
+    if let Some(mut stdin) = child.take_stdin() {
         let _ = Write::write_all(&mut stdin, &input);
     }
 
@@ -2737,13 +2737,13 @@ fn run_provider_readiness_invocation_with_timeout(
         .supervise(child)
         .map_err(|error| format!("failed to guard provider readiness invocation: {error}"))?;
     let (stdin_sender, stdin_receiver) = mpsc::sync_channel(1);
-    let stdin_writer = child.stdin.take().map(|mut stdin| {
+    let stdin_writer = child.take_stdin().map(|mut stdin| {
         std::thread::spawn(move || {
             let _ = stdin_sender.send(stdin.write_all(&input));
         })
     });
-    let stdout_reader = child.stdout.take().map(spawn_readiness_output_reader);
-    let stderr_reader = child.stderr.take().map(spawn_readiness_output_reader);
+    let stdout_reader = child.take_stdout().map(spawn_readiness_output_reader);
+    let stderr_reader = child.take_stderr().map(spawn_readiness_output_reader);
     let mut stdin_complete = stdin_writer.is_none();
     let terminal = loop {
         if !stdin_complete {
@@ -3129,7 +3129,7 @@ pub fn probe_provider_executor_resolves(
         }
     };
 
-    let stderr_reader = child.stderr.take().map(|mut stderr| {
+    let stderr_reader = child.take_stderr().map(|mut stderr| {
         let (send, receive) = std::sync::mpsc::sync_channel(1);
         std::thread::spawn(move || {
             let mut buffer = Vec::new();

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_tool_resolution.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_tool_resolution.rs
@@ -213,7 +213,7 @@ fn probe_capabilities(
             failure_classification: AgentTaskFailureClassification::Provider,
         }
     })?;
-    let mut child = command
+    let child = command
         .spawn()
         .map_err(|error| RuntimeToolResolutionError {
             class: "agent_task.runtime_tool_capability_probe_failed",
@@ -224,8 +224,7 @@ fn probe_capabilities(
             data: json!({ "tool": tool.id }),
             failure_classification: AgentTaskFailureClassification::Provider,
         })?;
-    if let Err(error) = containment.attach(&child) {
-        let _ = containment.terminate_live(&mut child);
+    if let Err(error) = containment.attach(child) {
         return Err(RuntimeToolResolutionError {
             class: "agent_task.runtime_tool_capability_probe_failed",
             message: format!(
@@ -239,7 +238,11 @@ fn probe_capabilities(
     let timeout = std::time::Duration::from_millis(tool.timeout_ms.unwrap_or(20_000));
     let started = std::time::Instant::now();
     loop {
-        match child.try_wait() {
+        match containment
+            .owner_mut()
+            .expect("attached probe owner")
+            .try_wait()
+        {
             Ok(Some(status)) if status.success() => {
                 let _ = containment.reap_after_exit();
                 return Ok(Some(AgentTaskRuntimeToolProbeEvidence {
@@ -257,7 +260,7 @@ fn probe_capabilities(
                 });
             }
             Ok(None) if started.elapsed() >= timeout => {
-                let _ = containment.terminate_live(&mut child);
+                let _ = containment.terminate_live();
                 return Err(RuntimeToolResolutionError {
                     class: "agent_task.runtime_tool_capability_probe_timeout",
                     message: format!("capability probe timed out for runtime tool '{}'", tool.id),
@@ -295,7 +298,7 @@ fn probe_version(
             failure_classification: AgentTaskFailureClassification::Provider,
         }
     })?;
-    let mut child = command
+    let child = command
         .spawn()
         .map_err(|error| RuntimeToolResolutionError {
             class: "agent_task.runtime_tool_readiness_failed",
@@ -306,8 +309,7 @@ fn probe_version(
             data: json!({ "tool": tool.id }),
             failure_classification: AgentTaskFailureClassification::Provider,
         })?;
-    if let Err(error) = containment.attach(&child) {
-        let _ = containment.terminate_live(&mut child);
+    if let Err(error) = containment.attach(child) {
         return Err(RuntimeToolResolutionError {
             class: "agent_task.runtime_tool_readiness_failed",
             message: format!(
@@ -321,14 +323,22 @@ fn probe_version(
     let timeout = std::time::Duration::from_millis(tool.timeout_ms.unwrap_or(20_000));
     let started = std::time::Instant::now();
     loop {
-        match child.try_wait() {
+        match containment
+            .owner_mut()
+            .expect("attached probe owner")
+            .try_wait()
+        {
             Ok(Some(status)) if status.success() => {
                 let _ = containment.reap_after_exit();
-                let output = child.stdout.take().and_then(|mut stdout| {
-                    let mut value = String::new();
-                    std::io::Read::read_to_string(&mut stdout, &mut value).ok()?;
-                    Some(value.trim().to_string())
-                });
+                let output = containment
+                    .owner_mut()
+                    .expect("attached probe owner")
+                    .take_stdout()
+                    .and_then(|mut stdout| {
+                        let mut value = String::new();
+                        std::io::Read::read_to_string(&mut stdout, &mut value).ok()?;
+                        Some(value.trim().to_string())
+                    });
                 return Ok(output.filter(|value| !value.is_empty()));
             }
             Ok(Some(_)) | Err(_) => {
@@ -341,7 +351,7 @@ fn probe_version(
                 });
             }
             Ok(None) if started.elapsed() >= timeout => {
-                let _ = containment.terminate_live(&mut child);
+                let _ = containment.terminate_live();
                 return Err(RuntimeToolResolutionError {
                     class: "agent_task.runtime_tool_readiness_timeout",
                     message: format!("readiness probe timed out for runtime tool '{}'", tool.id),

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -18,7 +18,7 @@ use homeboy::core::scope::{self, Scope};
 use homeboy::runner::runners as runner;
 use homeboy_deploy::ReleaseStateStatus;
 use homeboy_engine_primitives::command::{
-    wait_with_bounded_output_supervised_with_progress, CommandProgress, ControllerChildGuard,
+    wait_with_bounded_output_supervised_with_progress_owned, CommandProgress, ExecutionOwner,
     SupervisedCommandTermination,
 };
 use homeboy_release::release::version;
@@ -274,13 +274,7 @@ fn run_isolated_probe(
         .env("HOMEBOY_STATUS_PROBE_CHILD", "1")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let guard = ControllerChildGuard::prepare(&mut command)
-        .map_err(|error| homeboy::core::Error::internal_io(error.to_string(), None))?;
-    let mut child = command
-        .spawn()
-        .map_err(|error| homeboy::core::Error::internal_io(error.to_string(), None))?;
-    guard
-        .attach(&child)
+    let mut owner = ExecutionOwner::spawn(&mut command)
         .map_err(|error| homeboy::core::Error::internal_io(error.to_string(), None))?;
     // Leave headroom below the command-wide 30-second status deadline for the
     // parent to kill the child and serialize its partial snapshot.
@@ -290,12 +284,13 @@ fn run_isolated_probe(
         .then_some(remaining.min(GLOBAL_STATUS_PROBE_BUDGET))
         .unwrap_or(remaining);
     let mut latest_progress = None;
-    let supervised = wait_with_bounded_output_supervised_with_progress(
-        &mut child,
+    let supervised = wait_with_bounded_output_supervised_with_progress_owned(
+        &mut owner,
         STATUS_PROBE_CAPTURE_LIMIT,
         remaining,
         None,
         STATUS_PROBE_HEARTBEAT,
+        None,
         || false,
         |heartbeat| {
             if let Some(progress) = heartbeat.progress {

--- a/crates/homeboy-core/src/cleanup/external_storage.rs
+++ b/crates/homeboy-core/src/cleanup/external_storage.rs
@@ -11,8 +11,7 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime};
 
 use homeboy_engine_primitives::command::{
-    terminate_process_tree_and_reap, wait_with_bounded_output_supervised, ControllerChildGuard,
-    SupervisedCommandTermination,
+    wait_with_bounded_output_supervised_owned, ExecutionOwner, SupervisedCommandTermination,
 };
 use homeboy_engine_primitives::template;
 use homeboy_extension_contract::{
@@ -520,36 +519,19 @@ fn invoke_raw(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let guard = ControllerChildGuard::prepare(&mut command).map_err(|error| {
-        Error::internal_unexpected(format!(
-            "guard external storage provider '{}': {error}",
-            provider.id
-        ))
-    })?;
-    let mut child = command.spawn().map_err(|error| {
+    let mut owner = ExecutionOwner::spawn(&mut command).map_err(|error| {
         Error::internal_unexpected(format!(
             "start external storage provider '{}': {error}",
-            provider.id
-        ))
-    })?;
-    attach_guard_or_reap(
-        &mut child,
-        |child| guard.attach(child),
-        terminate_process_tree_and_reap,
-    )
-    .map_err(|error| {
-        Error::internal_unexpected(format!(
-            "attach external storage provider guard '{}': {error}",
             provider.id
         ))
     })?;
     // Start stdin delivery only after process-tree ownership is established.
     // The writer can block on a provider that never reads, while the supervisor
     // concurrently drains output and kills the tree at the shared deadline.
-    let mut stdin = child.stdin.take().expect("piped stdin");
+    let mut stdin = owner.take_stdin().expect("piped stdin");
     let writer = std::thread::spawn(move || stdin.write_all(&request));
-    let supervised = wait_with_bounded_output_supervised(
-        &mut child,
+    let supervised = wait_with_bounded_output_supervised_owned(
+        &mut owner,
         PROVIDER_OUTPUT_LIMIT,
         timeout,
         Duration::from_millis(100),
@@ -589,45 +571,6 @@ fn invoke_raw(
         }
     }
     Ok(result.output.stdout)
-}
-
-fn attach_guard_or_reap(
-    child: &mut std::process::Child,
-    attach: impl FnOnce(&std::process::Child) -> std::io::Result<()>,
-    reap: impl FnOnce(&mut std::process::Child) -> std::io::Result<std::process::ExitStatus>,
-) -> std::io::Result<()> {
-    if let Err(error) = attach(child) {
-        match reap(child) {
-            Ok(_) if child.try_wait()?.is_some() => return Err(error),
-            Ok(_) => {}
-            Err(cleanup_error) => {
-                return force_reap_after_attach_failure(child, error, cleanup_error);
-            }
-        }
-        return force_reap_after_attach_failure(
-            child,
-            error,
-            std::io::Error::other("guard cleanup returned without reaping the child"),
-        );
-    }
-    Ok(())
-}
-
-fn force_reap_after_attach_failure(
-    child: &mut std::process::Child,
-    attach_error: std::io::Error,
-    cleanup_error: std::io::Error,
-) -> std::io::Result<()> {
-    let kill_error = child.kill().err();
-    let wait_error = child.wait().err();
-    let fallback = match (kill_error, wait_error) {
-        (_, Some(error)) => format!("fallback reap failed: {error}"),
-        (Some(error), None) => format!("fallback kill failed: {error}"),
-        (None, None) => "fallback child kill and reap succeeded".to_string(),
-    };
-    Err(std::io::Error::other(format!(
-        "guard attach failed: {attach_error}; process-tree cleanup failed: {cleanup_error}; {fallback}"
-    )))
 }
 
 fn invoke_reclaim(
@@ -1152,27 +1095,6 @@ mod tests {
         )
         .is_err());
         assert!(started.elapsed() < Duration::from_secs(3));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn guard_attach_failure_reaps_spawned_process() {
-        let mut command = Command::new("sh");
-        command.arg("-c").arg("sleep 5");
-        let guard = ControllerChildGuard::prepare(&mut command).expect("guard");
-        let mut child = command.spawn().expect("spawn");
-        let result = attach_guard_or_reap(
-            &mut child,
-            |_| Err(std::io::Error::other("fixture attach failure")),
-            |_| Err(std::io::Error::other("fixture cleanup failure")),
-        );
-        assert!(result.is_err());
-        assert!(result
-            .expect_err("failure")
-            .to_string()
-            .contains("fixture cleanup failure"));
-        assert!(child.try_wait().expect("poll").is_some());
-        drop(guard);
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-core/src/extension/invoke/deadline_process.rs
+++ b/crates/homeboy-core/src/extension/invoke/deadline_process.rs
@@ -2,12 +2,8 @@ use std::io::{Read, Write};
 use std::process::{Command, ExitStatus, Stdio};
 use std::time::{Duration, Instant};
 
-#[cfg(not(windows))]
-use homeboy_engine_primitives::command::terminate_process_tree_and_reap;
-use homeboy_engine_primitives::command::{terminate_remaining_process_group, ControllerChildGuard};
+use homeboy_engine_primitives::command::ExecutionOwner;
 use tempfile::NamedTempFile;
-
-use crate::process::{force_terminate_process_tree_bounded, ProcessContainment};
 
 pub(crate) struct DeadlineProcessOutput {
     pub status: ExitStatus,
@@ -101,33 +97,13 @@ pub(crate) fn execute_deadline_process(
     let captures = CaptureFiles::create(capture_limit, label)?;
     let (stdout, stderr) = captures.stdio(label)?;
     command.stdin(Stdio::piped()).stdout(stdout).stderr(stderr);
-    let mut containment = ProcessContainment::prepare(&mut command)
-        .map_err(|error| failure(format!("{label} containment setup failed: {error}")))?;
-    let mut guard = Some(
-        ControllerChildGuard::prepare(&mut command)
-            .map_err(|error| failure(format!("{label} containment setup failed: {error}")))?,
-    );
-    let mut child = command.spawn().map_err(|error| {
+    let mut owner = ExecutionOwner::spawn(&mut command).map_err(|error| {
         failure(format!(
             "{label} spawn failed; capture files will be removed: {error}"
         ))
     })?;
-    if let Err(error) = containment.attach(&child) {
-        let errors = cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
-        return Err(failure(format!(
-            "{label} containment attach failed: {error}{}",
-            cleanup_diagnostic(&errors)
-        )));
-    }
-    if let Err(error) = guard.as_ref().expect("guard exists").attach(&child) {
-        let errors = cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
-        return Err(failure(format!(
-            "{label} containment attach failed: {error}{}",
-            cleanup_diagnostic(&errors)
-        )));
-    }
-    let mut stdin = child.stdin.take().ok_or_else(|| {
-        let errors = cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
+    let mut stdin = owner.take_stdin().ok_or_else(|| {
+        let errors = drain_owner(&mut owner, cleanup_budget);
         failure(format!(
             "{label} stdin was unavailable.{}",
             cleanup_diagnostic(&errors)
@@ -138,7 +114,7 @@ pub(crate) fn execute_deadline_process(
         .and_then(|_| stdin.write_all(b"\n"))
         .is_err()
     {
-        let errors = cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
+        let errors = drain_owner(&mut owner, cleanup_budget);
         return Err(failure(format!(
             "{label} stdin write failed.{}",
             cleanup_diagnostic(&errors)
@@ -147,15 +123,8 @@ pub(crate) fn execute_deadline_process(
     drop(stdin);
 
     loop {
-        match child.try_wait() {
+        match owner.try_wait() {
             Ok(Some(status)) => {
-                let errors = cleanup(&containment, &mut child, &mut guard, true, cleanup_budget);
-                if !errors.is_empty() {
-                    return Err(failure(format!(
-                        "{label} exited but cleanup could not be verified: {}",
-                        errors.join("; ")
-                    )));
-                }
                 return Ok(DeadlineProcessOutput {
                     status,
                     stdout: captures.snapshot("stdout", label)?,
@@ -166,8 +135,7 @@ pub(crate) fn execute_deadline_process(
                 std::thread::sleep(Duration::from_millis(10));
             }
             Ok(None) => {
-                let mut errors =
-                    cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
+                let mut errors = drain_owner(&mut owner, cleanup_budget);
                 errors.extend(capture_snapshot_errors(&captures, label));
                 return Err(failure(format!(
                     "{label} timed out; capture files were snapshotted without waiting for inherited handles{}.",
@@ -175,8 +143,7 @@ pub(crate) fn execute_deadline_process(
                 )));
             }
             Err(error) => {
-                let mut errors =
-                    cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
+                let mut errors = drain_owner(&mut owner, cleanup_budget);
                 errors.extend(capture_snapshot_errors(&captures, label));
                 return Err(failure(format!(
                     "{label} wait failed: {error}; capture files were snapshotted without waiting for inherited handles{}.",
@@ -187,66 +154,13 @@ pub(crate) fn execute_deadline_process(
     }
 }
 
-fn cleanup(
-    containment: &ProcessContainment,
-    child: &mut std::process::Child,
-    guard: &mut Option<ControllerChildGuard>,
-    leader_has_exited: bool,
-    cleanup_budget: Duration,
-) -> Vec<String> {
-    drop(guard.take());
-    let mut errors = Vec::new();
-    if !leader_has_exited {
-        if let Err(error) = containment.terminate_on_failure_bounded(cleanup_budget, false) {
-            errors.push(format!("containment termination: {error}"));
-        }
-        if let Err(error) = force_terminate_process_tree_bounded(child.id(), cleanup_budget) {
-            errors.push(format!("process-tree termination: {error}"));
-        }
-        if let Err(error) = reap_child_after_bounded_cleanup(child, cleanup_budget) {
-            errors.push(format!("child reap: {error}"));
-        }
-    }
-    #[cfg(target_os = "linux")]
-    if let Err(error) = containment.cleanup_after_leader_exit_bounded(cleanup_budget) {
-        errors.push(format!("descendant cleanup: {error}"));
-    }
-    if let Err(error) = terminate_remaining_process_group(child.id()) {
-        errors.push(format!("remaining process-group cleanup: {error}"));
-    }
-    errors
-}
-
-#[cfg(not(windows))]
-fn reap_child_after_bounded_cleanup(
-    child: &mut std::process::Child,
-    _cleanup_budget: Duration,
-) -> std::io::Result<()> {
-    terminate_process_tree_and_reap(child).map(|_| ())
-}
-
-#[cfg(windows)]
-fn reap_child_after_bounded_cleanup(
-    child: &mut std::process::Child,
-    cleanup_budget: Duration,
-) -> std::io::Result<()> {
-    let pid = child.id();
-    let deadline = Instant::now() + cleanup_budget;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => return Ok(()),
-            Ok(None) if Instant::now() >= deadline => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    format!(
-                        "child {pid} remained alive after bounded cleanup for {} ms",
-                        cleanup_budget.as_millis()
-                    ),
-                ));
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
-            Err(error) => return Err(error),
-        }
+fn drain_owner(owner: &mut ExecutionOwner, _cleanup_budget: Duration) -> Vec<String> {
+    match owner.drain_and_reap().and_then(|outcome| {
+        outcome.into_root_status()?;
+        Ok(())
+    }) {
+        Ok(()) => Vec::new(),
+        Err(error) => vec![format!("execution owner drain: {error}")],
     }
 }
 

--- a/crates/homeboy-core/src/extension/self_check.rs
+++ b/crates/homeboy-core/src/extension/self_check.rs
@@ -394,28 +394,24 @@ fn execute_bounded_self_check_command(
     timeout: Duration,
     passthrough: Option<homeboy_engine_primitives::command::StreamChunkObserver>,
 ) -> SelfCheckCommandOutput {
-    use homeboy_engine_primitives::command::{ControllerChildGuard, SupervisedCommandTermination};
+    use homeboy_engine_primitives::command::{
+        wait_with_bounded_output_supervised_with_progress_owned, ExecutionOwner,
+        SupervisedCommandTermination,
+    };
 
-    let guard = match ControllerChildGuard::prepare(&mut command) {
-        Ok(guard) => guard,
+    let mut owner = match ExecutionOwner::spawn(&mut command) {
+        Ok(owner) => owner,
         Err(error) => return self_check_spawn_error(error),
     };
-    let mut child = match command.spawn() {
-        Ok(child) => child,
-        Err(error) => return self_check_spawn_error(error),
-    };
-    if let Err(error) = guard.attach(&child) {
-        let _ = homeboy_engine_primitives::command::terminate_process_tree_and_reap(&mut child);
-        return self_check_spawn_error(error);
-    }
-    let supervised = match homeboy_engine_primitives::command::wait_with_bounded_output_supervised_with_passthrough(
-        &mut child,
+    let supervised = match wait_with_bounded_output_supervised_with_progress_owned(
+        &mut owner,
         SELF_CHECK_CAPTURE_LIMIT_BYTES,
         timeout,
+        None,
         Duration::from_secs(1),
         passthrough,
         || false,
-        |_, _| Ok(()),
+        |_| Ok(()),
     ) {
         Ok(output) => output,
         Err(error) => return self_check_spawn_error(error),

--- a/crates/homeboy-core/src/git/gh_client.rs
+++ b/crates/homeboy-core/src/git/gh_client.rs
@@ -10,14 +10,10 @@ use serde::de::DeserializeOwned;
 use crate::component::{GithubConfig, GithubHostConfig};
 use crate::error::{Error, Result};
 use crate::git::release_download::GitHubRepo;
-use crate::process::{force_terminate_process_tree_bounded, ProcessContainment};
-use homeboy_engine_primitives::command::{
-    terminate_process_tree_and_reap, terminate_remaining_process_group, ControllerChildGuard,
-};
+use homeboy_engine_primitives::command::ExecutionOwner;
 use std::collections::HashMap;
 
 const API_CAPTURE_LIMIT_BYTES: usize = 4 * 1024 * 1024;
-const API_CLEANUP_BUDGET: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone)]
 pub struct GhClient {
@@ -176,31 +172,11 @@ impl GhClient {
         }
         let mut command = self.command(args);
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
-        let mut containment = ProcessContainment::prepare(&mut command).map_err(|error| {
-            Error::internal_io(format!("Failed to contain gh: {error}"), Some("gh".into()))
-        })?;
-        let guard = ControllerChildGuard::prepare(&mut command).map_err(|error| {
-            Error::internal_io(format!("Failed to contain gh: {error}"), Some("gh".into()))
-        })?;
-        let mut child = command.spawn().map_err(|e| {
+        let mut owner = ExecutionOwner::spawn(&mut command).map_err(|e| {
             Error::internal_io(format!("Failed to invoke gh: {e}"), Some("gh".into()))
         })?;
-        if let Err(error) = containment.attach(&child) {
-            cleanup_gh_child(&containment, &mut child, false);
-            return Err(Error::internal_io(
-                format!("Failed to attach gh containment: {error}"),
-                Some("gh".into()),
-            ));
-        }
-        if let Err(error) = guard.attach(&child) {
-            cleanup_gh_child(&containment, &mut child, false);
-            return Err(Error::internal_io(
-                format!("Failed to guard gh: {error}"),
-                Some("gh".into()),
-            ));
-        }
-        let stdout = child.stdout.take().expect("piped stdout");
-        let stderr = child.stderr.take().expect("piped stderr");
+        let stdout = owner.take_stdout().expect("piped stdout");
+        let stderr = owner.take_stderr().expect("piped stderr");
         let (stdout_tx, stdout_rx) = mpsc::channel();
         let stdout_reader = std::thread::spawn(move || {
             let _ = stdout_tx.send(read_bounded(stdout, API_CAPTURE_LIMIT_BYTES));
@@ -210,21 +186,18 @@ impl GhClient {
             let _ = stderr_tx.send(read_bounded(stderr, API_CAPTURE_LIMIT_BYTES));
         });
         let status = loop {
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    cleanup_gh_child(&containment, &mut child, true);
-                    break status;
-                }
+            match owner.try_wait() {
+                Ok(Some(status)) => break status,
                 Ok(None) if Instant::now() < deadline => {
                     std::thread::sleep(Duration::from_millis(10))
                 }
                 Ok(None) => {
-                    cleanup_gh_child(&containment, &mut child, false);
+                    let _ = owner.drain_and_reap();
                     join_gh_readers(stdout_reader, stderr_reader);
                     return Err(Error::internal_io("GitHub API deadline exhausted", None));
                 }
                 Err(error) => {
-                    cleanup_gh_child(&containment, &mut child, false);
+                    let _ = owner.drain_and_reap();
                     join_gh_readers(stdout_reader, stderr_reader);
                     return Err(Error::internal_io(
                         format!("Failed while waiting for gh: {error}"),
@@ -237,12 +210,12 @@ impl GhClient {
         let stdout = match stdout_rx.recv_timeout(remaining) {
             Ok(Ok(result)) => result,
             Ok(Err(error)) => {
-                cleanup_gh_child(&containment, &mut child, true);
+                let _ = owner.drain_and_reap();
                 join_gh_readers(stdout_reader, stderr_reader);
                 return Err(error.into());
             }
             Err(_) => {
-                cleanup_gh_child(&containment, &mut child, true);
+                let _ = owner.drain_and_reap();
                 join_gh_readers(stdout_reader, stderr_reader);
                 return Err(Error::internal_io(
                     "GitHub API stdout did not close before the deadline",
@@ -254,12 +227,12 @@ impl GhClient {
             match stderr_rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
                 Ok(Ok(result)) => result,
                 Ok(Err(error)) => {
-                    cleanup_gh_child(&containment, &mut child, true);
+                    let _ = owner.drain_and_reap();
                     join_gh_readers(stdout_reader, stderr_reader);
                     return Err(error.into());
                 }
                 Err(_) => {
-                    cleanup_gh_child(&containment, &mut child, true);
+                    let _ = owner.drain_and_reap();
                     join_gh_readers(stdout_reader, stderr_reader);
                     return Err(Error::internal_io(
                         "GitHub API stderr did not close before the deadline",
@@ -311,20 +284,6 @@ impl GhClient {
         let combined = if stderr.is_empty() { stdout } else { stderr };
         Error::git_command_failed(format!("{action} failed: {combined}"))
     }
-}
-
-fn cleanup_gh_child(
-    containment: &ProcessContainment,
-    child: &mut std::process::Child,
-    leader_has_exited: bool,
-) {
-    // Snapshot procfs before reaping the leader so Linux cleanup also reaches a
-    // descendant that escaped the contained group with `setsid`.
-    let _ = containment.terminate_on_failure_bounded(API_CLEANUP_BUDGET, leader_has_exited);
-    let _ = containment.cleanup_after_leader_exit_bounded(API_CLEANUP_BUDGET);
-    let _ = force_terminate_process_tree_bounded(child.id(), API_CLEANUP_BUDGET);
-    let _ = terminate_remaining_process_group(child.id());
-    let _ = terminate_process_tree_and_reap(child);
 }
 
 fn join_gh_readers(stdout: std::thread::JoinHandle<()>, stderr: std::thread::JoinHandle<()>) {

--- a/crates/homeboy-core/src/server/transfer.rs
+++ b/crates/homeboy-core/src/server/transfer.rs
@@ -1,6 +1,6 @@
 use super::SshClient;
 use crate::engine::command::{
-    wait_with_bounded_output_supervised_with_progress, ControllerChildGuard,
+    wait_with_bounded_output_supervised_with_progress_owned, ExecutionOwner,
     SupervisedCommandHeartbeat, DEFAULT_CAPTURE_LIMIT_BYTES,
 };
 use crate::server::ssh_args::{
@@ -805,16 +805,15 @@ fn run_transfer_command_with_policy(
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped());
-    let guard = ControllerChildGuard::prepare(command)?;
-    let mut child = command.spawn()?;
-    guard.attach(&child)?;
+    let mut owner = ExecutionOwner::spawn(command)?;
     let mut schedule = TransferHeartbeatSchedule::new(quiet_after);
-    let output = wait_with_bounded_output_supervised_with_progress(
-        &mut child,
+    let output = wait_with_bounded_output_supervised_with_progress_owned(
+        &mut owner,
         DEFAULT_CAPTURE_LIMIT_BYTES,
         Duration::MAX,
         None,
         poll_interval,
+        None,
         || false,
         |progress| {
             if schedule.due(&progress, interval) {

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -16,6 +16,8 @@ use sha2::{Digest, Sha256};
 pub const DEFAULT_CAPTURE_LIMIT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_OBSERVED_LINE_BYTES: usize = 64 * 1024;
 #[cfg(unix)]
+type AdoptedGuard = Option<(u32, Option<u32>, u64)>;
+#[cfg(unix)]
 const PROCESS_TREE_TERM_GRACE: Duration = Duration::from_secs(2);
 #[cfg(unix)]
 const PROCESS_TREE_KILL_GRACE: Duration = Duration::from_secs(2);
@@ -81,10 +83,36 @@ pub fn process_is_running(pid: u32) -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn linux_process_state(pid: u32) -> Option<char> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LinuxProcStat {
+    state: char,
+    parent_pid: u32,
+    starttime_ticks: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_stat(pid: u32) -> Option<LinuxProcStat> {
     let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-    let (_, fields) = stat.rsplit_once(')')?;
-    fields.split_whitespace().next()?.chars().next()
+    parse_linux_proc_stat(&stat)
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_proc_stat(stat: &str) -> Option<LinuxProcStat> {
+    let after_command = stat.rsplit_once(") ")?.1;
+    let mut fields = after_command.split_whitespace();
+    let state = fields.next()?.chars().next()?;
+    let parent_pid = fields.next()?.parse().ok()?;
+    let starttime_ticks = after_command.split_whitespace().nth(19)?.parse().ok()?;
+    Some(LinuxProcStat {
+        state,
+        parent_pid,
+        starttime_ticks,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_state(pid: u32) -> Option<char> {
+    linux_process_stat(pid).map(|stat| stat.state)
 }
 
 /// Keeps an isolated child tree owned by the controller that spawned it.
@@ -119,6 +147,7 @@ impl ControllerChildGuard {
     pub fn prepare(command: &mut Command) -> io::Result<Self> {
         #[cfg(unix)]
         {
+            enable_child_subreaper()?;
             #[cfg(target_os = "linux")]
             let guard_id = CHILD_GUARD_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             #[cfg(target_os = "linux")]
@@ -229,7 +258,7 @@ impl ControllerChildGuard {
         {
             let _ = deadline;
             self.observe_owned_processes(child.id())?;
-            terminate_owned_processes_and_reap(child, &self.owned_processes)
+            terminate_owned_processes_and_reap(child, &self.owned_processes, self.adopted_guard()?)
         }
 
         #[cfg(windows)]
@@ -273,7 +302,11 @@ impl ControllerChildGuard {
             // Its ordinary descendants remain in the isolated process group;
             // drain that group before handling tracked session escapees.
             terminate_remaining_process_group(root_pid)?;
-            terminate_owned_processes_after_root_exit(root_pid, &self.owned_processes)
+            terminate_owned_processes_after_root_exit(
+                root_pid,
+                &self.owned_processes,
+                self.adopted_guard()?,
+            )
         }
 
         #[cfg(not(unix))]
@@ -297,19 +330,25 @@ impl ControllerChildGuard {
             .owned_processes
             .lock()
             .map_err(|_| io::Error::other("owned process identity lock poisoned"))?;
-        #[cfg(target_os = "linux")]
-        let adopted = Some((
-            self.controller_pid,
-            *self
-                .guard_pid
-                .lock()
-                .map_err(|_| io::Error::other("guard PID lock poisoned"))?,
-            self.guard_id,
-        ));
-        #[cfg(not(target_os = "linux"))]
-        let adopted = None;
-        extend_owned_processes(&mut owned, root_pid, &snapshot, adopted);
+        extend_owned_processes(&mut owned, root_pid, &snapshot, self.adopted_guard()?);
         Ok(())
+    }
+
+    #[cfg(unix)]
+    fn adopted_guard(&self) -> io::Result<AdoptedGuard> {
+        #[cfg(target_os = "linux")]
+        {
+            Ok(Some((
+                self.controller_pid,
+                *self
+                    .guard_pid
+                    .lock()
+                    .map_err(|_| io::Error::other("guard PID lock poisoned"))?,
+                self.guard_id,
+            )))
+        }
+        #[cfg(not(target_os = "linux"))]
+        Ok(None)
     }
 
     #[cfg(windows)]
@@ -1396,10 +1435,40 @@ fn descendant_pids(root_pid: u32) -> io::Result<Vec<u32>> {
 struct UnixProcessIdentity {
     pid: u32,
     parent_pid: u32,
+    #[cfg(not(target_os = "linux"))]
     started_at: String,
+    #[cfg(target_os = "linux")]
+    starttime_ticks: u64,
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
+fn unix_process_snapshot() -> io::Result<Vec<UnixProcessIdentity>> {
+    let mut processes = Vec::new();
+    let entries = std::fs::read_dir("/proc")
+        .map_err(|error| io::Error::other(format!("process identity discovery failed: {error}")))?;
+    for entry in entries.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        if pid == 0 || pid > i32::MAX as u32 {
+            continue;
+        }
+        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
+            continue;
+        };
+        let Some(parsed) = parse_linux_proc_stat(&stat) else {
+            continue;
+        };
+        processes.push(UnixProcessIdentity {
+            pid,
+            parent_pid: parsed.parent_pid,
+            starttime_ticks: parsed.starttime_ticks,
+        });
+    }
+    Ok(processes)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
 fn unix_process_snapshot() -> io::Result<Vec<UnixProcessIdentity>> {
     let output = Command::new("ps")
         .env("PATH", "/usr/bin:/bin")
@@ -1432,7 +1501,7 @@ fn extend_owned_processes(
     owned: &mut Vec<UnixProcessIdentity>,
     root_pid: u32,
     snapshot: &[UnixProcessIdentity],
-    adopted: Option<(u32, Option<u32>, u64)>,
+    adopted: AdoptedGuard,
 ) {
     if owned.is_empty() {
         if let Some(root) = snapshot.iter().find(|process| process.pid == root_pid) {
@@ -1451,7 +1520,9 @@ fn extend_owned_processes(
                         && Some(process.pid) != guard_pid
                         && process_has_guard_id(process.pid, guard_id)
                 });
-            if adopted_descendant || owned.iter().any(|known| known.pid == process.parent_pid) {
+            if adopted_descendant
+                || owned_contains_matching_parent(owned, snapshot, process.parent_pid)
+            {
                 owned.push(process.clone());
                 changed = true;
             }
@@ -1480,16 +1551,107 @@ fn process_has_guard_id(_pid: u32, _guard_id: u64) -> bool {
 }
 
 #[cfg(unix)]
-fn live_owned_pids(owned: &[UnixProcessIdentity], snapshot: &[UnixProcessIdentity]) -> Vec<u32> {
-    owned
-        .iter()
-        .filter_map(|known| {
-            snapshot
+fn owned_identity_matches(known: &UnixProcessIdentity, current: &UnixProcessIdentity) -> bool {
+    if known.pid != current.pid {
+        return false;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        known.starttime_ticks == current.starttime_ticks
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        known.started_at == current.started_at
+    }
+}
+
+#[cfg(unix)]
+fn owned_contains_matching_parent(
+    owned: &[UnixProcessIdentity],
+    snapshot: &[UnixProcessIdentity],
+    parent_pid: u32,
+) -> bool {
+    owned.iter().any(|known| {
+        known.pid == parent_pid
+            && snapshot
                 .iter()
-                .any(|process| process.pid == known.pid && process.started_at == known.started_at)
-                .then_some(known.pid)
-        })
-        .collect()
+                .any(|current| owned_identity_matches(known, current))
+    })
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OwnedPresence {
+    Gone,
+    Reused,
+    Live,
+    Zombie { parent_pid: u32 },
+}
+
+#[cfg(target_os = "linux")]
+fn interpret_owned_stat_contents(
+    pid: u32,
+    result: io::Result<String>,
+) -> io::Result<Option<LinuxProcStat>> {
+    match result {
+        Ok(body) => parse_linux_proc_stat(&body).map(Some).ok_or_else(|| {
+            io::Error::other(format!("owned process {pid} has invalid stat metadata"))
+        }),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(io::Error::other(format!(
+            "owned process {pid} identity is unverifiable: {error}"
+        ))),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_owned_identity(known: &UnixProcessIdentity) -> io::Result<OwnedPresence> {
+    let Some(stat) = interpret_owned_stat_contents(
+        known.pid,
+        std::fs::read_to_string(format!("/proc/{}/stat", known.pid)),
+    )?
+    else {
+        return Ok(OwnedPresence::Gone);
+    };
+    if stat.starttime_ticks != known.starttime_ticks {
+        return Ok(OwnedPresence::Reused);
+    }
+    if stat.state == 'Z' {
+        return Ok(OwnedPresence::Zombie {
+            parent_pid: stat.parent_pid,
+        });
+    }
+    Ok(OwnedPresence::Live)
+}
+
+#[cfg(unix)]
+fn owned_runnable_pids(
+    owned: &[UnixProcessIdentity],
+    snapshot: &[UnixProcessIdentity],
+) -> io::Result<Vec<u32>> {
+    let mut runnable = Vec::new();
+    #[cfg(target_os = "linux")]
+    {
+        let _ = snapshot;
+        for known in owned {
+            if matches!(inspect_owned_identity(known)?, OwnedPresence::Live) {
+                runnable.push(known.pid);
+            }
+        }
+        return Ok(runnable);
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        for known in owned {
+            let Some(current) = snapshot.iter().find(|process| process.pid == known.pid) else {
+                continue;
+            };
+            if owned_identity_matches(known, current) && process_is_running(known.pid) {
+                runnable.push(known.pid);
+            }
+        }
+        Ok(runnable)
+    }
 }
 
 #[cfg(unix)]
@@ -1497,10 +1659,11 @@ fn signal_owned_processes(
     owned: &mut Vec<UnixProcessIdentity>,
     root_pid: u32,
     signal: libc::c_int,
+    adopted: AdoptedGuard,
 ) -> io::Result<Vec<u32>> {
     let snapshot = unix_process_snapshot()?;
-    extend_owned_processes(owned, root_pid, &snapshot, None);
-    let pids = live_owned_pids(owned, &snapshot);
+    extend_owned_processes(owned, root_pid, &snapshot, adopted);
+    let pids = owned_runnable_pids(owned, &snapshot)?;
     signal_pids(&pids, signal);
     Ok(pids)
 }
@@ -1509,6 +1672,7 @@ fn signal_owned_processes(
 fn terminate_owned_processes_and_reap(
     child: &mut Child,
     owned_processes: &Mutex<Vec<UnixProcessIdentity>>,
+    adopted: AdoptedGuard,
 ) -> io::Result<ExitStatus> {
     enable_child_subreaper()?;
     let root_pid = child.id();
@@ -1516,7 +1680,7 @@ fn terminate_owned_processes_and_reap(
         .lock()
         .map_err(|_| io::Error::other("owned process identity lock poisoned"))?;
     signal_process_group(root_pid, libc::SIGTERM)?;
-    signal_owned_processes(&mut owned, root_pid, libc::SIGTERM)?;
+    signal_owned_processes(&mut owned, root_pid, libc::SIGTERM, adopted)?;
     let mut status = child.try_wait()?;
     if !wait_for_owned_process_exit(
         child,
@@ -1525,9 +1689,10 @@ fn terminate_owned_processes_and_reap(
         PROCESS_TREE_TERM_GRACE,
         libc::SIGTERM,
         &mut status,
+        adopted,
     )? {
         signal_process_group(root_pid, libc::SIGKILL)?;
-        signal_owned_processes(&mut owned, root_pid, libc::SIGKILL)?;
+        signal_owned_processes(&mut owned, root_pid, libc::SIGKILL, adopted)?;
         if !wait_for_owned_process_exit(
             child,
             root_pid,
@@ -1535,6 +1700,7 @@ fn terminate_owned_processes_and_reap(
             PROCESS_TREE_KILL_GRACE,
             libc::SIGKILL,
             &mut status,
+            adopted,
         )? {
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
@@ -1549,25 +1715,28 @@ fn terminate_owned_processes_and_reap(
 fn terminate_owned_processes_after_root_exit(
     root_pid: u32,
     owned_processes: &Mutex<Vec<UnixProcessIdentity>>,
+    adopted: AdoptedGuard,
 ) -> io::Result<()> {
     let mut owned = owned_processes
         .lock()
         .map_err(|_| io::Error::other("owned process identity lock poisoned"))?;
-    signal_owned_processes(&mut owned, root_pid, libc::SIGTERM)?;
+    signal_owned_processes(&mut owned, root_pid, libc::SIGTERM, adopted)?;
     if wait_for_owned_process_exit_without_child(
         root_pid,
         &mut owned,
         PROCESS_TREE_TERM_GRACE,
         libc::SIGTERM,
+        adopted,
     )? {
         return Ok(());
     }
-    signal_owned_processes(&mut owned, root_pid, libc::SIGKILL)?;
+    signal_owned_processes(&mut owned, root_pid, libc::SIGKILL, adopted)?;
     if wait_for_owned_process_exit_without_child(
         root_pid,
         &mut owned,
         PROCESS_TREE_KILL_GRACE,
         libc::SIGKILL,
+        adopted,
     )? {
         return Ok(());
     }
@@ -1585,17 +1754,20 @@ fn wait_for_owned_process_exit(
     grace: Duration,
     signal: libc::c_int,
     status: &mut Option<ExitStatus>,
+    adopted: AdoptedGuard,
 ) -> io::Result<bool> {
     let deadline = std::time::Instant::now() + grace;
     loop {
         let snapshot = unix_process_snapshot()?;
-        extend_owned_processes(owned, root_pid, &snapshot, None);
-        signal_pids(&live_owned_pids(owned, &snapshot), signal);
+        extend_owned_processes(owned, root_pid, &snapshot, adopted);
+        signal_pids(&owned_runnable_pids(owned, &snapshot)?, signal);
         if status.is_none() {
             *status = child.try_wait()?;
         }
-        reap_exited_process_group_children(root_pid);
-        if live_owned_pids(owned, &snapshot).is_empty() {
+        if status.is_some() {
+            reap_exited_process_group_children(root_pid);
+        }
+        if owned_processes_are_drained(owned, &snapshot, root_pid, adopted)? {
             return Ok(true);
         }
         if std::time::Instant::now() >= deadline {
@@ -1611,20 +1783,125 @@ fn wait_for_owned_process_exit_without_child(
     owned: &mut Vec<UnixProcessIdentity>,
     grace: Duration,
     signal: libc::c_int,
+    adopted: AdoptedGuard,
 ) -> io::Result<bool> {
     let deadline = std::time::Instant::now() + grace;
     loop {
         let snapshot = unix_process_snapshot()?;
-        extend_owned_processes(owned, root_pid, &snapshot, None);
-        signal_pids(&live_owned_pids(owned, &snapshot), signal);
+        extend_owned_processes(owned, root_pid, &snapshot, adopted);
+        signal_pids(&owned_runnable_pids(owned, &snapshot)?, signal);
         reap_exited_process_group_children(root_pid);
-        if live_owned_pids(owned, &snapshot).is_empty() {
+        if owned_processes_are_drained(owned, &snapshot, root_pid, adopted)? {
             return Ok(true);
         }
         if std::time::Instant::now() >= deadline {
             return Ok(false);
         }
         thread::sleep(PROCESS_TREE_POLL_INTERVAL);
+    }
+}
+
+#[cfg(unix)]
+fn owned_processes_are_drained(
+    owned: &[UnixProcessIdentity],
+    snapshot: &[UnixProcessIdentity],
+    root_pid: u32,
+    adopted: AdoptedGuard,
+) -> io::Result<bool> {
+    if !owned_runnable_pids(owned, snapshot)?.is_empty() {
+        return Ok(false);
+    }
+    reap_verified_adopted_zombies(owned, root_pid, adopted)?;
+    for known in owned {
+        if !owned_identity_is_absent(known, snapshot, root_pid, adopted)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+#[cfg(unix)]
+fn owned_identity_is_absent(
+    known: &UnixProcessIdentity,
+    snapshot: &[UnixProcessIdentity],
+    root_pid: u32,
+    adopted: AdoptedGuard,
+) -> io::Result<bool> {
+    #[cfg(target_os = "linux")]
+    {
+        let _ = snapshot;
+        Ok(match inspect_owned_identity(known)? {
+            OwnedPresence::Gone | OwnedPresence::Reused => true,
+            OwnedPresence::Live => false,
+            OwnedPresence::Zombie { parent_pid } => {
+                if known.pid == root_pid {
+                    false
+                } else if let Some((controller_pid, guard_pid, _)) = adopted {
+                    Some(known.pid) == guard_pid
+                        || controller_pid != std::process::id()
+                        || parent_pid != controller_pid
+                } else {
+                    true
+                }
+            }
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (root_pid, adopted);
+        Ok(!owned_runnable_pids(std::slice::from_ref(known), snapshot)?.contains(&known.pid))
+    }
+}
+
+#[cfg(unix)]
+fn reap_verified_adopted_zombies(
+    owned: &[UnixProcessIdentity],
+    root_pid: u32,
+    adopted: AdoptedGuard,
+) -> io::Result<()> {
+    let Some((controller_pid, guard_pid, _)) = adopted else {
+        return Ok(());
+    };
+    if controller_pid != std::process::id() {
+        return Ok(());
+    }
+    for known in owned {
+        if known.pid == root_pid || Some(known.pid) == guard_pid {
+            continue;
+        }
+        #[cfg(target_os = "linux")]
+        {
+            if let OwnedPresence::Zombie { parent_pid } = inspect_owned_identity(known)? {
+                if parent_pid == controller_pid {
+                    waitpid_exact_nohang(known.pid)?;
+                }
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = known;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn waitpid_exact_nohang(pid: u32) -> io::Result<bool> {
+    loop {
+        let mut status = 0;
+        let reaped = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
+        if reaped == pid as libc::pid_t {
+            return Ok(true);
+        }
+        if reaped == 0 {
+            return Ok(false);
+        }
+        let error = io::Error::last_os_error();
+        match error.raw_os_error() {
+            Some(libc::EINTR) => continue,
+            Some(libc::ECHILD) => return Ok(false),
+            _ => return Err(error),
+        }
     }
 }
 
@@ -1797,6 +2074,7 @@ fn wait_for_process_group_exit_without_child(root_pid: u32, grace: Duration) -> 
 #[cfg(all(test, target_os = "linux"))]
 mod process_group_liveness_tests {
     use super::*;
+    use std::io;
     use std::process::{Command, Stdio};
 
     /// A process group whose only remaining member is a zombie is not alive.
@@ -1859,6 +2137,42 @@ mod process_group_liveness_tests {
         );
 
         let _ = terminate_process_tree_and_reap(&mut child);
+    }
+
+    #[test]
+    fn parse_linux_proc_stat_handles_command_names_with_spaces() {
+        let stat = "123 (name with spaces) Z 1 456 456 0 -1 0 0 0 0 0 0 0 0 0 0 0 0 0 4242 extra";
+        let parsed = parse_linux_proc_stat(stat).expect("parse");
+        assert_eq!(parsed.state, 'Z');
+        assert_eq!(parsed.parent_pid, 1);
+        assert_eq!(parsed.starttime_ticks, 4242);
+    }
+
+    #[test]
+    fn owned_stat_not_found_is_gone() {
+        let gone = interpret_owned_stat_contents(
+            42,
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing")),
+        )
+        .expect("not found is gone");
+        assert!(gone.is_none());
+    }
+
+    #[test]
+    fn owned_stat_permission_denied_is_unverifiable() {
+        let error = interpret_owned_stat_contents(
+            42,
+            Err(io::Error::new(io::ErrorKind::PermissionDenied, "denied")),
+        )
+        .expect_err("permission denied cannot prove drain");
+        assert!(error.to_string().contains("unverifiable"));
+    }
+
+    #[test]
+    fn owned_stat_invalid_metadata_is_unverifiable() {
+        let error = interpret_owned_stat_contents(42, Ok("not-a-stat".to_string()))
+            .expect_err("invalid metadata cannot prove drain");
+        assert!(error.to_string().contains("invalid stat metadata"));
     }
 }
 
@@ -1942,6 +2256,326 @@ mod supervisor_zombie_guard_tests {
         );
         let _ = sibling.kill();
         let _ = sibling.wait();
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod adopted_child_reaping_tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::io;
+    use std::os::unix::process::CommandExt;
+    use std::path::Path;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    #[ignore = "subprocess fixture for a rapidly reparented guarded descendant"]
+    fn guarded_fast_double_fork_fixture() {
+        let target = std::env::var("HOMEBOY_ADOPTED_DAEMON_TARGET").expect("target");
+        let pid_file = std::env::var("HOMEBOY_ADOPTED_DAEMON_PID_FILE").expect("pid file");
+        let script = CString::new(format!(
+            "printf '%s' $$ > {}; sleep 0.25; printf stale > {}; sleep 30",
+            crate::shell::quote_path(&pid_file),
+            crate::shell::quote_path(&target),
+        ))
+        .expect("fixture script");
+        let shell = c"/bin/sh";
+        let shell_name = c"sh";
+        let command_flag = c"-c";
+
+        let intermediate = unsafe { libc::fork() };
+        assert_ne!(intermediate, -1, "fork intermediate");
+        if intermediate == 0 {
+            let daemon = unsafe { libc::fork() };
+            if daemon < 0 {
+                unsafe { libc::_exit(2) };
+            }
+            if daemon > 0 {
+                unsafe { libc::_exit(0) };
+            }
+            if unsafe { libc::setsid() } == -1 {
+                unsafe { libc::_exit(3) };
+            }
+            let max = unsafe { libc::sysconf(libc::_SC_OPEN_MAX) };
+            for fd in 0..if max > 0 { max as i32 } else { 1024 } {
+                unsafe {
+                    libc::close(fd);
+                }
+            }
+            unsafe {
+                libc::execl(
+                    shell.as_ptr(),
+                    shell_name.as_ptr(),
+                    command_flag.as_ptr(),
+                    script.as_ptr(),
+                    std::ptr::null::<libc::c_char>(),
+                );
+                libc::_exit(4);
+            }
+        }
+        let mut status = 0;
+        assert_eq!(
+            unsafe { libc::waitpid(intermediate, &mut status, 0) },
+            intermediate,
+            "reap intermediate"
+        );
+    }
+
+    #[test]
+    fn extend_owned_processes_does_not_follow_a_reused_parent_pid() {
+        let mut owned = vec![UnixProcessIdentity {
+            pid: 10,
+            parent_pid: 1,
+            starttime_ticks: 100,
+        }];
+        let snapshot = vec![
+            UnixProcessIdentity {
+                pid: 10,
+                parent_pid: 1,
+                starttime_ticks: 999,
+            },
+            UnixProcessIdentity {
+                pid: 11,
+                parent_pid: 10,
+                starttime_ticks: 200,
+            },
+        ];
+        extend_owned_processes(&mut owned, 10, &snapshot, None);
+        assert!(
+            owned.iter().all(|process| process.pid != 11),
+            "a child of a reused parent PID must not be adopted"
+        );
+        assert_eq!(owned[0].starttime_ticks, 100);
+    }
+
+    #[test]
+    fn extend_owned_processes_follows_a_still_matching_parent() {
+        let mut owned = vec![UnixProcessIdentity {
+            pid: 10,
+            parent_pid: 1,
+            starttime_ticks: 100,
+        }];
+        let snapshot = vec![
+            UnixProcessIdentity {
+                pid: 10,
+                parent_pid: 1,
+                starttime_ticks: 100,
+            },
+            UnixProcessIdentity {
+                pid: 11,
+                parent_pid: 10,
+                starttime_ticks: 200,
+            },
+        ];
+        extend_owned_processes(&mut owned, 10, &snapshot, None);
+        assert!(
+            owned
+                .iter()
+                .any(|process| process.pid == 11 && process.starttime_ticks == 200),
+            "a child of a still-matching parent remains owned"
+        );
+    }
+
+    #[test]
+    fn adopted_zombie_waitpid_consumes_only_owned_descendant_status() {
+        let mut sibling = Command::new("sh");
+        sibling
+            .args(["-c", "exec sleep 30"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let mut sibling = sibling.spawn().expect("spawn unrelated child");
+        let sibling_pid = sibling.id();
+        let sibling_ticks = linux_process_stat(sibling_pid)
+            .expect("sibling start identity")
+            .starttime_ticks;
+
+        let child_pid = unsafe { libc::fork() };
+        assert_ne!(child_pid, -1, "fork adopted child");
+        if child_pid == 0 {
+            unsafe { libc::_exit(0) };
+        }
+        let child_pid = child_pid as u32;
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let child_stat = loop {
+            if let Some(stat) = linux_process_stat(child_pid) {
+                if stat.state == 'Z' && stat.parent_pid == std::process::id() {
+                    break stat;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "forked child never became an owned zombie"
+            );
+            thread::sleep(Duration::from_millis(5));
+        };
+
+        let owned = vec![UnixProcessIdentity {
+            pid: child_pid,
+            parent_pid: std::process::id(),
+            starttime_ticks: child_stat.starttime_ticks,
+        }];
+        reap_verified_adopted_zombies(&owned, sibling_pid, Some((std::process::id(), None, 1)))
+            .expect("reap owned adopted zombie");
+        assert_eq!(
+            inspect_owned_identity(&owned[0]).expect("owned descendant after reap"),
+            OwnedPresence::Gone,
+            "owned adopted zombie must be gone after its wait status is consumed"
+        );
+        let mut status = 0;
+        let reaped = unsafe { libc::waitpid(child_pid as libc::pid_t, &mut status, libc::WNOHANG) };
+        assert_eq!(
+            reaped, -1,
+            "owned descendant wait status must already be consumed"
+        );
+        assert_eq!(
+            io::Error::last_os_error().raw_os_error(),
+            Some(libc::ECHILD)
+        );
+        assert!(
+            sibling.try_wait().expect("sibling status").is_none(),
+            "sibling Child status must remain available"
+        );
+        assert_eq!(
+            linux_process_stat(sibling_pid).map(|stat| stat.starttime_ticks),
+            Some(sibling_ticks)
+        );
+        let _ = sibling.kill();
+        let _ = sibling.wait();
+    }
+
+    fn wait_for_recorded_pid(path: &Path, deadline: Instant) -> u32 {
+        loop {
+            if let Ok(contents) = std::fs::read_to_string(path) {
+                if let Ok(pid) = contents.trim().parse::<u32>() {
+                    return pid;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "double-fork fixture did not publish its PID"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn cleanup_recorded_linux_process(pid: u32, starttime_ticks: u64) {
+        let Some(stat) = linux_process_stat(pid) else {
+            return;
+        };
+        if stat.starttime_ticks != starttime_ticks {
+            return;
+        }
+        if process_is_running(pid) {
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+        }
+        let Some(stat) = linux_process_stat(pid) else {
+            return;
+        };
+        if stat.starttime_ticks == starttime_ticks
+            && stat.state == 'Z'
+            && stat.parent_pid == std::process::id()
+        {
+            let mut status = 0;
+            unsafe {
+                libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG);
+            }
+        }
+    }
+
+    #[test]
+    fn guarded_completion_reaps_double_fork_setsid_closed_fd_without_touching_sibling() {
+        let mut sibling = Command::new("sh");
+        sibling
+            .args(["-c", "exec sleep 30"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let mut sibling = sibling.spawn().expect("spawn unrelated child");
+        let sibling_pid = sibling.id();
+        let sibling_ticks = linux_process_stat(sibling_pid)
+            .expect("sibling start identity")
+            .starttime_ticks;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let target = workspace.path().join("target");
+        let pid_file = workspace.path().join("daemon.pid");
+        std::fs::write(&target, b"original").expect("write target");
+        let test_binary = std::env::current_exe().expect("test executable");
+        let mut command = Command::new(&test_binary);
+        command
+            .args([
+                "--ignored",
+                "--exact",
+                "command::adopted_child_reaping_tests::guarded_fast_double_fork_fixture",
+                "--nocapture",
+            ])
+            .env("HOMEBOY_ADOPTED_DAEMON_TARGET", &target)
+            .env("HOMEBOY_ADOPTED_DAEMON_PID_FILE", &pid_file)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut guard = ControllerChildGuard::prepare(&mut command).expect("prepare guard");
+        let mut child = command.spawn().expect("spawn double-fork root");
+        guard.attach(&child).expect("attach guard");
+        let daemon_pid = wait_for_recorded_pid(&pid_file, Instant::now() + Duration::from_secs(2));
+        let daemon_ticks = linux_process_stat(daemon_pid)
+            .expect("daemon start identity")
+            .starttime_ticks;
+
+        let supervised = wait_with_bounded_output_supervised_guarded(
+            &mut child,
+            &mut guard,
+            4096,
+            Duration::from_secs(2),
+            Duration::from_millis(50),
+            || false,
+            |_, _| Ok(()),
+        );
+        if supervised.is_err() {
+            cleanup_recorded_linux_process(daemon_pid, daemon_ticks);
+        }
+        let supervised = supervised.expect("root completion contains reparented descendant");
+        assert_eq!(
+            supervised.termination,
+            SupervisedCommandTermination::Completed
+        );
+        thread::sleep(Duration::from_millis(350));
+        if std::fs::read(&target).ok().as_deref() != Some(b"original".as_slice())
+            || process_is_running(daemon_pid)
+                && linux_process_stat(daemon_pid)
+                    .is_some_and(|stat| stat.starttime_ticks == daemon_ticks)
+        {
+            cleanup_recorded_linux_process(daemon_pid, daemon_ticks);
+        }
+        assert_eq!(
+            std::fs::read(&target).expect("read target"),
+            b"original",
+            "descriptor-closing daemon mutated after root completion"
+        );
+        let daemon_still_same =
+            linux_process_stat(daemon_pid).is_some_and(|stat| stat.starttime_ticks == daemon_ticks);
+        assert!(
+            !daemon_still_same || !process_is_running(daemon_pid),
+            "adopted double-fork descendant remained runnable"
+        );
+
+        let sibling_stat = linux_process_stat(sibling_pid);
+        assert!(
+            sibling.try_wait().expect("sibling status").is_none(),
+            "an unrelated child must not be reaped"
+        );
+        assert_eq!(
+            sibling_stat.map(|stat| stat.starttime_ticks),
+            Some(sibling_ticks),
+            "unrelated child identity must remain the recorded process"
+        );
+        let _ = sibling.kill();
+        let _ = sibling.wait();
+        cleanup_recorded_linux_process(daemon_pid, daemon_ticks);
     }
 }
 

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -53,6 +53,7 @@ pub struct ExecutionIdentity {
     pub wait_pid: u32,
     pub root_pid: u32,
     pub root_pgid: Option<u32>,
+    starttime_ticks: Option<u64>,
 }
 
 impl ExecutionIdentity {
@@ -62,6 +63,7 @@ impl ExecutionIdentity {
             wait_pid,
             root_pid: wait_pid,
             root_pgid: Some(wait_pid),
+            starttime_ticks: None,
         }
     }
 
@@ -108,16 +110,15 @@ pub struct ExecutionOwnerPrep {
 impl ExecutionOwnerPrep {
     pub fn attach(self, mut child: Child) -> io::Result<ExecutionOwner> {
         let mut guard = self.guard;
+        let wait_pid = child.id();
         if let Err(error) = guard.attach(&child) {
-            let _ = guard.request_drain(child.id());
-            let _ = child.wait();
+            let _ = bounded_drain_wait_handle(&mut guard, &mut child, wait_pid, None);
             return Err(error);
         }
-        let identity = match guard.execution_identity(child.id()) {
+        let identity = match guard.execution_identity(wait_pid) {
             Ok(identity) => identity,
             Err(error) => {
-                let _ = guard.request_drain(child.id());
-                let _ = child.wait();
+                let _ = bounded_drain_wait_handle(&mut guard, &mut child, wait_pid, None);
                 return Err(error);
             }
         };
@@ -126,6 +127,8 @@ impl ExecutionOwnerPrep {
             identity,
             guard,
             outcome: None,
+            teardown_complete: false,
+            last_resort_done: false,
         })
     }
 }
@@ -137,6 +140,8 @@ pub struct ExecutionOwner {
     identity: ExecutionIdentity,
     guard: ControllerChildGuard,
     outcome: Option<ExecutionOutcome>,
+    teardown_complete: bool,
+    last_resort_done: bool,
 }
 
 impl ExecutionOwner {
@@ -179,14 +184,14 @@ impl ExecutionOwner {
         if let Some(outcome) = self.outcome {
             return Ok(Some(outcome));
         }
-        let Some(outcome) = self
-            .guard
-            .try_wait_outcome(&mut self.child, self.identity)?
-        else {
-            return Ok(None);
-        };
-        self.outcome = Some(outcome);
-        Ok(Some(outcome))
+        if self.teardown_complete {
+            return Err(io::Error::other("execution owner cleanup did not complete"));
+        }
+        match self.guard.try_wait_outcome(&mut self.child, self.identity) {
+            Ok(Some(outcome)) => Ok(Some(self.record_terminal(outcome))),
+            Ok(None) => Ok(None),
+            Err(error) => Err(self.fail_closed(error)),
+        }
     }
 
     pub fn request_drain(&mut self) -> io::Result<()> {
@@ -197,9 +202,106 @@ impl ExecutionOwner {
         if let Some(outcome) = self.outcome {
             return Ok(outcome);
         }
-        let outcome = self.guard.drain_and_reap(&mut self.child, self.identity)?;
+        if self.teardown_complete {
+            return Err(io::Error::other("execution owner cleanup did not complete"));
+        }
+        match self.guard.drain_and_reap(&mut self.child, self.identity) {
+            Ok(outcome) => Ok(self.record_terminal(outcome)),
+            Err(error) => Err(self.fail_closed(error)),
+        }
+    }
+
+    fn record_terminal(&mut self, outcome: ExecutionOutcome) -> ExecutionOutcome {
+        if outcome.cleanup == ExecutionCleanup::Incomplete {
+            self.last_resort_root_group();
+        }
+        self.teardown_complete = true;
         self.outcome = Some(outcome);
-        Ok(outcome)
+        outcome
+    }
+
+    fn fail_closed(&mut self, error: io::Error) -> io::Error {
+        self.last_resort_root_group();
+        let _ = reap_child_until(
+            &mut self.child,
+            std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE,
+        );
+        self.teardown_complete = true;
+        error
+    }
+
+    fn last_resort_root_group(&mut self) {
+        if self.last_resort_done {
+            return;
+        }
+        self.last_resort_done = true;
+        last_resort_signal_root_group(self.identity);
+    }
+}
+
+impl Drop for ExecutionOwner {
+    fn drop(&mut self) {
+        if self.teardown_complete || self.outcome.is_some() {
+            return;
+        }
+        let _ = self.drain_and_reap();
+    }
+}
+
+fn bounded_drain_wait_handle(
+    guard: &mut ControllerChildGuard,
+    child: &mut Child,
+    wait_pid: u32,
+    identity: Option<ExecutionIdentity>,
+) -> io::Result<ExitStatus> {
+    let _ = guard.request_drain(wait_pid);
+    if let Some(identity) = identity {
+        last_resort_signal_root_group(identity);
+    }
+    reap_child_until(
+        child,
+        std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE,
+    )
+}
+
+fn last_resort_signal_root_group(identity: ExecutionIdentity) {
+    #[cfg(unix)]
+    {
+        if !root_identity_is_live(identity) {
+            return;
+        }
+        let _ = terminate_remaining_process_group(identity.recovery_process_group());
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = identity;
+    }
+}
+
+#[cfg(unix)]
+fn root_identity_is_live(identity: ExecutionIdentity) -> bool {
+    let root = identity.root_pid;
+    if root == 0 || root > i32::MAX as u32 {
+        return false;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let Some(stat) = linux_process_stat(root) else {
+            return false;
+        };
+        let Some(ticks) = identity.starttime_ticks else {
+            return false;
+        };
+        if stat.starttime_ticks != ticks {
+            return false;
+        }
+        let expected = identity.root_pgid.unwrap_or(root);
+        let pgid = unsafe { libc::getpgid(root as libc::pid_t) };
+        pgid >= 0 && pgid as u32 == expected
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        process_is_running(root)
     }
 }
 
@@ -480,6 +582,7 @@ impl ControllerChildGuard {
                 wait_pid,
                 root_pid,
                 root_pgid: Some(root_pgid),
+                starttime_ticks: linux_process_stat(root_pid).map(|stat| stat.starttime_ticks),
             })
         }
         #[cfg(not(target_os = "linux"))]
@@ -4161,10 +4264,90 @@ mod tests {
             error.to_string().contains("execution owner"),
             "cleanup failure must not look like root exit 1: {error}"
         );
-        if process_is_running(root_pid) {
-            unsafe {
-                libc::kill(root_pid as libc::pid_t, libc::SIGKILL);
+        assert!(
+            !process_is_running(root_pid),
+            "incomplete last-resort must reap root {root_pid} before fixture cleanup"
+        );
+        assert!(
+            !process_is_running(wait_pid),
+            "supervisor {wait_pid} remained after protocol loss"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_drop_before_wait_reaps_supervisor_without_orphaning() {
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", "trap '' TERM; sleep 30"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        let owner = ExecutionOwner::spawn(&mut command).expect("spawn owner");
+        let wait_pid = owner.identity().wait_pid;
+        let root_pid = owner.identity().root_pid;
+        drop(owner);
+        assert!(
+            !process_is_running(wait_pid),
+            "supervisor {wait_pid} still running after owner drop"
+        );
+        assert!(
+            !process_is_running(root_pid),
+            "root {root_pid} still running after owner drop"
+        );
+        let waited =
+            unsafe { libc::waitpid(wait_pid as libc::pid_t, std::ptr::null_mut(), libc::WNOHANG) };
+        assert_eq!(
+            waited, -1,
+            "supervisor {wait_pid} remained waitable after owner drop"
+        );
+        assert_eq!(
+            io::Error::last_os_error().raw_os_error(),
+            Some(libc::ECHILD)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn supervisor_loss_last_resorts_root_and_stays_incomplete() {
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", "trap '' TERM; sleep 30"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        let mut owner = ExecutionOwner::spawn(&mut command).expect("spawn owner");
+        let wait_pid = owner.identity().wait_pid;
+        let root_pid = owner.identity().root_pid;
+        unsafe {
+            libc::kill(wait_pid as libc::pid_t, libc::SIGKILL);
+        }
+        let result = owner.drain_and_reap();
+        assert!(
+            !process_is_running(root_pid),
+            "last-resort must reap root {root_pid} before fixture cleanup"
+        );
+        assert!(
+            !process_is_running(wait_pid),
+            "supervisor {wait_pid} remained after drain"
+        );
+        match result {
+            Ok(outcome) => {
+                assert_eq!(outcome.cleanup, ExecutionCleanup::Incomplete);
+                assert!(
+                    outcome.into_root_status().is_err(),
+                    "incomplete cleanup must not become a successful root status"
+                );
             }
+            Err(error) => {
+                assert!(
+                    error.to_string().contains("execution owner"),
+                    "supervisor loss must stay distinct from root exit 1: {error}"
+                );
+            }
+        }
+        let second = owner.drain_and_reap();
+        match second {
+            Ok(outcome) => assert_eq!(outcome.cleanup, ExecutionCleanup::Incomplete),
+            Err(error) => assert!(error.to_string().contains("execution owner")),
         }
     }
 }

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -330,7 +330,7 @@ impl ControllerChildGuard {
             .owned_processes
             .lock()
             .map_err(|_| io::Error::other("owned process identity lock poisoned"))?;
-        extend_owned_processes(&mut owned, root_pid, &snapshot, self.adopted_guard()?);
+        extend_owned_processes(&mut owned, root_pid, &snapshot, self.adopted_guard()?)?;
         Ok(())
     }
 
@@ -1502,7 +1502,7 @@ fn extend_owned_processes(
     root_pid: u32,
     snapshot: &[UnixProcessIdentity],
     adopted: AdoptedGuard,
-) {
+) -> io::Result<()> {
     if owned.is_empty() {
         if let Some(root) = snapshot.iter().find(|process| process.pid == root_pid) {
             owned.push(root.clone());
@@ -1514,12 +1514,14 @@ fn extend_owned_processes(
             if owned.iter().any(|known| known.pid == process.pid) {
                 continue;
             }
-            let adopted_descendant =
-                adopted.is_some_and(|(controller_pid, guard_pid, guard_id)| {
-                    process.parent_pid == controller_pid
-                        && Some(process.pid) != guard_pid
-                        && process_has_guard_id(process.pid, guard_id)
-                });
+            let adopted_descendant = if let Some((controller_pid, guard_pid, guard_id)) = adopted {
+                process.parent_pid == controller_pid
+                    && Some(process.pid) != guard_pid
+                    && linux_thread_group_leader(process.pid)?
+                    && live_process_has_guard_id(process, guard_id)?
+            } else {
+                false
+            };
             if adopted_descendant
                 || owned_contains_matching_parent(owned, snapshot, process.parent_pid)
             {
@@ -1531,23 +1533,75 @@ fn extend_owned_processes(
             break;
         }
     }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn process_has_guard_id(pid: u32, guard_id: u64) -> bool {
-    let expected = format!("HOMEBOY_CHILD_GUARD_ID={guard_id}");
-    std::fs::read(format!("/proc/{pid}/environ"))
-        .ok()
-        .is_some_and(|environment| {
-            environment
-                .split(|byte| *byte == 0)
-                .any(|entry| entry == expected.as_bytes())
-        })
+fn interpret_owned_environ_contents(
+    pid: u32,
+    expected: &[u8],
+    result: io::Result<Vec<u8>>,
+) -> io::Result<bool> {
+    match result {
+        Ok(environment) => Ok(environment
+            .split(|byte| *byte == 0)
+            .any(|entry| entry == expected)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(io::Error::other(format!(
+            "owned process {pid} environment is unverifiable: {error}"
+        ))),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn interpret_owned_status_tgid(pid: u32, result: io::Result<String>) -> io::Result<Option<u32>> {
+    match result {
+        Ok(status) => Ok(status.lines().find_map(|line| {
+            line.strip_prefix("Tgid:")
+                .and_then(|value| value.trim().parse().ok())
+        })),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(io::Error::other(format!(
+            "owned process {pid} status is unverifiable: {error}"
+        ))),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_thread_group_leader(pid: u32) -> io::Result<bool> {
+    match interpret_owned_status_tgid(pid, std::fs::read_to_string(format!("/proc/{pid}/status")))?
+    {
+        Some(tgid) => Ok(tgid == pid),
+        None => Ok(false),
+    }
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
-fn process_has_guard_id(_pid: u32, _guard_id: u64) -> bool {
-    false
+fn linux_thread_group_leader(_pid: u32) -> io::Result<bool> {
+    Ok(true)
+}
+
+#[cfg(target_os = "linux")]
+fn live_process_has_guard_id(process: &UnixProcessIdentity, guard_id: u64) -> io::Result<bool> {
+    match inspect_owned_identity(process)? {
+        OwnedPresence::Live => process_has_guard_id(process.pid, guard_id),
+        _ => Ok(false),
+    }
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn live_process_has_guard_id(_process: &UnixProcessIdentity, _guard_id: u64) -> io::Result<bool> {
+    Ok(false)
+}
+
+#[cfg(target_os = "linux")]
+fn process_has_guard_id(pid: u32, guard_id: u64) -> io::Result<bool> {
+    let expected = format!("HOMEBOY_CHILD_GUARD_ID={guard_id}");
+    interpret_owned_environ_contents(
+        pid,
+        expected.as_bytes(),
+        std::fs::read(format!("/proc/{pid}/environ")),
+    )
 }
 
 #[cfg(unix)]
@@ -1625,62 +1679,16 @@ fn inspect_owned_identity(known: &UnixProcessIdentity) -> io::Result<OwnedPresen
 }
 
 #[cfg(unix)]
-fn owned_runnable_pids(
-    owned: &[UnixProcessIdentity],
-    snapshot: &[UnixProcessIdentity],
-) -> io::Result<Vec<u32>> {
-    let mut runnable = Vec::new();
-    #[cfg(target_os = "linux")]
-    {
-        let _ = snapshot;
-        for known in owned {
-            if matches!(inspect_owned_identity(known)?, OwnedPresence::Live) {
-                runnable.push(known.pid);
-            }
-        }
-        return Ok(runnable);
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        for known in owned {
-            let Some(current) = snapshot.iter().find(|process| process.pid == known.pid) else {
-                continue;
-            };
-            if owned_identity_matches(known, current) && process_is_running(known.pid) {
-                runnable.push(known.pid);
-            }
-        }
-        Ok(runnable)
-    }
-}
-
-#[cfg(unix)]
-fn signal_owned_processes(
-    owned: &mut Vec<UnixProcessIdentity>,
-    root_pid: u32,
-    signal: libc::c_int,
-    adopted: AdoptedGuard,
-) -> io::Result<Vec<u32>> {
-    let snapshot = unix_process_snapshot()?;
-    extend_owned_processes(owned, root_pid, &snapshot, adopted);
-    let pids = owned_runnable_pids(owned, &snapshot)?;
-    signal_pids(&pids, signal);
-    Ok(pids)
-}
-
-#[cfg(unix)]
 fn terminate_owned_processes_and_reap(
     child: &mut Child,
     owned_processes: &Mutex<Vec<UnixProcessIdentity>>,
     adopted: AdoptedGuard,
 ) -> io::Result<ExitStatus> {
-    enable_child_subreaper()?;
     let root_pid = child.id();
     let mut owned = owned_processes
         .lock()
         .map_err(|_| io::Error::other("owned process identity lock poisoned"))?;
     signal_process_group(root_pid, libc::SIGTERM)?;
-    signal_owned_processes(&mut owned, root_pid, libc::SIGTERM, adopted)?;
     let mut status = child.try_wait()?;
     if !wait_for_owned_process_exit(
         child,
@@ -1692,7 +1700,6 @@ fn terminate_owned_processes_and_reap(
         adopted,
     )? {
         signal_process_group(root_pid, libc::SIGKILL)?;
-        signal_owned_processes(&mut owned, root_pid, libc::SIGKILL, adopted)?;
         if !wait_for_owned_process_exit(
             child,
             root_pid,
@@ -1720,7 +1727,6 @@ fn terminate_owned_processes_after_root_exit(
     let mut owned = owned_processes
         .lock()
         .map_err(|_| io::Error::other("owned process identity lock poisoned"))?;
-    signal_owned_processes(&mut owned, root_pid, libc::SIGTERM, adopted)?;
     if wait_for_owned_process_exit_without_child(
         root_pid,
         &mut owned,
@@ -1730,7 +1736,6 @@ fn terminate_owned_processes_after_root_exit(
     )? {
         return Ok(());
     }
-    signal_owned_processes(&mut owned, root_pid, libc::SIGKILL, adopted)?;
     if wait_for_owned_process_exit_without_child(
         root_pid,
         &mut owned,
@@ -1758,16 +1763,13 @@ fn wait_for_owned_process_exit(
 ) -> io::Result<bool> {
     let deadline = std::time::Instant::now() + grace;
     loop {
-        let snapshot = unix_process_snapshot()?;
-        extend_owned_processes(owned, root_pid, &snapshot, adopted);
-        signal_pids(&owned_runnable_pids(owned, &snapshot)?, signal);
         if status.is_none() {
             *status = child.try_wait()?;
         }
         if status.is_some() {
             reap_exited_process_group_children(root_pid);
         }
-        if owned_processes_are_drained(owned, &snapshot, root_pid, adopted)? {
+        if drain_owned_processes(owned, root_pid, signal, adopted)? {
             return Ok(true);
         }
         if std::time::Instant::now() >= deadline {
@@ -1787,11 +1789,8 @@ fn wait_for_owned_process_exit_without_child(
 ) -> io::Result<bool> {
     let deadline = std::time::Instant::now() + grace;
     loop {
-        let snapshot = unix_process_snapshot()?;
-        extend_owned_processes(owned, root_pid, &snapshot, adopted);
-        signal_pids(&owned_runnable_pids(owned, &snapshot)?, signal);
         reap_exited_process_group_children(root_pid);
-        if owned_processes_are_drained(owned, &snapshot, root_pid, adopted)? {
+        if drain_owned_processes(owned, root_pid, signal, adopted)? {
             return Ok(true);
         }
         if std::time::Instant::now() >= deadline {
@@ -1802,87 +1801,82 @@ fn wait_for_owned_process_exit_without_child(
 }
 
 #[cfg(unix)]
-fn owned_processes_are_drained(
-    owned: &[UnixProcessIdentity],
-    snapshot: &[UnixProcessIdentity],
+fn drain_owned_processes(
+    owned: &mut Vec<UnixProcessIdentity>,
     root_pid: u32,
+    signal: libc::c_int,
     adopted: AdoptedGuard,
 ) -> io::Result<bool> {
-    if !owned_runnable_pids(owned, snapshot)?.is_empty() {
+    let snapshot = unix_process_snapshot()?;
+    extend_owned_processes(owned, root_pid, &snapshot, adopted)?;
+    if signal_and_reap_owned(owned, root_pid, signal, adopted)? {
         return Ok(false);
     }
-    reap_verified_adopted_zombies(owned, root_pid, adopted)?;
-    for known in owned {
-        if !owned_identity_is_absent(known, snapshot, root_pid, adopted)? {
-            return Ok(false);
-        }
-    }
-    Ok(true)
+    let discovered = owned.len();
+    let refresh = unix_process_snapshot()?;
+    extend_owned_processes(owned, root_pid, &refresh, adopted)?;
+    Ok(owned.len() == discovered)
 }
 
 #[cfg(unix)]
-fn owned_identity_is_absent(
-    known: &UnixProcessIdentity,
-    snapshot: &[UnixProcessIdentity],
+fn signal_and_reap_owned(
+    owned: &[UnixProcessIdentity],
     root_pid: u32,
+    signal: libc::c_int,
     adopted: AdoptedGuard,
 ) -> io::Result<bool> {
+    let mut remaining = false;
     #[cfg(target_os = "linux")]
     {
-        let _ = snapshot;
-        Ok(match inspect_owned_identity(known)? {
-            OwnedPresence::Gone | OwnedPresence::Reused => true,
-            OwnedPresence::Live => false,
-            OwnedPresence::Zombie { parent_pid } => {
-                if known.pid == root_pid {
-                    false
-                } else if let Some((controller_pid, guard_pid, _)) = adopted {
-                    Some(known.pid) == guard_pid
-                        || controller_pid != std::process::id()
-                        || parent_pid != controller_pid
-                } else {
-                    true
+        let controller_pid = adopted.map(|(pid, _, _)| pid);
+        let guard_pid = adopted.and_then(|(_, guard, _)| guard);
+        for known in owned {
+            match inspect_owned_identity(known)? {
+                OwnedPresence::Gone | OwnedPresence::Reused => {}
+                OwnedPresence::Live => {
+                    unsafe {
+                        let _ = libc::kill(known.pid as libc::pid_t, signal);
+                    }
+                    remaining = true;
+                }
+                OwnedPresence::Zombie { parent_pid } => {
+                    if known.pid == root_pid || Some(known.pid) == guard_pid {
+                        remaining = true;
+                        continue;
+                    }
+                    if controller_pid == Some(std::process::id())
+                        && parent_pid == std::process::id()
+                    {
+                        waitpid_exact_nohang(known.pid)?;
+                        if !matches!(
+                            inspect_owned_identity(known)?,
+                            OwnedPresence::Gone | OwnedPresence::Reused
+                        ) {
+                            remaining = true;
+                        }
+                    }
                 }
             }
-        })
+        }
+        return Ok(remaining);
     }
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (root_pid, adopted);
-        Ok(!owned_runnable_pids(std::slice::from_ref(known), snapshot)?.contains(&known.pid))
-    }
-}
-
-#[cfg(unix)]
-fn reap_verified_adopted_zombies(
-    owned: &[UnixProcessIdentity],
-    root_pid: u32,
-    adopted: AdoptedGuard,
-) -> io::Result<()> {
-    let Some((controller_pid, guard_pid, _)) = adopted else {
-        return Ok(());
-    };
-    if controller_pid != std::process::id() {
-        return Ok(());
-    }
-    for known in owned {
-        if known.pid == root_pid || Some(known.pid) == guard_pid {
-            continue;
-        }
-        #[cfg(target_os = "linux")]
-        {
-            if let OwnedPresence::Zombie { parent_pid } = inspect_owned_identity(known)? {
-                if parent_pid == controller_pid {
-                    waitpid_exact_nohang(known.pid)?;
+        let snapshot = unix_process_snapshot()?;
+        for known in owned {
+            let Some(current) = snapshot.iter().find(|process| process.pid == known.pid) else {
+                continue;
+            };
+            if owned_identity_matches(known, current) && process_is_running(known.pid) {
+                unsafe {
+                    let _ = libc::kill(known.pid as libc::pid_t, signal);
                 }
+                remaining = true;
             }
         }
-        #[cfg(not(target_os = "linux"))]
-        {
-            let _ = known;
-        }
+        let _ = (root_pid, adopted);
+        Ok(remaining)
     }
-    Ok(())
 }
 
 #[cfg(target_os = "linux")]
@@ -2174,6 +2168,57 @@ mod process_group_liveness_tests {
             .expect_err("invalid metadata cannot prove drain");
         assert!(error.to_string().contains("invalid stat metadata"));
     }
+
+    #[test]
+    fn owned_status_permission_denied_is_unverifiable() {
+        let error = interpret_owned_status_tgid(
+            42,
+            Err(io::Error::new(io::ErrorKind::PermissionDenied, "denied")),
+        )
+        .expect_err("inaccessible status cannot prove a process is not adopted");
+        assert!(error.to_string().contains("unverifiable"));
+    }
+
+    #[test]
+    fn owned_status_not_found_is_not_a_leader() {
+        assert!(interpret_owned_status_tgid(
+            42,
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing")),
+        )
+        .expect("gone process")
+        .is_none());
+    }
+
+    #[test]
+    fn owned_environ_not_found_is_not_adopted() {
+        assert!(!interpret_owned_environ_contents(
+            42,
+            b"HOMEBOY_CHILD_GUARD_ID=7",
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing")),
+        )
+        .expect("gone process is not adopted"));
+    }
+
+    #[test]
+    fn owned_environ_permission_denied_is_unverifiable() {
+        let error = interpret_owned_environ_contents(
+            42,
+            b"HOMEBOY_CHILD_GUARD_ID=7",
+            Err(io::Error::new(io::ErrorKind::PermissionDenied, "denied")),
+        )
+        .expect_err("inaccessible adopted child cannot yield success");
+        assert!(error.to_string().contains("unverifiable"));
+    }
+
+    #[test]
+    fn owned_environ_matching_guard_id_is_adopted() {
+        assert!(interpret_owned_environ_contents(
+            42,
+            b"HOMEBOY_CHILD_GUARD_ID=7",
+            Ok(b"HOME=/\0HOMEBOY_CHILD_GUARD_ID=7\0".to_vec()),
+        )
+        .expect("readable matching environ"));
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -2341,7 +2386,7 @@ mod adopted_child_reaping_tests {
                 starttime_ticks: 200,
             },
         ];
-        extend_owned_processes(&mut owned, 10, &snapshot, None);
+        extend_owned_processes(&mut owned, 10, &snapshot, None).expect("extend");
         assert!(
             owned.iter().all(|process| process.pid != 11),
             "a child of a reused parent PID must not be adopted"
@@ -2368,12 +2413,47 @@ mod adopted_child_reaping_tests {
                 starttime_ticks: 200,
             },
         ];
-        extend_owned_processes(&mut owned, 10, &snapshot, None);
+        extend_owned_processes(&mut owned, 10, &snapshot, None).expect("extend");
         assert!(
             owned
                 .iter()
                 .any(|process| process.pid == 11 && process.starttime_ticks == 200),
             "a child of a still-matching parent remains owned"
+        );
+    }
+
+    #[test]
+    fn extend_owned_processes_picks_up_a_late_parent_chain_descendant() {
+        let mut owned = vec![UnixProcessIdentity {
+            pid: 10,
+            parent_pid: 1,
+            starttime_ticks: 100,
+        }];
+        let first = [UnixProcessIdentity {
+            pid: 10,
+            parent_pid: 1,
+            starttime_ticks: 100,
+        }];
+        extend_owned_processes(&mut owned, 10, &first, None).expect("first extend");
+        assert_eq!(owned.len(), 1);
+        let later = [
+            UnixProcessIdentity {
+                pid: 10,
+                parent_pid: 1,
+                starttime_ticks: 100,
+            },
+            UnixProcessIdentity {
+                pid: 12,
+                parent_pid: 10,
+                starttime_ticks: 300,
+            },
+        ];
+        extend_owned_processes(&mut owned, 10, &later, None).expect("late extend");
+        assert!(
+            owned
+                .iter()
+                .any(|process| process.pid == 12 && process.starttime_ticks == 300),
+            "a descendant that appears after the first scan must still be claimed"
         );
     }
 
@@ -2416,8 +2496,13 @@ mod adopted_child_reaping_tests {
             parent_pid: std::process::id(),
             starttime_ticks: child_stat.starttime_ticks,
         }];
-        reap_verified_adopted_zombies(&owned, sibling_pid, Some((std::process::id(), None, 1)))
-            .expect("reap owned adopted zombie");
+        signal_and_reap_owned(
+            &owned,
+            sibling_pid,
+            libc::SIGTERM,
+            Some((std::process::id(), None, 1)),
+        )
+        .expect("reap owned adopted zombie");
         assert_eq!(
             inspect_owned_identity(&owned[0]).expect("owned descendant after reap"),
             OwnedPresence::Gone,
@@ -2460,28 +2545,46 @@ mod adopted_child_reaping_tests {
         }
     }
 
-    fn cleanup_recorded_linux_process(pid: u32, starttime_ticks: u64) {
-        let Some(stat) = linux_process_stat(pid) else {
-            return;
-        };
-        if stat.starttime_ticks != starttime_ticks {
-            return;
-        }
-        if process_is_running(pid) {
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    struct RecordedLinuxProcess {
+        pid: u32,
+        starttime_ticks: u64,
+    }
+
+    impl Drop for RecordedLinuxProcess {
+        fn drop(&mut self) {
+            let Some(stat) = linux_process_stat(self.pid) else {
+                return;
+            };
+            if stat.starttime_ticks != self.starttime_ticks {
+                return;
+            }
+            if process_is_running(self.pid) {
+                unsafe {
+                    libc::kill(self.pid as libc::pid_t, libc::SIGKILL);
+                }
+            }
+            let Some(stat) = linux_process_stat(self.pid) else {
+                return;
+            };
+            if stat.starttime_ticks == self.starttime_ticks
+                && stat.state == 'Z'
+                && stat.parent_pid == std::process::id()
+            {
+                let mut status = 0;
+                unsafe {
+                    libc::waitpid(self.pid as libc::pid_t, &mut status, libc::WNOHANG);
+                }
             }
         }
-        let Some(stat) = linux_process_stat(pid) else {
-            return;
-        };
-        if stat.starttime_ticks == starttime_ticks
-            && stat.state == 'Z'
-            && stat.parent_pid == std::process::id()
-        {
-            let mut status = 0;
-            unsafe {
-                libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG);
+    }
+
+    struct KillChildOnDrop(Option<std::process::Child>);
+
+    impl Drop for KillChildOnDrop {
+        fn drop(&mut self) {
+            if let Some(mut child) = self.0.take() {
+                let _ = child.kill();
+                let _ = child.wait();
             }
         }
     }
@@ -2494,11 +2597,12 @@ mod adopted_child_reaping_tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .process_group(0);
-        let mut sibling = sibling.spawn().expect("spawn unrelated child");
+        let sibling = sibling.spawn().expect("spawn unrelated child");
         let sibling_pid = sibling.id();
         let sibling_ticks = linux_process_stat(sibling_pid)
             .expect("sibling start identity")
             .starttime_ticks;
+        let mut sibling = KillChildOnDrop(Some(sibling));
 
         let workspace = tempfile::tempdir().expect("workspace");
         let target = workspace.path().join("target");
@@ -2525,6 +2629,10 @@ mod adopted_child_reaping_tests {
         let daemon_ticks = linux_process_stat(daemon_pid)
             .expect("daemon start identity")
             .starttime_ticks;
+        let _daemon = RecordedLinuxProcess {
+            pid: daemon_pid,
+            starttime_ticks: daemon_ticks,
+        };
 
         let supervised = wait_with_bounded_output_supervised_guarded(
             &mut child,
@@ -2534,23 +2642,13 @@ mod adopted_child_reaping_tests {
             Duration::from_millis(50),
             || false,
             |_, _| Ok(()),
-        );
-        if supervised.is_err() {
-            cleanup_recorded_linux_process(daemon_pid, daemon_ticks);
-        }
-        let supervised = supervised.expect("root completion contains reparented descendant");
+        )
+        .expect("root completion contains reparented descendant");
         assert_eq!(
             supervised.termination,
             SupervisedCommandTermination::Completed
         );
         thread::sleep(Duration::from_millis(350));
-        if std::fs::read(&target).ok().as_deref() != Some(b"original".as_slice())
-            || process_is_running(daemon_pid)
-                && linux_process_stat(daemon_pid)
-                    .is_some_and(|stat| stat.starttime_ticks == daemon_ticks)
-        {
-            cleanup_recorded_linux_process(daemon_pid, daemon_ticks);
-        }
         assert_eq!(
             std::fs::read(&target).expect("read target"),
             b"original",
@@ -2563,9 +2661,10 @@ mod adopted_child_reaping_tests {
             "adopted double-fork descendant remained runnable"
         );
 
+        let sibling_child = sibling.0.as_mut().expect("sibling child");
         let sibling_stat = linux_process_stat(sibling_pid);
         assert!(
-            sibling.try_wait().expect("sibling status").is_none(),
+            sibling_child.try_wait().expect("sibling status").is_none(),
             "an unrelated child must not be reaped"
         );
         assert_eq!(
@@ -2573,9 +2672,6 @@ mod adopted_child_reaping_tests {
             Some(sibling_ticks),
             "unrelated child identity must remain the recorded process"
         );
-        let _ = sibling.kill();
-        let _ = sibling.wait();
-        cleanup_recorded_linux_process(daemon_pid, daemon_ticks);
     }
 }
 

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -4,6 +4,8 @@ use std::io::{self, Read, Write};
 #[cfg(unix)]
 use std::os::fd::RawFd;
 use std::process::{Child, Command, ExitStatus, Output};
+#[cfg(target_os = "linux")]
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
@@ -29,6 +31,177 @@ const CONTROLLER_LOSS_KILL_GRACE: Duration = Duration::from_millis(400);
 const PROCESS_TREE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const CAPTURE_JOIN_GRACE: Duration = Duration::from_secs(2);
 const PROCESS_TREE_CLEANUP_DEADLINE: Duration = Duration::from_secs(4);
+#[cfg(target_os = "linux")]
+const EXECUTION_PROTOCOL_IDENTITY_LEN: usize = 8;
+#[cfg(target_os = "linux")]
+const EXECUTION_PROTOCOL_TERMINAL_LEN: usize = 5;
+#[cfg(target_os = "linux")]
+const EXECUTION_PROTOCOL_COMPLETE: u8 = 0;
+#[cfg(target_os = "linux")]
+const EXECUTION_PROTOCOL_INCOMPLETE: u8 = 1;
+#[cfg(target_os = "linux")]
+const EXECUTION_PROTOCOL_INCOMPLETE_NO_ROOT: u8 = 2;
+
+/// Waitable identity of one isolated execution.
+///
+/// `wait_pid` is the spawned handle (`Child::id`): the Linux supervisor, or the
+/// workload root elsewhere. Workload signaling, metrics, and persisted recovery
+/// use `root_pid` / `root_pgid` only. Never treat `wait_pid` as the workload
+/// process group on a supervised Linux execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExecutionIdentity {
+    pub wait_pid: u32,
+    pub root_pid: u32,
+    pub root_pgid: Option<u32>,
+}
+
+impl ExecutionIdentity {
+    #[cfg(not(target_os = "linux"))]
+    fn unmanaged(wait_pid: u32) -> Self {
+        Self {
+            wait_pid,
+            root_pid: wait_pid,
+            root_pgid: Some(wait_pid),
+        }
+    }
+
+    pub fn recovery_process_group(&self) -> u32 {
+        self.root_pgid.unwrap_or(self.root_pid)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionCleanup {
+    Complete,
+    Incomplete,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ExecutionOutcome {
+    pub root_status: ExitStatus,
+    pub cleanup: ExecutionCleanup,
+}
+
+impl ExecutionOutcome {
+    fn complete(root_status: ExitStatus) -> Self {
+        Self {
+            root_status,
+            cleanup: ExecutionCleanup::Complete,
+        }
+    }
+
+    pub fn into_root_status(self) -> io::Result<ExitStatus> {
+        match self.cleanup {
+            ExecutionCleanup::Complete => Ok(self.root_status),
+            ExecutionCleanup::Incomplete => {
+                Err(io::Error::other("execution owner cleanup did not complete"))
+            }
+        }
+    }
+}
+
+/// Prepared isolation that becomes an [`ExecutionOwner`] after spawn.
+pub struct ExecutionOwnerPrep {
+    guard: ControllerChildGuard,
+}
+
+impl ExecutionOwnerPrep {
+    pub fn attach(self, mut child: Child) -> io::Result<ExecutionOwner> {
+        let mut guard = self.guard;
+        if let Err(error) = guard.attach(&child) {
+            let _ = guard.request_drain(child.id());
+            let _ = child.wait();
+            return Err(error);
+        }
+        let identity = match guard.execution_identity(child.id()) {
+            Ok(identity) => identity,
+            Err(error) => {
+                let _ = guard.request_drain(child.id());
+                let _ = child.wait();
+                return Err(error);
+            }
+        };
+        Ok(ExecutionOwner {
+            child,
+            identity,
+            guard,
+            outcome: None,
+        })
+    }
+}
+
+/// Owns one isolated execution: supervisor wait handle, root identity, and
+/// terminal cleanup outcome. Cancellation requests drain through this owner.
+pub struct ExecutionOwner {
+    child: Child,
+    identity: ExecutionIdentity,
+    guard: ControllerChildGuard,
+    outcome: Option<ExecutionOutcome>,
+}
+
+impl ExecutionOwner {
+    pub fn prepare(command: &mut Command) -> io::Result<ExecutionOwnerPrep> {
+        Ok(ExecutionOwnerPrep {
+            guard: ControllerChildGuard::prepare(command)?,
+        })
+    }
+
+    pub fn spawn(command: &mut Command) -> io::Result<Self> {
+        let prep = Self::prepare(command)?;
+        let child = command.spawn()?;
+        prep.attach(child)
+    }
+
+    pub fn identity(&self) -> ExecutionIdentity {
+        self.identity
+    }
+
+    pub fn take_stdin(&mut self) -> Option<std::process::ChildStdin> {
+        self.child.stdin.take()
+    }
+
+    pub fn take_stdout(&mut self) -> Option<std::process::ChildStdout> {
+        self.child.stdout.take()
+    }
+
+    pub fn take_stderr(&mut self) -> Option<std::process::ChildStderr> {
+        self.child.stderr.take()
+    }
+
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        match self.try_wait_outcome()? {
+            Some(outcome) => Ok(Some(outcome.into_root_status()?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn try_wait_outcome(&mut self) -> io::Result<Option<ExecutionOutcome>> {
+        if let Some(outcome) = self.outcome {
+            return Ok(Some(outcome));
+        }
+        let Some(outcome) = self
+            .guard
+            .try_wait_outcome(&mut self.child, self.identity)?
+        else {
+            return Ok(None);
+        };
+        self.outcome = Some(outcome);
+        Ok(Some(outcome))
+    }
+
+    pub fn request_drain(&mut self) -> io::Result<()> {
+        self.guard.request_drain(self.identity.wait_pid)
+    }
+
+    pub fn drain_and_reap(&mut self) -> io::Result<ExecutionOutcome> {
+        if let Some(outcome) = self.outcome {
+            return Ok(outcome);
+        }
+        let outcome = self.guard.drain_and_reap(&mut self.child, self.identity)?;
+        self.outcome = Some(outcome);
+        Ok(outcome)
+    }
+}
 
 #[cfg(target_os = "linux")]
 static SUPERVISOR_TEARDOWN: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
@@ -135,6 +308,10 @@ pub struct ControllerChildGuard {
     child_registration_read_fd: RawFd,
     #[cfg(unix)]
     child_registration_fd: RawFd,
+    #[cfg(target_os = "linux")]
+    protocol_write_fd: AtomicI32,
+    #[cfg(target_os = "linux")]
+    root_identity: Mutex<Option<(u32, u32)>>,
     #[cfg(all(unix, not(target_os = "linux")))]
     owned_processes: Mutex<Vec<UnixProcessIdentity>>,
     #[cfg(windows)]
@@ -163,12 +340,35 @@ impl ControllerChildGuard {
             }
             #[cfg(target_os = "linux")]
             {
-                configure_isolated_process_tree(command, -1, fds[0]);
+                let mut protocol = [-1; 2];
+                if unsafe { libc::pipe(protocol.as_mut_ptr()) } != 0 {
+                    let error = io::Error::last_os_error();
+                    unsafe {
+                        libc::close(fds[0]);
+                        libc::close(fds[1]);
+                    }
+                    return Err(error);
+                }
+                for fd in protocol {
+                    if unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) } != 0 {
+                        let error = io::Error::last_os_error();
+                        unsafe {
+                            libc::close(fds[0]);
+                            libc::close(fds[1]);
+                            libc::close(protocol[0]);
+                            libc::close(protocol[1]);
+                        }
+                        return Err(error);
+                    }
+                }
+                configure_isolated_process_tree(command, protocol[1], fds[0]);
                 return Ok(Self {
                     controller_liveness_read_fd: fds[0],
                     controller_liveness_fd: fds[1],
-                    child_registration_read_fd: -1,
+                    child_registration_read_fd: protocol[0],
                     child_registration_fd: -1,
+                    protocol_write_fd: AtomicI32::new(protocol[1]),
+                    root_identity: Mutex::new(None),
                 });
             }
             #[cfg(not(target_os = "linux"))]
@@ -239,6 +439,16 @@ impl ControllerChildGuard {
 
         #[cfg(target_os = "linux")]
         {
+            self.close_protocol_write();
+            let mut identity = [0_u8; EXECUTION_PROTOCOL_IDENTITY_LEN];
+            read_exact_fd(self.child_registration_read_fd, &mut identity)?;
+            let root_pid = u32::from_ne_bytes(identity[..4].try_into().expect("root pid"));
+            let root_pgid = u32::from_ne_bytes(identity[4..].try_into().expect("root pgid"));
+            *self
+                .root_identity
+                .lock()
+                .map_err(|_| io::Error::other("execution identity lock poisoned"))? =
+                Some((root_pid, root_pgid));
             let _ = child;
             Ok(())
         }
@@ -256,6 +466,89 @@ impl ControllerChildGuard {
         }
     }
 
+    fn execution_identity(&self, wait_pid: u32) -> io::Result<ExecutionIdentity> {
+        #[cfg(target_os = "linux")]
+        {
+            let (root_pid, root_pgid) = self
+                .root_identity
+                .lock()
+                .map_err(|_| io::Error::other("execution identity lock poisoned"))?
+                .ok_or_else(|| {
+                    io::Error::other("execution owner attached without root identity")
+                })?;
+            Ok(ExecutionIdentity {
+                wait_pid,
+                root_pid,
+                root_pgid: Some(root_pgid),
+            })
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Ok(ExecutionIdentity::unmanaged(wait_pid))
+        }
+    }
+
+    fn request_drain(&mut self, wait_pid: u32) -> io::Result<()> {
+        #[cfg(target_os = "linux")]
+        {
+            self.close_liveness_write();
+            signal_pid(wait_pid, libc::SIGTERM)
+        }
+        #[cfg(all(unix, not(target_os = "linux")))]
+        {
+            signal_process_group(wait_pid, libc::SIGTERM)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = wait_pid;
+            Ok(())
+        }
+    }
+
+    fn try_wait_outcome(
+        &mut self,
+        child: &mut Child,
+        identity: ExecutionIdentity,
+    ) -> io::Result<Option<ExecutionOutcome>> {
+        match child.try_wait()? {
+            Some(status) => self.outcome_after_wait(status, identity).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn outcome_after_wait(
+        &mut self,
+        wait_status: ExitStatus,
+        identity: ExecutionIdentity,
+    ) -> io::Result<ExecutionOutcome> {
+        #[cfg(target_os = "linux")]
+        {
+            let _ = (wait_status, identity);
+            read_execution_protocol_outcome(self.child_registration_read_fd)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let deadline = std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE;
+            self.close_after_root_exit(identity.recovery_process_group(), deadline)?;
+            Ok(ExecutionOutcome::complete(wait_status))
+        }
+    }
+
+    fn drain_and_reap(
+        &mut self,
+        child: &mut Child,
+        identity: ExecutionIdentity,
+    ) -> io::Result<ExecutionOutcome> {
+        let deadline = std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE;
+        self.request_drain(identity.wait_pid)?;
+        match reap_child_until(child, deadline) {
+            Ok(status) => self.outcome_after_wait(status, identity),
+            Err(error) => Err(io::Error::other(format!(
+                "execution owner did not complete drain: {error}"
+            ))),
+        }
+    }
+
     fn terminate_and_reap(
         &mut self,
         child: &mut Child,
@@ -263,14 +556,15 @@ impl ControllerChildGuard {
     ) -> io::Result<ExitStatus> {
         #[cfg(target_os = "linux")]
         {
-            self.close_liveness_write();
-            signal_pid(child.id(), libc::SIGTERM)?;
+            let identity = self.execution_identity(child.id())?;
+            self.request_drain(identity.wait_pid)?;
             match reap_child_until(child, deadline) {
-                Ok(status) => Ok(status),
-                Err(_) => {
-                    signal_pid(child.id(), libc::SIGKILL)?;
-                    reap_child_until(child, deadline)
-                }
+                Ok(status) => self
+                    .outcome_after_wait(status, identity)?
+                    .into_root_status(),
+                Err(error) => Err(io::Error::other(format!(
+                    "execution owner did not complete drain: {error}"
+                ))),
             }
         }
 
@@ -300,7 +594,11 @@ impl ControllerChildGuard {
                 #[cfg(all(unix, not(target_os = "linux")))]
                 let _ = signal_process_group(child.id(), libc::SIGKILL);
                 #[cfg(target_os = "linux")]
-                self.close_liveness_write();
+                {
+                    self.close_liveness_write();
+                    let _ = signal_pid(child.id(), libc::SIGTERM);
+                }
+                #[cfg(not(target_os = "linux"))]
                 let _ = child.kill();
                 reap_child_until(child, deadline).map_err(|fallback| {
                     io::Error::other(format!(
@@ -311,17 +609,12 @@ impl ControllerChildGuard {
         }
     }
 
+    #[cfg(not(target_os = "linux"))]
     fn close_after_root_exit(
         &mut self,
         root_pid: u32,
         deadline: std::time::Instant,
     ) -> io::Result<()> {
-        #[cfg(target_os = "linux")]
-        {
-            let _ = (root_pid, deadline);
-            Ok(())
-        }
-
         #[cfg(all(unix, not(target_os = "linux")))]
         {
             let _ = deadline;
@@ -358,6 +651,16 @@ impl ControllerChildGuard {
                 libc::close(self.controller_liveness_fd);
             }
             self.controller_liveness_fd = -1;
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn close_protocol_write(&self) {
+        let fd = self.protocol_write_fd.swap(-1, Ordering::Relaxed);
+        if fd >= 0 {
+            unsafe {
+                libc::close(fd);
+            }
         }
     }
 
@@ -457,6 +760,8 @@ impl Drop for ControllerChildGuard {
                 self.child_registration_fd = -1;
             }
         }
+        #[cfg(target_os = "linux")]
+        self.close_protocol_write();
         #[cfg(windows)]
         if let Ok(mut job) = self.job.lock() {
             if !job.is_null() {
@@ -471,17 +776,21 @@ impl Drop for ControllerChildGuard {
 
 /// Close every descriptor this process inherited except `keep`.
 ///
-/// Runs in a forked child, so it stays inside async-signal-safe libc calls and
-/// walks a bounded descriptor range rather than allocating to enumerate
-/// `/proc/self/fd`.
+/// Runs in a forked child, so it stays inside async-signal-safe libc calls.
+/// Linux uses `close_range` so this does not walk `OPEN_MAX`.
 #[cfg(unix)]
 fn close_inherited_descriptors_except(keep: &[RawFd]) {
-    let max = unsafe { libc::sysconf(libc::_SC_OPEN_MAX) };
-    let max = if max > 0 { max as RawFd } else { 1024 };
-    for fd in 3..max {
-        if !keep.contains(&fd) {
-            unsafe {
-                libc::close(fd);
+    #[cfg(target_os = "linux")]
+    close_inherited_linux(keep);
+    #[cfg(not(target_os = "linux"))]
+    {
+        let max = unsafe { libc::sysconf(libc::_SC_OPEN_MAX) };
+        let max = if max > 0 { max as RawFd } else { 1024 };
+        for fd in 3..max {
+            if !keep.contains(&fd) {
+                unsafe {
+                    libc::close(fd);
+                }
             }
         }
     }
@@ -501,6 +810,33 @@ fn close_inherited_descriptors_except(keep: &[RawFd]) {
                 libc::close(devnull);
             }
         }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn close_inherited_linux(keep: &[RawFd]) {
+    let mut kept = [u32::MAX; 8];
+    let mut n = 0usize;
+    for &fd in keep {
+        if fd >= 3 && n < kept.len() {
+            kept[n] = fd as u32;
+            n += 1;
+        }
+    }
+    kept[..n].sort_unstable();
+    let mut start = 3u32;
+    for &fd in &kept[..n] {
+        if fd > start {
+            unsafe {
+                libc::syscall(libc::SYS_close_range, start, fd - 1, 0u32);
+            }
+        }
+        if fd >= start {
+            start = fd.saturating_add(1);
+        }
+    }
+    unsafe {
+        libc::syscall(libc::SYS_close_range, start, u32::MAX, 0u32);
     }
 }
 
@@ -952,6 +1288,58 @@ pub fn wait_with_bounded_output_until_cancelled_with_stdout_observer(
     })
 }
 
+pub fn wait_with_bounded_output_until_cancelled_owned(
+    owner: &mut ExecutionOwner,
+    byte_limit: usize,
+    is_cancelled: impl FnMut() -> bool,
+) -> io::Result<BoundedCommandOutput> {
+    wait_with_bounded_output_until_cancelled_with_stdout_observer_owned(
+        owner,
+        byte_limit,
+        is_cancelled,
+        None,
+    )
+}
+
+pub fn wait_with_bounded_output_until_cancelled_with_stdout_observer_owned(
+    owner: &mut ExecutionOwner,
+    byte_limit: usize,
+    mut is_cancelled: impl FnMut() -> bool,
+    stdout_line_observer: Option<StdoutLineObserver>,
+) -> io::Result<BoundedCommandOutput> {
+    let stdout = owner.child.stdout.take();
+    let stderr = owner.child.stderr.take();
+    let stdout_handle = stdout.map(|stream| {
+        thread::spawn(move || {
+            capture_tail_with_stdout_observer(stream, byte_limit, stdout_line_observer)
+        })
+    });
+    let stderr_handle =
+        stderr.map(|stream| thread::spawn(move || capture_tail(stream, byte_limit)));
+
+    let status = loop {
+        if let Some(outcome) = owner.try_wait_outcome()? {
+            break outcome.into_root_status()?;
+        }
+        if is_cancelled() {
+            break owner.drain_and_reap()?.into_root_status()?;
+        }
+        thread::sleep(Duration::from_millis(100));
+    };
+    let stdout = join_capture(stdout_handle)?;
+    let stderr = join_capture(stderr_handle)?;
+
+    Ok(BoundedCommandOutput {
+        status,
+        stdout: stdout.bytes,
+        stderr: stderr.bytes,
+        capture: CommandCaptureMetadata {
+            stdout: stdout.metadata,
+            stderr: stderr.metadata,
+        },
+    })
+}
+
 /// Wait for an isolated child while retaining bounded output and reporting
 /// liveness at a caller-selected cadence. The caller owns durable state; this
 /// primitive owns only child supervision and process-tree termination.
@@ -1041,9 +1429,13 @@ pub fn wait_with_bounded_output_supervised_guarded(
         };
         if let Some(status) = status {
             let deadline = std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE;
-            break guard
-                .close_after_root_exit(child.id(), deadline)
-                .map(|()| (status, SupervisedCommandTermination::Completed, deadline));
+            break (|| {
+                let identity = guard.execution_identity(child.id())?;
+                guard
+                    .outcome_after_wait(status, identity)?
+                    .into_root_status()
+                    .map(|status| (status, SupervisedCommandTermination::Completed, deadline))
+            })();
         }
         if is_cancelled() {
             let deadline = std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE;
@@ -1254,12 +1646,138 @@ pub fn wait_with_bounded_output_supervised_with_progress_and_passthrough(
     })
 }
 
+pub fn wait_with_bounded_output_supervised_owned(
+    owner: &mut ExecutionOwner,
+    byte_limit: usize,
+    timeout: Duration,
+    heartbeat_interval: Duration,
+    is_cancelled: impl FnMut() -> bool,
+    mut on_heartbeat: impl FnMut(Duration, &str) -> io::Result<()>,
+) -> io::Result<SupervisedCommandOutput> {
+    wait_with_bounded_output_supervised_with_progress_owned(
+        owner,
+        byte_limit,
+        timeout,
+        None,
+        heartbeat_interval,
+        None,
+        is_cancelled,
+        |heartbeat| on_heartbeat(heartbeat.elapsed, &heartbeat.output_tail),
+    )
+}
+
+/// Supervise an [`ExecutionOwner`] with wall-clock and optional structured-progress
+/// deadlines. Cancellation requests owner drain rather than signaling the wait
+/// handle as a workload process group.
+#[allow(clippy::too_many_arguments)]
+pub fn wait_with_bounded_output_supervised_with_progress_owned(
+    owner: &mut ExecutionOwner,
+    byte_limit: usize,
+    timeout: Duration,
+    no_progress_timeout: Option<Duration>,
+    heartbeat_interval: Duration,
+    passthrough: Option<StreamChunkObserver>,
+    mut is_cancelled: impl FnMut() -> bool,
+    mut on_heartbeat: impl FnMut(SupervisedCommandHeartbeat) -> io::Result<()>,
+) -> io::Result<SupervisedCommandOutput> {
+    let stdout = owner.child.stdout.take();
+    let stderr = owner.child.stderr.take();
+    let live_output = Arc::new(Mutex::new(LiveOutputTail::new(byte_limit)));
+    let stdout_handle = stdout.map({
+        let live_output = Arc::clone(&live_output);
+        let passthrough = passthrough.clone();
+        move |stream| {
+            thread::spawn(move || {
+                capture_tail_with_live_snapshot(stream, byte_limit, true, live_output, passthrough)
+            })
+        }
+    });
+    let stderr_handle = stderr.map({
+        let live_output = Arc::clone(&live_output);
+        let passthrough = passthrough.clone();
+        move |stream| {
+            thread::spawn(move || {
+                capture_tail_with_live_snapshot(stream, byte_limit, false, live_output, passthrough)
+            })
+        }
+    });
+    let started = std::time::Instant::now();
+    let mut last_heartbeat = started.checked_sub(heartbeat_interval).unwrap_or(started);
+    let (status, termination) = loop {
+        if let Some(outcome) = owner.try_wait_outcome()? {
+            break (
+                outcome.into_root_status()?,
+                SupervisedCommandTermination::Completed,
+            );
+        }
+        if is_cancelled() {
+            break (
+                owner.drain_and_reap()?.into_root_status()?,
+                SupervisedCommandTermination::Cancelled,
+            );
+        }
+        if started.elapsed() >= timeout {
+            break (
+                owner.drain_and_reap()?.into_root_status()?,
+                SupervisedCommandTermination::TimedOut,
+            );
+        }
+        if no_progress_timeout.is_some_and(|limit| {
+            live_output
+                .lock()
+                .map(|live| {
+                    live.last_progress
+                        .as_ref()
+                        .map(|(_, progress_at)| progress_at.elapsed())
+                        .unwrap_or_else(|| started.elapsed())
+                        >= limit
+                })
+                .unwrap_or(false)
+        }) {
+            break (
+                owner.drain_and_reap()?.into_root_status()?,
+                SupervisedCommandTermination::NoProgress,
+            );
+        }
+        if last_heartbeat.elapsed() >= heartbeat_interval {
+            let heartbeat = live_output
+                .lock()
+                .map(|tail| tail.heartbeat(started.elapsed()))
+                .unwrap_or_default();
+            if let Err(error) = on_heartbeat(heartbeat) {
+                return match owner.drain_and_reap() {
+                    Ok(_) => Err(error),
+                    Err(cleanup_error) => Err(io::Error::other(format!(
+                        "{error}; failed to drain execution owner after heartbeat failure: {cleanup_error}"
+                    ))),
+                };
+            }
+            last_heartbeat = std::time::Instant::now();
+        }
+        thread::sleep(Duration::from_millis(50));
+    };
+    let stdout = join_capture(stdout_handle)?;
+    let stderr = join_capture(stderr_handle)?;
+    Ok(SupervisedCommandOutput {
+        output: BoundedCommandOutput {
+            status,
+            stdout: stdout.bytes,
+            stderr: stderr.bytes,
+            capture: CommandCaptureMetadata {
+                stdout: stdout.metadata,
+                stderr: stderr.metadata,
+            },
+        },
+        termination,
+    })
+}
+
 /// A command can exit before a background descendant closes inherited output
 /// pipes. Stop that remaining process group before joining capture readers.
 ///
-/// Public so callers that run their own wait loop (the agent-task provider
-/// path supervises stdin delivery and liveness itself) can reap an isolated
-/// tree with the same semantics instead of reimplementing them.
+/// This is the unmanaged isolated-group path. Supervised Linux executions must
+/// drain through [`ExecutionOwner`] instead of treating `Child::id` as the
+/// workload process group.
 #[cfg(unix)]
 pub fn terminate_remaining_process_group(root_pid: u32) -> io::Result<()> {
     if !process_group_has_live_member(root_pid) {
@@ -1390,7 +1908,17 @@ fn capture_tail_with_live_snapshot(
 
 pub fn isolate_process_tree(command: &mut Command) {
     #[cfg(unix)]
-    configure_isolated_process_tree(command, -1, -1);
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setpgid(0, 0) != 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
 
     #[cfg(not(unix))]
     {
@@ -1421,21 +1949,18 @@ fn configure_isolated_process_tree(
                     return Err(io::Error::last_os_error());
                 }
                 if root == 0 {
+                    if registration_fd >= 0 {
+                        libc::close(registration_fd);
+                    }
+                    if liveness_read_fd >= 0 {
+                        libc::close(liveness_read_fd);
+                    }
                     if libc::setpgid(0, 0) != 0 {
                         return Err(io::Error::last_os_error());
                     }
-                    if registration_fd >= 0 {
-                        let pid = libc::getpid() as u32;
-                        let bytes = pid.to_ne_bytes();
-                        if libc::write(registration_fd, bytes.as_ptr().cast(), bytes.len())
-                            != bytes.len() as isize
-                        {
-                            return Err(io::Error::last_os_error());
-                        }
-                    }
                     return Ok(());
                 }
-                execution_supervisor_loop(root as u32, liveness_read_fd);
+                execution_supervisor_loop(root as u32, liveness_read_fd, registration_fd);
             }
             #[cfg(not(target_os = "linux"))]
             {
@@ -1480,17 +2005,32 @@ extern "C" fn handle_supervisor_term(_signal: libc::c_int) {
 }
 
 #[cfg(target_os = "linux")]
-fn execution_supervisor_loop(root_pid: u32, liveness_read_fd: RawFd) -> ! {
+fn execution_supervisor_loop(
+    root_pid: u32,
+    liveness_read_fd: RawFd,
+    protocol_write_fd: RawFd,
+) -> ! {
+    let mut identity = [0_u8; EXECUTION_PROTOCOL_IDENTITY_LEN];
+    identity[..4].copy_from_slice(&root_pid.to_ne_bytes());
+    identity[4..].copy_from_slice(&root_pid.to_ne_bytes());
+    if protocol_write_fd < 0 || !write_all_fd(protocol_write_fd, &identity) {
+        unsafe { libc::_exit(1) };
+    }
     // Close the std exec-error pipe write end inherited from Command::spawn.
     // The root child still holds it, so spawn can return on root exec success
     // or receive the root exec errno. Keeping this fd open would block spawn
     // until the supervisor exits.
-    let keep = [liveness_read_fd];
-    close_inherited_descriptors_except(if liveness_read_fd >= 0 {
-        &keep[..1]
-    } else {
-        &[]
-    });
+    let mut keep = [-1; 2];
+    let mut n = 0;
+    if liveness_read_fd >= 0 {
+        keep[n] = liveness_read_fd;
+        n += 1;
+    }
+    if protocol_write_fd >= 0 {
+        keep[n] = protocol_write_fd;
+        n += 1;
+    }
+    close_inherited_descriptors_except(&keep[..n]);
     SUPERVISOR_TEARDOWN.store(0, std::sync::atomic::Ordering::Relaxed);
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_IGN);
@@ -1508,6 +2048,7 @@ fn execution_supervisor_loop(root_pid: u32, liveness_read_fd: RawFd) -> ! {
         }
     }
 
+    let mut liveness_fd = liveness_read_fd;
     let mut root_wait_status = 0;
     let mut root_reaped = false;
     let mut tearing_down = false;
@@ -1537,13 +2078,17 @@ fn execution_supervisor_loop(root_pid: u32, liveness_read_fd: RawFd) -> ! {
                     continue;
                 }
                 if errno == Some(libc::ECHILD) && root_reaped {
-                    supervisor_exit_with_wait_status(root_wait_status);
+                    supervisor_finish(
+                        protocol_write_fd,
+                        EXECUTION_PROTOCOL_COMPLETE,
+                        root_wait_status,
+                    );
                 }
             }
             break;
         }
 
-        let liveness_closed = supervisor_liveness_closed(liveness_read_fd);
+        let liveness_closed = supervisor_liveness_closed(&mut liveness_fd);
         if !tearing_down
             && (SUPERVISOR_TEARDOWN.load(std::sync::atomic::Ordering::Relaxed) != 0
                 || liveness_closed)
@@ -1565,7 +2110,12 @@ fn execution_supervisor_loop(root_pid: u32, liveness_read_fd: RawFd) -> ! {
                     PROCESS_TREE_KILL_GRACE
                 });
             } else {
-                unsafe { libc::_exit(1) };
+                let tag = if root_reaped {
+                    EXECUTION_PROTOCOL_INCOMPLETE
+                } else {
+                    EXECUTION_PROTOCOL_INCOMPLETE_NO_ROOT
+                };
+                supervisor_finish(protocol_write_fd, tag, root_wait_status);
             }
         }
 
@@ -1580,7 +2130,7 @@ fn execution_supervisor_loop(root_pid: u32, liveness_read_fd: RawFd) -> ! {
             );
         }
 
-        supervisor_idle(liveness_read_fd);
+        supervisor_idle(&mut liveness_fd);
     }
 }
 
@@ -1616,38 +2166,58 @@ fn supervisor_deadline_reached(deadline: libc::timespec) -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn supervisor_liveness_closed(fd: RawFd) -> bool {
-    if fd < 0 {
-        return false;
+fn supervisor_disable_liveness(fd: &mut RawFd) {
+    if *fd >= 0 {
+        unsafe {
+            libc::close(*fd);
+        }
+        *fd = -1;
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn supervisor_liveness_closed(fd: &mut RawFd) -> bool {
+    if *fd < 0 {
+        return true;
     }
     let mut byte = 0_u8;
     loop {
-        let read = unsafe { libc::read(fd, (&mut byte as *mut u8).cast(), 1) };
+        let read = unsafe { libc::read(*fd, (&mut byte as *mut u8).cast(), 1) };
         if read == 0 {
+            supervisor_disable_liveness(fd);
             return true;
         }
         if read > 0 {
             continue;
         }
         let errno = io::Error::last_os_error().raw_os_error();
-        return !matches!(errno, Some(libc::EINTR | libc::EAGAIN));
+        if matches!(errno, Some(libc::EINTR | libc::EAGAIN)) {
+            return false;
+        }
+        supervisor_disable_liveness(fd);
+        return true;
     }
 }
 
 #[cfg(target_os = "linux")]
-fn supervisor_idle(fd: RawFd) {
-    if fd >= 0 {
+fn supervisor_idle(fd: &mut RawFd) {
+    if *fd >= 0 {
         let mut pollfd = libc::pollfd {
-            fd,
+            fd: *fd,
             events: libc::POLLIN | libc::POLLHUP,
             revents: 0,
         };
-        unsafe {
+        let result = unsafe {
             libc::poll(
                 &mut pollfd,
                 1,
                 PROCESS_TREE_POLL_INTERVAL.as_millis() as libc::c_int,
-            );
+            )
+        };
+        if result > 0 && pollfd.revents & (libc::POLLHUP | libc::POLLIN | libc::POLLERR) != 0 {
+            if supervisor_liveness_closed(fd) {
+                return;
+            }
         }
         return;
     }
@@ -1686,30 +2256,38 @@ fn supervisor_signal_children(signal: libc::c_int) {
     if fd < 0 {
         return;
     }
-    let mut buf = [0u8; 4096];
-    let read = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
-    unsafe {
-        libc::close(fd);
-    }
-    if read <= 0 {
-        return;
-    }
     let self_pid = unsafe { libc::getpid() } as u32;
+    let mut buf = [0u8; 4096];
     let mut pid = 0u32;
     let mut in_pid = false;
-    for &byte in &buf[..read as usize] {
-        if byte.is_ascii_digit() {
-            in_pid = true;
-            pid = pid.saturating_mul(10).saturating_add((byte - b'0') as u32);
-        } else if in_pid {
-            if pid != 0 && pid != self_pid {
-                unsafe {
-                    libc::kill(pid as libc::pid_t, signal);
-                }
-            }
-            pid = 0;
-            in_pid = false;
+    loop {
+        let read = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+        if read == 0 {
+            break;
         }
+        if read < 0 {
+            if io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            break;
+        }
+        for &byte in &buf[..read as usize] {
+            if byte.is_ascii_digit() {
+                in_pid = true;
+                pid = pid.saturating_mul(10).saturating_add((byte - b'0') as u32);
+            } else if in_pid {
+                if pid != 0 && pid != self_pid {
+                    unsafe {
+                        libc::kill(pid as libc::pid_t, signal);
+                    }
+                }
+                pid = 0;
+                in_pid = false;
+            }
+        }
+    }
+    unsafe {
+        libc::close(fd);
     }
     if in_pid && pid != 0 && pid != self_pid {
         unsafe {
@@ -1719,18 +2297,87 @@ fn supervisor_signal_children(signal: libc::c_int) {
 }
 
 #[cfg(target_os = "linux")]
-fn supervisor_exit_with_wait_status(status: libc::c_int) -> ! {
-    unsafe {
-        if libc::WIFEXITED(status) {
-            libc::_exit(libc::WEXITSTATUS(status));
+fn supervisor_finish(protocol_fd: RawFd, tag: u8, wait_status: libc::c_int) -> ! {
+    if protocol_fd >= 0 {
+        let mut payload = [0_u8; EXECUTION_PROTOCOL_TERMINAL_LEN];
+        payload[0] = tag;
+        payload[1..].copy_from_slice(&(wait_status as i32).to_ne_bytes());
+        let _ = write_all_fd(protocol_fd, &payload);
+        unsafe {
+            libc::close(protocol_fd);
         }
-        if libc::WIFSIGNALED(status) {
-            let signal = libc::WTERMSIG(status);
-            libc::signal(signal, libc::SIG_DFL);
-            libc::raise(signal);
-            libc::_exit(128 + signal);
+    }
+    unsafe { libc::_exit(0) };
+}
+
+#[cfg(target_os = "linux")]
+fn write_all_fd(fd: RawFd, bytes: &[u8]) -> bool {
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let wrote =
+            unsafe { libc::write(fd, bytes[offset..].as_ptr().cast(), bytes.len() - offset) };
+        if wrote < 0 {
+            if io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return false;
         }
-        libc::_exit(1);
+        if wrote == 0 {
+            return false;
+        }
+        offset += wrote as usize;
+    }
+    true
+}
+
+#[cfg(target_os = "linux")]
+fn read_exact_fd(fd: RawFd, bytes: &mut [u8]) -> io::Result<()> {
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let read = unsafe {
+            libc::read(
+                fd,
+                bytes[offset..].as_mut_ptr().cast(),
+                bytes.len() - offset,
+            )
+        };
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "execution owner protocol closed",
+            ));
+        }
+        if read < 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return Err(error);
+        }
+        offset += read as usize;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn read_execution_protocol_outcome(fd: RawFd) -> io::Result<ExecutionOutcome> {
+    use std::os::unix::process::ExitStatusExt;
+    let mut payload = [0_u8; EXECUTION_PROTOCOL_TERMINAL_LEN];
+    read_exact_fd(fd, &mut payload)?;
+    let wait_status = i32::from_ne_bytes(payload[1..].try_into().expect("wait status"));
+    let root_status = ExitStatus::from_raw(wait_status);
+    match payload[0] {
+        EXECUTION_PROTOCOL_COMPLETE => Ok(ExecutionOutcome::complete(root_status)),
+        EXECUTION_PROTOCOL_INCOMPLETE => Ok(ExecutionOutcome {
+            root_status,
+            cleanup: ExecutionCleanup::Incomplete,
+        }),
+        EXECUTION_PROTOCOL_INCOMPLETE_NO_ROOT => Err(io::Error::other(
+            "execution owner cleanup did not complete before root status was observed",
+        )),
+        tag => Err(io::Error::other(format!(
+            "execution owner protocol tag {tag} is invalid"
+        ))),
     }
 }
 
@@ -2147,7 +2794,7 @@ fn reap_exited_process_group_children(root_pid: u32) {
     }
 }
 
-#[cfg(all(unix, not(target_os = "linux")))]
+#[cfg(unix)]
 fn wait_for_process_group_exit(
     child: &mut Child,
     root_pid: u32,
@@ -2717,37 +3364,21 @@ mod adopted_child_reaping_tests {
 /// On platforms without process groups, `Child::kill` still provides portable
 /// termination and reaping of the spawned process.
 pub fn terminate_process_tree_and_reap(child: &mut Child) -> io::Result<ExitStatus> {
-    #[cfg(target_os = "linux")]
-    {
-        let supervisor_pid = child.id();
-        signal_pid(supervisor_pid, libc::SIGTERM)?;
-        match reap_child_until(
-            child,
-            std::time::Instant::now() + PROCESS_TREE_TERM_GRACE + PROCESS_TREE_KILL_GRACE,
-        ) {
-            Ok(status) => Ok(status),
-            Err(_) => {
-                signal_pid(supervisor_pid, libc::SIGKILL)?;
-                reap_child_until(
-                    child,
-                    std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE,
-                )
-            }
-        }
-    }
-
-    #[cfg(all(unix, not(target_os = "linux")))]
+    #[cfg(unix)]
     {
         let root_pid = child.id();
         // Shells can put background jobs in a distinct process group. Snapshot
         // descendants before terminating the root so those jobs cannot retain
         // output pipes and strand capture-reader joins.
+        #[cfg(not(target_os = "linux"))]
         let descendants = descendant_pids(root_pid)?;
         signal_process_group(root_pid, libc::SIGTERM)?;
+        #[cfg(not(target_os = "linux"))]
         signal_pids(&descendants, libc::SIGTERM);
         let mut status = child.try_wait()?;
         if !wait_for_process_group_exit(child, root_pid, PROCESS_TREE_TERM_GRACE, &mut status)? {
             signal_process_group(root_pid, libc::SIGKILL)?;
+            #[cfg(not(target_os = "linux"))]
             signal_pids(&descendants, libc::SIGKILL);
             if !wait_for_process_group_exit(child, root_pid, PROCESS_TREE_KILL_GRACE, &mut status)?
             {
@@ -3385,5 +4016,155 @@ mod tests {
             !process_is_running(descendant_pid as u32),
             "cancellable wait left descendant {descendant_pid} runnable"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_preserves_root_exit_one_as_command_status() {
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", "exit 1"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let mut owner = ExecutionOwner::spawn(&mut command).expect("spawn owner");
+        let identity = owner.identity();
+        #[cfg(target_os = "linux")]
+        assert_ne!(
+            identity.wait_pid, identity.root_pid,
+            "linux supervisor must not share the workload pid"
+        );
+        let output = wait_with_bounded_output_until_cancelled_owned(&mut owner, 64, || false)
+            .expect("root exit 1 is a completed command status");
+        assert_eq!(output.status.code(), Some(1));
+        assert_eq!(identity.recovery_process_group(), identity.root_pid);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_cancel_reaps_term_resistant_descendants() {
+        struct ReapOnDrop(u32);
+        impl Drop for ReapOnDrop {
+            fn drop(&mut self) {
+                if self.0 != 0 && process_is_running(self.0) {
+                    unsafe {
+                        libc::kill(self.0 as libc::pid_t, libc::SIGKILL);
+                    }
+                }
+            }
+        }
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let pid_file = temp.path().join("descendant.pid");
+        let script = format!(
+            "trap '' TERM; sleep 30 & echo $! > {}; wait",
+            crate::shell::quote_path(&pid_file.display().to_string())
+        );
+        let mut command = Command::new("sh");
+        command.args(["-c", &script]);
+        let mut owner = ExecutionOwner::spawn(&mut command).expect("spawn owner");
+        let root_guard = ReapOnDrop(owner.identity().root_pid);
+        let output =
+            wait_with_bounded_output_until_cancelled_owned(&mut owner, 1024, || pid_file.exists())
+                .expect("owner drain cancels the tree");
+        assert!(!output.status.success());
+        let descendant_pid = std::fs::read_to_string(&pid_file)
+            .expect("descendant pid")
+            .trim()
+            .parse::<u32>()
+            .expect("numeric descendant pid");
+        let _descendant_guard = ReapOnDrop(descendant_pid);
+        assert!(
+            !process_is_running(descendant_pid),
+            "owner cancel left TERM-resistant descendant {descendant_pid} runnable"
+        );
+        let _ = root_guard;
+    }
+
+    #[cfg(all(unix, target_os = "linux"))]
+    fn unix_exit_wait_status(code: i32) -> i32 {
+        code << 8
+    }
+
+    #[cfg(all(unix, target_os = "linux"))]
+    fn write_protocol_outcome(tag: u8, wait_status: i32) -> ExecutionOutcome {
+        let mut fds = [-1; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let mut payload = [0_u8; EXECUTION_PROTOCOL_TERMINAL_LEN];
+        payload[0] = tag;
+        payload[1..].copy_from_slice(&wait_status.to_ne_bytes());
+        assert!(write_all_fd(fds[1], &payload));
+        unsafe {
+            libc::close(fds[1]);
+        }
+        let outcome = read_execution_protocol_outcome(fds[0]).expect("read protocol");
+        unsafe {
+            libc::close(fds[0]);
+        }
+        outcome
+    }
+
+    #[cfg(all(unix, target_os = "linux"))]
+    #[test]
+    fn protocol_incomplete_cleanup_is_not_root_exit_one() {
+        let complete =
+            write_protocol_outcome(EXECUTION_PROTOCOL_COMPLETE, unix_exit_wait_status(1));
+        assert_eq!(complete.cleanup, ExecutionCleanup::Complete);
+        assert_eq!(complete.root_status.code(), Some(1));
+        assert_eq!(
+            complete.into_root_status().expect("complete exit 1").code(),
+            Some(1)
+        );
+
+        let incomplete =
+            write_protocol_outcome(EXECUTION_PROTOCOL_INCOMPLETE, unix_exit_wait_status(1));
+        assert_eq!(incomplete.cleanup, ExecutionCleanup::Incomplete);
+        assert_eq!(incomplete.root_status.code(), Some(1));
+        let error = incomplete
+            .into_root_status()
+            .expect_err("incomplete cleanup must not become root exit 1");
+        assert!(
+            error
+                .to_string()
+                .contains("execution owner cleanup did not complete"),
+            "cleanup failure must stay distinct from root exit 1: {error}"
+        );
+    }
+
+    #[cfg(all(unix, target_os = "linux"))]
+    #[test]
+    fn missing_owner_protocol_is_cleanup_failure_not_root_exit_one() {
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", "trap '' TERM; sleep 30"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        let mut owner = ExecutionOwner::spawn(&mut command).expect("spawn owner");
+        let wait_pid = owner.identity().wait_pid;
+        let root_pid = owner.identity().root_pid;
+        unsafe {
+            libc::kill(wait_pid as libc::pid_t, libc::SIGKILL);
+        }
+        let error = loop {
+            match owner.try_wait_outcome() {
+                Ok(Some(outcome)) => {
+                    break outcome
+                        .into_root_status()
+                        .expect_err("killed supervisor without protocol is not root status");
+                }
+                Ok(None) => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => break error,
+            }
+        };
+        assert!(
+            error.to_string().contains("execution owner"),
+            "cleanup failure must not look like root exit 1: {error}"
+        );
+        if process_is_running(root_pid) {
+            unsafe {
+                libc::kill(root_pid as libc::pid_t, libc::SIGKILL);
+            }
+        }
     }
 }

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -15,21 +15,23 @@ use sha2::{Digest, Sha256};
 
 pub const DEFAULT_CAPTURE_LIMIT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_OBSERVED_LINE_BYTES: usize = 64 * 1024;
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 type AdoptedGuard = Option<(u32, Option<u32>, u64)>;
 #[cfg(unix)]
 const PROCESS_TREE_TERM_GRACE: Duration = Duration::from_secs(2);
 #[cfg(unix)]
 const PROCESS_TREE_KILL_GRACE: Duration = Duration::from_secs(2);
+#[cfg(target_os = "linux")]
+const CONTROLLER_LOSS_TERM_GRACE: Duration = Duration::from_millis(200);
+#[cfg(target_os = "linux")]
+const CONTROLLER_LOSS_KILL_GRACE: Duration = Duration::from_millis(400);
 #[cfg(any(unix, windows))]
 const PROCESS_TREE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const CAPTURE_JOIN_GRACE: Duration = Duration::from_secs(2);
 const PROCESS_TREE_CLEANUP_DEADLINE: Duration = Duration::from_secs(4);
 
 #[cfg(target_os = "linux")]
-static CHILD_SUBREAPER_ENABLED: std::sync::OnceLock<io::Result<()>> = std::sync::OnceLock::new();
-#[cfg(target_os = "linux")]
-static CHILD_GUARD_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+static SUPERVISOR_TEARDOWN: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
 
 pub type StdoutLineObserver = Arc<dyn Fn(&str) + Send + Sync + 'static>;
 pub type StreamChunkObserver = Arc<dyn Fn(&[u8], bool) + Send + Sync + 'static>;
@@ -117,9 +119,13 @@ fn linux_process_state(pid: u32) -> Option<char> {
 
 /// Keeps an isolated child tree owned by the controller that spawned it.
 ///
-/// On Unix, a small guard process watches a pipe whose write end is held only
-/// by the controller. Controller exit closes the pipe and the guard kills the
-/// complete child process group, including descendants which ignore SIGTERM.
+/// On Linux, the spawned child is an execution-scoped supervisor: it is the
+/// parent and subreaper for only that command, waits the root separately, and
+/// reaps every descendant — including never-observed adopted zombies — without
+/// consuming unrelated `Child` statuses. Controller exit closes a pipe whose
+/// write end is held only by this guard; the supervisor then tears the tree
+/// down. Other Unix platforms keep a sibling death watcher over the isolated
+/// process group. Windows uses a kill-on-close job object.
 pub struct ControllerChildGuard {
     #[cfg(unix)]
     controller_liveness_read_fd: RawFd,
@@ -129,14 +135,8 @@ pub struct ControllerChildGuard {
     child_registration_read_fd: RawFd,
     #[cfg(unix)]
     child_registration_fd: RawFd,
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "linux")))]
     owned_processes: Mutex<Vec<UnixProcessIdentity>>,
-    #[cfg(target_os = "linux")]
-    controller_pid: u32,
-    #[cfg(target_os = "linux")]
-    guard_pid: Mutex<Option<u32>>,
-    #[cfg(target_os = "linux")]
-    guard_id: u64,
     #[cfg(windows)]
     job: Mutex<windows_sys::Win32::Foundation::HANDLE>,
 }
@@ -147,72 +147,73 @@ impl ControllerChildGuard {
     pub fn prepare(command: &mut Command) -> io::Result<Self> {
         #[cfg(unix)]
         {
-            enable_child_subreaper()?;
-            #[cfg(target_os = "linux")]
-            let guard_id = CHILD_GUARD_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            #[cfg(target_os = "linux")]
-            command.env("HOMEBOY_CHILD_GUARD_ID", guard_id.to_string());
             let mut fds = [-1; 2];
-            let mut registration_fds = [-1; 2];
             if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
                 return Err(io::Error::last_os_error());
             }
-            if unsafe { libc::pipe(registration_fds.as_mut_ptr()) } != 0 {
-                let error = io::Error::last_os_error();
-                unsafe {
-                    libc::close(fds[0]);
-                    libc::close(fds[1]);
-                }
-                return Err(error);
-            }
-            for fd in fds.into_iter().chain(registration_fds) {
+            for fd in fds {
                 if unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) } != 0 {
+                    let error = io::Error::last_os_error();
                     unsafe {
                         libc::close(fds[0]);
                         libc::close(fds[1]);
-                        libc::close(registration_fds[0]);
-                        libc::close(registration_fds[1]);
                     }
-                    return Err(io::Error::last_os_error());
+                    return Err(error);
                 }
             }
-            // The child reports its PID from pre_exec, after it became its own
-            // process-group leader but before it can execute workload code.
-            // That lets the already-running guard cover spawn-to-attach.
-            configure_isolated_process_tree(command, registration_fds[1]);
-            let guard = Self {
-                controller_liveness_read_fd: fds[0],
-                controller_liveness_fd: fds[1],
-                child_registration_read_fd: registration_fds[0],
-                child_registration_fd: registration_fds[1],
-                owned_processes: Mutex::new(Vec::new()),
-                #[cfg(target_os = "linux")]
-                controller_pid: std::process::id(),
-                #[cfg(target_os = "linux")]
-                guard_pid: Mutex::new(None),
-                #[cfg(target_os = "linux")]
-                guard_id,
-            };
-            match unsafe { libc::fork() } {
-                -1 => Err(io::Error::last_os_error()),
-                0 => controller_death_guard_loop(
-                    guard.controller_liveness_read_fd,
-                    guard.controller_liveness_fd,
-                    guard.child_registration_read_fd,
-                    guard.child_registration_fd,
-                ),
-                guard_pid => {
-                    #[cfg(target_os = "linux")]
-                    {
-                        *guard
-                            .guard_pid
-                            .lock()
-                            .map_err(|_| io::Error::other("guard PID lock poisoned"))? =
-                            Some(guard_pid as u32);
+            #[cfg(target_os = "linux")]
+            {
+                configure_isolated_process_tree(command, -1, fds[0]);
+                return Ok(Self {
+                    controller_liveness_read_fd: fds[0],
+                    controller_liveness_fd: fds[1],
+                    child_registration_read_fd: -1,
+                    child_registration_fd: -1,
+                });
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let mut registration_fds = [-1; 2];
+                if unsafe { libc::pipe(registration_fds.as_mut_ptr()) } != 0 {
+                    let error = io::Error::last_os_error();
+                    unsafe {
+                        libc::close(fds[0]);
+                        libc::close(fds[1]);
                     }
-                    #[cfg(not(target_os = "linux"))]
-                    let _ = guard_pid;
-                    Ok(guard)
+                    return Err(error);
+                }
+                for fd in registration_fds {
+                    if unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) } != 0 {
+                        let error = io::Error::last_os_error();
+                        unsafe {
+                            libc::close(fds[0]);
+                            libc::close(fds[1]);
+                            libc::close(registration_fds[0]);
+                            libc::close(registration_fds[1]);
+                        }
+                        return Err(error);
+                    }
+                }
+                // The child reports its PID from pre_exec, after it became its own
+                // process-group leader but before it can execute workload code.
+                // That lets the already-running guard cover spawn-to-attach.
+                configure_isolated_process_tree(command, registration_fds[1], -1);
+                let guard = Self {
+                    controller_liveness_read_fd: fds[0],
+                    controller_liveness_fd: fds[1],
+                    child_registration_read_fd: registration_fds[0],
+                    child_registration_fd: registration_fds[1],
+                    owned_processes: Mutex::new(Vec::new()),
+                };
+                match unsafe { libc::fork() } {
+                    -1 => Err(io::Error::last_os_error()),
+                    0 => controller_death_guard_loop(
+                        guard.controller_liveness_read_fd,
+                        guard.controller_liveness_fd,
+                        guard.child_registration_read_fd,
+                        guard.child_registration_fd,
+                    ),
+                    _guard_pid => Ok(guard),
                 }
             }
         }
@@ -230,9 +231,15 @@ impl ControllerChildGuard {
     /// Record the child after spawn. The guard already runs from `prepare`, so
     /// controller death during this handoff cannot leave workload descendants.
     pub fn attach(&self, child: &Child) -> io::Result<()> {
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_os = "linux")))]
         {
             self.observe_owned_processes(child.id())?;
+            Ok(())
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let _ = child;
             Ok(())
         }
 
@@ -254,7 +261,20 @@ impl ControllerChildGuard {
         child: &mut Child,
         deadline: std::time::Instant,
     ) -> io::Result<ExitStatus> {
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
+        {
+            self.close_liveness_write();
+            signal_pid(child.id(), libc::SIGTERM)?;
+            match reap_child_until(child, deadline) {
+                Ok(status) => Ok(status),
+                Err(_) => {
+                    signal_pid(child.id(), libc::SIGKILL)?;
+                    reap_child_until(child, deadline)
+                }
+            }
+        }
+
+        #[cfg(all(unix, not(target_os = "linux")))]
         {
             let _ = deadline;
             self.observe_owned_processes(child.id())?;
@@ -277,8 +297,10 @@ impl ControllerChildGuard {
         match self.terminate_and_reap(child, deadline) {
             Ok(status) => Ok(status),
             Err(primary) => {
-                #[cfg(unix)]
+                #[cfg(all(unix, not(target_os = "linux")))]
                 let _ = signal_process_group(child.id(), libc::SIGKILL);
+                #[cfg(target_os = "linux")]
+                self.close_liveness_write();
                 let _ = child.kill();
                 reap_child_until(child, deadline).map_err(|fallback| {
                     io::Error::other(format!(
@@ -294,7 +316,13 @@ impl ControllerChildGuard {
         root_pid: u32,
         deadline: std::time::Instant,
     ) -> io::Result<()> {
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
+        {
+            let _ = (root_pid, deadline);
+            Ok(())
+        }
+
+        #[cfg(all(unix, not(target_os = "linux")))]
         {
             let _ = deadline;
             self.observe_owned_processes(root_pid)?;
@@ -323,7 +351,17 @@ impl ControllerChildGuard {
         }
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
+    fn close_liveness_write(&mut self) {
+        if self.controller_liveness_fd >= 0 {
+            unsafe {
+                libc::close(self.controller_liveness_fd);
+            }
+            self.controller_liveness_fd = -1;
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
     fn observe_owned_processes(&self, root_pid: u32) -> io::Result<()> {
         let snapshot = unix_process_snapshot()?;
         let mut owned = self
@@ -334,20 +372,8 @@ impl ControllerChildGuard {
         Ok(())
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "linux")))]
     fn adopted_guard(&self) -> io::Result<AdoptedGuard> {
-        #[cfg(target_os = "linux")]
-        {
-            Ok(Some((
-                self.controller_pid,
-                *self
-                    .guard_pid
-                    .lock()
-                    .map_err(|_| io::Error::other("guard PID lock poisoned"))?,
-                self.guard_id,
-            )))
-        }
-        #[cfg(not(target_os = "linux"))]
         Ok(None)
     }
 
@@ -414,10 +440,22 @@ impl Drop for ControllerChildGuard {
     fn drop(&mut self) {
         #[cfg(unix)]
         unsafe {
-            libc::close(self.controller_liveness_read_fd);
-            libc::close(self.controller_liveness_fd);
-            libc::close(self.child_registration_read_fd);
-            libc::close(self.child_registration_fd);
+            if self.controller_liveness_read_fd >= 0 {
+                libc::close(self.controller_liveness_read_fd);
+                self.controller_liveness_read_fd = -1;
+            }
+            if self.controller_liveness_fd >= 0 {
+                libc::close(self.controller_liveness_fd);
+                self.controller_liveness_fd = -1;
+            }
+            if self.child_registration_read_fd >= 0 {
+                libc::close(self.child_registration_read_fd);
+                self.child_registration_read_fd = -1;
+            }
+            if self.child_registration_fd >= 0 {
+                libc::close(self.child_registration_fd);
+                self.child_registration_fd = -1;
+            }
         }
         #[cfg(windows)]
         if let Ok(mut job) = self.job.lock() {
@@ -466,7 +504,7 @@ fn close_inherited_descriptors_except(keep: &[RawFd]) {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn controller_death_guard_loop(
     read_fd: RawFd,
     write_fd: RawFd,
@@ -538,7 +576,7 @@ fn write_u32_nul(buf: &mut [u8; 12], mut value: u32) -> *const libc::c_char {
 /// descendants by both PID and kernel-reported start time. The root is still
 /// alive when controller death closes the pipe, so session/group escapees remain
 /// connected through PPID for the first snapshot.
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn controller_death_cleanup(root_pid: u32) -> ! {
     const SCRIPT: &str = concat!(
         r#"
@@ -993,7 +1031,7 @@ pub fn wait_with_bounded_output_supervised_guarded(
     let started = std::time::Instant::now();
     let mut last_heartbeat = started.checked_sub(heartbeat_interval).unwrap_or(started);
     let supervision: io::Result<_> = loop {
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_os = "linux")))]
         if let Err(error) = guard.observe_owned_processes(child.id()) {
             break Err(error);
         }
@@ -1224,7 +1262,6 @@ pub fn wait_with_bounded_output_supervised_with_progress_and_passthrough(
 /// tree with the same semantics instead of reimplementing them.
 #[cfg(unix)]
 pub fn terminate_remaining_process_group(root_pid: u32) -> io::Result<()> {
-    enable_child_subreaper()?;
     if !process_group_has_live_member(root_pid) {
         return Ok(());
     }
@@ -1352,11 +1389,8 @@ fn capture_tail_with_live_snapshot(
 }
 
 pub fn isolate_process_tree(command: &mut Command) {
-    // Enable adoption before spawn: descendants that outlive their direct
-    // parent are then reparented here and can be reaped during cleanup.
-    let _ = enable_child_subreaper();
     #[cfg(unix)]
-    configure_isolated_process_tree(command, -1);
+    configure_isolated_process_tree(command, -1, -1);
 
     #[cfg(not(unix))]
     {
@@ -1365,25 +1399,338 @@ pub fn isolate_process_tree(command: &mut Command) {
 }
 
 #[cfg(unix)]
-fn configure_isolated_process_tree(command: &mut Command, registration_fd: RawFd) {
+fn configure_isolated_process_tree(
+    command: &mut Command,
+    registration_fd: RawFd,
+    liveness_read_fd: RawFd,
+) {
     unsafe {
         use std::os::unix::process::CommandExt;
 
         command.pre_exec(move || {
-            if libc::setpgid(0, 0) != 0 {
-                return Err(io::Error::last_os_error());
-            }
-            if registration_fd >= 0 {
-                let pid = libc::getpid() as u32;
-                let bytes = pid.to_ne_bytes();
-                if libc::write(registration_fd, bytes.as_ptr().cast(), bytes.len())
-                    != bytes.len() as isize
-                {
+            #[cfg(target_os = "linux")]
+            {
+                if libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0 {
                     return Err(io::Error::last_os_error());
                 }
+                if libc::setpgid(0, 0) != 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                let root = libc::fork();
+                if root < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if root == 0 {
+                    if libc::setpgid(0, 0) != 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if registration_fd >= 0 {
+                        let pid = libc::getpid() as u32;
+                        let bytes = pid.to_ne_bytes();
+                        if libc::write(registration_fd, bytes.as_ptr().cast(), bytes.len())
+                            != bytes.len() as isize
+                        {
+                            return Err(io::Error::last_os_error());
+                        }
+                    }
+                    return Ok(());
+                }
+                execution_supervisor_loop(root as u32, liveness_read_fd);
             }
-            Ok(())
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = liveness_read_fd;
+                if libc::setpgid(0, 0) != 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if registration_fd >= 0 {
+                    let pid = libc::getpid() as u32;
+                    let bytes = pid.to_ne_bytes();
+                    if libc::write(registration_fd, bytes.as_ptr().cast(), bytes.len())
+                        != bytes.len() as isize
+                    {
+                        return Err(io::Error::last_os_error());
+                    }
+                }
+                Ok(())
+            }
         });
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn signal_pid(pid: u32, signal: libc::c_int) -> io::Result<()> {
+    if pid == 0 || pid > i32::MAX as u32 {
+        return Ok(());
+    }
+    unsafe {
+        if libc::kill(pid as libc::pid_t, signal) != 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+extern "C" fn handle_supervisor_term(_signal: libc::c_int) {
+    SUPERVISOR_TEARDOWN.store(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(target_os = "linux")]
+fn execution_supervisor_loop(root_pid: u32, liveness_read_fd: RawFd) -> ! {
+    // Close the std exec-error pipe write end inherited from Command::spawn.
+    // The root child still holds it, so spawn can return on root exec success
+    // or receive the root exec errno. Keeping this fd open would block spawn
+    // until the supervisor exits.
+    let keep = [liveness_read_fd];
+    close_inherited_descriptors_except(if liveness_read_fd >= 0 {
+        &keep[..1]
+    } else {
+        &[]
+    });
+    SUPERVISOR_TEARDOWN.store(0, std::sync::atomic::Ordering::Relaxed);
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+        let mut action: libc::sigaction = std::mem::zeroed();
+        action.sa_sigaction = handle_supervisor_term as *const () as libc::sighandler_t;
+        if libc::sigemptyset(&mut action.sa_mask) != 0
+            || libc::sigaction(libc::SIGTERM, &action, std::ptr::null_mut()) != 0
+        {
+            libc::_exit(1);
+        }
+        if liveness_read_fd >= 0
+            && libc::fcntl(liveness_read_fd, libc::F_SETFL, libc::O_NONBLOCK) == -1
+        {
+            libc::_exit(1);
+        }
+    }
+
+    let mut root_wait_status = 0;
+    let mut root_reaped = false;
+    let mut tearing_down = false;
+    let mut kill_phase = false;
+    let mut controller_loss = false;
+    let mut phase_deadline = supervisor_now();
+
+    loop {
+        loop {
+            let mut status = 0;
+            let reaped = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
+            if reaped > 0 {
+                if reaped == root_pid as libc::pid_t {
+                    root_wait_status = status;
+                    root_reaped = true;
+                    if !tearing_down {
+                        tearing_down = true;
+                        kill_phase = false;
+                        phase_deadline = supervisor_deadline(PROCESS_TREE_TERM_GRACE);
+                    }
+                }
+                continue;
+            }
+            if reaped < 0 {
+                let errno = io::Error::last_os_error().raw_os_error();
+                if errno == Some(libc::EINTR) {
+                    continue;
+                }
+                if errno == Some(libc::ECHILD) && root_reaped {
+                    supervisor_exit_with_wait_status(root_wait_status);
+                }
+            }
+            break;
+        }
+
+        let liveness_closed = supervisor_liveness_closed(liveness_read_fd);
+        if !tearing_down
+            && (SUPERVISOR_TEARDOWN.load(std::sync::atomic::Ordering::Relaxed) != 0
+                || liveness_closed)
+        {
+            tearing_down = true;
+            controller_loss = liveness_closed;
+            kill_phase = false;
+            phase_deadline = supervisor_deadline(if controller_loss {
+                CONTROLLER_LOSS_TERM_GRACE
+            } else {
+                PROCESS_TREE_TERM_GRACE
+            });
+        } else if tearing_down && supervisor_deadline_reached(phase_deadline) {
+            if !kill_phase {
+                kill_phase = true;
+                phase_deadline = supervisor_deadline(if controller_loss {
+                    CONTROLLER_LOSS_KILL_GRACE
+                } else {
+                    PROCESS_TREE_KILL_GRACE
+                });
+            } else {
+                unsafe { libc::_exit(1) };
+            }
+        }
+
+        if tearing_down {
+            supervisor_signal_remaining(
+                root_pid,
+                if kill_phase {
+                    libc::SIGKILL
+                } else {
+                    libc::SIGTERM
+                },
+            );
+        }
+
+        supervisor_idle(liveness_read_fd);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn supervisor_now() -> libc::timespec {
+    let mut now = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    if unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now) } != 0 {
+        unsafe { libc::_exit(1) };
+    }
+    now
+}
+
+#[cfg(target_os = "linux")]
+fn supervisor_deadline(grace: Duration) -> libc::timespec {
+    let mut deadline = supervisor_now();
+    deadline.tv_sec += grace.as_secs() as libc::time_t;
+    deadline.tv_nsec += grace.subsec_nanos() as libc::c_long;
+    if deadline.tv_nsec >= 1_000_000_000 {
+        deadline.tv_sec += 1;
+        deadline.tv_nsec -= 1_000_000_000;
+    }
+    deadline
+}
+
+#[cfg(target_os = "linux")]
+fn supervisor_deadline_reached(deadline: libc::timespec) -> bool {
+    let now = supervisor_now();
+    now.tv_sec > deadline.tv_sec
+        || (now.tv_sec == deadline.tv_sec && now.tv_nsec >= deadline.tv_nsec)
+}
+
+#[cfg(target_os = "linux")]
+fn supervisor_liveness_closed(fd: RawFd) -> bool {
+    if fd < 0 {
+        return false;
+    }
+    let mut byte = 0_u8;
+    loop {
+        let read = unsafe { libc::read(fd, (&mut byte as *mut u8).cast(), 1) };
+        if read == 0 {
+            return true;
+        }
+        if read > 0 {
+            continue;
+        }
+        let errno = io::Error::last_os_error().raw_os_error();
+        return !matches!(errno, Some(libc::EINTR | libc::EAGAIN));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn supervisor_idle(fd: RawFd) {
+    if fd >= 0 {
+        let mut pollfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN | libc::POLLHUP,
+            revents: 0,
+        };
+        unsafe {
+            libc::poll(
+                &mut pollfd,
+                1,
+                PROCESS_TREE_POLL_INTERVAL.as_millis() as libc::c_int,
+            );
+        }
+        return;
+    }
+    let mut sleep_for = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: PROCESS_TREE_POLL_INTERVAL.as_nanos() as libc::c_long,
+    };
+    unsafe {
+        libc::nanosleep(&mut sleep_for, std::ptr::null_mut());
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn supervisor_signal_remaining(root_pid: u32, signal: libc::c_int) {
+    unsafe {
+        libc::kill(-(root_pid as libc::pid_t), signal);
+    }
+    supervisor_signal_children(signal);
+}
+
+#[cfg(target_os = "linux")]
+fn supervisor_signal_children(signal: libc::c_int) {
+    let mut path = [0u8; 64];
+    let prefix = b"/proc/self/task/";
+    path[..prefix.len()].copy_from_slice(prefix);
+    let mut pid_buf = [0u8; 12];
+    let pid = write_u32_nul(&mut pid_buf, unsafe { libc::getpid() } as u32);
+    let pid_bytes = unsafe { std::ffi::CStr::from_ptr(pid) }.to_bytes();
+    let mut offset = prefix.len();
+    path[offset..offset + pid_bytes.len()].copy_from_slice(pid_bytes);
+    offset += pid_bytes.len();
+    let suffix = b"/children";
+    path[offset..offset + suffix.len()].copy_from_slice(suffix);
+    path[offset + suffix.len()] = 0;
+    let fd = unsafe { libc::open(path.as_ptr().cast(), libc::O_RDONLY | libc::O_CLOEXEC) };
+    if fd < 0 {
+        return;
+    }
+    let mut buf = [0u8; 4096];
+    let read = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+    unsafe {
+        libc::close(fd);
+    }
+    if read <= 0 {
+        return;
+    }
+    let self_pid = unsafe { libc::getpid() } as u32;
+    let mut pid = 0u32;
+    let mut in_pid = false;
+    for &byte in &buf[..read as usize] {
+        if byte.is_ascii_digit() {
+            in_pid = true;
+            pid = pid.saturating_mul(10).saturating_add((byte - b'0') as u32);
+        } else if in_pid {
+            if pid != 0 && pid != self_pid {
+                unsafe {
+                    libc::kill(pid as libc::pid_t, signal);
+                }
+            }
+            pid = 0;
+            in_pid = false;
+        }
+    }
+    if in_pid && pid != 0 && pid != self_pid {
+        unsafe {
+            libc::kill(pid as libc::pid_t, signal);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn supervisor_exit_with_wait_status(status: libc::c_int) -> ! {
+    unsafe {
+        if libc::WIFEXITED(status) {
+            libc::_exit(libc::WEXITSTATUS(status));
+        }
+        if libc::WIFSIGNALED(status) {
+            let signal = libc::WTERMSIG(status);
+            libc::signal(signal, libc::SIG_DFL);
+            libc::raise(signal);
+            libc::_exit(128 + signal);
+        }
+        libc::_exit(1);
     }
 }
 
@@ -1401,7 +1748,7 @@ fn signal_process_group(root_pid: u32, signal: libc::c_int) -> io::Result<()> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn descendant_pids(root_pid: u32) -> io::Result<Vec<u32>> {
     // Process-tree cleanup is controller infrastructure, not workload code. It
     // must remain available when a caller replaces the ambient PATH.
@@ -1430,42 +1777,12 @@ fn descendant_pids(root_pid: u32) -> io::Result<Vec<u32>> {
     Ok(descendants)
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct UnixProcessIdentity {
     pid: u32,
     parent_pid: u32,
-    #[cfg(not(target_os = "linux"))]
     started_at: String,
-    #[cfg(target_os = "linux")]
-    starttime_ticks: u64,
-}
-
-#[cfg(target_os = "linux")]
-fn unix_process_snapshot() -> io::Result<Vec<UnixProcessIdentity>> {
-    let mut processes = Vec::new();
-    let entries = std::fs::read_dir("/proc")
-        .map_err(|error| io::Error::other(format!("process identity discovery failed: {error}")))?;
-    for entry in entries.flatten() {
-        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
-            continue;
-        };
-        if pid == 0 || pid > i32::MAX as u32 {
-            continue;
-        }
-        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
-            continue;
-        };
-        let Some(parsed) = parse_linux_proc_stat(&stat) else {
-            continue;
-        };
-        processes.push(UnixProcessIdentity {
-            pid,
-            parent_pid: parsed.parent_pid,
-            starttime_ticks: parsed.starttime_ticks,
-        });
-    }
-    Ok(processes)
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
@@ -1496,13 +1813,14 @@ fn unix_process_snapshot() -> io::Result<Vec<UnixProcessIdentity>> {
         .collect())
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn extend_owned_processes(
     owned: &mut Vec<UnixProcessIdentity>,
     root_pid: u32,
     snapshot: &[UnixProcessIdentity],
     adopted: AdoptedGuard,
 ) -> io::Result<()> {
+    let _ = adopted;
     if owned.is_empty() {
         if let Some(root) = snapshot.iter().find(|process| process.pid == root_pid) {
             owned.push(root.clone());
@@ -1514,17 +1832,7 @@ fn extend_owned_processes(
             if owned.iter().any(|known| known.pid == process.pid) {
                 continue;
             }
-            let adopted_descendant = if let Some((controller_pid, guard_pid, guard_id)) = adopted {
-                process.parent_pid == controller_pid
-                    && Some(process.pid) != guard_pid
-                    && linux_thread_group_leader(process.pid)?
-                    && live_process_has_guard_id(process, guard_id)?
-            } else {
-                false
-            };
-            if adopted_descendant
-                || owned_contains_matching_parent(owned, snapshot, process.parent_pid)
-            {
+            if owned_contains_matching_parent(owned, snapshot, process.parent_pid) {
                 owned.push(process.clone());
                 changed = true;
             }
@@ -1536,90 +1844,12 @@ fn extend_owned_processes(
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
-fn interpret_owned_environ_contents(
-    pid: u32,
-    expected: &[u8],
-    result: io::Result<Vec<u8>>,
-) -> io::Result<bool> {
-    match result {
-        Ok(environment) => Ok(environment
-            .split(|byte| *byte == 0)
-            .any(|entry| entry == expected)),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(io::Error::other(format!(
-            "owned process {pid} environment is unverifiable: {error}"
-        ))),
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn interpret_owned_status_tgid(pid: u32, result: io::Result<String>) -> io::Result<Option<u32>> {
-    match result {
-        Ok(status) => Ok(status.lines().find_map(|line| {
-            line.strip_prefix("Tgid:")
-                .and_then(|value| value.trim().parse().ok())
-        })),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(io::Error::other(format!(
-            "owned process {pid} status is unverifiable: {error}"
-        ))),
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn linux_thread_group_leader(pid: u32) -> io::Result<bool> {
-    match interpret_owned_status_tgid(pid, std::fs::read_to_string(format!("/proc/{pid}/status")))?
-    {
-        Some(tgid) => Ok(tgid == pid),
-        None => Ok(false),
-    }
-}
-
 #[cfg(all(unix, not(target_os = "linux")))]
-fn linux_thread_group_leader(_pid: u32) -> io::Result<bool> {
-    Ok(true)
-}
-
-#[cfg(target_os = "linux")]
-fn live_process_has_guard_id(process: &UnixProcessIdentity, guard_id: u64) -> io::Result<bool> {
-    match inspect_owned_identity(process)? {
-        OwnedPresence::Live => process_has_guard_id(process.pid, guard_id),
-        _ => Ok(false),
-    }
-}
-
-#[cfg(all(unix, not(target_os = "linux")))]
-fn live_process_has_guard_id(_process: &UnixProcessIdentity, _guard_id: u64) -> io::Result<bool> {
-    Ok(false)
-}
-
-#[cfg(target_os = "linux")]
-fn process_has_guard_id(pid: u32, guard_id: u64) -> io::Result<bool> {
-    let expected = format!("HOMEBOY_CHILD_GUARD_ID={guard_id}");
-    interpret_owned_environ_contents(
-        pid,
-        expected.as_bytes(),
-        std::fs::read(format!("/proc/{pid}/environ")),
-    )
-}
-
-#[cfg(unix)]
 fn owned_identity_matches(known: &UnixProcessIdentity, current: &UnixProcessIdentity) -> bool {
-    if known.pid != current.pid {
-        return false;
-    }
-    #[cfg(target_os = "linux")]
-    {
-        known.starttime_ticks == current.starttime_ticks
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        known.started_at == current.started_at
-    }
+    known.pid == current.pid && known.started_at == current.started_at
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn owned_contains_matching_parent(
     owned: &[UnixProcessIdentity],
     snapshot: &[UnixProcessIdentity],
@@ -1633,52 +1863,7 @@ fn owned_contains_matching_parent(
     })
 }
 
-#[cfg(target_os = "linux")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OwnedPresence {
-    Gone,
-    Reused,
-    Live,
-    Zombie { parent_pid: u32 },
-}
-
-#[cfg(target_os = "linux")]
-fn interpret_owned_stat_contents(
-    pid: u32,
-    result: io::Result<String>,
-) -> io::Result<Option<LinuxProcStat>> {
-    match result {
-        Ok(body) => parse_linux_proc_stat(&body).map(Some).ok_or_else(|| {
-            io::Error::other(format!("owned process {pid} has invalid stat metadata"))
-        }),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(io::Error::other(format!(
-            "owned process {pid} identity is unverifiable: {error}"
-        ))),
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn inspect_owned_identity(known: &UnixProcessIdentity) -> io::Result<OwnedPresence> {
-    let Some(stat) = interpret_owned_stat_contents(
-        known.pid,
-        std::fs::read_to_string(format!("/proc/{}/stat", known.pid)),
-    )?
-    else {
-        return Ok(OwnedPresence::Gone);
-    };
-    if stat.starttime_ticks != known.starttime_ticks {
-        return Ok(OwnedPresence::Reused);
-    }
-    if stat.state == 'Z' {
-        return Ok(OwnedPresence::Zombie {
-            parent_pid: stat.parent_pid,
-        });
-    }
-    Ok(OwnedPresence::Live)
-}
-
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn terminate_owned_processes_and_reap(
     child: &mut Child,
     owned_processes: &Mutex<Vec<UnixProcessIdentity>>,
@@ -1718,7 +1903,7 @@ fn terminate_owned_processes_and_reap(
     status.map(Ok).unwrap_or_else(|| child.wait())
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn terminate_owned_processes_after_root_exit(
     root_pid: u32,
     owned_processes: &Mutex<Vec<UnixProcessIdentity>>,
@@ -1751,7 +1936,7 @@ fn terminate_owned_processes_after_root_exit(
     ))
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn wait_for_owned_process_exit(
     child: &mut Child,
     root_pid: u32,
@@ -1779,7 +1964,7 @@ fn wait_for_owned_process_exit(
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn wait_for_owned_process_exit_without_child(
     root_pid: u32,
     owned: &mut Vec<UnixProcessIdentity>,
@@ -1800,7 +1985,7 @@ fn wait_for_owned_process_exit_without_child(
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn drain_owned_processes(
     owned: &mut Vec<UnixProcessIdentity>,
     root_pid: u32,
@@ -1818,7 +2003,7 @@ fn drain_owned_processes(
     Ok(owned.len() == discovered)
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn signal_and_reap_owned(
     owned: &[UnixProcessIdentity],
     root_pid: u32,
@@ -1826,80 +2011,23 @@ fn signal_and_reap_owned(
     adopted: AdoptedGuard,
 ) -> io::Result<bool> {
     let mut remaining = false;
-    #[cfg(target_os = "linux")]
-    {
-        let controller_pid = adopted.map(|(pid, _, _)| pid);
-        let guard_pid = adopted.and_then(|(_, guard, _)| guard);
-        for known in owned {
-            match inspect_owned_identity(known)? {
-                OwnedPresence::Gone | OwnedPresence::Reused => {}
-                OwnedPresence::Live => {
-                    unsafe {
-                        let _ = libc::kill(known.pid as libc::pid_t, signal);
-                    }
-                    remaining = true;
-                }
-                OwnedPresence::Zombie { parent_pid } => {
-                    if known.pid == root_pid || Some(known.pid) == guard_pid {
-                        remaining = true;
-                        continue;
-                    }
-                    if controller_pid == Some(std::process::id())
-                        && parent_pid == std::process::id()
-                    {
-                        waitpid_exact_nohang(known.pid)?;
-                        if !matches!(
-                            inspect_owned_identity(known)?,
-                            OwnedPresence::Gone | OwnedPresence::Reused
-                        ) {
-                            remaining = true;
-                        }
-                    }
-                }
+    let snapshot = unix_process_snapshot()?;
+    for known in owned {
+        let Some(current) = snapshot.iter().find(|process| process.pid == known.pid) else {
+            continue;
+        };
+        if owned_identity_matches(known, current) && process_is_running(known.pid) {
+            unsafe {
+                let _ = libc::kill(known.pid as libc::pid_t, signal);
             }
+            remaining = true;
         }
-        return Ok(remaining);
     }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let snapshot = unix_process_snapshot()?;
-        for known in owned {
-            let Some(current) = snapshot.iter().find(|process| process.pid == known.pid) else {
-                continue;
-            };
-            if owned_identity_matches(known, current) && process_is_running(known.pid) {
-                unsafe {
-                    let _ = libc::kill(known.pid as libc::pid_t, signal);
-                }
-                remaining = true;
-            }
-        }
-        let _ = (root_pid, adopted);
-        Ok(remaining)
-    }
+    let _ = (root_pid, adopted);
+    Ok(remaining)
 }
 
-#[cfg(target_os = "linux")]
-fn waitpid_exact_nohang(pid: u32) -> io::Result<bool> {
-    loop {
-        let mut status = 0;
-        let reaped = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
-        if reaped == pid as libc::pid_t {
-            return Ok(true);
-        }
-        if reaped == 0 {
-            return Ok(false);
-        }
-        let error = io::Error::last_os_error();
-        match error.raw_os_error() {
-            Some(libc::EINTR) => continue,
-            Some(libc::ECHILD) => return Ok(false),
-            _ => return Err(error),
-        }
-    }
-}
-
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn signal_pids(pids: &[u32], signal: libc::c_int) {
     for pid in pids {
         unsafe {
@@ -2019,7 +2147,7 @@ fn reap_exited_process_group_children(root_pid: u32) {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn wait_for_process_group_exit(
     child: &mut Child,
     root_pid: u32,
@@ -2068,7 +2196,6 @@ fn wait_for_process_group_exit_without_child(root_pid: u32, grace: Duration) -> 
 #[cfg(all(test, target_os = "linux"))]
 mod process_group_liveness_tests {
     use super::*;
-    use std::io;
     use std::process::{Command, Stdio};
 
     /// A process group whose only remaining member is a zombie is not alive.
@@ -2140,84 +2267,6 @@ mod process_group_liveness_tests {
         assert_eq!(parsed.state, 'Z');
         assert_eq!(parsed.parent_pid, 1);
         assert_eq!(parsed.starttime_ticks, 4242);
-    }
-
-    #[test]
-    fn owned_stat_not_found_is_gone() {
-        let gone = interpret_owned_stat_contents(
-            42,
-            Err(io::Error::new(io::ErrorKind::NotFound, "missing")),
-        )
-        .expect("not found is gone");
-        assert!(gone.is_none());
-    }
-
-    #[test]
-    fn owned_stat_permission_denied_is_unverifiable() {
-        let error = interpret_owned_stat_contents(
-            42,
-            Err(io::Error::new(io::ErrorKind::PermissionDenied, "denied")),
-        )
-        .expect_err("permission denied cannot prove drain");
-        assert!(error.to_string().contains("unverifiable"));
-    }
-
-    #[test]
-    fn owned_stat_invalid_metadata_is_unverifiable() {
-        let error = interpret_owned_stat_contents(42, Ok("not-a-stat".to_string()))
-            .expect_err("invalid metadata cannot prove drain");
-        assert!(error.to_string().contains("invalid stat metadata"));
-    }
-
-    #[test]
-    fn owned_status_permission_denied_is_unverifiable() {
-        let error = interpret_owned_status_tgid(
-            42,
-            Err(io::Error::new(io::ErrorKind::PermissionDenied, "denied")),
-        )
-        .expect_err("inaccessible status cannot prove a process is not adopted");
-        assert!(error.to_string().contains("unverifiable"));
-    }
-
-    #[test]
-    fn owned_status_not_found_is_not_a_leader() {
-        assert!(interpret_owned_status_tgid(
-            42,
-            Err(io::Error::new(io::ErrorKind::NotFound, "missing")),
-        )
-        .expect("gone process")
-        .is_none());
-    }
-
-    #[test]
-    fn owned_environ_not_found_is_not_adopted() {
-        assert!(!interpret_owned_environ_contents(
-            42,
-            b"HOMEBOY_CHILD_GUARD_ID=7",
-            Err(io::Error::new(io::ErrorKind::NotFound, "missing")),
-        )
-        .expect("gone process is not adopted"));
-    }
-
-    #[test]
-    fn owned_environ_permission_denied_is_unverifiable() {
-        let error = interpret_owned_environ_contents(
-            42,
-            b"HOMEBOY_CHILD_GUARD_ID=7",
-            Err(io::Error::new(io::ErrorKind::PermissionDenied, "denied")),
-        )
-        .expect_err("inaccessible adopted child cannot yield success");
-        assert!(error.to_string().contains("unverifiable"));
-    }
-
-    #[test]
-    fn owned_environ_matching_guard_id_is_adopted() {
-        assert!(interpret_owned_environ_contents(
-            42,
-            b"HOMEBOY_CHILD_GUARD_ID=7",
-            Ok(b"HOME=/\0HOMEBOY_CHILD_GUARD_ID=7\0".to_vec()),
-        )
-        .expect("readable matching environ"));
     }
 }
 
@@ -2308,7 +2357,6 @@ mod supervisor_zombie_guard_tests {
 mod adopted_child_reaping_tests {
     use super::*;
     use std::ffi::CString;
-    use std::io;
     use std::os::unix::process::CommandExt;
     use std::path::Path;
     use std::process::{Command, Stdio};
@@ -2368,166 +2416,29 @@ mod adopted_child_reaping_tests {
     }
 
     #[test]
-    fn extend_owned_processes_does_not_follow_a_reused_parent_pid() {
-        let mut owned = vec![UnixProcessIdentity {
-            pid: 10,
-            parent_pid: 1,
-            starttime_ticks: 100,
-        }];
-        let snapshot = vec![
-            UnixProcessIdentity {
-                pid: 10,
-                parent_pid: 1,
-                starttime_ticks: 999,
-            },
-            UnixProcessIdentity {
-                pid: 11,
-                parent_pid: 10,
-                starttime_ticks: 200,
-            },
-        ];
-        extend_owned_processes(&mut owned, 10, &snapshot, None).expect("extend");
-        assert!(
-            owned.iter().all(|process| process.pid != 11),
-            "a child of a reused parent PID must not be adopted"
-        );
-        assert_eq!(owned[0].starttime_ticks, 100);
-    }
-
-    #[test]
-    fn extend_owned_processes_follows_a_still_matching_parent() {
-        let mut owned = vec![UnixProcessIdentity {
-            pid: 10,
-            parent_pid: 1,
-            starttime_ticks: 100,
-        }];
-        let snapshot = vec![
-            UnixProcessIdentity {
-                pid: 10,
-                parent_pid: 1,
-                starttime_ticks: 100,
-            },
-            UnixProcessIdentity {
-                pid: 11,
-                parent_pid: 10,
-                starttime_ticks: 200,
-            },
-        ];
-        extend_owned_processes(&mut owned, 10, &snapshot, None).expect("extend");
-        assert!(
-            owned
-                .iter()
-                .any(|process| process.pid == 11 && process.starttime_ticks == 200),
-            "a child of a still-matching parent remains owned"
-        );
-    }
-
-    #[test]
-    fn extend_owned_processes_picks_up_a_late_parent_chain_descendant() {
-        let mut owned = vec![UnixProcessIdentity {
-            pid: 10,
-            parent_pid: 1,
-            starttime_ticks: 100,
-        }];
-        let first = [UnixProcessIdentity {
-            pid: 10,
-            parent_pid: 1,
-            starttime_ticks: 100,
-        }];
-        extend_owned_processes(&mut owned, 10, &first, None).expect("first extend");
-        assert_eq!(owned.len(), 1);
-        let later = [
-            UnixProcessIdentity {
-                pid: 10,
-                parent_pid: 1,
-                starttime_ticks: 100,
-            },
-            UnixProcessIdentity {
-                pid: 12,
-                parent_pid: 10,
-                starttime_ticks: 300,
-            },
-        ];
-        extend_owned_processes(&mut owned, 10, &later, None).expect("late extend");
-        assert!(
-            owned
-                .iter()
-                .any(|process| process.pid == 12 && process.starttime_ticks == 300),
-            "a descendant that appears after the first scan must still be claimed"
-        );
-    }
-
-    #[test]
-    fn adopted_zombie_waitpid_consumes_only_owned_descendant_status() {
-        let mut sibling = Command::new("sh");
-        sibling
-            .args(["-c", "exec sleep 30"])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .process_group(0);
-        let mut sibling = sibling.spawn().expect("spawn unrelated child");
-        let sibling_pid = sibling.id();
-        let sibling_ticks = linux_process_stat(sibling_pid)
-            .expect("sibling start identity")
-            .starttime_ticks;
-
-        let child_pid = unsafe { libc::fork() };
-        assert_ne!(child_pid, -1, "fork adopted child");
-        if child_pid == 0 {
+    #[ignore = "subprocess fixture for an immediately-exiting reparented descendant"]
+    fn guarded_instant_double_fork_fixture() {
+        let intermediate = unsafe { libc::fork() };
+        assert_ne!(intermediate, -1, "fork intermediate");
+        if intermediate == 0 {
+            let daemon = unsafe { libc::fork() };
+            if daemon < 0 {
+                unsafe { libc::_exit(2) };
+            }
+            if daemon > 0 {
+                unsafe { libc::_exit(0) };
+            }
+            if unsafe { libc::setsid() } == -1 {
+                unsafe { libc::_exit(3) };
+            }
             unsafe { libc::_exit(0) };
         }
-        let child_pid = child_pid as u32;
-        let deadline = Instant::now() + Duration::from_secs(2);
-        let child_stat = loop {
-            if let Some(stat) = linux_process_stat(child_pid) {
-                if stat.state == 'Z' && stat.parent_pid == std::process::id() {
-                    break stat;
-                }
-            }
-            assert!(
-                Instant::now() < deadline,
-                "forked child never became an owned zombie"
-            );
-            thread::sleep(Duration::from_millis(5));
-        };
-
-        let owned = vec![UnixProcessIdentity {
-            pid: child_pid,
-            parent_pid: std::process::id(),
-            starttime_ticks: child_stat.starttime_ticks,
-        }];
-        signal_and_reap_owned(
-            &owned,
-            sibling_pid,
-            libc::SIGTERM,
-            Some((std::process::id(), None, 1)),
-        )
-        .expect("reap owned adopted zombie");
-        assert_eq!(
-            inspect_owned_identity(&owned[0]).expect("owned descendant after reap"),
-            OwnedPresence::Gone,
-            "owned adopted zombie must be gone after its wait status is consumed"
-        );
         let mut status = 0;
-        let reaped = unsafe { libc::waitpid(child_pid as libc::pid_t, &mut status, libc::WNOHANG) };
         assert_eq!(
-            reaped, -1,
-            "owned descendant wait status must already be consumed"
+            unsafe { libc::waitpid(intermediate, &mut status, 0) },
+            intermediate,
+            "reap intermediate"
         );
-        assert_eq!(
-            io::Error::last_os_error().raw_os_error(),
-            Some(libc::ECHILD)
-        );
-        assert!(
-            sibling.try_wait().expect("sibling status").is_none(),
-            "sibling Child status must remain available"
-        );
-        assert_eq!(
-            linux_process_stat(sibling_pid).map(|stat| stat.starttime_ticks),
-            Some(sibling_ticks)
-        );
-        let _ = sibling.kill();
-        let _ = sibling.wait();
     }
 
     fn wait_for_recorded_pid(path: &Path, deadline: Instant) -> u32 {
@@ -2673,15 +2584,160 @@ mod adopted_child_reaping_tests {
             "unrelated child identity must remain the recorded process"
         );
     }
+
+    fn our_zombie_pids() -> Vec<u32> {
+        let self_pid = std::process::id();
+        let mut zombies = Vec::new();
+        let Ok(entries) = std::fs::read_dir("/proc") else {
+            return zombies;
+        };
+        for entry in entries.flatten() {
+            let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
+                continue;
+            };
+            let Some(stat) = linux_process_stat(pid) else {
+                continue;
+            };
+            if stat.state == 'Z' && stat.parent_pid == self_pid {
+                zombies.push(pid);
+            }
+        }
+        zombies
+    }
+
+    fn run_instant_double_fork() -> SupervisedCommandOutput {
+        let test_binary = std::env::current_exe().expect("test executable");
+        let mut command = Command::new(&test_binary);
+        command
+            .args([
+                "--ignored",
+                "--exact",
+                "command::adopted_child_reaping_tests::guarded_instant_double_fork_fixture",
+                "--nocapture",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut guard = ControllerChildGuard::prepare(&mut command).expect("prepare guard");
+        let mut child = command.spawn().expect("spawn instant double-fork root");
+        guard.attach(&child).expect("attach guard");
+        wait_with_bounded_output_supervised_guarded(
+            &mut child,
+            &mut guard,
+            4096,
+            Duration::from_secs(2),
+            Duration::from_millis(50),
+            || false,
+            |_, _| Ok(()),
+        )
+        .expect("instant double-fork root completes")
+    }
+
+    #[test]
+    fn guarded_completion_reaps_instant_double_fork_without_touching_sibling() {
+        let mut sibling = Command::new("sh");
+        sibling
+            .args(["-c", "exec sleep 30"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let sibling = sibling.spawn().expect("spawn unrelated child");
+        let sibling_pid = sibling.id();
+        let sibling_ticks = linux_process_stat(sibling_pid)
+            .expect("sibling start identity")
+            .starttime_ticks;
+        let mut sibling = KillChildOnDrop(Some(sibling));
+        let zombies_before = our_zombie_pids();
+
+        let supervised = run_instant_double_fork();
+        assert_eq!(
+            supervised.termination,
+            SupervisedCommandTermination::Completed
+        );
+        assert_eq!(
+            our_zombie_pids(),
+            zombies_before,
+            "never-observed adopted descendant became a controller zombie"
+        );
+
+        let sibling_child = sibling.0.as_mut().expect("sibling child");
+        assert!(
+            sibling_child.try_wait().expect("sibling status").is_none(),
+            "an unrelated child must not be reaped"
+        );
+        assert_eq!(
+            linux_process_stat(sibling_pid).map(|stat| stat.starttime_ticks),
+            Some(sibling_ticks),
+            "unrelated child identity must remain the recorded process"
+        );
+    }
+
+    #[test]
+    fn repeated_instant_double_forks_leave_no_adopted_zombies() {
+        let mut sibling = Command::new("sh");
+        sibling
+            .args(["-c", "exec sleep 30"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let mut sibling = KillChildOnDrop(Some(sibling.spawn().expect("spawn unrelated child")));
+        let sibling_pid = sibling.0.as_ref().expect("sibling").id();
+        let zombies_before = our_zombie_pids();
+
+        for _ in 0..8 {
+            let supervised = run_instant_double_fork();
+            assert_eq!(
+                supervised.termination,
+                SupervisedCommandTermination::Completed
+            );
+        }
+
+        assert_eq!(
+            our_zombie_pids(),
+            zombies_before,
+            "repeated executions left adopted zombies on the controller"
+        );
+        assert!(
+            sibling
+                .0
+                .as_mut()
+                .expect("sibling")
+                .try_wait()
+                .expect("sibling status")
+                .is_none(),
+            "unrelated Child status must remain available across repeated executions"
+        );
+        assert_eq!(
+            linux_process_stat(sibling_pid).map(|stat| stat.parent_pid),
+            Some(std::process::id())
+        );
+    }
 }
 
 /// Terminate an isolated child process tree and reap its direct child process.
 /// On platforms without process groups, `Child::kill` still provides portable
 /// termination and reaping of the spawned process.
 pub fn terminate_process_tree_and_reap(child: &mut Child) -> io::Result<ExitStatus> {
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     {
-        enable_child_subreaper()?;
+        let supervisor_pid = child.id();
+        signal_pid(supervisor_pid, libc::SIGTERM)?;
+        match reap_child_until(
+            child,
+            std::time::Instant::now() + PROCESS_TREE_TERM_GRACE + PROCESS_TREE_KILL_GRACE,
+        ) {
+            Ok(status) => Ok(status),
+            Err(_) => {
+                signal_pid(supervisor_pid, libc::SIGKILL)?;
+                reap_child_until(
+                    child,
+                    std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE,
+                )
+            }
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    {
         let root_pid = child.id();
         // Shells can put background jobs in a distinct process group. Snapshot
         // descendants before terminating the root so those jobs cannot retain
@@ -2737,28 +2793,6 @@ fn reap_child_until(child: &mut Child, deadline: std::time::Instant) -> io::Resu
         }
         thread::sleep(Duration::from_millis(10));
     }
-}
-
-/// Adopt orphaned descendants while their isolated process group is being
-/// terminated, so they can be reaped instead of remaining zombies under PID 1.
-#[cfg(target_os = "linux")]
-fn enable_child_subreaper() -> io::Result<()> {
-    CHILD_SUBREAPER_ENABLED
-        .get_or_init(|| {
-            if unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) } == 0 {
-                Ok(())
-            } else {
-                Err(io::Error::last_os_error())
-            }
-        })
-        .as_ref()
-        .copied()
-        .map_err(|error| io::Error::new(error.kind(), error.to_string()))
-}
-
-#[cfg(not(target_os = "linux"))]
-fn enable_child_subreaper() -> io::Result<()> {
-    Ok(())
 }
 
 #[derive(Debug)]
@@ -3052,6 +3086,98 @@ mod tests {
         .expect_err("heartbeat persistence failure stops gate");
         assert!(error.to_string().contains("durable heartbeat write failed"));
         assert_ne!(unsafe { libc::kill(pid as libc::pid_t, 0) }, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn isolated_spawn_returns_before_the_command_exits() {
+        let mut command = Command::new("sleep");
+        command
+            .arg("30")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        isolate_process_tree(&mut command);
+        let started = std::time::Instant::now();
+        let mut child = command
+            .spawn()
+            .expect("spawn must not wait on the supervisor exec-error pipe");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "Command::spawn blocked until the isolated command finished"
+        );
+        let _ = terminate_process_tree_and_reap(&mut child);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn isolated_spawn_reports_root_exec_failure() {
+        let mut command = Command::new("/no/such/homeboy-execution-supervisor-probe");
+        command
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        isolate_process_tree(&mut command);
+        let error = command
+            .spawn()
+            .expect_err("root exec failure must fail spawn, not return a live supervisor");
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn guarded_nonzero_root_exit_status_is_preserved() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exit 7"]);
+        command
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let mut guard = ControllerChildGuard::prepare(&mut command).expect("prepare guard");
+        let mut child = command.spawn().expect("spawn nonzero root");
+        guard.attach(&child).expect("attach guard");
+        let supervised = wait_with_bounded_output_supervised_guarded(
+            &mut child,
+            &mut guard,
+            4096,
+            Duration::from_secs(2),
+            Duration::from_millis(50),
+            || false,
+            |_, _| Ok(()),
+        )
+        .expect("nonzero root completes");
+        assert_eq!(
+            supervised.termination,
+            SupervisedCommandTermination::Completed
+        );
+        assert_eq!(supervised.output.status.code(), Some(7));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn guarded_root_term_signal_status_is_preserved() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let mut command = Command::new("sh");
+        command.args(["-c", "kill -TERM $$"]);
+        command
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let mut guard = ControllerChildGuard::prepare(&mut command).expect("prepare guard");
+        let mut child = command.spawn().expect("spawn signaled root");
+        guard.attach(&child).expect("attach guard");
+        let supervised = wait_with_bounded_output_supervised_guarded(
+            &mut child,
+            &mut guard,
+            4096,
+            Duration::from_secs(2),
+            Duration::from_millis(50),
+            || false,
+            |_, _| Ok(()),
+        )
+        .expect("signaled root completes");
+        assert_eq!(
+            supervised.termination,
+            SupervisedCommandTermination::Completed
+        );
+        assert_eq!(supervised.output.status.signal(), Some(libc::SIGTERM));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/resource_metrics.rs
+++ b/crates/homeboy-lab-runner/src/resource_metrics.rs
@@ -8,9 +8,9 @@ use std::time::{Duration, Instant};
 use serde_json::{json, Value};
 
 use homeboy_core::engine::command::{
-    isolate_process_tree, supports_process_tree_isolation, terminate_process_tree_and_reap,
-    wait_with_bounded_output, wait_with_bounded_output_until_cancelled_with_stdout_observer,
-    CommandCaptureMetadata, StdoutLineObserver, DEFAULT_CAPTURE_LIMIT_BYTES,
+    supports_process_tree_isolation, wait_with_bounded_output,
+    wait_with_bounded_output_until_cancelled_with_stdout_observer_owned, CommandCaptureMetadata,
+    ExecutionOwner, StdoutLineObserver, DEFAULT_CAPTURE_LIMIT_BYTES,
 };
 use homeboy_core::error::{Error, Result};
 use homeboy_core::redaction::RedactionPolicy;
@@ -133,15 +133,16 @@ pub(crate) fn measured_command_output_until_cancelled_with_progress(
         require_process_tree_isolation()?;
     }
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    isolate_process_tree(command);
     let started = Instant::now();
-    let mut child = command
-        .spawn()
+    let mut owner = ExecutionOwner::spawn(command)
         .map_err(|error| runner_command_spawn_error(command, &error))?;
-    let pid = child.id();
+    let pid = owner.identity().root_pid;
     if let Some(child_started) = child_started {
         if let Err(error) = child_started(pid) {
-            let cleanup = terminate_unpersisted_child_and_reap(&mut child);
+            let cleanup = owner
+                .drain_and_reap()
+                .and_then(homeboy_core::engine::command::ExecutionOutcome::into_root_status)
+                .map(|_| ());
             let cleanup_context = cleanup
                 .err()
                 .map(|cleanup_error| format!("; child cleanup also failed: {cleanup_error}"))
@@ -170,7 +171,10 @@ pub(crate) fn measured_command_output_until_cancelled_with_progress(
             pid,
             process_tree_resource_summary(pid),
         )) {
-            let cleanup = terminate_unpersisted_child_and_reap(&mut child);
+            let cleanup = owner
+                .drain_and_reap()
+                .and_then(homeboy_core::engine::command::ExecutionOutcome::into_root_status)
+                .map(|_| ());
             let cleanup_context = cleanup
                 .err()
                 .map(|error| format!("; child cleanup also failed: {error}"))
@@ -192,8 +196,8 @@ pub(crate) fn measured_command_output_until_cancelled_with_progress(
         resource_guard_env,
         concurrency_limit,
     );
-    let bounded_output = wait_with_bounded_output_until_cancelled_with_stdout_observer(
-        &mut child,
+    let bounded_output = wait_with_bounded_output_until_cancelled_with_stdout_observer_owned(
+        &mut owner,
         DEFAULT_CAPTURE_LIMIT_BYTES,
         || {
             is_cancelled()
@@ -296,16 +300,6 @@ fn runner_command_spawn_error(command: &Command, error: &std::io::Error) -> Erro
 
 fn os_str_bytes(value: &OsStr) -> usize {
     value.as_encoded_bytes().len()
-}
-
-/// Terminate and reap an unrecorded child through the same bounded, verified
-/// process-tree lifecycle used by cancellation.
-fn terminate_unpersisted_child_and_reap(child: &mut std::process::Child) -> Result<()> {
-    terminate_process_tree_and_reap(child)
-        .map(|_| ())
-        .map_err(|error| {
-            Error::internal_io(error.to_string(), Some("reap runner child".to_string()))
-        })
 }
 
 struct ResourceMetricsCollector {
@@ -958,6 +952,93 @@ mod tests {
         assert!(!homeboy_core::process::pid_is_running(
             pid.load(Ordering::SeqCst)
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runner_cancel_reaps_term_resistant_descendants_and_persists_root_identity() {
+        struct ReapOnDrop(Arc<Mutex<Vec<u32>>>);
+        impl Drop for ReapOnDrop {
+            fn drop(&mut self) {
+                for pid in self.0.lock().expect("cleanup pids").iter().copied() {
+                    if pid != 0 && homeboy_core::process::pid_is_running(pid) {
+                        unsafe {
+                            libc::kill(pid as libc::pid_t, libc::SIGKILL);
+                        }
+                    }
+                }
+            }
+        }
+
+        let temp = tempfile::tempdir().expect("unique tempfile dir");
+        let pid_file = temp.path().join("descendant.pid");
+        let cleanup_pids = Arc::new(Mutex::new(Vec::new()));
+        let _cleanup = ReapOnDrop(Arc::clone(&cleanup_pids));
+        let script = format!(
+            "trap '' TERM; sleep 30 & echo $! > {}; wait",
+            pid_file.display()
+        );
+        let mut command = Command::new("sh");
+        command.args(["-c", &script]);
+        let persisted = Arc::new(AtomicU32::new(0));
+        let persisted_pgid = Arc::new(AtomicU32::new(0));
+        let callback_pid = Arc::clone(&persisted);
+        let callback_pgid = Arc::clone(&persisted_pgid);
+        let callback_cleanup = Arc::clone(&cleanup_pids);
+        let output = measured_command_output_until_cancelled_with_progress(
+            &mut command,
+            || pid_file.exists(),
+            None,
+            false,
+            None,
+            Some(Arc::new(move |root_pid| {
+                callback_pid.store(root_pid, Ordering::SeqCst);
+                callback_cleanup
+                    .lock()
+                    .expect("cleanup pids")
+                    .push(root_pid);
+                #[cfg(target_os = "linux")]
+                {
+                    let pgid = unsafe { libc::getpgid(root_pid as libc::pid_t) };
+                    assert!(
+                        pgid >= 0,
+                        "getpgid must succeed while the runner root is still alive"
+                    );
+                    callback_pgid.store(pgid as u32, Ordering::SeqCst);
+                }
+                #[cfg(not(target_os = "linux"))]
+                {
+                    let _ = callback_pgid;
+                }
+                Ok(())
+            })),
+            &HashMap::new(),
+            None,
+        )
+        .expect("runner cancel completes");
+        assert!(!output.output.status.success());
+        let root_pid = persisted.load(Ordering::SeqCst);
+        assert_ne!(root_pid, 0);
+        #[cfg(target_os = "linux")]
+        assert_eq!(
+            persisted_pgid.load(Ordering::SeqCst),
+            root_pid,
+            "persisted runner identity is the live root leader"
+        );
+        let descendant_pid = std::fs::read_to_string(&pid_file)
+            .expect("descendant pid")
+            .trim()
+            .parse::<u32>()
+            .expect("numeric descendant");
+        cleanup_pids
+            .lock()
+            .expect("cleanup pids")
+            .push(descendant_pid);
+        assert!(
+            !homeboy_core::process::pid_is_running(descendant_pid),
+            "runner cancel left TERM-resistant descendant {descendant_pid}"
+        );
+        assert!(!homeboy_core::process::pid_is_running(root_pid));
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -7,7 +7,7 @@ use homeboy_core::error::CommandEvidence;
 use homeboy_core::git::release_download::GitHubRepo;
 use homeboy_core::redaction::RedactionPolicy;
 use homeboy_engine_primitives::command::{
-    wait_with_bounded_output_supervised, ControllerChildGuard, SupervisedCommandTermination,
+    wait_with_bounded_output_supervised_owned, ExecutionOwner, SupervisedCommandTermination,
 };
 use homeboy_engine_primitives::content_hash;
 use serde::Serialize;
@@ -1810,19 +1810,8 @@ fn parse_github_request_id(value: &str) -> Option<String> {
 
 pub(crate) fn run_gh_command(mut command: Command, timeout: Duration) -> GhCommandOutput {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let _controller_guard = match ControllerChildGuard::prepare(&mut command) {
-        Ok(guard) => guard,
-        Err(error) => {
-            return GhCommandOutput {
-                stdout: String::new(),
-                stderr: gh_diagnostic_text(&format!("could not contain gh command: {error}")),
-                exit_code: None,
-                timed_out: false,
-            }
-        }
-    };
-    let mut child = match command.spawn() {
-        Ok(child) => child,
+    let mut owner = match ExecutionOwner::spawn(&mut command) {
+        Ok(owner) => owner,
         Err(error) => {
             return GhCommandOutput {
                 stdout: String::new(),
@@ -1832,18 +1821,8 @@ pub(crate) fn run_gh_command(mut command: Command, timeout: Duration) -> GhComma
             }
         }
     };
-    if let Err(error) = _controller_guard.attach(&child) {
-        let _ = child.kill();
-        let _ = child.wait();
-        return GhCommandOutput {
-            stdout: String::new(),
-            stderr: gh_diagnostic_text(&format!("could not guard gh command: {error}")),
-            exit_code: None,
-            timed_out: false,
-        };
-    }
-    match wait_with_bounded_output_supervised(
-        &mut child,
+    match wait_with_bounded_output_supervised_owned(
+        &mut owner,
         GITHUB_COMMAND_OUTPUT_LIMIT,
         timeout,
         timeout,

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -4,8 +4,7 @@ use homeboy_core::error::{Error, Result};
 use homeboy_core::git::{run_git, run_git_output};
 use homeboy_core::stream_capture::StreamCaptureMetadata;
 use homeboy_engine_primitives::command::{
-    supports_process_tree_isolation, terminate_process_tree_and_reap,
-    wait_with_bounded_output_supervised_guarded, ControllerChildGuard,
+    supports_process_tree_isolation, wait_with_bounded_output_supervised_owned, ExecutionOwner,
     SupervisedCommandTermination,
 };
 use serde::{Deserialize, Serialize};
@@ -535,11 +534,11 @@ fn supervise_installer_shell_command<A>(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let mut guard = ControllerChildGuard::prepare(&mut command)
+    let prep = ExecutionOwner::prepare(&mut command)
         .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
     // The capability is intentionally scoped to this exact supervised spawn.
     let mutation_fence = authorize_before_spawn(&mut command)?;
-    let mut child = command
+    let child = command
         .spawn()
         .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
     drop(mutation_fence);
@@ -556,25 +555,23 @@ fn supervise_installer_shell_command<A>(
             std::thread::park_timeout(Duration::from_secs(30));
         }
     }
-    if let Err(error) = guard.attach(&child) {
-        let primary = Error::internal_io(
+    let mut owner = prep.attach(child).map_err(|error| {
+        Error::internal_io(
             format!("failed to attach installer process guard: {error}"),
             Some(context.to_string()),
-        );
-        return Err(append_cleanup_failure_context(
-            primary,
-            terminate_process_tree_and_reap(&mut child).err(),
-        ));
-    }
-    start_gate.release().map_err(|error| {
-        append_cleanup_failure_context(
-            Error::internal_io(error.to_string(), Some(context.to_string())),
-            terminate_process_tree_and_reap(&mut child).err(),
         )
     })?;
-    let supervised = wait_with_bounded_output_supervised_guarded(
-        &mut child,
-        &mut guard,
+    if let Err(error) = start_gate.release() {
+        return Err(append_cleanup_failure_context(
+            Error::internal_io(error.to_string(), Some(context.to_string())),
+            owner
+                .drain_and_reap()
+                .and_then(homeboy_engine_primitives::command::ExecutionOutcome::into_root_status)
+                .err(),
+        ));
+    }
+    let supervised = wait_with_bounded_output_supervised_owned(
+        &mut owner,
         UPGRADE_CAPTURE_LIMIT_BYTES,
         timeout,
         INSTALLER_SUPERVISION_POLL_INTERVAL,
@@ -586,7 +583,12 @@ fn supervise_installer_shell_command<A>(
         Err(error) => {
             return Err(append_cleanup_failure_context(
                 Error::internal_io(error.to_string(), Some(context.to_string())),
-                guard.terminate_and_reap_bounded(&mut child).err(),
+                owner
+                    .drain_and_reap()
+                    .and_then(
+                        homeboy_engine_primitives::command::ExecutionOutcome::into_root_status,
+                    )
+                    .err(),
             ));
         }
     };
@@ -1095,25 +1097,11 @@ fn run_source_upgrade_command(
             .env("CARGO_TARGET_DIR", cargo_target_dir)
             .env("HOMEBOY_CARGO_TARGET_RESOLUTION", resolution);
     }
-    let mut guard = ControllerChildGuard::prepare(&mut child_command).map_err(|error| {
+    let mut owner = ExecutionOwner::spawn(&mut child_command).map_err(|error| {
         Error::internal_io(error.to_string(), Some("run source upgrade".to_string()))
     })?;
-    let mut child = child_command
-        .spawn()
-        .map_err(|e| Error::internal_io(e.to_string(), Some("run source upgrade".to_string())))?;
-    if let Err(error) = guard.attach(&child) {
-        let primary = Error::internal_io(
-            format!("failed to attach source-upgrade process guard: {error}"),
-            Some("run source upgrade".to_string()),
-        );
-        return Err(append_cleanup_failure_context(
-            primary,
-            terminate_process_tree_and_reap(&mut child).err(),
-        ));
-    }
-    let supervised = wait_with_bounded_output_supervised_guarded(
-        &mut child,
-        &mut guard,
+    let supervised = wait_with_bounded_output_supervised_owned(
+        &mut owner,
         0,
         timeout,
         INSTALLER_SUPERVISION_POLL_INTERVAL,
@@ -1125,7 +1113,12 @@ fn run_source_upgrade_command(
         Err(error) => {
             return Err(append_cleanup_failure_context(
                 Error::internal_io(error.to_string(), Some("run source upgrade".to_string())),
-                guard.terminate_and_reap_bounded(&mut child).err(),
+                owner
+                    .drain_and_reap()
+                    .and_then(
+                        homeboy_engine_primitives::command::ExecutionOutcome::into_root_status,
+                    )
+                    .err(),
             ));
         }
     };


### PR DESCRIPTION
## Summary

Replace the draft's Linux scan-based adopted-child reconstruction with an execution-local supervisor under #12008 / #11932. Remains draft pending review of the changed execution boundary and CI.

The earlier candidate contained live session escapees but could not attribute zombies that exited before observation. A process-global subreaper cannot safely reap those unknown children without risking unrelated `Child` exit statuses. This revision establishes ownership before execution instead.

## Ownership

The current revision exposes `ExecutionOwner` and `ExecutionIdentity`: the supervisor wait handle is distinct from workload PID/PGID, and terminal cleanup status is distinct from the root's exit status. A missing or incomplete owner protocol result is an error, not an ordinary command exit 1. Raw access to the supervisor's `Child` is not exposed by the owner API.

Owner Drop and attach-failure paths use bounded drain/reap. Last-resort workload-group recovery is centralized in the owner and requires the recorded Linux start-time identity and current PGID; it runs only during active teardown, not on later reads of a cached incomplete outcome. Recovery never upgrades an incomplete outcome to complete. The previous agent-only group-cleanup fallback is deleted.

On Linux, the isolated spawn creates a supervisor which owns only that execution's root and adopted descendants. The supervisor is the subreaper, not the controller. It can reap its entire child set without consuming unrelated controller children. It mirrors root exit status only after the owned child set is empty; teardown exhaustion returns non-success.

- Remove Linux guard-ID environment reconstruction and controller-side adopted-child scans from this path.
- Preserve root exec-error-pipe semantics, nonzero exit codes and signal exits.
- Observe controller liveness and perform bounded TERM/KILL cleanup.
- Retain existing non-Linux Unix and Windows behavior rather than claiming Linux subreaping is portable.
- Update the agent containment test to assert the stronger Linux guarantee: descendants are drained when the supervisor exits. Preserve its original non-Linux assertion.

The core `HOMEBOY_PROCESS_SCOPE` recovery scanner remains outside this slice. This is not completion of every containment migration.

Guarded callers have been migrated across agent containment, gates/provider commands, runner metrics, transfer, external storage, extension deadline/self-check, GitHub command execution, status and upgrades. Unguarded `isolate_process_tree` retains its original unmanaged process-group semantics. Persisted recovery references use workload root PGIDs, not the supervisor group. Old per-caller guard/killpg compositions removed by this migration are not retained as compatibility paths.

## Verification

Linux, three consecutive runs: 13 engine-primitives tests plus four upgrade tests passed each run (51 passing executions). Two ignored subprocess fixtures are invoked by their parent tests, not counted as standalone proofs.

```sh
cargo test -p homeboy-engine-primitives --lib -- --test-threads=1 adopted_child_reaping_tests isolated_spawn guarded_nonzero_root_exit_status_is_preserved guarded_root_term_signal_status_is_preserved cancellation_reaps_the_entire_isolated_process_group controller_loss_reaps_the_release_mutation_process_group completed_parent_does_not_deadlock_on_a_background_output_holder timing_out_a_guarded_child_reports_a_timeout_not_a_supervision_error reaping_is_scoped_to_the_target_process_group cancellable_wait_does_not_deadlock_on_a_background_output_holder
cargo test -p homeboy-upgrade --lib -- --test-threads=1 installer_completion_contains_fast_double_fork_after_inherited_descriptors_close installer_timeout_terminates_and_reaps_the_process_tree installer_timeout_kills_setsid_descendant_before_delayed_mutation controller_death_cannot_leave_an_installer_to_mutate_after_successor_handoff
cargo test -p homeboy-agents --lib agent_task_process_containment -- --test-threads=1
```

The four agent containment tests also passed on Linux. Tests include instant double-fork exit before observation, repeated executions leaving no adopted zombies, unrelated sibling isolation, delayed mutation, inherited descriptors, cancellation, controller death, exec failure, and root status preservation.

Latest caller-migration verification on Linux: 16 selected engine tests, 4 agent-containment tests, 19 runner resource-metrics tests, 17 external-storage tests, and 3 upgrade tests passed (59 total). This includes runner cancellation of TERM-resistant descendants with the root PGID captured while alive. `cargo check --workspace --offline` passes locally. These results supersede the earlier primitive-only evidence for the migrated callers; CI must rerun on this revision.

Latest ownership-finalization pass: 18 selected engine tests (including dropped owner and killed supervisor), all 4 containment tests and all 19 runner resource-metrics tests passed on Linux. The two new regressions were rerun after requiring a recorded start-time identity for last-resort signalling. Workspace typecheck and formatting/diff checks pass.

macOS engine-primitives suite passed before the final Linux-only corrections; new spawn/status cases passed separately. Linux cross-target typecheck and formatting/diff checks pass. Broad nextest, Windows and independent architectural review remain pending. Prior CI green results apply to the superseded scan-based revision, not this replacement.

## AI Assistance

xAI Grok 4.6 (`xai/grok-4.6`) via direct OpenCode CLI implemented and tested the supervisor replacement. OpenAI gpt-6-astra via OpenCode reviewed ownership, exec-pipe and false-success risks, required Linux proof and corrective iterations, strengthened the consumer assertion, and managed this draft. Chris explicitly directed replacing the incomplete ownership reconstruction rather than adding more scan exceptions.
