### PR TITLE
Bind shared runtime assets for extension execution

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/exec_context.rs
+++ b/crates/contracts/homeboy-extension-contract/src/exec_context.rs
@@ -16,6 +16,10 @@ pub const EXTENSION_PATH: &str = "HOMEBOY_EXTENSION_PATH";
 pub const PROJECT_PATH: &str = "HOMEBOY_PROJECT_PATH";
 /// Filesystem path to the component directory.
 pub const COMPONENT_PATH: &str = "HOMEBOY_COMPONENT_PATH";
+/// Filesystem path to shared extension script libraries in the active runtime.
+pub const SHARED_LIB_DIR: &str = "HOMEBOY_SHARED_LIB_DIR";
+/// Filesystem path to agent runtime packages in the active runtime.
+pub const AGENT_RUNTIMES_DIR: &str = "HOMEBOY_AGENT_RUNTIMES_DIR";
 
 /// Run only specific steps (comma-separated). Scripts should skip steps not in this list.
 pub const STEP: &str = "HOMEBOY_STEP";

--- a/crates/homeboy-core/src/extension/invoke.rs
+++ b/crates/homeboy-core/src/extension/invoke.rs
@@ -726,6 +726,103 @@ mod tests {
         });
     }
 
+    #[test]
+    fn build_exec_env_binds_active_shared_runtime_assets_for_hashed_extensions() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let config_root = homeboy_core::paths::homeboy().expect("isolated config root");
+            let shared_source = home.path().join("materialized-assets").join("shared-lib");
+            std::fs::create_dir_all(&shared_source).expect("shared library source");
+            std::fs::write(
+                shared_source.join("fixture-helper.sh"),
+                "fixture_helper() { printf shared-runtime; }\n",
+            )
+            .expect("shared helper");
+
+            let shared_lib_dir = homeboy_core::paths::extensions_in_root(&config_root)
+                .join("scripts")
+                .join("lib");
+            std::fs::create_dir_all(shared_lib_dir.parent().expect("shared lib parent"))
+                .expect("shared lib parent");
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&shared_source, &shared_lib_dir)
+                .expect("link shared library into active runtime");
+            #[cfg(windows)]
+            std::os::windows::fs::symlink_dir(&shared_source, &shared_lib_dir)
+                .expect("link shared library into active runtime");
+
+            let agent_runtimes_dir = homeboy_core::paths::agent_runtimes_in_root(&config_root);
+            std::fs::create_dir_all(&agent_runtimes_dir).expect("agent runtimes");
+            std::fs::write(agent_runtimes_dir.join("fixture-runtime"), "active")
+                .expect("agent runtime asset");
+
+            let hashed_extension_source = home
+                .path()
+                .join("extension-snapshots")
+                .join("fixture-9f86d081884c7d65");
+            std::fs::create_dir_all(&hashed_extension_source).expect("hashed extension source");
+
+            // The root resolver is pinned by the isolated-home context, not the
+            // ambient HOME inherited by the extension child.
+            std::env::set_var("HOME", "/primary-home-must-not-be-selected");
+            let env = build_exec_env(
+                "fixture",
+                None,
+                None,
+                "{}",
+                Some(&hashed_extension_source.to_string_lossy()),
+                None,
+                None,
+                None,
+            );
+
+            for (name, expected) in [
+                (exec_context::SHARED_LIB_DIR, &shared_lib_dir),
+                (exec_context::AGENT_RUNTIMES_DIR, &agent_runtimes_dir),
+            ] {
+                assert_eq!(
+                    env.iter()
+                        .find(|(key, _)| key == name)
+                        .map(|(_, value)| value.as_str()),
+                    Some(expected.to_string_lossy().as_ref()),
+                    "{name} must name the active runtime asset directory"
+                );
+            }
+
+            let result = execute_extension_command(
+                "sh -c '. \"$HOMEBOY_SHARED_LIB_DIR/fixture-helper.sh\"; fixture_helper; test -f \"$HOMEBOY_AGENT_RUNTIMES_DIR/fixture-runtime\"'",
+                &[],
+                Some(&hashed_extension_source.to_string_lossy()),
+                &env,
+                ExtensionExecutionMode::Captured,
+            )
+            .expect("execute fixture child");
+            assert_eq!(
+                result.exit_code, 0,
+                "fixture child failed: {}",
+                result.output.stderr
+            );
+            assert_eq!(result.output.stdout, "shared-runtime");
+        });
+    }
+
+    #[test]
+    fn build_exec_env_omits_missing_shared_runtime_asset_bindings() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let env = build_exec_env("fixture", None, None, "{}", None, None, None, None);
+
+            assert!(
+                !env.iter()
+                    .any(|(key, _)| key == exec_context::SHARED_LIB_DIR),
+                "missing shared library assets must not produce a bogus binding"
+            );
+            assert!(
+                !env.iter()
+                    .any(|(key, _)| key == exec_context::AGENT_RUNTIMES_DIR),
+                "missing agent runtime assets must not produce a bogus binding"
+            );
+        });
+    }
+
     /// The toolchain PATH is forwarded from the rig provider, never fabricated.
     ///
     /// This used to assert only `PATH.is_some()`. That was true while this code

--- a/crates/homeboy-core/src/extension/invoke/environment.rs
+++ b/crates/homeboy-core/src/extension/invoke/environment.rs
@@ -358,6 +358,28 @@ pub(crate) fn build_exec_env(
         env.push((exec_context::EXTENSION_PATH.to_string(), mp.to_string()));
     }
 
+    // Installed extensions can be immutable snapshots while their shared script
+    // libraries and runner packages live at the active runtime root.
+    if let Ok(config_root) = homeboy_core::paths::homeboy() {
+        let shared_lib_dir = homeboy_core::paths::extensions_in_root(&config_root)
+            .join("scripts")
+            .join("lib");
+        if shared_lib_dir.is_dir() {
+            env.push((
+                exec_context::SHARED_LIB_DIR.to_string(),
+                shared_lib_dir.to_string_lossy().to_string(),
+            ));
+        }
+
+        let agent_runtimes_dir = homeboy_core::paths::agent_runtimes_in_root(&config_root);
+        if agent_runtimes_dir.is_dir() {
+            env.push((
+                exec_context::AGENT_RUNTIMES_DIR.to_string(),
+                agent_runtimes_dir.to_string_lossy().to_string(),
+            ));
+        }
+    }
+
     if let Ok(helper_pairs) = runtime_helper::ensure_all_helpers() {
         env.extend(helper_pairs);
     }


### PR DESCRIPTION
## Summary

Core prerequisite for Extra-Chill/homeboy-extensions#2508, exposed by the MDI consumer verification workflow (Automattic/markdown-database-integration#377).

- Export HOMEBOY_SHARED_LIB_DIR and HOMEBOY_AGENT_RUNTIMES_DIR from the active runtime config root when the corresponding directories exist.
- Let child processes locate separately materialized assets when their extension code runs from a hashed snapshot.
- Preserve existing environment override precedence and development layouts; these are default bindings, not a new immutable security boundary.
- Keep core generic: it supplies asset directories, not WordPress- or WP Codebox-specific filenames.

Companion parser PR: https://github.com/Extra-Chill/homeboy-extensions/pull/2840

## Verification

```sh
cargo fmt --all --check
cargo test -p homeboy-core build_exec_env_ --lib -- --test-threads=1
git diff --check
```

All five selected tests passed on homeboy-lab. Coverage includes an isolated active config root, separately materialized/symlinked shared assets, a hashed extension source, a real child sourcing the helper, HOME isolation, and omission of absent assets.

- Commit: 12f45fa38
- Homeboy run: mdi-377-shared-runtime-core-final
- Runner job: c42bd4c6-b19b-4f73-bc2d-6c164bb570ca
- Artifact: runner-exec-7d6ce11de9822bda82695f02be1697e240c6e5f9cb08d9b67420f066fe39933d
- Artifact filename: shared-runtime-core-check.log

These are operator-retained evidence references, not public artifact links. The commands above are repository-native reproduction steps.

## Boundary

This fixes harness asset discovery only. The companion parser repair and runtime installation are still required before rerunning the correctly pinned native/MySQL consumer pair. No full SQL parity, release, deployment, or runtime upgrade is claimed.

## AI Assistance

OpenAI GPT-6 Astra (openai/gpt-6-astra) via OpenCode traced the packaged-runtime failure, coordinated isolated implementation and review, kept the change scoped to default bindings, ran managed Lab verification, and prepared this PR under Chris Huber’s direction.
