### PR TITLE
fix(runner): expand remote home paths in doctor probes

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -1652,9 +1652,11 @@ pub(crate) fn local_path_or_parent_writable(path: &Path) -> bool {
 }
 
 pub(crate) fn remote_path_writable(client: &SshClient, path: &str) -> bool {
-    client
-        .execute(&format!("test -w {}", common::shell_word(path)))
-        .success
+    client.execute(&remote_path_writable_command(path)).success
+}
+
+pub(super) fn remote_path_writable_command(path: &str) -> String {
+    format!("test -w {}", common::shell_path_expr(path))
 }
 
 pub(crate) fn remote_artifact_store_available(client: &SshClient, path: &str) -> bool {
@@ -1664,7 +1666,7 @@ pub(crate) fn remote_artifact_store_available(client: &SshClient, path: &str) ->
 }
 
 pub(super) fn remote_artifact_store_available_command(path: &str) -> String {
-    let path = common::shell_word(path);
+    let path = common::shell_path_expr(path);
     format!(
         "if [ -e {path} ]; then test -d {path} && test -w {path}; else parent=$(dirname {path}); test -d \"$parent\" && test -w \"$parent\"; fi"
     )

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
@@ -193,6 +193,110 @@ fn artifact_store_contract_succeeds(path: &std::path::Path) -> bool {
 }
 
 #[test]
+fn remote_writable_probes_execute_home_relative_and_absolute_path_semantics() {
+    let home = tempfile::tempdir().expect("isolated HOME");
+    let home_path = home.path();
+
+    let artifacts = home_path.join(".local/share/homeboy/artifacts");
+    std::fs::create_dir_all(&artifacts).expect("home-relative artifacts");
+    assert!(probe_with_home(
+        home_path,
+        &probes::remote_artifact_store_available_command("~/.local/share/homeboy/artifacts"),
+    ));
+    assert!(probe_with_home(
+        home_path,
+        &probes::remote_path_writable_command("~/.local/share/homeboy/artifacts"),
+    ));
+
+    let spaced = home_path.join("artifact store");
+    std::fs::create_dir(&spaced).expect("spaced path");
+    assert!(probe_with_home(
+        home_path,
+        &probes::remote_artifact_store_available_command("~/artifact store"),
+    ));
+    assert!(probe_with_home(
+        home_path,
+        &probes::remote_path_writable_command("~/artifact store"),
+    ));
+
+    let meta_name = "art$(touch pwned);.store";
+    std::fs::create_dir(home_path.join(meta_name)).expect("metacharacter path");
+    let meta_path = format!("~/{meta_name}");
+    assert!(probe_with_home(
+        home_path,
+        &probes::remote_artifact_store_available_command(&meta_path),
+    ));
+    assert!(probe_with_home(
+        home_path,
+        &probes::remote_path_writable_command(&meta_path),
+    ));
+    assert!(!home_path.join("pwned").exists());
+
+    let absolute = artifacts.to_string_lossy().into_owned();
+    assert!(probe_with_home(
+        home_path,
+        &probes::remote_artifact_store_available_command(&absolute),
+    ));
+    assert!(probe_with_home(
+        home_path,
+        &probes::remote_path_writable_command(&absolute),
+    ));
+
+    assert!(probe_with_home(
+        home_path,
+        &probes::remote_artifact_store_available_command("~/missing-root"),
+    ));
+    assert!(!probe_with_home(
+        home_path,
+        &probes::remote_path_writable_command("~/missing-root"),
+    ));
+
+    let unwritable = home_path.join("unwritable");
+    std::fs::create_dir(&unwritable).expect("unwritable path");
+    let original = std::fs::metadata(&unwritable)
+        .expect("unwritable metadata")
+        .permissions();
+    let mut readonly = original.clone();
+    readonly.set_readonly(true);
+    std::fs::set_permissions(&unwritable, readonly).expect("make unwritable");
+    let artifact_unwritable = probe_with_home(
+        home_path,
+        &probes::remote_artifact_store_available_command("~/unwritable"),
+    );
+    let path_unwritable = probe_with_home(
+        home_path,
+        &probes::remote_path_writable_command("~/unwritable"),
+    );
+    let child_unwritable = probe_with_home(
+        home_path,
+        &probes::remote_artifact_store_available_command("~/unwritable/child"),
+    );
+    // Root can write through read-only mode bits; compare against the shell's
+    // absolute-path verdict rather than assuming the test user's privileges.
+    let absolute_unwritable = std::process::Command::new("sh")
+        .args(["-c", "test -w \"$1\"", "sh"])
+        .arg(&unwritable)
+        .status()
+        .expect("absolute writable probe")
+        .success();
+    std::fs::set_permissions(&unwritable, original).expect("restore unwritable");
+    assert_eq!(artifact_unwritable, absolute_unwritable);
+    assert_eq!(path_unwritable, absolute_unwritable);
+    assert_eq!(child_unwritable, absolute_unwritable);
+}
+
+fn probe_with_home(home: &std::path::Path, command: &str) -> bool {
+    std::process::Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .env("HOME", home)
+        .current_dir(home)
+        .status()
+        .expect("run remote path probe")
+        .success()
+}
+
+#[test]
 fn unreachable_transport_report_is_terminal_and_has_no_daemon_evidence() {
     let runner = Runner {
         id: "lab".to_string(),


### PR DESCRIPTION
## Summary

Use the existing remote path-expression renderer for runner doctor workspace-writability and artifact-store probes.

The probes used literal shell-word quoting for `~/.local/share/homeboy/artifacts`, so the remote shell checked a path beginning with a literal tilde. Live `agent-task doctor --runner <runner> --backend opencode` failed artifact-store readiness even though the runner's expanded home-relative directory existed and was writable.

The fix delegates home expansion to the runner's `${HOME}` while keeping the remainder safely quoted. No controller-home expansion, eval, permission/config changes or provider-specific behavior is introduced.

## Verification

```sh
cargo test -p homeboy-cli --lib --offline -- --test-threads=1 remote_writable_probes_execute remote_artifact_store_availability_contract
cargo fmt --check
git diff --check
```

Both tests passed. The regression executes the generated shell probes with isolated HOME and cwd, covering home-relative/absolute paths, spaces, literal shell metacharacters, existing/missing roots and read-only behavior compared against the same shell's absolute-path verdict. Existing non-directory failure coverage remains intact. Live doctor verification using the installed repaired binary remains pending release.

## AI Assistance

xAI Grok 4.6 (`xai/grok-4.6`) through direct OpenCode CLI traced and implemented the fix. OpenAI gpt-6-astra through OpenCode verified the live failure, reviewed the patch, removed source-shape assertions, tightened isolated shell verification, reran tests and prepared this PR. Chris directed continuing Homeboy runtime stabilization.
