### PR TITLE
Fix inconsistent runner admission job counts

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -2238,14 +2238,11 @@ pub(crate) fn status_with_admission_projection_until_in_roots(
         .map(|generation| generation.active_job_count);
     let active_job_error = match (active_job_error, direct_daemon_active_jobs) {
         (Some(error), _) => Some(error),
-        (None, Some(direct_daemon_active_jobs))
-            if authoritative_generation_count
-                .is_some_and(|count| count != direct_daemon_active_jobs) =>
-        {
+        (None, Some(_)) if authoritative_generation_count.is_some_and(|count| count != active_job_count) => {
             Some(RunnerActiveJobError {
                 code: "retained_active_job_count_inconsistent".to_string(),
                 message: format!(
-                    "selected daemon reports {direct_daemon_active_jobs} active job(s), but its authoritative generation ledger retains {}",
+                    "selected daemon reports {active_job_count} active job(s), but its authoritative generation ledger retains {}",
                     authoritative_generation_count.expect("guarded by is_some_and")
                 ),
             })

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -2248,6 +2248,141 @@ fn daemon_count_divergence_reconciles_to_typed_owners_without_cancelling_them() 
 }
 
 #[test]
+fn status_admission_uses_typed_jobs_not_a_differing_direct_count() {
+    test_support::with_isolated_home(|_| {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        listener
+            .set_nonblocking(true)
+            .expect("nonblocking listener");
+        let address = listener.local_addr().expect("listener address");
+        let active_job = serde_json::to_value(sample_active_job(Some("run-live"), "live job"))
+            .expect("serialize active job");
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_server = std::sync::Arc::clone(&stop);
+        let server = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(30);
+            while !stop_server.load(std::sync::atomic::Ordering::Acquire)
+                && std::time::Instant::now() < deadline
+            {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    std::thread::sleep(Duration::from_millis(1));
+                    continue;
+                };
+                let mut request = [0; 4096];
+                let length = stream.read(&mut request).expect("read request");
+                let request = String::from_utf8_lossy(&request[..length]);
+                let body = if request.starts_with("GET /health ") {
+                    serde_json::json!({
+                        "freshness": {
+                            "fresh": true,
+                            "restartable": true,
+                            "lease_id": "lease-live",
+                            "pid": 4242,
+                            "active_jobs": 2,
+                        },
+                        "pid": 4242,
+                    })
+                } else if request.starts_with("GET /jobs ") {
+                    serde_json::json!({
+                        "success": true,
+                        "data": { "body": {
+                            "active_runner_jobs": [active_job],
+                            "stale_runner_jobs": [],
+                        }},
+                    })
+                } else {
+                    serde_json::json!({
+                        "version": "test",
+                        "build_identity": { "display": "homeboy test+abc123" },
+                    })
+                }
+                .to_string();
+                stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .expect("write response");
+            }
+        });
+
+        server::create(
+            r#"{"id":"homeboy-lab","host":"localhost","user":"test"}"#,
+            false,
+        )
+        .expect("create server");
+        crate::create(
+            r#"{"id":"homeboy-lab","kind":"ssh","homeboy_path":"true"}"#,
+            false,
+        )
+        .expect("create runner");
+        let mut session = direct_ssh_session("lease-live");
+        session.local_url = Some(format!("http://{address}"));
+        session.local_port = Some(address.port());
+        session.tunnel_pid = Some(std::process::id());
+        write_session(&session).expect("write session");
+        let mut generations = crate::RollingGenerations::new("lease-live", session);
+        let admission = generations
+            .generations
+            .get_mut("lease-live")
+            .expect("admission generation");
+        admission.active_jobs = 1;
+        admission.observed_active_jobs = Some(1);
+        crate::generation_store::write("homeboy-lab", &generations)
+            .expect("write generation ledger");
+
+        let (report, generations, owners) =
+            status_with_admission_projection("homeboy-lab").expect("status observation");
+        let summary = report.admission_summary_with_generations(&generations, &owners, 0);
+
+        assert_eq!(report.active_job_count, 1);
+        assert!(report.active_job_error.is_none());
+        assert!(summary.retained_job_inconsistency.is_none());
+
+        let mut mismatched = crate::generation_store::read("homeboy-lab", report.session.as_ref())
+            .expect("read generation ledger")
+            .expect("generation ledger");
+        let admission_owner = mismatched.admission_owner.clone();
+        mismatched
+            .generations
+            .get_mut(&admission_owner)
+            .expect("admission generation")
+            .active_jobs = 2;
+        mismatched
+            .generations
+            .get_mut(&admission_owner)
+            .expect("admission generation")
+            .observed_active_jobs = Some(2);
+        crate::generation_store::write("homeboy-lab", &mismatched)
+            .expect("write mismatched ledger");
+
+        let (mismatched_report, mismatched_generations, mismatched_owners) =
+            status_with_admission_projection("homeboy-lab").expect("mismatched status observation");
+        let mismatch = mismatched_report.admission_summary_with_generations(
+            &mismatched_generations,
+            &mismatched_owners,
+            0,
+        );
+        assert_eq!(mismatched_report.active_job_count, 1);
+        assert_eq!(
+            mismatched_report
+                .active_job_error
+                .as_ref()
+                .map(|error| error.code.as_str()),
+            Some("retained_active_job_count_inconsistent")
+        );
+        assert!(!mismatch.accepting_jobs);
+        assert!(mismatch.retained_job_inconsistency.is_some());
+
+        stop.store(true, std::sync::atomic::Ordering::Release);
+        server.join().expect("daemon server");
+    });
+}
+
+#[test]
 fn synthetic_active_job_run_summaries_are_not_child_runs() {
     let mut synthetic = sample_run_summary("runner-job-job-1");
     synthetic.status_note =


### PR DESCRIPTION
## Summary

Use the reconciled typed `/jobs` count when checking the authoritative generation ledger, rather than returning to the earlier direct daemon count.

Observed status accepted one active job, but the immediately following dispatch rejected admission with `retained_active_job_count_inconsistent`: the direct observation reported two jobs while the typed job list and ledger contained one. The status code already reconciles these observations; its final consistency check was using the unreconciled value.

Real ledger disagreements remain fail-closed. This change neither cancels jobs nor restarts the runner.

Related to #14574. This narrowly addresses inconsistent count selection, not the separate queued-job expiry or cancellation-settlement gaps in that issue.

## Verification

A behavior-level regression exercises the actual status path against a loopback daemon and persisted generation ledger. Direct count 2 with typed count 1 and ledger count 1 produces no retained inconsistency; changing the ledger to 2 preserves the admission block.

Reproduce from this branch:

```sh
cargo test -p homeboy-lab-runner connection::tests::session
cargo fmt --check
```

Both commands passed on managed Homeboy Lab; the session suite passed all 90 tests. Operator-retained evidence IDs (not public artifact links):

- Tests: `runner-exec-cargo-test-homeboy-lab-6dab2ebf-6222-46bd-84ce-7ef1af2a21e7`
- Formatting: `runner-exec-cargo-fmt-homeboy-lab-27c3eb7c-0f2a-4be6-9dd9-0207b70a7ca5`

The final source snapshot was tested before committing; no production runtime replacement or downstream consumer acceptance is claimed.

## AI Assistance

OpenAI gpt-6-astra via OpenCode investigated the status/dispatch discrepancy, implemented the narrow fix in an isolated worktree, strengthened the regression through review, and ran verification on managed Homeboy Lab. Chris authorized the changes and PR.